### PR TITLE
feat: add maestro doctor preflight check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Onboarding Preflight Check — `maestro doctor` (#49)
+
+- New `src/doctor.rs` module with a self-contained preflight check system
+- `CheckSeverity` enum (`Required`, `Optional`) — distinguishes blocking failures from soft warnings
+- `CheckResult` struct with `pass()` and `fail()` constructors; `symbol()` returns `"OK"`, `"FAIL"`, or `"WARN"` based on severity and outcome
+- `DoctorReport` struct aggregating all check results; exposes `has_failures()`, `has_warnings()`, and `failed_checks()` helpers
+- `run_all_checks(config)` executes 9 individual checks in order:
+  - `check_gh_installed` — verifies `gh` CLI is on `$PATH` (Required)
+  - `check_gh_authenticated` — runs `gh auth status` (Required)
+  - `check_git_installed` — verifies `git` is on `$PATH` (Required)
+  - `check_git_user_config` — confirms `user.name` and `user.email` are set (Required)
+  - `check_git_remote` — ensures at least one remote is configured (Required)
+  - `check_config_exists` — looks for `maestro.toml` in the working directory (Required)
+  - `check_az_cli` — runs only when the configured provider is `AzureDevops` (Optional)
+  - `check_claude_cli` — verifies `claude` CLI is available; failure is a warning, not a hard block (Optional)
+  - `check_gh_repo_accessible` — runs `gh repo view` only when `gh auth` passed (Required)
+- `print_report(report)` renders a colour-coded table to stdout (green OK, red FAIL, yellow WARN) with a one-line summary at the end
+- `Commands::Doctor` variant added to the clap CLI in `src/main.rs`; `cmd_doctor()` handler loads config optionally (no error if `maestro.toml` is absent) and exits with a non-zero code when required checks fail
+- TUI dashboard integration: `cmd_dashboard()` in `src/main.rs` now runs `run_all_checks()` at startup and passes the list of failed/warned check messages into `HomeScreen`
+- `HomeScreen` in `src/tui/screens/home.rs` gains a `warnings: Vec<String>` field, a `draw_warnings()` method that renders a yellow bordered panel beneath the logo, and dynamic layout that hides the panel entirely when there are no warnings
+
 ### Live GitHub Data Fetching and Session Launch from TUI (#46, #47, #48)
 
 - **Issue browser live fetch (#46):** opening the issue browser now triggers an async GitHub fetch via `tokio::spawn` + `mpsc` channel; the screen shows a loading state while data arrives and calls `set_issues()` on the `IssueBrowserScreen` once the fetch completes

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-03 00:00 (UTC)
+> Last updated: 2026-04-03 12:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -57,9 +57,10 @@ maestro/
 │       ├── ci.yml                         # GitHub Actions CI pipeline
 │       └── release.yml                    # Release workflow: cross-platform builds, GitHub Release, Homebrew tap trigger
 ├── src/
-│   ├── main.rs                            # CLI entry point (clap); Run, Queue, Add, Status, Cost, Init; module declarations (includes provider)  [Issue #29]
+│   ├── main.rs                            # CLI entry point (clap); Run, Queue, Add, Status, Cost, Init, Doctor; module declarations (includes doctor, provider)  [Issue #29, #49]
 │   ├── config.rs                          # maestro.toml parsing; ModelsConfig, GatesConfig, ReviewConfig; ContextOverflowConfig; ProviderConfig (kind, organization, az_project); guardrail_prompt in SessionsConfig  [Issue #29, #43]
 │   ├── budget.rs                          # BudgetEnforcer: per-session and global budget checks  [Phase 3]
+│   ├── doctor.rs                          # Preflight checks: CheckSeverity, CheckResult, DoctorReport, run_all_checks(), print_report(), 9 check functions  [Issue #49]
 │   ├── git.rs                             # GitOps trait, CliGitOps: commit and push operations  [Phase 3]
 │   ├── models.rs                          # ModelRouter: label-based model routing  [Phase 3]
 │   ├── prompts.rs                         # PromptBuilder: structured issue prompts with task-type detection; ProjectLanguage enum; detect_project_language(); default_guardrail(); resolve_guardrail()  [Phase 3, Issue #43]
@@ -124,7 +125,7 @@ maestro/
 │   │   ├── ui.rs                          # ratatui rendering; budget display, TUI mode switching, notification banners, screen rendering branches  [Phase 3, Issue #31-33]
 │   │   └── screens/                       # Interactive screen components  [Issue #31-33]
 │   │       ├── mod.rs                     # Screen types: ScreenAction enum, SessionConfig; re-exports HomeScreen, IssueBrowserScreen, MilestoneScreen
-│   │       ├── home.rs                    # HomeScreen: idle dashboard, logo, quick-actions menu, recent sessions panel  [Issue #31]
+│   │       ├── home.rs                    # HomeScreen: idle dashboard, logo, quick-actions menu, recent sessions panel, doctor warnings banner  [Issue #31, #49]
 │   │       ├── issue_browser.rs           # IssueBrowserScreen: navigable issue list, multi-select, label/milestone filters, preview pane; set_issues() for async data delivery  [Issue #32, #46]
 │   │       └── milestone.rs               # MilestoneScreen: milestone list, progress gauge, issue detail pane, run-all action  [Issue #33]
 │   └── work/                              # Work queue and scheduling  [Phase 2]
@@ -173,6 +174,7 @@ maestro/
 | `.claude/worktrees/` | Worktree checkouts managed by maestro |
 | `src/` | Rust source code |
 | `src/budget.rs` | Per-session and global budget enforcement (Phase 3) |
+| `src/doctor.rs` | Preflight check system: `CheckSeverity`, `CheckResult`, `DoctorReport`, `run_all_checks()`, `print_report()` (Issue #49) |
 | `src/git.rs` | GitOps trait and CLI-backed commit+push (Phase 3) |
 | `src/models.rs` | Label-based model routing (Phase 3) |
 | `src/prompts.rs` | Structured issue prompt builder with task-type detection; ProjectLanguage detection; guardrail resolution (Phase 3, Issue #43) |
@@ -218,7 +220,7 @@ maestro/
 | `src/tui/panels.rs` | Split-pane multi-session view |
 | `src/tui/screens/` | Interactive TUI screen components (Issues #31-33) |
 | `src/tui/screens/mod.rs` | `ScreenAction` enum, `SessionConfig`; re-exports all screen types |
-| `src/tui/screens/home.rs` | `HomeScreen`: idle dashboard with logo, quick-actions, and recent activity (Issue #31) |
+| `src/tui/screens/home.rs` | `HomeScreen`: idle dashboard with logo, quick-actions, recent activity, and doctor warnings banner (Issues #31, #49) |
 | `src/tui/screens/issue_browser.rs` | `IssueBrowserScreen`: navigable issue list with multi-select, label/milestone filters; `set_issues()` (Issues #32, #46) |
 | `src/tui/screens/milestone.rs` | `MilestoneScreen`: milestone list with progress gauge and run-all action (Issue #33) |
 | `src/work/` | Work queue and dependency scheduling (Phase 2) |

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,0 +1,434 @@
+use std::process::Command;
+
+use crate::config::Config;
+use crate::provider::types::ProviderKind;
+
+/// Severity of a preflight check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheckSeverity {
+    Required,
+    Optional,
+}
+
+/// Result of a single preflight check.
+#[derive(Debug, Clone)]
+pub struct CheckResult {
+    pub name: String,
+    pub passed: bool,
+    pub message: String,
+    pub severity: CheckSeverity,
+}
+
+impl CheckResult {
+    pub fn pass(
+        name: impl Into<String>,
+        message: impl Into<String>,
+        severity: CheckSeverity,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            passed: true,
+            message: message.into(),
+            severity,
+        }
+    }
+
+    pub fn fail(
+        name: impl Into<String>,
+        message: impl Into<String>,
+        severity: CheckSeverity,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            passed: false,
+            message: message.into(),
+            severity,
+        }
+    }
+
+    pub fn symbol(&self) -> &'static str {
+        match (self.passed, self.severity) {
+            (true, _) => "OK",
+            (false, CheckSeverity::Required) => "FAIL",
+            (false, CheckSeverity::Optional) => "WARN",
+        }
+    }
+}
+
+/// Summary of all preflight checks.
+#[derive(Debug, Clone)]
+pub struct DoctorReport {
+    pub checks: Vec<CheckResult>,
+}
+
+impl DoctorReport {
+    pub fn has_failures(&self) -> bool {
+        self.checks
+            .iter()
+            .any(|c| !c.passed && c.severity == CheckSeverity::Required)
+    }
+
+    pub fn has_warnings(&self) -> bool {
+        self.checks.iter().any(|c| !c.passed)
+    }
+
+    pub fn failed_checks(&self) -> Vec<&CheckResult> {
+        self.checks.iter().filter(|c| !c.passed).collect()
+    }
+}
+
+/// Run all preflight checks and return a report.
+pub fn run_all_checks(config: Option<&Config>) -> DoctorReport {
+    let mut checks = vec![
+        check_gh_installed(),
+        check_gh_authenticated(),
+        check_git_installed(),
+        check_git_user_config(),
+        check_git_remote(),
+        check_config_exists(),
+    ];
+
+    if let Some(cfg) = config
+        && cfg.provider.kind == ProviderKind::AzureDevops
+    {
+        checks.push(check_az_cli());
+    }
+
+    checks.push(check_claude_cli());
+
+    // Only check repo access if gh is authenticated
+    if checks.iter().any(|c| c.name == "gh auth" && c.passed) {
+        checks.push(check_gh_repo_accessible());
+    }
+
+    DoctorReport { checks }
+}
+
+/// Print a formatted report to stdout.
+pub fn print_report(report: &DoctorReport) {
+    println!();
+    let header = format!("  {:<16} {:<8} {}", "Check", "Status", "Details");
+    println!("{header}");
+    let separator = format!("  {}", "-".repeat(60));
+    println!("{separator}");
+
+    for check in &report.checks {
+        let status = match (check.passed, check.severity) {
+            (true, _) => "\x1b[32mOK\x1b[0m    ",
+            (false, CheckSeverity::Required) => "\x1b[31mFAIL\x1b[0m  ",
+            (false, CheckSeverity::Optional) => "\x1b[33mWARN\x1b[0m  ",
+        };
+        println!("  {:<16} {} {}", check.name, status, check.message);
+    }
+
+    println!();
+    if report.has_failures() {
+        println!("  \x1b[31mSome required checks failed. Maestro may not work correctly.\x1b[0m");
+    } else if report.has_warnings() {
+        println!(
+            "  \x1b[33mAll required checks passed, but some optional tools are missing.\x1b[0m"
+        );
+    } else {
+        println!("  \x1b[32mAll checks passed! Maestro is ready to use.\x1b[0m");
+    }
+    println!();
+}
+
+/// Strip control characters from subprocess output for safe terminal display.
+fn sanitize(s: &str) -> String {
+    s.chars().filter(|c| !c.is_control()).collect()
+}
+
+// --- Individual check functions ---
+
+fn check_gh_installed() -> CheckResult {
+    match Command::new("gh").arg("--version").output() {
+        Ok(out) if out.status.success() => {
+            let version = String::from_utf8_lossy(&out.stdout);
+            let ver_line = sanitize(version.lines().next().unwrap_or("unknown"));
+            CheckResult::pass("gh cli", ver_line, CheckSeverity::Required)
+        }
+        _ => CheckResult::fail(
+            "gh cli",
+            "not installed — https://cli.github.com",
+            CheckSeverity::Required,
+        ),
+    }
+}
+
+fn check_gh_authenticated() -> CheckResult {
+    match Command::new("gh").args(["auth", "status"]).output() {
+        Ok(out) if out.status.success() => {
+            CheckResult::pass("gh auth", "authenticated", CheckSeverity::Required)
+        }
+        _ => CheckResult::fail(
+            "gh auth",
+            "not authenticated — run `gh auth login`",
+            CheckSeverity::Required,
+        ),
+    }
+}
+
+fn check_git_installed() -> CheckResult {
+    match Command::new("git").arg("--version").output() {
+        Ok(out) if out.status.success() => {
+            let version = sanitize(String::from_utf8_lossy(&out.stdout).trim());
+            CheckResult::pass("git", version, CheckSeverity::Required)
+        }
+        _ => CheckResult::fail("git", "not installed", CheckSeverity::Required),
+    }
+}
+
+fn check_git_user_config() -> CheckResult {
+    let name_ok = Command::new("git")
+        .args(["config", "user.name"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    let email_ok = Command::new("git")
+        .args(["config", "user.email"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+
+    match (name_ok, email_ok) {
+        (true, true) => CheckResult::pass(
+            "git config",
+            "user.name and user.email set",
+            CheckSeverity::Required,
+        ),
+        (false, _) => CheckResult::fail(
+            "git config",
+            "user.name not set — run `git config --global user.name \"Your Name\"`",
+            CheckSeverity::Required,
+        ),
+        (_, false) => CheckResult::fail(
+            "git config",
+            "user.email not set — run `git config --global user.email \"you@example.com\"`",
+            CheckSeverity::Required,
+        ),
+    }
+}
+
+fn check_git_remote() -> CheckResult {
+    match Command::new("git").args(["remote", "-v"]).output() {
+        Ok(out) if out.status.success() && !out.stdout.is_empty() => {
+            CheckResult::pass("git remote", "remote configured", CheckSeverity::Required)
+        }
+        _ => CheckResult::fail(
+            "git remote",
+            "no git remote found — are you in a git repo?",
+            CheckSeverity::Required,
+        ),
+    }
+}
+
+fn check_config_exists() -> CheckResult {
+    if std::path::Path::new("maestro.toml").exists() {
+        match Config::find_and_load() {
+            Ok(_) => CheckResult::pass("maestro.toml", "found and valid", CheckSeverity::Required),
+            Err(e) => CheckResult::fail(
+                "maestro.toml",
+                format!("found but invalid — {}", e),
+                CheckSeverity::Required,
+            ),
+        }
+    } else {
+        CheckResult::fail(
+            "maestro.toml",
+            "not found — run `maestro init`",
+            CheckSeverity::Required,
+        )
+    }
+}
+
+fn check_claude_cli() -> CheckResult {
+    match Command::new("claude").arg("--version").output() {
+        Ok(out) if out.status.success() => {
+            let version = sanitize(String::from_utf8_lossy(&out.stdout).trim());
+            CheckResult::pass("claude cli", version, CheckSeverity::Optional)
+        }
+        _ => CheckResult::fail(
+            "claude cli",
+            "not installed — sessions won't launch",
+            CheckSeverity::Optional,
+        ),
+    }
+}
+
+fn check_az_cli() -> CheckResult {
+    match Command::new("az").arg("--version").output() {
+        Ok(out) if out.status.success() => {
+            CheckResult::pass("az cli", "installed", CheckSeverity::Optional)
+        }
+        _ => CheckResult::fail(
+            "az cli",
+            "not installed — required for Azure DevOps provider",
+            CheckSeverity::Optional,
+        ),
+    }
+}
+
+fn check_gh_repo_accessible() -> CheckResult {
+    match Command::new("gh")
+        .args(["repo", "view", "--json", "name", "-q", ".name"])
+        .output()
+    {
+        Ok(out) if out.status.success() => {
+            let name = sanitize(String::from_utf8_lossy(&out.stdout).trim());
+            CheckResult::pass(
+                "gh repo",
+                format!("accessible ({})", name),
+                CheckSeverity::Required,
+            )
+        }
+        _ => CheckResult::fail(
+            "gh repo",
+            "cannot access repo — check permissions",
+            CheckSeverity::Required,
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // CheckResult constructors
+
+    #[test]
+    fn check_result_pass_sets_fields() {
+        let r = CheckResult::pass("test", "all good", CheckSeverity::Required);
+        assert!(r.passed);
+        assert_eq!(r.name, "test");
+        assert_eq!(r.message, "all good");
+        assert_eq!(r.severity, CheckSeverity::Required);
+    }
+
+    #[test]
+    fn check_result_fail_sets_fields() {
+        let r = CheckResult::fail("test", "broken", CheckSeverity::Optional);
+        assert!(!r.passed);
+        assert_eq!(r.name, "test");
+        assert_eq!(r.message, "broken");
+        assert_eq!(r.severity, CheckSeverity::Optional);
+    }
+
+    // symbol()
+
+    #[test]
+    fn symbol_ok_when_passed() {
+        let r = CheckResult::pass("x", "y", CheckSeverity::Required);
+        assert_eq!(r.symbol(), "OK");
+    }
+
+    #[test]
+    fn symbol_ok_when_passed_optional() {
+        let r = CheckResult::pass("x", "y", CheckSeverity::Optional);
+        assert_eq!(r.symbol(), "OK");
+    }
+
+    #[test]
+    fn symbol_fail_when_required_fails() {
+        let r = CheckResult::fail("x", "y", CheckSeverity::Required);
+        assert_eq!(r.symbol(), "FAIL");
+    }
+
+    #[test]
+    fn symbol_warn_when_optional_fails() {
+        let r = CheckResult::fail("x", "y", CheckSeverity::Optional);
+        assert_eq!(r.symbol(), "WARN");
+    }
+
+    // DoctorReport::has_failures
+
+    #[test]
+    fn has_failures_true_when_required_check_fails() {
+        let report = DoctorReport {
+            checks: vec![
+                CheckResult::pass("a", "ok", CheckSeverity::Required),
+                CheckResult::fail("b", "bad", CheckSeverity::Required),
+            ],
+        };
+        assert!(report.has_failures());
+    }
+
+    #[test]
+    fn has_failures_false_when_only_optional_fails() {
+        let report = DoctorReport {
+            checks: vec![
+                CheckResult::pass("a", "ok", CheckSeverity::Required),
+                CheckResult::fail("b", "missing", CheckSeverity::Optional),
+            ],
+        };
+        assert!(!report.has_failures());
+    }
+
+    #[test]
+    fn has_failures_false_when_all_pass() {
+        let report = DoctorReport {
+            checks: vec![
+                CheckResult::pass("a", "ok", CheckSeverity::Required),
+                CheckResult::pass("b", "ok", CheckSeverity::Optional),
+            ],
+        };
+        assert!(!report.has_failures());
+    }
+
+    // DoctorReport::has_warnings
+
+    #[test]
+    fn has_warnings_true_when_any_check_fails() {
+        let report = DoctorReport {
+            checks: vec![
+                CheckResult::pass("a", "ok", CheckSeverity::Required),
+                CheckResult::fail("b", "missing", CheckSeverity::Optional),
+            ],
+        };
+        assert!(report.has_warnings());
+    }
+
+    #[test]
+    fn has_warnings_true_when_required_fails() {
+        let report = DoctorReport {
+            checks: vec![CheckResult::fail("a", "bad", CheckSeverity::Required)],
+        };
+        assert!(report.has_warnings());
+    }
+
+    #[test]
+    fn has_warnings_false_when_all_pass() {
+        let report = DoctorReport {
+            checks: vec![
+                CheckResult::pass("a", "ok", CheckSeverity::Required),
+                CheckResult::pass("b", "ok", CheckSeverity::Optional),
+            ],
+        };
+        assert!(!report.has_warnings());
+    }
+
+    // DoctorReport::failed_checks
+
+    #[test]
+    fn failed_checks_returns_only_failed() {
+        let report = DoctorReport {
+            checks: vec![
+                CheckResult::pass("a", "ok", CheckSeverity::Required),
+                CheckResult::fail("b", "bad", CheckSeverity::Required),
+                CheckResult::fail("c", "missing", CheckSeverity::Optional),
+            ],
+        };
+        let failed = report.failed_checks();
+        assert_eq!(failed.len(), 2);
+        assert_eq!(failed[0].name, "b");
+        assert_eq!(failed[1].name, "c");
+    }
+
+    #[test]
+    fn failed_checks_empty_when_all_pass() {
+        let report = DoctorReport {
+            checks: vec![CheckResult::pass("a", "ok", CheckSeverity::Required)],
+        };
+        assert!(report.failed_checks().is_empty());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod budget;
 mod config;
+mod doctor;
 mod gates;
 mod git;
 mod github;
@@ -111,6 +112,8 @@ enum Commands {
         /// Shell to generate completions for (bash, zsh, fish)
         shell: String,
     },
+    /// Check environment setup and required tools
+    Doctor,
 }
 
 #[tokio::main]
@@ -141,6 +144,7 @@ async fn main() -> anyhow::Result<()> {
         Some(Commands::Resume { session }) => cmd_resume(session).await,
         Some(Commands::TestSlack) => cmd_test_slack().await,
         Some(Commands::Completions { shell }) => cmd_completions(&shell),
+        Some(Commands::Doctor) => cmd_doctor(),
         Some(Commands::Status) => cmd_status(),
         Some(Commands::Cost) => cmd_cost(),
         Some(Commands::Queue) => cmd_queue().await,
@@ -619,6 +623,17 @@ fn cmd_completions(shell: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn cmd_doctor() -> anyhow::Result<()> {
+    let config = Config::find_and_load().ok();
+    let report = doctor::run_all_checks(config.as_ref());
+    doctor::print_report(&report);
+
+    if report.has_failures() {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
 async fn cmd_run(
     prompt: Option<String>,
     issue: Option<String>,
@@ -877,8 +892,25 @@ async fn cmd_dashboard() -> anyhow::Result<()> {
         Vec::new(),
     );
 
+    // Run preflight checks on a blocking thread to avoid stalling async runtime
+    let config_clone = config.clone();
+    let doctor_warnings = tokio::task::spawn_blocking(move || {
+        let report = doctor::run_all_checks(config_clone.as_ref());
+        report
+            .failed_checks()
+            .iter()
+            .map(|c| format!("{}: {}", c.name, c.message))
+            .collect::<Vec<_>>()
+    })
+    .await
+    .unwrap_or_default();
+
     // Set up home screen and start in Dashboard mode
-    app.home_screen = Some(tui::screens::HomeScreen::new(project_info, recent_sessions));
+    app.home_screen = Some(tui::screens::HomeScreen::new(
+        project_info,
+        recent_sessions,
+        doctor_warnings,
+    ));
     app.tui_mode = tui::app::TuiMode::Dashboard;
     app.config = config;
 

--- a/src/tui/screens/home.rs
+++ b/src/tui/screens/home.rs
@@ -45,17 +45,23 @@ pub struct HomeScreen {
     pub selected_action: usize,
     pub recent_sessions: Vec<SessionSummary>,
     pub project_info: ProjectInfo,
+    pub warnings: Vec<String>,
 }
 
 impl HomeScreen {
     pub const NUM_ACTIONS: usize = QUICK_ACTIONS.len();
     pub const QUIT_ACTION_INDEX: usize = 5;
 
-    pub fn new(project_info: ProjectInfo, recent_sessions: Vec<SessionSummary>) -> Self {
+    pub fn new(
+        project_info: ProjectInfo,
+        recent_sessions: Vec<SessionSummary>,
+        warnings: Vec<String>,
+    ) -> Self {
         Self {
             selected_action: 0,
             recent_sessions,
             project_info,
+            warnings,
         }
     }
 
@@ -94,22 +100,33 @@ impl HomeScreen {
     }
 
     pub fn draw(&self, f: &mut Frame, area: Rect) {
+        let warning_height = if self.warnings.is_empty() {
+            0
+        } else {
+            (self.warnings.len() as u16 + 2).min(6)
+        };
+
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
-                Constraint::Length(8), // logo
-                Constraint::Length(3), // project info
-                Constraint::Min(8),    // quick actions + recent sessions
+                Constraint::Length(8),              // logo
+                Constraint::Length(3),              // project info
+                Constraint::Length(warning_height), // warnings (0 if none)
+                Constraint::Min(8),                 // quick actions + recent sessions
             ])
             .split(area);
 
         self.draw_logo(f, chunks[0]);
         self.draw_project_info(f, chunks[1]);
 
+        if !self.warnings.is_empty() {
+            self.draw_warnings(f, chunks[2]);
+        }
+
         let bottom = Layout::default()
             .direction(Direction::Horizontal)
             .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
-            .split(chunks[2]);
+            .split(chunks[3]);
 
         self.draw_quick_actions(f, bottom[0]);
         self.draw_recent_sessions(f, bottom[1]);
@@ -153,6 +170,27 @@ impl HomeScreen {
         let para = Paragraph::new(info)
             .block(block)
             .alignment(Alignment::Center);
+        f.render_widget(para, area);
+    }
+
+    fn draw_warnings(&self, f: &mut Frame, area: Rect) {
+        let block = Block::default()
+            .title(" Warnings ")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Yellow));
+
+        let lines: Vec<Line> = self
+            .warnings
+            .iter()
+            .map(|w| {
+                Line::from(vec![
+                    Span::styled("  ! ", Style::default().fg(Color::Yellow)),
+                    Span::styled(w.as_str(), Style::default().fg(Color::White)),
+                ])
+            })
+            .collect();
+
+        let para = Paragraph::new(lines).block(block);
         f.render_widget(para, area);
     }
 
@@ -265,13 +303,13 @@ mod tests {
 
     #[test]
     fn home_initial_selected_action_is_zero() {
-        let screen = HomeScreen::new(make_project_info(), vec![]);
+        let screen = HomeScreen::new(make_project_info(), vec![], vec![]);
         assert_eq!(screen.selected_action, 0);
     }
 
     #[test]
     fn home_key_j_moves_selection_down() {
-        let mut screen = HomeScreen::new(make_project_info(), vec![]);
+        let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
         let action = screen.handle_input(&key_event(KeyCode::Char('j')));
         assert_eq!(action, ScreenAction::None);
         assert_eq!(screen.selected_action, 1);
@@ -279,14 +317,14 @@ mod tests {
 
     #[test]
     fn home_key_down_moves_selection_down() {
-        let mut screen = HomeScreen::new(make_project_info(), vec![]);
+        let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
         screen.handle_input(&key_event(KeyCode::Down));
         assert_eq!(screen.selected_action, 1);
     }
 
     #[test]
     fn home_key_k_moves_selection_up() {
-        let mut screen = HomeScreen::new(make_project_info(), vec![]);
+        let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
         screen.handle_input(&key_event(KeyCode::Char('j')));
         screen.handle_input(&key_event(KeyCode::Char('j')));
         assert_eq!(screen.selected_action, 2);
@@ -296,7 +334,7 @@ mod tests {
 
     #[test]
     fn home_key_k_does_not_underflow_at_zero() {
-        let mut screen = HomeScreen::new(make_project_info(), vec![]);
+        let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
         screen.handle_input(&key_event(KeyCode::Char('k')));
         screen.handle_input(&key_event(KeyCode::Char('k')));
         assert_eq!(screen.selected_action, 0);
@@ -304,7 +342,7 @@ mod tests {
 
     #[test]
     fn home_key_j_does_not_overflow_past_last_action() {
-        let mut screen = HomeScreen::new(make_project_info(), vec![]);
+        let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
         let num_actions = HomeScreen::NUM_ACTIONS;
         for _ in 0..num_actions + 5 {
             screen.handle_input(&key_event(KeyCode::Char('j')));
@@ -314,7 +352,7 @@ mod tests {
 
     #[test]
     fn home_key_up_moves_selection_up() {
-        let mut screen = HomeScreen::new(make_project_info(), vec![]);
+        let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
         screen.handle_input(&key_event(KeyCode::Down));
         screen.handle_input(&key_event(KeyCode::Up));
         assert_eq!(screen.selected_action, 0);
@@ -322,35 +360,35 @@ mod tests {
 
     #[test]
     fn home_key_i_returns_push_issue_browser() {
-        let mut screen = HomeScreen::new(make_project_info(), vec![]);
+        let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
         let action = screen.handle_input(&key_event(KeyCode::Char('i')));
         assert_eq!(action, ScreenAction::Push(TuiMode::IssueBrowser));
     }
 
     #[test]
     fn home_key_m_returns_push_milestone_view() {
-        let mut screen = HomeScreen::new(make_project_info(), vec![]);
+        let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
         let action = screen.handle_input(&key_event(KeyCode::Char('m')));
         assert_eq!(action, ScreenAction::Push(TuiMode::MilestoneView));
     }
 
     #[test]
     fn home_key_q_returns_quit() {
-        let mut screen = HomeScreen::new(make_project_info(), vec![]);
+        let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
         let action = screen.handle_input(&key_event(KeyCode::Char('q')));
         assert_eq!(action, ScreenAction::Quit);
     }
 
     #[test]
     fn home_enter_on_issues_action_returns_push_issue_browser() {
-        let mut screen = HomeScreen::new(make_project_info(), vec![]);
+        let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
         let action = screen.handle_input(&key_event(KeyCode::Enter));
         assert_eq!(action, ScreenAction::Push(TuiMode::IssueBrowser));
     }
 
     #[test]
     fn home_enter_on_milestones_action_returns_push_milestone_view() {
-        let mut screen = HomeScreen::new(make_project_info(), vec![]);
+        let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
         screen.handle_input(&key_event(KeyCode::Down));
         let action = screen.handle_input(&key_event(KeyCode::Enter));
         assert_eq!(action, ScreenAction::Push(TuiMode::MilestoneView));
@@ -358,7 +396,7 @@ mod tests {
 
     #[test]
     fn home_enter_on_quit_action_returns_quit() {
-        let mut screen = HomeScreen::new(make_project_info(), vec![]);
+        let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
         for _ in 0..HomeScreen::QUIT_ACTION_INDEX {
             screen.handle_input(&key_event(KeyCode::Down));
         }
@@ -368,14 +406,14 @@ mod tests {
 
     #[test]
     fn home_esc_returns_none() {
-        let mut screen = HomeScreen::new(make_project_info(), vec![]);
+        let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
         let action = screen.handle_input(&key_event(KeyCode::Esc));
         assert_eq!(action, ScreenAction::None);
     }
 
     #[test]
     fn home_tick_does_not_panic() {
-        let mut screen = HomeScreen::new(make_project_info(), vec![]);
+        let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
         screen.tick();
         screen.tick();
         screen.tick();
@@ -384,7 +422,7 @@ mod tests {
     #[test]
     fn home_recent_sessions_stored() {
         let sessions = vec![make_session_summary(10), make_session_summary(11)];
-        let screen = HomeScreen::new(make_project_info(), sessions);
+        let screen = HomeScreen::new(make_project_info(), sessions, vec![]);
         assert_eq!(screen.recent_sessions.len(), 2);
         assert_eq!(screen.recent_sessions[0].issue_number, 10);
         assert_eq!(screen.recent_sessions[1].issue_number, 11);
@@ -392,7 +430,7 @@ mod tests {
 
     #[test]
     fn home_unknown_key_returns_none() {
-        let mut screen = HomeScreen::new(make_project_info(), vec![]);
+        let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
         let action = screen.handle_input(&key_event(KeyCode::Char('x')));
         assert_eq!(action, ScreenAction::None);
     }


### PR DESCRIPTION
## Summary
- New `maestro doctor` subcommand that runs 9 preflight checks (gh CLI, gh auth, git, git config, git remote, maestro.toml, claude CLI, az CLI, repo access) and prints a colored summary table
- TUI home screen shows a yellow warning bar when any check fails, populated via `spawn_blocking` at startup
- Each failed check includes a clear remediation message (e.g., "Run `gh auth login`")
- Exit code 1 when required checks fail, making it CI/script friendly

Closes #49

## Test plan
- [x] All 553 tests pass (14 new doctor tests)
- [x] Clippy clean with `-D warnings`
- [x] `maestro doctor` prints correct status for all checks
- [ ] Verify TUI warning bar renders when a check fails
- [x] Verify `maestro doctor` returns exit code 1 on failure