### PR TITLE
feat: provider auth verification and user context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Provider Auth Verification and User Context (#34)
+
+- `src/doctor.rs` — `build_gh_auth_result(auth_ok, username, scopes)` extracted as a pure, testable function; `check_gh_authenticated()` refactored to call `gh api user -q .login` for the authenticated username and to parse token scopes from `gh auth status` stderr; success message now reads `authenticated as @<username>, scopes: <scopes>`
+- `src/doctor.rs` — `check_az_identity()` added: runs `az account show -o tsv --query user.name` and surfaces the signed-in Azure identity as an Optional check; only executed when the Azure DevOps provider is configured and `az cli` is already passing
+- `src/tui/screens/home.rs` — `ProjectInfo` struct gains `username: Option<String>` field; `draw_project_info()` renders `@<username>` (or `@unknown` as fallback) in the project info bar alongside repo and branch
+- `src/main.rs` — `cmd_dashboard()` extracts the authenticated username from the `gh auth` check result produced by `run_all_checks()` and passes it into `ProjectInfo`; no additional subprocess is spawned — username is reused from the doctor report
+
 ### Standardized Issue Templates with Definition of Ready (#53)
 
 - `.github/ISSUE_TEMPLATE/config.yml` — template chooser added; blank issues disabled to enforce structured reporting

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-03 14:00 (UTC)
+> Last updated: 2026-04-03 18:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -61,10 +61,10 @@ maestro/
 │       ├── ci.yml                         # GitHub Actions CI pipeline
 │       └── release.yml                    # Release workflow: cross-platform builds, GitHub Release, Homebrew tap trigger
 ├── src/
-│   ├── main.rs                            # CLI entry point (clap); Run, Queue, Add, Status, Cost, Init, Doctor; module declarations (includes doctor, provider)  [Issue #29, #49]
+│   ├── main.rs                            # CLI entry point (clap); Run, Queue, Add, Status, Cost, Init, Doctor; module declarations (includes doctor, provider); cmd_dashboard() fetches username from doctor report and passes it into ProjectInfo  [Issue #29, #49, #34]
 │   ├── config.rs                          # maestro.toml parsing; ModelsConfig, GatesConfig, ReviewConfig; ContextOverflowConfig; ProviderConfig (kind, organization, az_project); guardrail_prompt in SessionsConfig  [Issue #29, #43]
 │   ├── budget.rs                          # BudgetEnforcer: per-session and global budget checks  [Phase 3]
-│   ├── doctor.rs                          # Preflight checks: CheckSeverity, CheckResult, DoctorReport, run_all_checks(), print_report(), 9 check functions  [Issue #49]
+│   ├── doctor.rs                          # Preflight checks: CheckSeverity, CheckResult, DoctorReport, run_all_checks(), print_report(); build_gh_auth_result() (pure, testable); check_az_identity(); 10 check functions  [Issue #49, #34]
 │   ├── git.rs                             # GitOps trait, CliGitOps: commit and push operations  [Phase 3]
 │   ├── models.rs                          # ModelRouter: label-based model routing  [Phase 3]
 │   ├── prompts.rs                         # PromptBuilder: structured issue prompts with task-type detection; ProjectLanguage enum; detect_project_language(); default_guardrail(); resolve_guardrail()  [Phase 3, Issue #43]
@@ -129,7 +129,7 @@ maestro/
 │   │   ├── ui.rs                          # ratatui rendering; budget display, TUI mode switching, notification banners, screen rendering branches  [Phase 3, Issue #31-33]
 │   │   └── screens/                       # Interactive screen components  [Issue #31-33]
 │   │       ├── mod.rs                     # Screen types: ScreenAction enum, SessionConfig; re-exports HomeScreen, IssueBrowserScreen, MilestoneScreen
-│   │       ├── home.rs                    # HomeScreen: idle dashboard, logo, quick-actions menu, recent sessions panel, doctor warnings banner  [Issue #31, #49]
+│   │       ├── home.rs                    # HomeScreen: idle dashboard, logo, quick-actions menu, recent sessions panel, doctor warnings banner; ProjectInfo gains username field; draw_project_info() renders @username  [Issue #31, #49, #34]
 │   │       ├── issue_browser.rs           # IssueBrowserScreen: navigable issue list, multi-select, label/milestone filters, preview pane; set_issues() for async data delivery  [Issue #32, #46]
 │   │       └── milestone.rs               # MilestoneScreen: milestone list, progress gauge, issue detail pane, run-all action  [Issue #33]
 │   └── work/                              # Work queue and scheduling  [Phase 2]
@@ -181,7 +181,7 @@ maestro/
 | `.claude/worktrees/` | Worktree checkouts managed by maestro |
 | `src/` | Rust source code |
 | `src/budget.rs` | Per-session and global budget enforcement (Phase 3) |
-| `src/doctor.rs` | Preflight check system: `CheckSeverity`, `CheckResult`, `DoctorReport`, `run_all_checks()`, `print_report()` (Issue #49) |
+| `src/doctor.rs` | Preflight check system: `CheckSeverity`, `CheckResult`, `DoctorReport`, `run_all_checks()`, `print_report()`; `build_gh_auth_result()` (pure/testable); `check_az_identity()` for Azure DevOps (Issues #49, #34) |
 | `src/git.rs` | GitOps trait and CLI-backed commit+push (Phase 3) |
 | `src/models.rs` | Label-based model routing (Phase 3) |
 | `src/prompts.rs` | Structured issue prompt builder with task-type detection; ProjectLanguage detection; guardrail resolution (Phase 3, Issue #43) |
@@ -227,7 +227,7 @@ maestro/
 | `src/tui/panels.rs` | Split-pane multi-session view |
 | `src/tui/screens/` | Interactive TUI screen components (Issues #31-33) |
 | `src/tui/screens/mod.rs` | `ScreenAction` enum, `SessionConfig`; re-exports all screen types |
-| `src/tui/screens/home.rs` | `HomeScreen`: idle dashboard with logo, quick-actions, recent activity, and doctor warnings banner (Issues #31, #49) |
+| `src/tui/screens/home.rs` | `HomeScreen`: idle dashboard with logo, quick-actions, recent activity, doctor warnings banner, and `@username` display; `ProjectInfo` gains `username: Option<String>` (Issues #31, #49, #34) |
 | `src/tui/screens/issue_browser.rs` | `IssueBrowserScreen`: navigable issue list with multi-select, label/milestone filters; `set_issues()` (Issues #32, #46) |
 | `src/tui/screens/milestone.rs` | `MilestoneScreen`: milestone list with progress gauge and run-all action (Issue #33) |
 | `src/work/` | Work queue and dependency scheduling (Phase 2) |

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -92,6 +92,10 @@ pub fn run_all_checks(config: Option<&Config>) -> DoctorReport {
         && cfg.provider.kind == ProviderKind::AzureDevops
     {
         checks.push(check_az_cli());
+        // Add Azure identity check only if az cli is available
+        if checks.iter().any(|c| c.name == "az cli" && c.passed) {
+            checks.push(check_az_identity());
+        }
     }
 
     checks.push(check_claude_cli());
@@ -139,6 +143,33 @@ fn sanitize(s: &str) -> String {
     s.chars().filter(|c| !c.is_control()).collect()
 }
 
+/// Pure, testable core of the gh auth check.
+/// Accepts the outputs of the external process calls as plain values.
+pub(crate) fn build_gh_auth_result(
+    auth_ok: bool,
+    username: Option<&str>,
+    scopes: Option<&str>,
+) -> CheckResult {
+    if !auth_ok {
+        return CheckResult::fail(
+            "gh auth",
+            "not authenticated — run `gh auth login`",
+            CheckSeverity::Required,
+        );
+    }
+    let mut parts: Vec<String> = Vec::new();
+    match username {
+        Some(u) => parts.push(format!("authenticated as @{}", u)),
+        None => parts.push("authenticated".to_string()),
+    }
+    if let Some(s) = scopes
+        && !s.is_empty()
+    {
+        parts.push(format!("scopes: {}", s));
+    }
+    CheckResult::pass("gh auth", parts.join(", "), CheckSeverity::Required)
+}
+
 // --- Individual check functions ---
 
 fn check_gh_installed() -> CheckResult {
@@ -157,16 +188,41 @@ fn check_gh_installed() -> CheckResult {
 }
 
 fn check_gh_authenticated() -> CheckResult {
-    match Command::new("gh").args(["auth", "status"]).output() {
-        Ok(out) if out.status.success() => {
-            CheckResult::pass("gh auth", "authenticated", CheckSeverity::Required)
-        }
-        _ => CheckResult::fail(
-            "gh auth",
-            "not authenticated — run `gh auth login`",
-            CheckSeverity::Required,
-        ),
-    }
+    let auth_output = Command::new("gh").args(["auth", "status"]).output();
+    let auth_ok = auth_output
+        .as_ref()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+
+    let username = if auth_ok {
+        Command::new("gh")
+            .args(["api", "user", "-q", ".login"])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| sanitize(String::from_utf8_lossy(&o.stdout).trim()))
+            .filter(|s| !s.is_empty())
+    } else {
+        None
+    };
+
+    let scopes = if auth_ok {
+        auth_output
+            .ok()
+            .map(|o| {
+                let stderr = String::from_utf8_lossy(&o.stderr);
+                stderr
+                    .lines()
+                    .find(|l| l.contains("Token scopes:") || l.contains("scopes:"))
+                    .map(|l| sanitize(l.trim()))
+                    .unwrap_or_default()
+            })
+            .filter(|s| !s.is_empty())
+    } else {
+        None
+    };
+
+    build_gh_auth_result(auth_ok, username.as_deref(), scopes.as_deref())
 }
 
 fn check_git_installed() -> CheckResult {
@@ -264,6 +320,35 @@ fn check_az_cli() -> CheckResult {
         _ => CheckResult::fail(
             "az cli",
             "not installed — required for Azure DevOps provider",
+            CheckSeverity::Optional,
+        ),
+    }
+}
+
+fn check_az_identity() -> CheckResult {
+    match Command::new("az")
+        .args(["account", "show", "-o", "tsv", "--query", "user.name"])
+        .output()
+    {
+        Ok(out) if out.status.success() => {
+            let username = sanitize(String::from_utf8_lossy(&out.stdout).trim());
+            if username.is_empty() {
+                CheckResult::fail(
+                    "az identity",
+                    "could not fetch identity",
+                    CheckSeverity::Optional,
+                )
+            } else {
+                CheckResult::pass(
+                    "az identity",
+                    format!("logged in as {}", username),
+                    CheckSeverity::Optional,
+                )
+            }
+        }
+        _ => CheckResult::fail(
+            "az identity",
+            "could not fetch identity",
             CheckSeverity::Optional,
         ),
     }
@@ -430,5 +515,73 @@ mod tests {
             checks: vec![CheckResult::pass("a", "ok", CheckSeverity::Required)],
         };
         assert!(report.failed_checks().is_empty());
+    }
+
+    // --- Tests for build_gh_auth_result() (Issue #34) ---
+
+    #[test]
+    fn gh_auth_check_pass_with_username_includes_username_in_message() {
+        let result = build_gh_auth_result(true, Some("carlos"), None);
+        assert!(result.passed);
+        assert!(result.message.contains("carlos"));
+    }
+
+    #[test]
+    fn gh_auth_check_pass_with_username_prefixes_at_sign() {
+        let result = build_gh_auth_result(true, Some("carlos"), None);
+        assert!(result.message.contains("@carlos"));
+    }
+
+    #[test]
+    fn gh_auth_check_pass_without_username_falls_back_to_authenticated() {
+        let result = build_gh_auth_result(true, None, None);
+        assert!(result.passed);
+        assert!(result.message.contains("authenticated"));
+    }
+
+    #[test]
+    fn gh_auth_check_fail_returns_not_authenticated() {
+        let result = build_gh_auth_result(false, None, None);
+        assert!(!result.passed);
+        assert_eq!(result.severity, CheckSeverity::Required);
+        assert!(result.message.contains("gh auth login"));
+    }
+
+    #[test]
+    fn gh_auth_check_pass_with_scopes_includes_scopes_in_message() {
+        let result = build_gh_auth_result(true, Some("carlos"), Some("repo,read:org"));
+        assert!(result.passed);
+        assert!(result.message.contains("repo,read:org"));
+    }
+
+    #[test]
+    fn gh_auth_check_pass_without_scopes_does_not_panic() {
+        let result = build_gh_auth_result(true, Some("carlos"), None);
+        assert!(result.passed);
+        assert!(!result.message.is_empty());
+    }
+
+    #[test]
+    fn report_with_username_check_has_no_failures_when_passed() {
+        let report = DoctorReport {
+            checks: vec![CheckResult::pass(
+                "gh auth",
+                "authenticated as @carlos",
+                CheckSeverity::Required,
+            )],
+        };
+        assert!(!report.has_failures());
+    }
+
+    #[test]
+    fn report_with_failed_auth_check_has_failures() {
+        let report = DoctorReport {
+            checks: vec![CheckResult::fail(
+                "gh auth",
+                "not authenticated — run `gh auth login`",
+                CheckSeverity::Required,
+            )],
+        };
+        assert!(report.has_failures());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -859,9 +859,36 @@ async fn cmd_dashboard() -> anyhow::Result<()> {
         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
         .unwrap_or_else(|| "unknown".to_string());
 
+    // Run preflight checks and fetch user identity on a blocking thread
+    let config_clone = config.clone();
+    let (doctor_warnings, username) = tokio::task::spawn_blocking(move || {
+        let report = doctor::run_all_checks(config_clone.as_ref());
+        let warnings: Vec<String> = report
+            .failed_checks()
+            .iter()
+            .map(|c| format!("{}: {}", c.name, c.message))
+            .collect();
+
+        // Extract username from the gh auth check result if present
+        let username = report
+            .checks
+            .iter()
+            .find(|c| c.name == "gh auth" && c.passed)
+            .and_then(|c| {
+                c.message
+                    .strip_prefix("authenticated as @")
+                    .map(|rest| rest.split(',').next().unwrap_or(rest).to_string())
+            });
+
+        (warnings, username)
+    })
+    .await
+    .unwrap_or_default();
+
     let project_info = tui::screens::home::ProjectInfo {
         repo: repo_name,
         branch,
+        username,
     };
 
     // Build recent sessions from saved state
@@ -891,19 +918,6 @@ async fn cmd_dashboard() -> anyhow::Result<()> {
         "bypassPermissions".into(),
         Vec::new(),
     );
-
-    // Run preflight checks on a blocking thread to avoid stalling async runtime
-    let config_clone = config.clone();
-    let doctor_warnings = tokio::task::spawn_blocking(move || {
-        let report = doctor::run_all_checks(config_clone.as_ref());
-        report
-            .failed_checks()
-            .iter()
-            .map(|c| format!("{}: {}", c.name, c.message))
-            .collect::<Vec<_>>()
-    })
-    .await
-    .unwrap_or_default();
 
     // Set up home screen and start in Dashboard mode
     app.home_screen = Some(tui::screens::HomeScreen::new(

--- a/src/tui/screens/home.rs
+++ b/src/tui/screens/home.rs
@@ -31,6 +31,7 @@ const LOGO: &str = r#"
 pub struct ProjectInfo {
     pub repo: String,
     pub branch: String,
+    pub username: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -156,6 +157,8 @@ impl HomeScreen {
     }
 
     fn draw_project_info(&self, f: &mut Frame, area: Rect) {
+        let username_display = self.project_info.username.as_deref().unwrap_or("unknown");
+
         let info = Line::from(vec![
             Span::styled("  Repo: ", Style::default().fg(Color::DarkGray)),
             Span::styled(&self.project_info.repo, Style::default().fg(Color::Cyan)),
@@ -164,6 +167,12 @@ impl HomeScreen {
             Span::styled(
                 &self.project_info.branch,
                 Style::default().fg(Color::Yellow),
+            ),
+            Span::raw("  |  "),
+            Span::styled("User: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format!("@{}", username_display),
+                Style::default().fg(Color::Green),
             ),
         ]);
         let block = Block::default().borders(Borders::BOTTOM);
@@ -289,6 +298,15 @@ mod tests {
         ProjectInfo {
             repo: "owner/repo".to_string(),
             branch: "main".to_string(),
+            username: None,
+        }
+    }
+
+    fn make_project_info_with_user(name: &str) -> ProjectInfo {
+        ProjectInfo {
+            repo: "owner/repo".to_string(),
+            branch: "main".to_string(),
+            username: Some(name.to_string()),
         }
     }
 
@@ -433,5 +451,33 @@ mod tests {
         let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
         let action = screen.handle_input(&key_event(KeyCode::Char('x')));
         assert_eq!(action, ScreenAction::None);
+    }
+
+    // --- Tests for ProjectInfo.username field (Issue #34) ---
+
+    #[test]
+    fn project_info_with_user_stores_username() {
+        let info = make_project_info_with_user("carlos");
+        assert_eq!(info.username, Some("carlos".to_string()));
+    }
+
+    #[test]
+    fn project_info_without_user_is_none() {
+        let info = make_project_info();
+        assert!(info.username.is_none());
+    }
+
+    #[test]
+    fn home_screen_stores_project_info_with_user() {
+        let info = make_project_info_with_user("testuser");
+        let screen = HomeScreen::new(info, vec![], vec![]);
+        assert_eq!(screen.project_info.username, Some("testuser".to_string()));
+    }
+
+    #[test]
+    fn home_screen_stores_project_info_without_user() {
+        let info = make_project_info();
+        let screen = HomeScreen::new(info, vec![], vec![]);
+        assert!(screen.project_info.username.is_none());
     }
 }


### PR DESCRIPTION
## Summary

- Show authenticated GitHub username (`@user`) on TUI home screen project info bar, with `@unknown` fallback
- Enhance `maestro doctor` to display username and token scopes in the `gh auth` check
- Add Azure DevOps identity check (`az identity`) when provider is configured
- 12 new tests covering all auth result combinations and ProjectInfo username field

Closes #34

## Test plan
- [x] `cargo test` — 565 tests pass (12 new)
- [x] `cargo clippy` — no new warnings
- [x] `cargo fmt` — formatted
- [x] Manual: run `maestro` (dashboard mode) and verify `@username` appears in project info bar
- [x] Manual: run `maestro doctor` and verify username + scopes shown in `gh auth` check