### PR TITLE
chore: configure repo in maestro.toml

### DIFF
--- a/maestro.toml
+++ b/maestro.toml
@@ -1,5 +1,5 @@
 [project]
-repo = ""
+repo = "CarlosDanielDev/maestro"
 base_branch = "main"
 
 [sessions]


### PR DESCRIPTION
## Summary
- Set `repo = "CarlosDanielDev/maestro"` in `maestro.toml` so Maestro can orchestrate its own issues
- Required for `cargo run -- run --issue 5` to work

## Test plan
- [x] `cargo run -- run --issue 5` resolves the repo correctly