### PR TITLE
feat: Phase 4 — Plugin system, modes, TUI polish, resume, and completions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 crossterm = { version = "0.28", features = ["event-stream"] }
 ratatui = "0.29"
 tokio = { version = "1", features = ["full"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,10 @@ pub struct Config {
     pub concurrency: ConcurrencyConfig,
     #[serde(default)]
     pub monitoring: MonitoringConfig,
+    #[serde(default)]
+    pub plugins: Vec<PluginConfig>,
+    #[serde(default)]
+    pub modes: std::collections::HashMap<String, ModeConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -218,6 +222,34 @@ impl Default for MonitoringConfig {
             work_tick_interval_secs: default_work_tick_interval(),
         }
     }
+}
+
+/// Plugin configuration: shell commands triggered on hook events.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PluginConfig {
+    /// Display name for the plugin.
+    pub name: String,
+    /// Hook point to trigger on (e.g., "session_completed", "pr_created").
+    pub on: String,
+    /// Shell command to execute.
+    pub run: String,
+    /// Per-plugin timeout override in seconds.
+    #[serde(default)]
+    pub timeout_secs: Option<u64>,
+}
+
+/// Mode configuration: defines system prompt and allowed tools for a named mode.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModeConfig {
+    /// System prompt override for this mode.
+    #[serde(default)]
+    pub system_prompt: String,
+    /// Allowed tools whitelist. Empty = all tools.
+    #[serde(default)]
+    pub allowed_tools: Vec<String>,
+    /// Permission mode override for this mode.
+    #[serde(default)]
+    pub permission_mode: Option<String>,
 }
 
 fn default_heavy_task_limit() -> usize {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,9 @@ mod gates;
 mod git;
 mod github;
 mod models;
+mod modes;
 mod notifications;
+mod plugins;
 mod prompts;
 mod review;
 mod session;
@@ -54,6 +56,10 @@ enum Commands {
         #[arg(short, long)]
         model: Option<String>,
 
+        /// Session mode (orchestrator, vibe, review, or custom)
+        #[arg(long)]
+        mode: Option<String>,
+
         /// Max concurrent sessions (overrides config)
         #[arg(long)]
         max_concurrent: Option<usize>,
@@ -90,6 +96,17 @@ enum Commands {
         #[arg(long)]
         export: Option<String>,
     },
+    /// Resume interrupted sessions from saved state
+    Resume {
+        /// Resume a specific session by ID
+        #[arg(long)]
+        session: Option<String>,
+    },
+    /// Generate shell completions
+    Completions {
+        /// Shell to generate completions for (bash, zsh, fish)
+        shell: String,
+    },
 }
 
 #[tokio::main]
@@ -117,6 +134,8 @@ async fn main() -> anyhow::Result<()> {
         Some(Commands::Init) => cmd_init(),
         Some(Commands::Clean { dry_run }) => cmd_clean(dry_run),
         Some(Commands::Logs { session, export }) => cmd_logs(session, export),
+        Some(Commands::Resume { session }) => cmd_resume(session).await,
+        Some(Commands::Completions { shell }) => cmd_completions(&shell),
         Some(Commands::Status) => cmd_status(),
         Some(Commands::Cost) => cmd_cost(),
         Some(Commands::Queue) => cmd_queue().await,
@@ -126,9 +145,21 @@ async fn main() -> anyhow::Result<()> {
             issue,
             milestone,
             model,
+            mode,
             max_concurrent,
             resume,
-        }) => cmd_run(prompt, issue, milestone, model, max_concurrent, resume).await,
+        }) => {
+            cmd_run(
+                prompt,
+                issue,
+                milestone,
+                model,
+                mode,
+                max_concurrent,
+                resume,
+            )
+            .await
+        }
         // Default: launch TUI with no sessions (dashboard mode)
         None => cmd_dashboard().await,
     }
@@ -189,6 +220,20 @@ heavy_task_limit = 2                    # Max concurrent heavy tasks
 
 [monitoring]
 work_tick_interval_secs = 10
+
+# Plugin hooks — shell commands triggered on lifecycle events
+# [[plugins]]
+# name = "notify-team"
+# on = "session_completed"             # Hook points: session_started, session_completed, tests_passed,
+#                                      #   tests_failed, budget_threshold, file_conflict, pr_created
+# run = "curl -X POST https://slack.webhook/..."
+# timeout_secs = 30                    # Optional per-plugin timeout
+
+# Custom modes — define system prompt and allowed tools
+# [modes.review]
+# system_prompt = "You are a code reviewer. Review the PR and leave comments."
+# allowed_tools = ["Read", "Grep", "Glob"]
+# permission_mode = "plan"
 "#;
 
     std::fs::write(&path, content)?;
@@ -423,16 +468,125 @@ fn cmd_clean(dry_run: bool) -> anyhow::Result<()> {
     Ok(())
 }
 
