### PR TITLE
ci: Release workflow and Homebrew auto-update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,100 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-apple-darwin
+            os: macos-13
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package tarball
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          ARCHIVE="maestro-${TAG}-${{ matrix.target }}.tar.gz"
+          cd target/${{ matrix.target }}/release
+          tar czf "../../../${ARCHIVE}" maestro
+          cd ../../..
+          echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: maestro-${{ matrix.target }}
+          path: ${{ env.ARCHIVE }}
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Generate checksums
+        run: |
+          cd artifacts
+          sha256sum *.tar.gz > sha256sums.txt
+          cat sha256sums.txt
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            artifacts/*.tar.gz
+            artifacts/sha256sums.txt
+
+  update-homebrew:
+    name: Update Homebrew Tap
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger homebrew-tap update
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${TAP_TOKEN}" \
+            https://api.github.com/repos/CarlosDanielDev/homebrew-tap/dispatches \
+            -d "{\"event_type\": \"formula-update\", \"client_payload\": {\"version\": \"${TAG#v}\", \"tag\": \"${TAG}\"}}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Homebrew Release Automation (#27)
+
+- `.github/workflows/release.yml`: on `v*` tag push, builds cross-platform release binaries for `aarch64-apple-darwin`, `x86_64-apple-darwin`, and `x86_64-unknown-linux-gnu` using a matrix strategy with Rust stable toolchain and `rust-cache`
+- Packages each binary as a `maestro-<tag>-<target>.tar.gz` tarball, uploads artifacts, then aggregates them in a dedicated `release` job that generates a `sha256sums.txt` and creates a GitHub Release with auto-generated release notes via `softprops/action-gh-release`
+- A follow-on `update-homebrew` job fires a `repository_dispatch` event (`formula-update`) against `CarlosDanielDev/homebrew-tap`, passing version and tag in the payload so the tap's `update-formula.yml` workflow can update the formula URL and sha256 automatically
+- `HOMEBREW_TAP_TOKEN` repository secret required for the cross-repo dispatch
+
 ## [0.2.0] - 2026-03-31
 
 ### Context Overflow Detection and Auto-Fork (#12)

--- a/README.md
+++ b/README.md
@@ -63,8 +63,30 @@ Maestro spawns and monitors multiple [Claude Code](https://claude.ai/claude-code
 
 ## Install
 
+### Homebrew (macOS and Linux)
+
 ```bash
-# From source
+brew tap CarlosDanielDev/tap
+brew install maestro
+```
+
+### Pre-built binary
+
+Download the tarball for your platform from the [latest GitHub Release](https://github.com/CarlosDanielDev/maestro/releases/latest), extract it, and place the `maestro` binary on your `PATH`.
+
+Supported targets:
+
+| Platform | Archive |
+|----------|---------|
+| macOS (Apple Silicon) | `maestro-<version>-aarch64-apple-darwin.tar.gz` |
+| macOS (Intel) | `maestro-<version>-x86_64-apple-darwin.tar.gz` |
+| Linux (x86_64) | `maestro-<version>-x86_64-unknown-linux-gnu.tar.gz` |
+
+A `sha256sums.txt` file is included in each release for checksum verification.
+
+### From source
+
+```bash
 git clone https://github.com/CarlosDanielDev/maestro.git
 cd maestro
 cargo build --release

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,10 +45,10 @@ Hardening, missing PRD features, test coverage, and distribution.
 
 ### Infrastructure & Docs
 
-| Issue | Title | Priority |
-|-------|-------|----------|
-| [#17] | Release workflow for binary builds and distribution | P2 |
-| [#18] | Man page and shell completion installation guide | P2 |
+| Issue | Title | Priority | Status |
+|-------|-------|----------|--------|
+| [#17] | Release workflow for binary builds and distribution | P2 | Done |
+| [#18] | Man page and shell completion installation guide | P2 | Planned |
 
 ---
 
@@ -83,7 +83,7 @@ v0.2.0 🔧 In Progress
   ├── #15 Integration tests ─────────┐
   ├── #16 TUI snapshot tests ────────┤ Quality (parallel)
   ├── #19 Parser benchmarks ─────────┘
-  ├── #17 Release workflow
+  ├── #17 Release workflow ─────────✅ Done
   └── #18 Completion docs
 
 v0.3.0 🌐 Planned

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-03-31 00:00 (UTC)
+> Last updated: 2026-03-31 12:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -54,7 +54,8 @@ maestro/
 │           └── SKILL.md                   # Video frame extraction patterns
 ├── .github/
 │   └── workflows/
-│       └── ci.yml                         # GitHub Actions CI pipeline
+│       ├── ci.yml                         # GitHub Actions CI pipeline
+│       └── release.yml                    # Release workflow: cross-platform builds, GitHub Release, Homebrew tap trigger
 ├── src/
 │   ├── main.rs                            # CLI entry point (clap); Run, Queue, Add, Status, Cost, Init; module declarations
 │   ├── config.rs                          # maestro.toml parsing; ModelsConfig, GatesConfig, ReviewConfig; ContextOverflowConfig (overflow_threshold_pct, auto_fork, commit_prompt_pct, max_fork_depth)
@@ -153,7 +154,8 @@ maestro/
 
 | Path | Description |
 |------|-------------|
-| `.github/workflows/` | GitHub Actions CI/CD pipelines |
+| `.github/workflows/ci.yml` | GitHub Actions CI pipeline |
+| `.github/workflows/release.yml` | Release automation: build binaries, create GitHub Release, update Homebrew tap |
 | `.claude/` | Claude Code agent configuration |
 | `.claude/agents/` | Subagent definitions |
 | `.claude/commands/` | Slash command definitions |


### PR DESCRIPTION
## Summary

- Add `.github/workflows/release.yml` — cross-platform release builds (macOS arm64/x86_64, Linux x86_64) triggered on `v*` tag push
- Creates GitHub Release with tarballs and `sha256sums.txt` checksums
- Triggers `CarlosDanielDev/homebrew-tap` formula auto-update via `repository_dispatch`

Closes #27

## Test plan
- [x] CI passes (no Rust code changes, only workflow YAML and docs)
- [ ] Create a `HOMEBREW_TAP_TOKEN` secret in repo settings
- [ ] Test by pushing a new tag (e.g., `v0.2.1`) and verifying release assets appear
- [ ] Verify homebrew-tap formula is auto-updated after release
