### PR TITLE
feat: Session prompt guardrails with language auto-detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Session Prompt Guardrails (#43)
+
+- `ProjectLanguage` enum (`Rust`, `TypeScript`, `Python`, `Go`, `Unknown`) in `src/prompts.rs`
+- `detect_project_language(dir)`: inspects manifest files (`Cargo.toml`, `package.json`, `pyproject.toml`, `requirements.txt`, `go.mod`) to identify the project language
+- `default_guardrail(lang)`: returns a language-specific, pre-completion checklist (format, lint, test, commit) for each supported language; falls back to a generic checklist for unknown projects
+- `resolve_guardrail(custom, dir)`: uses the custom prompt from config when non-empty, otherwise auto-detects via `detect_project_language`
+- `SessionsConfig.guardrail_prompt: Option<String>` added to `config.rs`; when `None` or empty the guardrail is auto-detected
+- `SessionPool.guardrail_prompt` field and `set_guardrail_prompt()` setter in `session/pool.rs`; `try_promote()` appends the guardrail to every session's system prompt
+- `App::configure()` in `tui/app.rs` now calls `resolve_guardrail` and forwards the result to `pool.set_guardrail_prompt()`
+- `maestro.toml`: `guardrail_prompt` option added as a commented-out example under `[sessions]` with inline documentation
+
 ## [0.3.0] - 2026-04-01
 
 ### Multi-Provider Support (#29)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Maestro spawns and monitors multiple [Claude Code](https://claude.ai/claude-code
 - **Context overflow detection** — monitors context window usage per session; automatically forks into a continuation session at a configurable threshold with a structured handoff prompt
 - **Fork depth limiting** — configurable maximum fork chain depth prevents runaway continuation loops
 - **Multi-provider support** — works with GitHub (via `gh` CLI) or Azure DevOps (via `az` CLI); provider is auto-detected from the git remote or set explicitly in config
+- **Session prompt guardrails** — a language-specific pre-completion checklist (format, lint, test) is automatically detected from the project root and appended to every session's system prompt; can be overridden with a custom prompt via `guardrail_prompt` in `maestro.toml`
 
 ### Roadmap
 
@@ -144,6 +145,8 @@ max_concurrent = 3        # Max parallel Claude sessions
 stall_timeout_secs = 300  # Kill stalled sessions after 5 min
 default_model = "opus"    # opus, sonnet, haiku
 default_mode = "orchestrator"
+# guardrail_prompt = "..."  # Custom pre-completion checklist injected into every session prompt
+                            # Omit to auto-detect from project language (Rust/TS/Python/Go)
 
 [budget]
 per_session_usd = 5.0     # Max spend per session
@@ -184,7 +187,7 @@ See [directory-tree.md](directory-tree.md) for the complete project structure.
 maestro (Rust binary)
 ├── src/
 │   ├── main.rs              # CLI entry point (clap); Run/Queue/Add/Status/Cost/Init
-│   ├── config.rs            # maestro.toml parsing; ProviderConfig
+│   ├── config.rs            # maestro.toml parsing; ProviderConfig; guardrail_prompt in SessionsConfig
 │   ├── provider/            # Multi-provider abstraction [Issue #29]
 │   │   ├── mod.rs           # create_provider factory; detect_provider_from_remote
 │   │   ├── types.rs         # ProviderKind (Github, AzureDevops); type re-exports
@@ -198,7 +201,7 @@ maestro (Rust binary)
 │   │   ├── types.rs         # Session state machine, StreamEvent, issue_title
 │   │   ├── parser.rs        # Claude stream-json line parser
 │   │   ├── manager.rs       # Process spawn, stdin/stdout, lifecycle
-│   │   ├── pool.rs          # Concurrent session pool [Phase 1]
+│   │   ├── pool.rs          # Concurrent session pool; guardrail injected into system prompt [Phase 1, #43]
 │   │   └── worktree.rs      # Git worktree isolation [Phase 1]
 │   ├── state/
 │   │   ├── types.rs         # MaestroState, file claims, issue_cache

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-03-31 14:00 (UTC)
+> Last updated: 2026-03-31 15:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -58,11 +58,11 @@ maestro/
 │       └── release.yml                    # Release workflow: cross-platform builds, GitHub Release, Homebrew tap trigger
 ├── src/
 │   ├── main.rs                            # CLI entry point (clap); Run, Queue, Add, Status, Cost, Init; module declarations (includes provider)  [Issue #29]
-│   ├── config.rs                          # maestro.toml parsing; ModelsConfig, GatesConfig, ReviewConfig; ContextOverflowConfig; ProviderConfig (kind, organization, az_project)  [Issue #29]
+│   ├── config.rs                          # maestro.toml parsing; ModelsConfig, GatesConfig, ReviewConfig; ContextOverflowConfig; ProviderConfig (kind, organization, az_project); guardrail_prompt in SessionsConfig  [Issue #29, #43]
 │   ├── budget.rs                          # BudgetEnforcer: per-session and global budget checks  [Phase 3]
 │   ├── git.rs                             # GitOps trait, CliGitOps: commit and push operations  [Phase 3]
 │   ├── models.rs                          # ModelRouter: label-based model routing  [Phase 3]
-│   ├── prompts.rs                         # PromptBuilder: structured issue prompts with task-type detection  [Phase 3]
+│   ├── prompts.rs                         # PromptBuilder: structured issue prompts with task-type detection; ProjectLanguage enum; detect_project_language(); default_guardrail(); resolve_guardrail()  [Phase 3, Issue #43]
 │   ├── util.rs                            # Shared utilities (truncate, etc.)
 │   ├── gates/                             # Completion gates framework  [Phase 3]
 │   │   ├── mod.rs                         # Module exports
@@ -96,7 +96,7 @@ maestro/
 │   │   ├── mod.rs                         # Module exports (includes pool, worktree, health, retry, context_monitor, fork)
 │   │   ├── manager.rs                     # Claude CLI process management; handles ContextUpdate events  [Phase 3]
 │   │   ├── parser.rs                      # stream-json output parser; parses system events for context usage  [Phase 3]
-│   │   ├── pool.rs                        # Session pool: max_concurrent, queue, auto-promote; branch tracking  [Phase 3]
+│   │   ├── pool.rs                        # Session pool: max_concurrent, queue, auto-promote; branch tracking; guardrail_prompt field; set_guardrail_prompt(); merged into system prompt in try_promote()  [Phase 3, Issue #43]
 │   │   ├── types.rs                       # Session state machine; fork fields (parent_session_id, child_session_ids, fork_depth); ContextUpdate StreamEvent  [Phase 3]
 │   │   ├── worktree.rs                    # Git worktree isolation: WorktreeManager trait, GitWorktreeManager, MockWorktreeManager  [Phase 1]
 │   │   ├── health.rs                      # HealthMonitor: stall detection, HealthCheck trait  [Phase 3]
@@ -113,7 +113,7 @@ maestro/
 │   │   └── types.rs                       # State types; fork_lineage HashMap; record_fork, fork_chain, fork_depth methods  [Issue #12]
 │   ├── tui/
 │   │   ├── mod.rs                         # Event loop; keybindings: Tab, Esc, Enter, 1-9, d  [Phase 3]
-│   │   ├── app.rs                         # App state; context_monitor and fork_policy fields; check_context_overflow method  [Issue #12]
+│   │   ├── app.rs                         # App state; context_monitor and fork_policy fields; check_context_overflow method; configure() resolves and sets guardrail prompt  [Issue #12, #43]
 │   │   ├── activity_log.rs                # Scrollable activity log widget with LogLevel color coding  [Phase 1]
 │   │   ├── cost_dashboard.rs              # Cost dashboard widget: per-session and aggregate cost display  [Phase 3]
 │   │   ├── dep_graph.rs                   # ASCII dependency graph visualization  [Phase 3]
@@ -151,7 +151,7 @@ maestro/
 ├── ROADMAP.md                             # Project milestones and implementation order
 ├── directory-tree.md                      # This file — SINGLE SOURCE OF TRUTH for structure
 ├── maestro-state.json                     # Runtime state persistence file
-└── maestro.toml                           # Runtime configuration; [sessions.context_overflow] section added  [Issue #12]
+└── maestro.toml                           # Runtime configuration; [sessions.context_overflow] section; guardrail_prompt option (commented)  [Issue #12, #43]
 ```
 
 ## Quick Reference
@@ -170,7 +170,7 @@ maestro/
 | `src/budget.rs` | Per-session and global budget enforcement (Phase 3) |
 | `src/git.rs` | GitOps trait and CLI-backed commit+push (Phase 3) |
 | `src/models.rs` | Label-based model routing (Phase 3) |
-| `src/prompts.rs` | Structured issue prompt builder with task-type detection (Phase 3) |
+| `src/prompts.rs` | Structured issue prompt builder with task-type detection; ProjectLanguage detection; guardrail resolution (Phase 3, Issue #43) |
 | `src/gates/` | Completion gates: TestsPass, FileExists, FileContains, PrCreated (Phase 3) |
 | `src/provider/` | Multi-provider abstraction layer (Issue #29) |
 | `src/provider/mod.rs` | create_provider factory; detect_provider_from_remote |
@@ -191,7 +191,7 @@ maestro/
 | `src/session/` | Claude CLI process and session lifecycle management |
 | `src/session/health.rs` | Stall detection and HealthCheck trait (Phase 3) |
 | `src/session/retry.rs` | Configurable retry policy (Phase 3) |
-| `src/session/pool.rs` | Concurrent session pool with queue and auto-promote |
+| `src/session/pool.rs` | Concurrent session pool with queue and auto-promote; guardrail_prompt merged into system prompt (Issue #43) |
 | `src/session/worktree.rs` | Git worktree isolation per session |
 | `src/session/cleanup.rs` | Orphaned worktree detection and removal (Phase 3) |
 | `src/session/logger.rs` | Per-session file logging to .maestro/logs/ (Phase 3) |

--- a/maestro.toml
+++ b/maestro.toml
@@ -9,6 +9,8 @@ default_model = "opus"
 default_mode = "orchestrator"
 permission_mode = "bypassPermissions"  # Options: default, acceptEdits, bypassPermissions, dontAsk, plan, auto
 allowed_tools = []                      # Empty = all tools. Example: ["Bash", "Read", "Write", "Edit"]
+# guardrail_prompt = "..."              # Custom guardrail injected into every session prompt
+                                        # If unset, auto-detected from project language (Rust/TS/Python/Go)
 
 [sessions.context_overflow]
 overflow_threshold_pct = 70             # Context % at which auto-fork triggers

--- a/src/config.rs
+++ b/src/config.rs
@@ -66,6 +66,10 @@ pub struct SessionsConfig {
     /// Conflict detection policy configuration.
     #[serde(default)]
     pub conflict: ConflictConfig,
+    /// Custom guardrail prompt injected into every session's system prompt.
+    /// If unset, a default is auto-detected based on project language.
+    #[serde(default)]
+    pub guardrail_prompt: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/prompts.rs
+++ b/src/prompts.rs
@@ -1,5 +1,82 @@
 use crate::config::Config;
 use crate::github::types::GhIssue;
+use std::path::Path;
+
+/// Detected project language for guardrail defaults.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProjectLanguage {
+    Rust,
+    TypeScript,
+    Python,
+    Go,
+    Unknown,
+}
+
+/// Detect project language from manifest files in the given directory.
+pub fn detect_project_language(dir: &Path) -> ProjectLanguage {
+    if dir.join("Cargo.toml").exists() {
+        ProjectLanguage::Rust
+    } else if dir.join("package.json").exists() {
+        ProjectLanguage::TypeScript
+    } else if dir.join("pyproject.toml").exists() || dir.join("requirements.txt").exists() {
+        ProjectLanguage::Python
+    } else if dir.join("go.mod").exists() {
+        ProjectLanguage::Go
+    } else {
+        ProjectLanguage::Unknown
+    }
+}
+
+/// Return the default guardrail prompt for a given project language.
+pub fn default_guardrail(lang: ProjectLanguage) -> &'static str {
+    match lang {
+        ProjectLanguage::Rust => {
+            "BEFORE completing your work:\n\
+             1. Run `cargo fmt` to format all code\n\
+             2. Run `cargo clippy -- -D warnings` and fix any warnings\n\
+             3. Run `cargo test` and ensure all tests pass\n\
+             4. Only commit after all three pass"
+        }
+        ProjectLanguage::TypeScript => {
+            "BEFORE completing your work:\n\
+             1. Run the project linter (e.g., `npm run lint` or `npx eslint .`) and fix any issues\n\
+             2. Run the formatter (e.g., `npm run format` or `npx prettier --write .`)\n\
+             3. Run `npm test` and ensure all tests pass\n\
+             4. Only commit after all checks pass"
+        }
+        ProjectLanguage::Python => {
+            "BEFORE completing your work:\n\
+             1. Run the formatter (e.g., `black .` or `ruff format .`)\n\
+             2. Run the linter (e.g., `ruff check .` or `flake8`)\n\
+             3. Run `pytest` and ensure all tests pass\n\
+             4. Only commit after all checks pass"
+        }
+        ProjectLanguage::Go => {
+            "BEFORE completing your work:\n\
+             1. Run `gofmt -w .` to format all code\n\
+             2. Run `go vet ./...` and fix any issues\n\
+             3. Run `go test ./...` and ensure all tests pass\n\
+             4. Only commit after all checks pass"
+        }
+        ProjectLanguage::Unknown => {
+            "BEFORE completing your work:\n\
+             1. Run the project's formatter and linter if configured\n\
+             2. Run the test suite and ensure all tests pass\n\
+             3. Only commit after all checks pass"
+        }
+    }
+}
+
+/// Resolve the guardrail prompt: use custom if configured, otherwise auto-detect.
+pub fn resolve_guardrail(custom: Option<&str>, project_dir: &Path) -> String {
+    if let Some(prompt) = custom
+        && !prompt.is_empty()
+    {
+        return prompt.to_string();
+    }
+    let lang = detect_project_language(project_dir);
+    default_guardrail(lang).to_string()
+}
 
 /// Builds structured prompts for Claude sessions based on issue type and config.
 pub struct PromptBuilder;
@@ -230,5 +307,116 @@ mod tests {
         let config = make_config();
         let prompt = PromptBuilder::build_issue_prompt(&issue, &config);
         assert!(prompt.contains("Base branch: main"));
+    }
+
+    // Language detection tests
+
+    #[test]
+    fn detect_rust_from_cargo_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("Cargo.toml"), "").unwrap();
+        assert_eq!(detect_project_language(dir.path()), ProjectLanguage::Rust);
+    }
+
+    #[test]
+    fn detect_typescript_from_package_json() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("package.json"), "").unwrap();
+        assert_eq!(
+            detect_project_language(dir.path()),
+            ProjectLanguage::TypeScript
+        );
+    }
+
+    #[test]
+    fn detect_python_from_pyproject_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("pyproject.toml"), "").unwrap();
+        assert_eq!(detect_project_language(dir.path()), ProjectLanguage::Python);
+    }
+
+    #[test]
+    fn detect_python_from_requirements_txt() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("requirements.txt"), "").unwrap();
+        assert_eq!(detect_project_language(dir.path()), ProjectLanguage::Python);
+    }
+
+    #[test]
+    fn detect_go_from_go_mod() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("go.mod"), "").unwrap();
+        assert_eq!(detect_project_language(dir.path()), ProjectLanguage::Go);
+    }
+
+    #[test]
+    fn detect_unknown_when_no_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            detect_project_language(dir.path()),
+            ProjectLanguage::Unknown
+        );
+    }
+
+    // Default guardrail tests
+
+    #[test]
+    fn default_guardrail_rust_mentions_cargo_fmt() {
+        let g = default_guardrail(ProjectLanguage::Rust);
+        assert!(g.contains("cargo fmt"));
+        assert!(g.contains("cargo clippy"));
+        assert!(g.contains("cargo test"));
+    }
+
+    #[test]
+    fn default_guardrail_typescript_mentions_lint() {
+        let g = default_guardrail(ProjectLanguage::TypeScript);
+        assert!(g.contains("lint"));
+        assert!(g.contains("npm test"));
+    }
+
+    #[test]
+    fn default_guardrail_python_mentions_pytest() {
+        let g = default_guardrail(ProjectLanguage::Python);
+        assert!(g.contains("pytest"));
+    }
+
+    #[test]
+    fn default_guardrail_go_mentions_gofmt() {
+        let g = default_guardrail(ProjectLanguage::Go);
+        assert!(g.contains("gofmt"));
+        assert!(g.contains("go test"));
+    }
+
+    #[test]
+    fn default_guardrail_unknown_is_generic() {
+        let g = default_guardrail(ProjectLanguage::Unknown);
+        assert!(g.contains("test suite"));
+    }
+
+    // resolve_guardrail tests
+
+    #[test]
+    fn resolve_guardrail_uses_custom_when_provided() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("Cargo.toml"), "").unwrap();
+        let result = resolve_guardrail(Some("Run my custom checks"), dir.path());
+        assert_eq!(result, "Run my custom checks");
+    }
+
+    #[test]
+    fn resolve_guardrail_auto_detects_when_none() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("Cargo.toml"), "").unwrap();
+        let result = resolve_guardrail(None, dir.path());
+        assert!(result.contains("cargo fmt"));
+    }
+
+    #[test]
+    fn resolve_guardrail_auto_detects_when_empty_string() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("go.mod"), "").unwrap();
+        let result = resolve_guardrail(Some(""), dir.path());
+        assert!(result.contains("gofmt"));
     }
 }

--- a/src/session/pool.rs
+++ b/src/session/pool.rs
@@ -19,6 +19,8 @@ pub struct SessionPool {
     permission_mode: String,
     /// Allowed tools whitelist passed to Claude CLI sessions.
     allowed_tools: Vec<String>,
+    /// Guardrail prompt appended to every session's system prompt.
+    guardrail_prompt: Option<String>,
 }
 
 impl SessionPool {
@@ -37,6 +39,7 @@ impl SessionPool {
             event_tx,
             permission_mode: "bypassPermissions".to_string(),
             allowed_tools: Vec::new(),
+            guardrail_prompt: None,
         }
     }
 
@@ -48,6 +51,11 @@ impl SessionPool {
     /// Set the permission mode for new sessions.
     pub fn set_permission_mode(&mut self, mode: String) {
         self.permission_mode = mode;
+    }
+
+    /// Set the guardrail prompt appended to every session's system prompt.
+    pub fn set_guardrail_prompt(&mut self, prompt: String) {
+        self.guardrail_prompt = Some(prompt);
     }
 
     /// Set the allowed tools whitelist for new sessions.
@@ -88,8 +96,15 @@ impl SessionPool {
                 }
             };
 
-            // Build system prompt with file claims for other sessions
-            let system_prompt = self.file_claims.build_system_prompt(session.id);
+            // Build system prompt with file claims and guardrails
+            let mut system_prompt = self.file_claims.build_system_prompt(session.id);
+            if let Some(ref guardrail) = self.guardrail_prompt {
+                let combined = match system_prompt {
+                    Some(existing) => Some(format!("{}\n\n{}", existing, guardrail)),
+                    None => Some(guardrail.clone()),
+                };
+                system_prompt = combined;
+            }
 
             session.status = SessionStatus::Queued; // Still queued until spawned
             let mut managed =

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -165,6 +165,12 @@ impl App {
         self.fork_policy = Some(ForkPolicy::new(
             config.sessions.context_overflow.max_fork_depth,
         ));
+        // Resolve guardrail prompt: custom from config or auto-detected default
+        let guardrail = crate::prompts::resolve_guardrail(
+            config.sessions.guardrail_prompt.as_deref(),
+            &std::path::PathBuf::from("."),
+        );
+        self.pool.set_guardrail_prompt(guardrail);
         self.config = Some(config);
     }
 


### PR DESCRIPTION
## Summary

- Inject a pre-completion checklist (format, lint, test) into every session's system prompt via `--append-system-prompt`
- Auto-detect project language from manifest files (Cargo.toml, package.json, pyproject.toml, go.mod) with language-specific defaults
- Configurable via `guardrail_prompt` in `[sessions]` section of `maestro.toml` — omit to use auto-detected default

Closes #43

## Test plan
- [x] 471 tests passing (14 new for language detection, default guardrails, resolve logic)
- [x] Clippy clean, fmt clean
- [x] Verify guardrail appears in session's system prompt when running maestro
- [x] Verify custom `guardrail_prompt` in config overrides auto-detection