+async fn cmd_resume(session_filter: Option<String>) -> anyhow::Result<()> {
+    let config = Config::find_and_load()?;
+    let store = StateStore::new(StateStore::default_path());
+    let state = store.load()?;
+    let repo_root = std::env::current_dir()?;
+
+    // Find incomplete sessions
+    let incomplete: Vec<&Session> = state
+        .sessions
+        .iter()
+        .filter(|s| {
+            matches!(
+                s.status,
+                session::types::SessionStatus::Running
+                    | session::types::SessionStatus::Spawning
+                    | session::types::SessionStatus::Queued
+                    | session::types::SessionStatus::Stalled
+                    | session::types::SessionStatus::Errored
+                    | session::types::SessionStatus::Retrying
+            )
+        })
+        .filter(|s| {
+            if let Some(ref filter) = session_filter {
+                s.id.to_string().starts_with(filter)
+                    || s.issue_number
+                        .map(|n| n.to_string() == *filter)
+                        .unwrap_or(false)
+            } else {
+                true
+            }
+        })
+        .collect();
+
+    if incomplete.is_empty() {
+        println!("No incomplete sessions to resume.");
+        return Ok(());
+    }
+
+    println!("Resuming {} incomplete session(s)...", incomplete.len());
+
+    let worktree_mgr = Box::new(GitWorktreeManager::new(repo_root));
+    let max_concurrent = config.sessions.max_concurrent;
+
+    let mut app = App::new(
+        store,
+        max_concurrent,
+        worktree_mgr,
+        config.sessions.permission_mode.clone(),
+        config.sessions.allowed_tools.clone(),
+    );
+
+    // Wire up from config
+    app.budget_enforcer = Some(crate::budget::BudgetEnforcer::new(
+        config.budget.per_session_usd,
+        config.budget.total_usd,
+        config.budget.alert_threshold_pct,
+    ));
+    app.model_router = Some(crate::models::ModelRouter::new(
+        config.models.routing.clone(),
+        config.sessions.default_model.clone(),
+    ));
+    app.notifications =
+        crate::notifications::dispatcher::NotificationDispatcher::new(config.notifications.desktop);
+    if !config.plugins.is_empty() {
+        app.plugin_runner = Some(crate::plugins::runner::PluginRunner::new(
+            config.plugins.clone(),
+            30,
+        ));
+    }
+
+    // Re-enqueue incomplete sessions with their original prompts
+    for s in &incomplete {
+        let mut new_session = Session::new(
+            s.prompt.clone(),
+            s.model.clone(),
+            s.mode.clone(),
+            s.issue_number,
+        );
+        new_session.issue_title = s.issue_title.clone();
+        new_session.retry_count = s.retry_count;
+        app.add_session(new_session).await?;
+    }
+
+    // Set up GitHub client for label management
+    let client = GhCliClient::new();
+    app.github_client = Some(Box::new(client));
+    app.config = Some(config);
+
+    tui::run(app).await
+}
+
+fn cmd_completions(shell: &str) -> anyhow::Result<()> {
+    use clap::CommandFactory;
+    use clap_complete::{Shell, generate};
+
+    let shell = match shell.to_lowercase().as_str() {
+        "bash" => Shell::Bash,
+        "zsh" => Shell::Zsh,
+        "fish" => Shell::Fish,
+        other => anyhow::bail!("Unsupported shell: {}. Use bash, zsh, or fish.", other),
+    };
+
+    let mut cmd = Cli::command();
+    generate(shell, &mut cmd, "maestro", &mut std::io::stdout());
+    Ok(())
+}
+
 async fn cmd_run(
     prompt: Option<String>,
     issue: Option<String>,
     milestone: Option<String>,
     model: Option<String>,
+    mode: Option<String>,
     max_concurrent_override: Option<usize>,
     resume: bool,
 ) -> anyhow::Result<()> {
     let config = Config::find_and_load()?;
     let model = model.unwrap_or(config.sessions.default_model.clone());
+    let session_mode = mode.unwrap_or(config.sessions.default_mode.clone());
     let max_concurrent = max_concurrent_override.unwrap_or(config.sessions.max_concurrent);
 
     let store = StateStore::new(StateStore::default_path());
@@ -486,6 +640,14 @@ async fn cmd_run(
     app.notifications =
         crate::notifications::dispatcher::NotificationDispatcher::new(config.notifications.desktop);
 
+    // Wire up plugin runner from config
+    if !config.plugins.is_empty() {
+        app.plugin_runner = Some(crate::plugins::runner::PluginRunner::new(
+            config.plugins.clone(),
+            30, // default timeout
+        ));
+    }
+
     // Resume from previous state if requested
     if resume {
         let mut recovered = 0;
@@ -508,12 +670,7 @@ async fn cmd_run(
 
     // Determine what to run
     if let Some(prompt_text) = prompt {
-        let session = Session::new(
-            prompt_text,
-            model,
-            config.sessions.default_mode.clone(),
-            None,
-        );
+        let session = Session::new(prompt_text, model, session_mode.clone(), None);
         app.add_session(session).await?;
     } else if let Some(milestone_name) = milestone {
         // Fetch all issues in the milestone
@@ -541,10 +698,13 @@ async fn cmd_run(
                 .map_err(|_| anyhow::anyhow!("Invalid issue number: {}", num_str.trim()))?;
 
             let gh_issue = client.get_issue(num).await?;
+            // Use mode from label (maestro:mode:X) or CLI --mode or config default
+            let issue_mode = crate::modes::mode_from_labels(&gh_issue.labels)
+                .unwrap_or_else(|| session_mode.clone());
             let mut session = Session::new(
                 gh_issue.unattended_prompt(),
                 model.clone(),
-                config.sessions.default_mode.clone(),
+                issue_mode,
                 Some(num),
             );
             session.issue_title = Some(gh_issue.title.clone());
@@ -590,7 +750,27 @@ async fn cmd_run(
 
 async fn cmd_dashboard() -> anyhow::Result<()> {
     let store = StateStore::new(StateStore::default_path());
+    let state = store.load().unwrap_or_default();
     let repo_root = std::env::current_dir()?;
+
+    // Check for incomplete sessions and offer auto-resume
+    let has_incomplete = state.sessions.iter().any(|s| {
+        matches!(
+            s.status,
+            session::types::SessionStatus::Running
+                | session::types::SessionStatus::Spawning
+                | session::types::SessionStatus::Queued
+                | session::types::SessionStatus::Stalled
+                | session::types::SessionStatus::Retrying
+        )
+    });
+
+    if has_incomplete {
+        eprintln!(
+            "Found incomplete sessions from previous run. Use `maestro resume` to continue them."
+        );
+    }
+
     let worktree_mgr = Box::new(GitWorktreeManager::new(repo_root));
     let app = App::new(
         store,

--- a/src/modes/mod.rs
+++ b/src/modes/mod.rs
@@ -1,0 +1,102 @@
+use crate::config::{Config, ModeConfig};
+
+/// Built-in mode definitions. These are available even without config.
+pub fn builtin_modes() -> Vec<(&'static str, ModeConfig)> {
+    vec![
+        (
+            "orchestrator",
+            ModeConfig {
+                system_prompt: String::new(),
+                allowed_tools: Vec::new(),
+                permission_mode: None,
+            },
+        ),
+        (
+            "vibe",
+            ModeConfig {
+                system_prompt: String::new(),
+                allowed_tools: Vec::new(),
+                permission_mode: None,
+            },
+        ),
+        (
+            "review",
+            ModeConfig {
+                system_prompt: "You are a code reviewer. Review the PR and leave comments. \
+                    Focus on correctness, security, performance, and code quality."
+                    .into(),
+                allowed_tools: vec!["Read".into(), "Grep".into(), "Glob".into(), "Bash".into()],
+                permission_mode: Some("plan".into()),
+            },
+        ),
+    ]
+}
+
+/// Resolve a mode name to its configuration.
+/// Priority: config-defined modes > built-in modes.
+pub fn resolve_mode(name: &str, config: Option<&Config>) -> Option<ModeConfig> {
+    // Check config-defined modes first
+    if let Some(cfg) = config
+        && let Some(mode) = cfg.modes.get(name)
+    {
+        return Some(mode.clone());
+    }
+
+    // Fall back to built-in modes
+    builtin_modes()
+        .into_iter()
+        .find(|(n, _)| *n == name)
+        .map(|(_, m)| m)
+}
+
+/// Extract mode name from issue labels. Looks for `maestro:mode:<name>` labels.
+pub fn mode_from_labels(labels: &[String]) -> Option<String> {
+    labels
+        .iter()
+        .find_map(|l| l.strip_prefix("maestro:mode:").map(|s| s.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_modes_has_three_defaults() {
+        let modes = builtin_modes();
+        assert_eq!(modes.len(), 3);
+        let names: Vec<&str> = modes.iter().map(|(n, _)| *n).collect();
+        assert!(names.contains(&"orchestrator"));
+        assert!(names.contains(&"vibe"));
+        assert!(names.contains(&"review"));
+    }
+
+    #[test]
+    fn resolve_mode_finds_builtin() {
+        let mode = resolve_mode("review", None);
+        assert!(mode.is_some());
+        let mode = mode.unwrap();
+        assert!(!mode.system_prompt.is_empty());
+        assert!(mode.allowed_tools.contains(&"Read".to_string()));
+    }
+
+    #[test]
+    fn resolve_mode_returns_none_for_unknown() {
+        assert!(resolve_mode("nonexistent", None).is_none());
+    }
+
+    #[test]
+    fn mode_from_labels_extracts_mode() {
+        let labels = vec![
+            "bug".into(),
+            "maestro:mode:review".into(),
+            "priority:P0".into(),
+        ];
+        assert_eq!(mode_from_labels(&labels), Some("review".into()));
+    }
+
+    #[test]
+    fn mode_from_labels_returns_none_when_absent() {
+        let labels = vec!["bug".into(), "priority:P1".into()];
+        assert_eq!(mode_from_labels(&labels), None);
+    }
+}

--- a/src/plugins/hooks.rs
+++ b/src/plugins/hooks.rs
@@ -1,0 +1,137 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Hook points where plugins can execute.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HookPoint {
+    SessionStarted,
+    SessionCompleted,
+    TestsPassed,
+    TestsFailed,
+    BudgetThreshold,
+    FileConflict,
+    PrCreated,
+}
+
+impl HookPoint {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::SessionStarted => "session_started",
+            Self::SessionCompleted => "session_completed",
+            Self::TestsPassed => "tests_passed",
+            Self::TestsFailed => "tests_failed",
+            Self::BudgetThreshold => "budget_threshold",
+            Self::FileConflict => "file_conflict",
+            Self::PrCreated => "pr_created",
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "session_started" => Some(Self::SessionStarted),
+            "session_completed" => Some(Self::SessionCompleted),
+            "tests_passed" => Some(Self::TestsPassed),
+            "tests_failed" => Some(Self::TestsFailed),
+            "budget_threshold" => Some(Self::BudgetThreshold),
+            "file_conflict" => Some(Self::FileConflict),
+            "pr_created" => Some(Self::PrCreated),
+            _ => None,
+        }
+    }
+}
+
+/// Context passed to plugins via environment variables.
+#[derive(Debug, Clone, Default)]
+pub struct HookContext {
+    pub vars: HashMap<String, String>,
+}
+
+impl HookContext {
+    pub fn new() -> Self {
+        Self {
+            vars: HashMap::new(),
+        }
+    }
+
+    pub fn with_session(mut self, session_id: &str, issue_number: Option<u64>) -> Self {
+        self.vars
+            .insert("MAESTRO_SESSION_ID".into(), session_id.into());
+        if let Some(num) = issue_number {
+            self.vars
+                .insert("MAESTRO_ISSUE_NUMBER".into(), num.to_string());
+        }
+        self
+    }
+
+    pub fn with_cost(mut self, cost_usd: f64) -> Self {
+        self.vars
+            .insert("MAESTRO_COST_USD".into(), format!("{:.2}", cost_usd));
+        self
+    }
+
+    pub fn with_pr(mut self, pr_number: u64) -> Self {
+        self.vars
+            .insert("MAESTRO_PR_NUMBER".into(), pr_number.to_string());
+        self
+    }
+
+    pub fn with_branch(mut self, branch: &str) -> Self {
+        self.vars.insert("MAESTRO_BRANCH".into(), branch.into());
+        self
+    }
+
+    pub fn with_files(mut self, files: &[String]) -> Self {
+        self.vars.insert("MAESTRO_FILES".into(), files.join(","));
+        self
+    }
+
+    pub fn with_var(mut self, key: &str, value: &str) -> Self {
+        self.vars.insert(key.into(), value.into());
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hook_point_round_trips() {
+        let points = [
+            HookPoint::SessionStarted,
+            HookPoint::SessionCompleted,
+            HookPoint::TestsPassed,
+            HookPoint::TestsFailed,
+            HookPoint::BudgetThreshold,
+            HookPoint::FileConflict,
+            HookPoint::PrCreated,
+        ];
+        for point in points {
+            assert_eq!(HookPoint::from_str(point.as_str()), Some(point));
+        }
+    }
+
+    #[test]
+    fn hook_point_from_str_unknown() {
+        assert_eq!(HookPoint::from_str("unknown"), None);
+    }
+
+    #[test]
+    fn hook_context_builds_env_vars() {
+        let ctx = HookContext::new()
+            .with_session("abc-123", Some(42))
+            .with_cost(3.50)
+            .with_pr(99)
+            .with_branch("maestro/issue-42")
+            .with_files(&["src/main.rs".into(), "src/lib.rs".into()]);
+
+        assert_eq!(ctx.vars["MAESTRO_SESSION_ID"], "abc-123");
+        assert_eq!(ctx.vars["MAESTRO_ISSUE_NUMBER"], "42");
+        assert_eq!(ctx.vars["MAESTRO_COST_USD"], "3.50");
+        assert_eq!(ctx.vars["MAESTRO_PR_NUMBER"], "99");
+        assert_eq!(ctx.vars["MAESTRO_BRANCH"], "maestro/issue-42");
+        assert_eq!(ctx.vars["MAESTRO_FILES"], "src/main.rs,src/lib.rs");
+    }
+}

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,0 +1,2 @@
+pub mod hooks;
+pub mod runner;

--- a/src/plugins/runner.rs
+++ b/src/plugins/runner.rs
@@ -1,0 +1,186 @@
+use super::hooks::{HookContext, HookPoint};
+use crate::config::PluginConfig;
+use std::time::Duration;
+use tokio::process::Command;
+
+/// Result of a plugin execution.
+#[derive(Debug, Clone)]
+pub struct PluginResult {
+    pub plugin_name: String,
+    pub success: bool,
+    pub output: String,
+    pub duration_ms: u64,
+}
+
+/// Executes plugins registered for specific hook points.
+pub struct PluginRunner {
+    plugins: Vec<PluginConfig>,
+    timeout: Duration,
+}
+
+impl PluginRunner {
+    pub fn new(plugins: Vec<PluginConfig>, timeout_secs: u64) -> Self {
+        Self {
+            plugins,
+            timeout: Duration::from_secs(timeout_secs),
+        }
+    }
+
+    /// Get all plugins registered for a specific hook point.
+    pub fn plugins_for(&self, hook: HookPoint) -> Vec<&PluginConfig> {
+        self.plugins
+            .iter()
+            .filter(|p| p.on == hook.as_str())
+            .collect()
+    }
+
+    /// Execute all plugins for a hook point with the given context.
+    /// Returns results for each plugin. Plugins run sequentially.
+    pub async fn fire(&self, hook: HookPoint, ctx: &HookContext) -> Vec<PluginResult> {
+        let matching = self.plugins_for(hook);
+        let mut results = Vec::new();
+
+        for plugin in matching {
+            let result = self.execute_plugin(plugin, ctx).await;
+            results.push(result);
+        }
+
+        results
+    }
+
+    async fn execute_plugin(&self, plugin: &PluginConfig, ctx: &HookContext) -> PluginResult {
+        let start = std::time::Instant::now();
+
+        let result = tokio::time::timeout(self.timeout, async {
+            let mut cmd = Command::new("sh");
+            cmd.args(["-c", &plugin.run]);
+
+            // Inject environment variables from context
+            for (key, value) in &ctx.vars {
+                cmd.env(key, value);
+            }
+
+            // Add hook point as env var
+            cmd.env("MAESTRO_HOOK", plugin.on.as_str());
+            cmd.env("MAESTRO_PLUGIN_NAME", &plugin.name);
+
+            cmd.output().await
+        })
+        .await;
+
+        let duration_ms = start.elapsed().as_millis() as u64;
+
+        match result {
+            Ok(Ok(output)) => {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let combined = if stderr.is_empty() {
+                    stdout.to_string()
+                } else {
+                    format!("{}\n{}", stdout.trim(), stderr.trim())
+                };
+                PluginResult {
+                    plugin_name: plugin.name.clone(),
+                    success: output.status.success(),
+                    output: combined,
+                    duration_ms,
+                }
+            }
+            Ok(Err(e)) => PluginResult {
+                plugin_name: plugin.name.clone(),
+                success: false,
+                output: format!("Failed to execute: {}", e),
+                duration_ms,
+            },
+            Err(_) => PluginResult {
+                plugin_name: plugin.name.clone(),
+                success: false,
+                output: format!("Plugin timed out after {}s", self.timeout.as_secs()),
+                duration_ms,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_plugin(name: &str, on: &str, run: &str) -> PluginConfig {
+        PluginConfig {
+            name: name.into(),
+            on: on.into(),
+            run: run.into(),
+            timeout_secs: None,
+        }
+    }
+
+    #[test]
+    fn plugins_for_filters_by_hook() {
+        let plugins = vec![
+            make_plugin("a", "session_completed", "echo done"),
+            make_plugin("b", "session_started", "echo start"),
+            make_plugin("c", "session_completed", "echo also done"),
+        ];
+        let runner = PluginRunner::new(plugins, 30);
+        let matching = runner.plugins_for(HookPoint::SessionCompleted);
+        assert_eq!(matching.len(), 2);
+        assert_eq!(matching[0].name, "a");
+        assert_eq!(matching[1].name, "c");
+    }
+
+    #[test]
+    fn plugins_for_returns_empty_when_no_match() {
+        let plugins = vec![make_plugin("a", "session_started", "echo start")];
+        let runner = PluginRunner::new(plugins, 30);
+        let matching = runner.plugins_for(HookPoint::PrCreated);
+        assert!(matching.is_empty());
+    }
+
+    #[tokio::test]
+    async fn fire_executes_matching_plugins() {
+        let plugins = vec![make_plugin("echo-test", "session_completed", "echo hello")];
+        let runner = PluginRunner::new(plugins, 5);
+        let ctx = HookContext::new();
+        let results = runner.fire(HookPoint::SessionCompleted, &ctx).await;
+        assert_eq!(results.len(), 1);
+        assert!(results[0].success);
+        assert!(results[0].output.contains("hello"));
+    }
+
+    #[tokio::test]
+    async fn fire_passes_env_vars() {
+        let plugins = vec![make_plugin(
+            "env-test",
+            "session_started",
+            "echo $MAESTRO_SESSION_ID",
+        )];
+        let runner = PluginRunner::new(plugins, 5);
+        let ctx = HookContext::new().with_session("test-id-123", None);
+        let results = runner.fire(HookPoint::SessionStarted, &ctx).await;
+        assert_eq!(results.len(), 1);
+        assert!(results[0].success);
+        assert!(results[0].output.contains("test-id-123"));
+    }
+
+    #[tokio::test]
+    async fn fire_handles_timeout() {
+        let plugins = vec![make_plugin("slow", "session_completed", "sleep 10")];
+        let runner = PluginRunner::new(plugins, 1);
+        let ctx = HookContext::new();
+        let results = runner.fire(HookPoint::SessionCompleted, &ctx).await;
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].success);
+        assert!(results[0].output.contains("timed out"));
+    }
+
+    #[tokio::test]
+    async fn fire_handles_failed_command() {
+        let plugins = vec![make_plugin("fail", "session_completed", "exit 1")];
+        let runner = PluginRunner::new(plugins, 5);
+        let ctx = HookContext::new();
+        let results = runner.fire(HookPoint::SessionCompleted, &ctx).await;
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].success);
+    }
+}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -9,6 +9,8 @@ use crate::github::labels::LabelManager;
 use crate::github::pr::PrCreator;
 use crate::models::ModelRouter;
 use crate::notifications::dispatcher::NotificationDispatcher;
+use crate::plugins::hooks::{HookContext, HookPoint};
+use crate::plugins::runner::PluginRunner;
 use crate::prompts::PromptBuilder;
 use crate::session::health::{HealthCheck, HealthMonitor};
 use crate::session::logger::SessionLogger;
@@ -37,6 +39,15 @@ pub enum TuiMode {
     Detail(usize),
     /// Dependency graph visualization.
     DependencyGraph,
+    /// Full-screen agent view (expanded single agent output).
+    Fullscreen(usize),
+    /// Cost dashboard view.
+    CostDashboard,
+}
+
+struct PendingHook {
+    hook: HookPoint,
+    ctx: HookContext,
 }
 
 struct PendingIssueCompletion {
@@ -67,6 +78,8 @@ pub struct App {
     pub config: Option<Config>,
     /// Pending issue completions to process in the next async check_completions tick.
     pending_issue_completions: Vec<PendingIssueCompletion>,
+    /// Pending plugin hooks to fire in the next async tick.
+    pending_hooks: Vec<PendingHook>,
     /// Health monitor for stall detection.
     pub health_monitor: Box<dyn HealthCheck>,
     /// Budget enforcer for cost limits.
@@ -87,6 +100,10 @@ pub struct App {
     last_ci_poll: Instant,
     /// Last time work assigner was ticked.
     last_work_tick: Instant,
+    /// Plugin runner for hook-based plugin execution.
+    pub plugin_runner: Option<PluginRunner>,
+    /// Whether the help overlay is visible.
+    pub show_help: bool,
 }
 
 impl App {
@@ -117,6 +134,7 @@ impl App {
             github_client: None,
             config: None,
             pending_issue_completions: Vec::new(),
+            pending_hooks: Vec::new(),
             health_monitor: Box::new(HealthMonitor::new()),
             budget_enforcer: None,
             model_router: None,
@@ -127,6 +145,8 @@ impl App {
             pending_pr_checks: Vec::new(),
             last_ci_poll: Instant::now(),
             last_work_tick: Instant::now(),
+            plugin_runner: None,
+            show_help: false,
         }
     }
 
@@ -161,6 +181,12 @@ impl App {
                         "Session started".into(),
                         LogLevel::Info,
                     );
+                    // Fire session_started plugin hook
+                    let ctx = HookContext::new().with_session(
+                        &managed.session.id.to_string(),
+                        managed.session.issue_number,
+                    );
+                    self.fire_plugin_hook(HookPoint::SessionStarted, ctx).await;
                 }
             }
         }
@@ -199,6 +225,14 @@ impl App {
                     ),
                     LogLevel::Error,
                 );
+                // Queue file_conflict hook
+                self.pending_hooks.push(PendingHook {
+                    hook: HookPoint::FileConflict,
+                    ctx: HookContext::new()
+                        .with_session(&session_id.to_string(), None)
+                        .with_var("MAESTRO_CONFLICT_FILE", path)
+                        .with_var("MAESTRO_CONFLICT_OWNER", &owner.to_string()),
+                });
             }
         }
 
@@ -253,6 +287,17 @@ impl App {
                         format!("Completed (${:.2})", cost_usd),
                         LogLevel::Info,
                     );
+                    // Queue session_completed plugin hook
+                    self.pending_hooks.push(PendingHook {
+                        hook: HookPoint::SessionCompleted,
+                        ctx: HookContext::new()
+                            .with_session(
+                                &managed.session.id.to_string(),
+                                managed.session.issue_number,
+                            )
+                            .with_cost(*cost_usd)
+                            .with_files(&managed.session.files_touched),
+                    });
                     // Queue issue completion for async processing
                     if let Some(issue_num) = managed.session.issue_number {
                         self.pending_issue_completions.push(PendingIssueCompletion {
@@ -349,6 +394,12 @@ impl App {
                     ),
                     LogLevel::Error,
                 );
+                self.pending_hooks.push(PendingHook {
+                    hook: HookPoint::BudgetThreshold,
+                    ctx: HookContext::new()
+                        .with_cost(self.total_cost)
+                        .with_var("MAESTRO_BUDGET_EXCEEDED", "true"),
+                });
                 self.running = false;
             }
             BudgetAction::Alert(pct) => {
@@ -367,6 +418,12 @@ impl App {
 
     /// Check for completed sessions and promote queued ones.
     pub async fn check_completions(&mut self) -> anyhow::Result<()> {
+        // Fire pending plugin hooks
+        let pending_hooks = std::mem::take(&mut self.pending_hooks);
+        for ph in pending_hooks {
+            self.fire_plugin_hook(ph.hook, ph.ctx).await;
+        }
+
         // Process pending issue completions (gates, git push, label updates, PR creation)
         let pending = std::mem::take(&mut self.pending_issue_completions);
         let gates_config = self.config.as_ref().map(|c| c.gates.clone());
@@ -396,12 +453,20 @@ impl App {
                     );
                     // Mark as failed — retry system will pick it up
                     completion.success = false;
+                    // Fire tests_failed hook
+                    let ctx = HookContext::new()
+                        .with_session("", Some(completion.issue_number))
+                        .with_var("MAESTRO_GATE_FAILURES", &failures.join("; "));
+                    self.fire_plugin_hook(HookPoint::TestsFailed, ctx).await;
                 } else {
                     self.activity_log.push_simple(
                         format!("#{}", completion.issue_number),
                         "All gates passed".into(),
                         LogLevel::Info,
                     );
+                    // Fire tests_passed hook
+                    let ctx = HookContext::new().with_session("", Some(completion.issue_number));
+                    self.fire_plugin_hook(HookPoint::TestsPassed, ctx).await;
                 }
             }
 
@@ -807,6 +872,13 @@ impl App {
                         });
                     }
                     self.dispatch_review(pr_num, branch, issue_number);
+                    // Fire pr_created hook
+                    let ctx = HookContext::new()
+                        .with_session("", Some(issue_number))
+                        .with_pr(pr_num)
+                        .with_branch(branch)
+                        .with_cost(cost_usd);
+                    self.fire_plugin_hook(HookPoint::PrCreated, ctx).await;
                 }
                 Err(e) => {
                     self.activity_log.push_simple(
@@ -1029,6 +1101,34 @@ impl App {
         completed_indices.sort_unstable();
         for i in completed_indices.into_iter().rev() {
             self.pending_pr_checks.remove(i);
+        }
+    }
+
+    /// Fire a plugin hook asynchronously and log results.
+    pub async fn fire_plugin_hook(&mut self, hook: HookPoint, ctx: HookContext) {
+        let Some(ref runner) = self.plugin_runner else {
+            return;
+        };
+        let results = runner.fire(hook, &ctx).await;
+        for result in results {
+            let level = if result.success {
+                LogLevel::Info
+            } else {
+                LogLevel::Error
+            };
+            let msg = if result.success {
+                format!(
+                    "Plugin '{}' completed ({}ms)",
+                    result.plugin_name, result.duration_ms
+                )
+            } else {
+                format!(
+                    "Plugin '{}' failed: {}",
+                    result.plugin_name,
+                    result.output.lines().next().unwrap_or("unknown error")
+                )
+            };
+            self.activity_log.push_simple("PLUGIN".into(), msg, level);
         }
     }
 

--- a/src/tui/cost_dashboard.rs
+++ b/src/tui/cost_dashboard.rs
@@ -1,0 +1,205 @@
+use crate::session::types::{Session, SessionStatus};
+use ratatui::{
+    Frame,
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Gauge, Paragraph},
+};
+
+/// Draw the cost dashboard view showing spending breakdown.
+pub fn draw_cost_dashboard(
+    f: &mut Frame,
+    sessions: &[&Session],
+    total_cost: f64,
+    budget_limit: Option<f64>,
+    area: Rect,
+) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(5), // budget gauge
+            Constraint::Length(3), // summary stats
+            Constraint::Min(5),    // per-session breakdown
+        ])
+        .split(area);
+
+    draw_budget_gauge(f, total_cost, budget_limit, chunks[0]);
+    draw_summary_stats(f, sessions, total_cost, chunks[1]);
+    draw_session_costs(f, sessions, chunks[2]);
+}
+
+fn draw_budget_gauge(f: &mut Frame, total_cost: f64, budget_limit: Option<f64>, area: Rect) {
+    let (ratio, label) = match budget_limit {
+        Some(limit) if limit > 0.0 => {
+            let pct = (total_cost / limit * 100.0).min(100.0);
+            let ratio = (total_cost / limit).min(1.0);
+            (
+                ratio,
+                format!("${:.2} / ${:.2} ({:.0}%)", total_cost, limit, pct),
+            )
+        }
+        _ => (0.0, format!("${:.2} spent (no budget limit)", total_cost)),
+    };
+
+    let color = if ratio >= 0.9 {
+        Color::Red
+    } else if ratio >= 0.7 {
+        Color::Yellow
+    } else {
+        Color::Green
+    };
+
+    let gauge = Gauge::default()
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(color))
+                .title(" Budget ")
+                .title_alignment(Alignment::Center),
+        )
+        .gauge_style(Style::default().fg(color).bg(Color::DarkGray))
+        .ratio(ratio)
+        .label(Span::styled(
+            label,
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ));
+
+    f.render_widget(gauge, area);
+}
+
+fn draw_summary_stats(f: &mut Frame, sessions: &[&Session], total_cost: f64, area: Rect) {
+    let completed = sessions
+        .iter()
+        .filter(|s| s.status == SessionStatus::Completed)
+        .count();
+    let errored = sessions
+        .iter()
+        .filter(|s| s.status == SessionStatus::Errored)
+        .count();
+    let running = sessions
+        .iter()
+        .filter(|s| s.status == SessionStatus::Running)
+        .count();
+    let avg_cost = if !sessions.is_empty() {
+        total_cost / sessions.len() as f64
+    } else {
+        0.0
+    };
+
+    let stats = Line::from(vec![
+        Span::styled(" Sessions: ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            sessions.len().to_string(),
+            Style::default().fg(Color::White),
+        ),
+        Span::raw("  "),
+        Span::styled(
+            format!("{} running", running),
+            Style::default().fg(Color::Green),
+        ),
+        Span::raw("  "),
+        Span::styled(
+            format!("{} completed", completed),
+            Style::default().fg(Color::Cyan),
+        ),
+        Span::raw("  "),
+        Span::styled(
+            format!("{} errored", errored),
+            Style::default().fg(Color::Red),
+        ),
+        Span::raw("    "),
+        Span::styled(" Avg cost: ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            format!("${:.2}", avg_cost),
+            Style::default().fg(Color::Yellow),
+        ),
+    ]);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::DarkGray));
+
+    f.render_widget(Paragraph::new(stats).block(block), area);
+}
+
+fn draw_session_costs(f: &mut Frame, sessions: &[&Session], area: Rect) {
+    let mut lines: Vec<Line> = vec![Line::from(vec![Span::styled(
+        format!(
+            "  {:<12} {:<45} {:>10} {:>10} {:>10}",
+            "ID", "Title", "Cost", "Status", "Elapsed"
+        ),
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    )])];
+
+    lines.push(Line::from(Span::styled(
+        format!("  {}", "─".repeat(89)),
+        Style::default().fg(Color::DarkGray),
+    )));
+
+    // Sort by cost descending
+    let mut sorted: Vec<&&Session> = sessions.iter().collect();
+    sorted.sort_by(|a, b| {
+        b.cost_usd
+            .partial_cmp(&a.cost_usd)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    for session in sorted {
+        let id_str = match session.issue_number {
+            Some(n) => format!("#{}", n),
+            None => session.id.to_string()[..8].to_string(),
+        };
+
+        let title = session.issue_title.as_deref().unwrap_or(&session.prompt);
+        let title_display: String = if title.chars().count() > 43 {
+            let truncated: String = title.chars().take(40).collect();
+            format!("{}...", truncated)
+        } else {
+            title.to_string()
+        };
+
+        let status_color = match session.status {
+            SessionStatus::Running => Color::Green,
+            SessionStatus::Completed => Color::Cyan,
+            SessionStatus::Errored => Color::Red,
+            _ => Color::White,
+        };
+
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(format!("{:<12}", id_str), Style::default().fg(Color::White)),
+            Span::raw(" "),
+            Span::styled(
+                format!("{:<45}", title_display),
+                Style::default().fg(Color::White),
+            ),
+            Span::styled(
+                format!("{:>10}", format!("${:.2}", session.cost_usd)),
+                Style::default().fg(Color::Yellow),
+            ),
+            Span::styled(
+                format!("{:>10}", session.status.label()),
+                Style::default().fg(status_color),
+            ),
+            Span::styled(
+                format!("{:>10}", session.elapsed_display()),
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]));
+    }
+
+    let paragraph = Paragraph::new(lines).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::DarkGray))
+            .title(" Session Costs ")
+            .title_alignment(Alignment::Center),
+    );
+
+    f.render_widget(paragraph, area);
+}

--- a/src/tui/fullscreen.rs
+++ b/src/tui/fullscreen.rs
@@ -1,0 +1,155 @@
+use crate::session::types::Session;
+use crate::state::progress::ProgressTracker;
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Wrap},
+};
+
+/// Draw a full-screen view for a single agent session.
+pub fn draw_fullscreen(
+    f: &mut Frame,
+    session: &Session,
+    progress_tracker: &ProgressTracker,
+    area: Rect,
+) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // session header
+            Constraint::Min(10),   // output
+            Constraint::Length(3), // footer with stats
+        ])
+        .split(area);
+
+    draw_session_header(f, session, chunks[0]);
+    draw_session_output(f, session, chunks[1]);
+    draw_session_footer(f, session, progress_tracker, chunks[2]);
+}
+
+fn draw_session_header(f: &mut Frame, session: &Session, area: Rect) {
+    let title = match session.issue_number {
+        Some(n) => {
+            let issue_title = session.issue_title.as_deref().unwrap_or("untitled");
+            format!("#{} — {}", n, issue_title)
+        }
+        None => format!("Session {}", &session.id.to_string()[..8]),
+    };
+
+    let status_color = match session.status {
+        crate::session::types::SessionStatus::Running => Color::Green,
+        crate::session::types::SessionStatus::Completed => Color::Cyan,
+        crate::session::types::SessionStatus::Errored => Color::Red,
+        crate::session::types::SessionStatus::Paused => Color::Yellow,
+        _ => Color::White,
+    };
+
+    let header = Line::from(vec![
+        Span::styled(
+            format!(" {} {} ", session.status.symbol(), session.status.label()),
+            Style::default()
+                .fg(Color::Black)
+                .bg(status_color)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("  "),
+        Span::styled(
+            &title,
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("  "),
+        Span::styled(
+            format!("model: {}", session.model),
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::raw("  "),
+        Span::styled(
+            format!("mode: {}", session.mode),
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(status_color));
+
+    f.render_widget(Paragraph::new(header).block(block), area);
+}
+
+fn draw_session_output(f: &mut Frame, session: &Session, area: Rect) {
+    let output = if session.last_message.is_empty() {
+        "Waiting for output...".to_string()
+    } else {
+        session.last_message.clone()
+    };
+
+    let paragraph = Paragraph::new(output)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::DarkGray))
+                .title(" Agent Output "),
+        )
+        .wrap(Wrap { trim: false })
+        .scroll((
+            // Show the last lines — scroll to bottom
+            {
+                let inner_height = area.height.saturating_sub(2);
+                let line_count = session.last_message.lines().count() as u16;
+                line_count.saturating_sub(inner_height)
+            },
+            0,
+        ));
+
+    f.render_widget(paragraph, area);
+}
+
+fn draw_session_footer(
+    f: &mut Frame,
+    session: &Session,
+    progress_tracker: &ProgressTracker,
+    area: Rect,
+) {
+    let elapsed = session.elapsed_display();
+    let files_count = session.files_touched.len();
+
+    let phase = progress_tracker
+        .get(&session.id)
+        .map(|p| p.phase.label().to_string())
+        .unwrap_or_else(|| "—".into());
+
+    let footer = Line::from(vec![
+        Span::styled(" Cost: ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            format!("${:.2}", session.cost_usd),
+            Style::default().fg(Color::Yellow),
+        ),
+        Span::raw("  "),
+        Span::styled(" Elapsed: ", Style::default().fg(Color::DarkGray)),
+        Span::styled(elapsed, Style::default().fg(Color::White)),
+        Span::raw("  "),
+        Span::styled(" Files: ", Style::default().fg(Color::DarkGray)),
+        Span::styled(files_count.to_string(), Style::default().fg(Color::Cyan)),
+        Span::raw("  "),
+        Span::styled(" Phase: ", Style::default().fg(Color::DarkGray)),
+        Span::styled(phase, Style::default().fg(Color::Green)),
+        Span::raw("  "),
+        Span::styled(" Activity: ", Style::default().fg(Color::DarkGray)),
+        Span::styled(&session.current_activity, Style::default().fg(Color::White)),
+        Span::raw("    "),
+        Span::styled(
+            "[Esc] back  [↑↓] scroll",
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::DarkGray));
+
+    f.render_widget(Paragraph::new(footer).block(block), area);
+}

--- a/src/tui/help.rs
+++ b/src/tui/help.rs
@@ -1,0 +1,109 @@
+use ratatui::{
+    Frame,
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
+};
+
+/// Draw the help overlay popup centered on the screen.
+pub fn draw_help_overlay(f: &mut Frame, area: Rect) {
+    let popup = centered_rect(60, 70, area);
+
+    // Clear background behind popup
+    f.render_widget(Clear, popup);
+
+    let help_text = vec![
+        Line::from(vec![Span::styled(
+            "Keyboard Shortcuts",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )]),
+        Line::from(""),
+        section_header("Navigation"),
+        key_line("Tab", "Cycle views (Overview → Dependencies → Overview)"),
+        key_line("Esc", "Return to Overview / Close help"),
+        key_line("Enter", "Open detail view for selected session"),
+        key_line("1-9", "Jump to session detail by index"),
+        key_line("?", "Toggle this help overlay"),
+        Line::from(""),
+        section_header("Views"),
+        key_line("f", "Full-screen view for selected session"),
+        key_line("$", "Cost dashboard view"),
+        Line::from(""),
+        section_header("Session Control"),
+        key_line("p", "Pause all running sessions (SIGSTOP)"),
+        key_line("r", "Resume all paused sessions (SIGCONT)"),
+        key_line("k", "Kill all sessions"),
+        key_line("d", "Dismiss notification banner"),
+        Line::from(""),
+        section_header("Scrolling"),
+        key_line("↑/↓", "Scroll agent panel output"),
+        key_line("Shift+↑/↓", "Scroll activity log"),
+        key_line("Mouse wheel", "Scroll focused panel"),
+        Line::from(""),
+        section_header("General"),
+        key_line("q / Ctrl+c", "Quit maestro"),
+        Line::from(""),
+        Line::from(vec![Span::styled(
+            "Press ? or Esc to close",
+            Style::default().fg(Color::DarkGray),
+        )]),
+    ];
+
+    let paragraph = Paragraph::new(help_text)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Cyan))
+                .title(" Help ")
+                .title_alignment(Alignment::Center),
+        )
+        .wrap(Wrap { trim: false });
+
+    f.render_widget(paragraph, popup);
+}
+
+fn section_header(title: &str) -> Line<'_> {
+    Line::from(vec![Span::styled(
+        format!("  {}", title),
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    )])
+}
+
+fn key_line<'a>(key: &'a str, desc: &'a str) -> Line<'a> {
+    Line::from(vec![
+        Span::raw("    "),
+        Span::styled(
+            format!("{:<16}", key),
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(desc, Style::default().fg(Color::White)),
+    ])
+}
+
+/// Create a centered rectangle within the given area.
+fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(area);
+
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(vertical[1])[1]
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,13 +1,18 @@
 pub mod activity_log;
 pub mod app;
+pub mod cost_dashboard;
 pub mod dep_graph;
 pub mod detail;
+pub mod fullscreen;
+pub mod help;
 pub mod panels;
 pub mod ui;
 
 use app::App;
 use crossterm::{
-    event::{self, Event, KeyCode, KeyModifiers},
+    event::{
+        self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyModifiers, MouseEventKind,
+    },
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
@@ -20,7 +25,7 @@ pub async fn run(mut app: App) -> anyhow::Result<()> {
     // Setup terminal
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen)?;
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
@@ -28,7 +33,11 @@ pub async fn run(mut app: App) -> anyhow::Result<()> {
 
     // Restore terminal
     disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    )?;
     terminal.show_cursor()?;
 
     // Cleanup: kill any remaining sessions
@@ -64,68 +73,105 @@ async fn event_loop(
         // Check for completed sessions and promote queued ones
         app.check_completions().await?;
 
-        // Check for keyboard input (with timeout for responsive updates)
-        if event::poll(Duration::from_millis(50))?
-            && let Event::Key(key) = event::read()?
-        {
-            match (key.code, key.modifiers) {
-                (KeyCode::Char('q'), _) | (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
-                    app.running = false;
-                    return Ok(());
-                }
-                #[cfg(unix)]
-                (KeyCode::Char('p'), _) => {
-                    app.pause_all();
-                }
-                #[cfg(unix)]
-                (KeyCode::Char('r'), _) => {
-                    app.resume_all();
-                }
-                (KeyCode::Char('k'), _) => {
-                    app.kill_all().await;
-                }
-                // Tab cycles TUI modes: Overview -> DependencyGraph -> Overview
-                (KeyCode::Tab, _) => {
-                    app.tui_mode = match app.tui_mode {
-                        app::TuiMode::Overview => app::TuiMode::DependencyGraph,
-                        app::TuiMode::DependencyGraph => app::TuiMode::Overview,
-                        app::TuiMode::Detail(_) => app::TuiMode::Overview,
-                    };
-                }
-                // Esc returns to overview from any mode
-                (KeyCode::Esc, _) => {
-                    app.tui_mode = app::TuiMode::Overview;
-                }
-                // Enter opens detail view for selected session
-                (KeyCode::Enter, _) => {
-                    let selected = app.panel_view.selected_index();
-                    app.tui_mode = app::TuiMode::Detail(selected);
-                }
-                // 1-9 jump to session detail by index
-                (KeyCode::Char(c), _) if c.is_ascii_digit() && c != '0' => {
-                    let idx = (c as usize) - ('1' as usize);
-                    if idx < app.pool.all_sessions().len() {
-                        app.tui_mode = app::TuiMode::Detail(idx);
+        // Check for keyboard/mouse input (with timeout for responsive updates)
+        if event::poll(Duration::from_millis(50))? {
+            match event::read()? {
+                Event::Key(key) => {
+                    // Help overlay intercepts all keys when visible
+                    if app.show_help {
+                        match key.code {
+                            KeyCode::Char('?') | KeyCode::Esc => app.show_help = false,
+                            _ => {}
+                        }
+                        continue;
+                    }
+
+                    match (key.code, key.modifiers) {
+                        (KeyCode::Char('q'), _) | (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
+                            app.running = false;
+                            return Ok(());
+                        }
+                        #[cfg(unix)]
+                        (KeyCode::Char('p'), _) => {
+                            app.pause_all();
+                        }
+                        #[cfg(unix)]
+                        (KeyCode::Char('r'), _) => {
+                            app.resume_all();
+                        }
+                        (KeyCode::Char('k'), _) => {
+                            app.kill_all().await;
+                        }
+                        // Help overlay
+                        (KeyCode::Char('?'), _) => {
+                            app.show_help = true;
+                        }
+                        // Full-screen view for selected session
+                        (KeyCode::Char('f'), _) => {
+                            let selected = app.panel_view.selected_index();
+                            app.tui_mode = app::TuiMode::Fullscreen(selected);
+                        }
+                        // Cost dashboard
+                        (KeyCode::Char('$'), _) => {
+                            app.tui_mode = app::TuiMode::CostDashboard;
+                        }
+                        // Tab cycles TUI modes: Overview -> DependencyGraph -> CostDashboard -> Overview
+                        (KeyCode::Tab, _) => {
+                            app.tui_mode = match app.tui_mode {
+                                app::TuiMode::Overview => app::TuiMode::DependencyGraph,
+                                app::TuiMode::DependencyGraph => app::TuiMode::CostDashboard,
+                                app::TuiMode::CostDashboard => app::TuiMode::Overview,
+                                app::TuiMode::Detail(_) | app::TuiMode::Fullscreen(_) => {
+                                    app::TuiMode::Overview
+                                }
+                            };
+                        }
+                        // Esc returns to overview from any mode
+                        (KeyCode::Esc, _) => {
+                            app.tui_mode = app::TuiMode::Overview;
+                        }
+                        // Enter opens detail view for selected session
+                        (KeyCode::Enter, _) => {
+                            let selected = app.panel_view.selected_index();
+                            app.tui_mode = app::TuiMode::Detail(selected);
+                        }
+                        // 1-9 jump to session detail by index
+                        (KeyCode::Char(c), _) if c.is_ascii_digit() && c != '0' => {
+                            let idx = (c as usize) - ('1' as usize);
+                            if idx < app.pool.all_sessions().len() {
+                                app.tui_mode = app::TuiMode::Detail(idx);
+                            }
+                        }
+                        // Dismiss notification
+                        (KeyCode::Char('d'), _) => {
+                            app.notifications.dismiss_latest();
+                        }
+                        // Scroll activity log (Shift+arrows)
+                        (KeyCode::Up, KeyModifiers::SHIFT) => {
+                            app.activity_log.scroll_down();
+                        }
+                        (KeyCode::Down, KeyModifiers::SHIFT) => {
+                            app.activity_log.scroll_up();
+                        }
+                        // Scroll agent panel output (plain arrows)
+                        (KeyCode::Up, _) => {
+                            app.panel_view.scroll_up();
+                        }
+                        (KeyCode::Down, _) => {
+                            app.panel_view.scroll_down();
+                        }
+                        _ => {}
                     }
                 }
-                // Dismiss notification
-                (KeyCode::Char('d'), _) => {
-                    app.notifications.dismiss_latest();
-                }
-                // Scroll activity log (Shift+arrows)
-                (KeyCode::Up, KeyModifiers::SHIFT) => {
-                    app.activity_log.scroll_down();
-                }
-                (KeyCode::Down, KeyModifiers::SHIFT) => {
-                    app.activity_log.scroll_up();
-                }
-                // Scroll agent panel output (plain arrows)
-                (KeyCode::Up, _) => {
-                    app.panel_view.scroll_up();
-                }
-                (KeyCode::Down, _) => {
-                    app.panel_view.scroll_down();
-                }
+                Event::Mouse(mouse) => match mouse.kind {
+                    MouseEventKind::ScrollUp => {
+                        app.panel_view.scroll_up();
+                    }
+                    MouseEventKind::ScrollDown => {
+                        app.panel_view.scroll_down();
+                    }
+                    _ => {}
+                },
                 _ => {}
             }
         }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,6 +1,9 @@
 use crate::tui::app::{App, TuiMode};
+use crate::tui::cost_dashboard;
 use crate::tui::dep_graph;
 use crate::tui::detail;
+use crate::tui::fullscreen;
+use crate::tui::help;
 use chrono::Utc;
 use ratatui::{
     Frame,
@@ -35,12 +38,30 @@ pub fn draw(f: &mut Frame, app: &App) {
             if let Some(session) = sessions.get(idx) {
                 detail::draw_detail(f, session, &app.progress_tracker, chunks[1]);
             } else {
-                // Invalid index, fall back to panels
                 app.panel_view.draw(f, &sessions, chunks[1]);
             }
         }
         TuiMode::DependencyGraph => {
             dep_graph::draw_dep_graph(f, app.work_assigner.as_ref(), chunks[1]);
+        }
+        TuiMode::Fullscreen(idx) => {
+            let sessions = app.pool.all_sessions();
+            if let Some(session) = sessions.get(idx) {
+                fullscreen::draw_fullscreen(f, session, &app.progress_tracker, chunks[1]);
+            } else {
+                app.panel_view.draw(f, &sessions, chunks[1]);
+            }
+        }
+        TuiMode::CostDashboard => {
+            let sessions = app.pool.all_sessions();
+            let budget_limit = app.budget_enforcer.as_ref().map(|e| e.total_limit());
+            cost_dashboard::draw_cost_dashboard(
+                f,
+                &sessions,
+                app.total_cost,
+                budget_limit,
+                chunks[1],
+            );
         }
     }
 
@@ -54,6 +75,11 @@ pub fn draw(f: &mut Frame, app: &App) {
     }
 
     draw_help_bar(f, app, chunks[3]);
+
+    // Draw help overlay on top of everything if active
+    if app.show_help {
+        help::draw_help_overlay(f, f.area());
+    }
 }
 
 fn draw_status_bar(f: &mut Frame, app: &App, area: Rect) {
@@ -157,6 +183,8 @@ fn draw_help_bar(f: &mut Frame, app: &App, area: Rect) {
         TuiMode::Overview => "Overview",
         TuiMode::Detail(_) => "Detail",
         TuiMode::DependencyGraph => "Dependencies",
+        TuiMode::Fullscreen(_) => "Fullscreen",
+        TuiMode::CostDashboard => "Costs",
     };
 
     let help = Line::from(vec![
@@ -169,8 +197,12 @@ fn draw_help_bar(f: &mut Frame, app: &App, area: Rect) {
         Span::raw("uit "),
         Span::styled("[Tab]", Style::default().fg(Color::Yellow)),
         Span::raw("mode "),
-        Span::styled("[1-9]", Style::default().fg(Color::Yellow)),
-        Span::raw("detail "),
+        Span::styled("[f]", Style::default().fg(Color::Yellow)),
+        Span::raw("ull "),
+        Span::styled("[$]", Style::default().fg(Color::Yellow)),
+        Span::raw("cost "),
+        Span::styled("[?]", Style::default().fg(Color::Yellow)),
+        Span::raw("help "),
         Span::styled("[Esc]", Style::default().fg(Color::Yellow)),
         Span::raw("back "),
         Span::styled("[p]", Style::default().fg(Color::Yellow)),


### PR DESCRIPTION
Add extensibility via config-driven plugin hooks, a mode system for customizing session behavior, and comprehensive TUI improvements for a production-ready tool.

Plugin system:
- Define 7 hook points: session_started, session_completed, tests_passed, tests_failed, budget_threshold, file_conflict, pr_created
- Plugins configured in maestro.toml as [[plugins]] with name, on, run
- Execute as shell commands with env vars (session ID, issue, cost, etc.)
- Plugin timeout and error handling with async execution

Mode system:
- Modes defined in maestro.toml [modes.<name>] with system_prompt, allowed_tools, and permission_mode
- 3 built-in modes: orchestrator, vibe, review
- Per-issue assignment via labels (maestro:mode:<name>)
- Per-session via CLI flag (--mode)

TUI polish:
- Help overlay (? key) with full keybinding reference
- Full-screen agent view (f key) with scrolling output
- Cost dashboard view ($ key) with budget gauge and per-session breakdown
- Mouse support for scroll via EnableMouseCapture
- Tab cycles through Overview → Dependencies → Costs → Overview

Session resumption:
- `maestro resume` command re-enqueues incomplete sessions
- Optional --session filter for specific session resume
- Auto-detection of incomplete sessions on bare `maestro` launch

Shell completions:
- `maestro completions <shell>` for bash, zsh, fish via clap_complete