### PR TITLE
feat: add context-aware work suggestions to home screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Work Suggestions and Quick Commands (#35)
+
+- `src/tui/screens/home.rs` — `SuggestionKind` enum added with four variants: `ReadyIssues { count }`, `MilestoneProgress { title, closed, total }`, `IdleSessions`, and `FailedIssues { count }`
+- `src/tui/screens/home.rs` — `Suggestion` struct added with `kind`, `message`, `shortcut`, and `action` fields; `build_suggestions()` factory method derives contextual hints from GitHub data (ready/failed issue counts, milestone progress) and current session state
+- `src/tui/screens/home.rs` — `HomeSection` enum added (`QuickActions`, `Suggestions`); `HomeScreen` gains `suggestions`, `selected_suggestion`, and `focus_section` fields; `Tab` key toggles focus between panels; `j`/`k`/arrows navigate within the focused panel; `Enter` executes the highlighted item in either panel; `set_suggestions()` method for async data delivery
+- `src/tui/screens/home.rs` — `draw()` bottom section refactored from a 2-column to a 3-column layout: Quick Actions (30%) | Suggestions (35%) | Recent Activity (35%); `draw_suggestions()` renders the new panel with focus-aware green/gray border and an empty-state fallback message
+- `src/tui/app.rs` — `SuggestionDataPayload` struct added (`ready_issue_count`, `failed_issue_count`, `milestones`); `TuiCommand::FetchSuggestionData` variant added; `TuiDataEvent::SuggestionData(SuggestionDataPayload)` variant added; `handle_data_event()` routes `SuggestionData` into `Suggestion::build_suggestions()` and delivers the result to `HomeScreen::set_suggestions()`
+- `src/tui/mod.rs` — `FetchSuggestionData` branch added to the command processing loop: spawns a background `tokio` task that fetches `maestro:ready` and `maestro:failed` issue counts and open milestone progress via `GhCliClient`, then delivers a `SuggestionData` event
+- `src/main.rs` — `cmd_dashboard()` queues `TuiCommand::FetchSuggestionData` immediately after `App` construction so suggestions are populated on first render
+
 ### Session Launch with Worktree Isolation from TUI (#36)
 
 - `src/main.rs` — `setup_app_from_config()` helper introduced: consolidates `App` construction shared between `cmd_run` and `cmd_dashboard`; wires `BudgetEnforcer`, `ModelRouter`, `NotificationDispatcher`, and `PluginRunner` from config; reads `permission_mode` and `allowed_tools` from `[sessions]` config rather than hardcoding them

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,6 +51,7 @@ Hardening, missing PRD features, test coverage, and distribution.
 | [#31] | Interactive home screen with idle dashboard | P1 | Done |
 | [#32] | Interactive issue browser with selection and launch | P1 | Done |
 | [#33] | Milestone overview with progress tracking | P1 | Done |
+| [#35] | Work suggestions and quick commands on home screen | P1 | Done |
 
 ### Testing & Quality
 

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-03 19:00 (UTC)
+> Last updated: 2026-04-03 21:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -61,7 +61,7 @@ maestro/
 │       ├── ci.yml                         # GitHub Actions CI pipeline
 │       └── release.yml                    # Release workflow: cross-platform builds, GitHub Release, Homebrew tap trigger
 ├── src/
-│   ├── main.rs                            # CLI entry point (clap); Run, Queue, Add, Status, Cost, Init, Doctor; setup_app_from_config() shared helper wires budget, model router, notifications, plugins, and permission_mode/allowed_tools from config; cmd_dashboard() performs orphan worktree cleanup, log cleanup, fetches username from doctor report, and delegates App construction to setup_app_from_config(); cmd_run() refactored to use same helper  [Issue #29, #49, #34, #36]
+│   ├── main.rs                            # CLI entry point (clap); Run, Queue, Add, Status, Cost, Init, Doctor; setup_app_from_config() shared helper wires budget, model router, notifications, plugins, and permission_mode/allowed_tools from config; cmd_dashboard() performs orphan worktree cleanup, log cleanup, fetches username from doctor report, delegates App construction to setup_app_from_config(), and queues FetchSuggestionData on startup; cmd_run() refactored to use same helper  [Issue #29, #49, #34, #36, #35]
 │   ├── config.rs                          # maestro.toml parsing; ModelsConfig, GatesConfig, ReviewConfig; ContextOverflowConfig; ProviderConfig (kind, organization, az_project); guardrail_prompt in SessionsConfig  [Issue #29, #43]
 │   ├── budget.rs                          # BudgetEnforcer: per-session and global budget checks  [Phase 3]
 │   ├── doctor.rs                          # Preflight checks: CheckSeverity, CheckResult, DoctorReport, run_all_checks(), print_report(); build_gh_auth_result() (pure, testable); check_az_identity(); 10 check functions  [Issue #49, #34]
@@ -117,8 +117,8 @@ maestro/
 │   │   ├── store.rs                       # JSON state persistence
 │   │   └── types.rs                       # State types; fork_lineage HashMap; record_fork, fork_chain, fork_depth methods  [Issue #12]
 │   ├── tui/
-│   │   ├── mod.rs                         # Event loop; keybindings; handle_screen_action() rewritten; command processing loop; launch_session_from_config()  [Phase 3, Issue #31-33, #46-48]
-│   │   ├── app.rs                         # App state; TuiMode; TuiCommand enum; TuiDataEvent enum; handle_data_event(); data_tx/data_rx channel; pending_commands  [Issue #12, #31-33, #43, #46-48]
+│   │   ├── mod.rs                         # Event loop; keybindings; handle_screen_action() rewritten; command processing loop; launch_session_from_config(); FetchSuggestionData async handler spawns background GitHub fetch for ready/failed counts and milestone progress  [Phase 3, Issue #31-33, #46-48, #35]
+│   │   ├── app.rs                         # App state; TuiMode; TuiCommand enum (FetchIssues, FetchMilestones, FetchSuggestionData, LaunchSession, LaunchSessions); TuiDataEvent enum (Issues, Milestones, Issue, SuggestionData); SuggestionDataPayload; handle_data_event(); data_tx/data_rx channel; pending_commands  [Issue #12, #31-33, #43, #46-48, #35]
 │   │   ├── activity_log.rs                # Scrollable activity log widget with LogLevel color coding  [Phase 1]
 │   │   ├── cost_dashboard.rs              # Cost dashboard widget: per-session and aggregate cost display  [Phase 3]
 │   │   ├── dep_graph.rs                   # ASCII dependency graph visualization  [Phase 3]
@@ -129,7 +129,7 @@ maestro/
 │   │   ├── ui.rs                          # ratatui rendering; budget display, TUI mode switching, notification banners, screen rendering branches  [Phase 3, Issue #31-33]
 │   │   └── screens/                       # Interactive screen components  [Issue #31-33]
 │   │       ├── mod.rs                     # Screen types: ScreenAction enum, SessionConfig; re-exports HomeScreen, IssueBrowserScreen, MilestoneScreen
-│   │       ├── home.rs                    # HomeScreen: idle dashboard, logo, quick-actions menu, recent sessions panel, doctor warnings banner; ProjectInfo gains username field; draw_project_info() renders @username  [Issue #31, #49, #34]
+│   │       ├── home.rs                    # HomeScreen: idle dashboard, logo, quick-actions menu, suggestions panel, recent activity panel; SuggestionKind enum, Suggestion struct, HomeSection enum; build_suggestions() derives contextual hints from GitHub data; draw_suggestions() renders Suggestions panel; Tab-based focus navigation between QuickActions and Suggestions; ProjectInfo gains username field  [Issue #31, #49, #34, #35]
 │   │       ├── issue_browser.rs           # IssueBrowserScreen: navigable issue list, multi-select, label/milestone filters, preview pane; set_issues() for async data delivery  [Issue #32, #46]
 │   │       └── milestone.rs               # MilestoneScreen: milestone list, progress gauge, issue detail pane, run-all action  [Issue #33]
 │   └── work/                              # Work queue and scheduling  [Phase 2]
@@ -180,7 +180,7 @@ maestro/
 | `.claude/skills/` | Reusable knowledge bases for subagents |
 | `.claude/worktrees/` | Worktree checkouts managed by maestro |
 | `src/` | Rust source code |
-| `src/main.rs` | CLI entry point; `setup_app_from_config()` shared App setup helper; `cmd_dashboard()` with startup cleanup and config-driven wiring; `cmd_run()` refactored to use shared helper (Issues #29, #34, #36, #49) |
+| `src/main.rs` | CLI entry point; `setup_app_from_config()` shared App setup helper; `cmd_dashboard()` with startup cleanup, config-driven wiring, and `FetchSuggestionData` queued on startup; `cmd_run()` refactored to use shared helper (Issues #29, #34, #35, #36, #49) |
 | `src/budget.rs` | Per-session and global budget enforcement (Phase 3) |
 | `src/doctor.rs` | Preflight check system: `CheckSeverity`, `CheckResult`, `DoctorReport`, `run_all_checks()`, `print_report()`; `build_gh_auth_result()` (pure/testable); `check_az_identity()` for Azure DevOps (Issues #49, #34) |
 | `src/git.rs` | GitOps trait and CLI-backed commit+push (Phase 3) |
@@ -217,8 +217,8 @@ maestro/
 | `src/state/file_claims.rs` | Per-session file claim registry |
 | `src/state/progress.rs` | Session phase tracking (Phase 3) |
 | `src/tui/` | Terminal UI (ratatui) |
-| `src/tui/mod.rs` | Event loop; `handle_screen_action()`; command processing; `launch_session_from_config()` (Issues #31-33, #46-48) |
-| `src/tui/app.rs` | `App` struct; `TuiMode`; `TuiCommand`; `TuiDataEvent`; `handle_data_event()`; `data_tx`/`data_rx` channel (Issues #12, #31-33, #43, #46-48) |
+| `src/tui/mod.rs` | Event loop; `handle_screen_action()`; command processing; `launch_session_from_config()`; `FetchSuggestionData` async handler for GitHub ready/failed counts and milestone progress (Issues #31-33, #35, #46-48) |
+| `src/tui/app.rs` | `App` struct; `TuiMode`; `TuiCommand` (adds `FetchSuggestionData`); `TuiDataEvent` (adds `SuggestionData`); `SuggestionDataPayload`; `handle_data_event()`; `data_tx`/`data_rx` channel (Issues #12, #31-33, #35, #43, #46-48) |
 | `src/tui/activity_log.rs` | Scrollable log widget |
 | `src/tui/cost_dashboard.rs` | Per-session and aggregate cost display (Phase 3) |
 | `src/tui/dep_graph.rs` | ASCII dependency graph visualization (Phase 3) |
@@ -228,7 +228,7 @@ maestro/
 | `src/tui/panels.rs` | Split-pane multi-session view |
 | `src/tui/screens/` | Interactive TUI screen components (Issues #31-33) |
 | `src/tui/screens/mod.rs` | `ScreenAction` enum, `SessionConfig`; re-exports all screen types |
-| `src/tui/screens/home.rs` | `HomeScreen`: idle dashboard with logo, quick-actions, recent activity, doctor warnings banner, and `@username` display; `ProjectInfo` gains `username: Option<String>` (Issues #31, #49, #34) |
+| `src/tui/screens/home.rs` | `HomeScreen`: idle dashboard with 3-column layout (Quick Actions 30% / Suggestions 35% / Recent Activity 35%); `SuggestionKind` enum (`ReadyIssues`, `MilestoneProgress`, `IdleSessions`, `FailedIssues`); `Suggestion` struct with `build_suggestions()` factory; `HomeSection` enum for Tab-based focus toggle; `draw_suggestions()` renderer; `@username` display in project info bar (Issues #31, #34, #35, #49) |
 | `src/tui/screens/issue_browser.rs` | `IssueBrowserScreen`: navigable issue list with multi-select, label/milestone filters; `set_issues()` (Issues #32, #46) |
 | `src/tui/screens/milestone.rs` | `MilestoneScreen`: milestone list with progress gauge and run-all action (Issue #33) |
 | `src/work/` | Work queue and dependency scheduling (Phase 2) |

--- a/src/main.rs
+++ b/src/main.rs
@@ -907,6 +907,10 @@ async fn cmd_dashboard() -> anyhow::Result<()> {
     ));
     app.tui_mode = tui::app::TuiMode::Dashboard;
 
+    // Queue suggestion data fetch for the home screen
+    app.pending_commands
+        .push(tui::app::TuiCommand::FetchSuggestionData);
+
     tui::run(app).await
 }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -58,10 +58,18 @@ pub enum TuiMode {
     MilestoneView,
 }
 
+/// Payload for suggestion data fetched from GitHub.
+pub struct SuggestionDataPayload {
+    pub ready_issue_count: usize,
+    pub failed_issue_count: usize,
+    pub milestones: Vec<(String, u32, u32)>,
+}
+
 /// Commands queued by synchronous screen action handlers for async processing.
 pub enum TuiCommand {
     FetchIssues,
     FetchMilestones,
+    FetchSuggestionData,
     LaunchSession(SessionConfig),
     LaunchSessions(Vec<SessionConfig>),
 }
@@ -72,6 +80,8 @@ pub enum TuiDataEvent {
     Milestones(anyhow::Result<Vec<(GhMilestone, Vec<GhIssue>)>>),
     /// Single issue for session launch — ready to create session.
     Issue(anyhow::Result<GhIssue>),
+    /// Suggestion data for the home screen.
+    SuggestionData(SuggestionDataPayload),
 }
 
 struct PendingHook {
@@ -754,6 +764,18 @@ impl App {
                     format!("Failed to fetch issue: {}", e),
                     LogLevel::Error,
                 );
+            }
+            TuiDataEvent::SuggestionData(payload) => {
+                let active = self.pool.active_count();
+                let suggestions = crate::tui::screens::home::Suggestion::build_suggestions(
+                    payload.ready_issue_count,
+                    payload.failed_issue_count,
+                    &payload.milestones,
+                    active,
+                );
+                if let Some(ref mut screen) = self.home_screen {
+                    screen.set_suggestions(suggestions);
+                }
             }
         }
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -244,6 +244,34 @@ async fn event_loop(
                         let _ = tx.send(app::TuiDataEvent::Issues(result));
                     });
                 }
+                app::TuiCommand::FetchSuggestionData => {
+                    let tx = app.data_tx.clone();
+                    tokio::spawn(async move {
+                        let client = GhCliClient::new();
+                        let (ready_result, failed_result, milestones_result) = tokio::join!(
+                            client.list_issues(&["maestro:ready"]),
+                            client.list_issues(&["maestro:failed"]),
+                            client.list_milestones("open"),
+                        );
+                        let ready_count = ready_result.map(|v| v.len()).unwrap_or(0);
+                        let failed_count = failed_result.map(|v| v.len()).unwrap_or(0);
+                        let milestones = milestones_result
+                            .unwrap_or_default()
+                            .into_iter()
+                            .map(|ms| {
+                                let total = ms.open_issues + ms.closed_issues;
+                                (ms.title, ms.closed_issues, total)
+                            })
+                            .collect();
+                        let _ = tx.send(app::TuiDataEvent::SuggestionData(
+                            app::SuggestionDataPayload {
+                                ready_issue_count: ready_count,
+                                failed_issue_count: failed_count,
+                                milestones,
+                            },
+                        ));
+                    });
+                }
                 app::TuiCommand::FetchMilestones => {
                     let tx = app.data_tx.clone();
                     tokio::spawn(async move {

--- a/src/tui/screens/home.rs
+++ b/src/tui/screens/home.rs
@@ -42,11 +42,117 @@ pub struct SessionSummary {
     pub cost_usd: f64,
 }
 
+/// The kind of suggestion determines its icon, color, and action.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SuggestionKind {
+    /// N issues are labeled maestro:ready
+    ReadyIssues { count: usize },
+    /// Milestone progress report
+    MilestoneProgress {
+        title: String,
+        closed: u32,
+        total: u32,
+    },
+    /// No sessions are currently running
+    IdleSessions,
+    /// Issues labeled maestro:failed exist
+    FailedIssues { count: usize },
+}
+
+/// A single actionable suggestion displayed on the home screen.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Suggestion {
+    pub kind: SuggestionKind,
+    pub message: String,
+    pub action: TuiMode,
+}
+
+impl Suggestion {
+    /// Build contextual suggestions from GitHub data and session state.
+    pub fn build_suggestions(
+        ready_issue_count: usize,
+        failed_issue_count: usize,
+        milestones: &[(String, u32, u32)],
+        active_session_count: usize,
+    ) -> Vec<Suggestion> {
+        let mut suggestions = Vec::new();
+
+        if ready_issue_count > 0 {
+            suggestions.push(Suggestion {
+                kind: SuggestionKind::ReadyIssues {
+                    count: ready_issue_count,
+                },
+                message: format!(
+                    "{} issue{} labeled maestro:ready — press [i] to browse",
+                    ready_issue_count,
+                    if ready_issue_count == 1 { "" } else { "s" }
+                ),
+
+                action: TuiMode::IssueBrowser,
+            });
+        }
+
+        for (title, closed, total) in milestones {
+            if *total > 0 {
+                let pct = (*closed as f64 / *total as f64 * 100.0).clamp(0.0, 100.0) as u32;
+                suggestions.push(Suggestion {
+                    kind: SuggestionKind::MilestoneProgress {
+                        title: title.clone(),
+                        closed: *closed,
+                        total: *total,
+                    },
+                    message: format!(
+                        "Milestone {} is {}% complete ({}/{} closed)",
+                        title, pct, closed, total
+                    ),
+
+                    action: TuiMode::MilestoneView,
+                });
+            }
+        }
+
+        if failed_issue_count > 0 {
+            suggestions.push(Suggestion {
+                kind: SuggestionKind::FailedIssues {
+                    count: failed_issue_count,
+                },
+                message: format!(
+                    "{} issue{} labeled maestro:failed — press [i] to review",
+                    failed_issue_count,
+                    if failed_issue_count == 1 { "" } else { "s" }
+                ),
+
+                action: TuiMode::IssueBrowser,
+            });
+        }
+
+        if active_session_count == 0 {
+            suggestions.push(Suggestion {
+                kind: SuggestionKind::IdleSessions,
+                message: "No sessions running — press [r] to start".to_string(),
+
+                action: TuiMode::Overview,
+            });
+        }
+
+        suggestions
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HomeSection {
+    QuickActions,
+    Suggestions,
+}
+
 pub struct HomeScreen {
     pub selected_action: usize,
     pub recent_sessions: Vec<SessionSummary>,
     pub project_info: ProjectInfo,
     pub warnings: Vec<String>,
+    pub suggestions: Vec<Suggestion>,
+    pub selected_suggestion: usize,
+    pub focus_section: HomeSection,
 }
 
 impl HomeScreen {
@@ -63,6 +169,9 @@ impl HomeScreen {
             recent_sessions,
             project_info,
             warnings,
+            suggestions: Vec::new(),
+            selected_suggestion: 0,
+            focus_section: HomeSection::QuickActions,
         }
     }
 
@@ -74,25 +183,50 @@ impl HomeScreen {
         }) = event
         {
             match code {
-                // Direct shortcut keys
                 KeyCode::Char('i') => return ScreenAction::Push(TuiMode::IssueBrowser),
                 KeyCode::Char('m') => return ScreenAction::Push(TuiMode::MilestoneView),
                 KeyCode::Char('s') => return ScreenAction::Push(TuiMode::Overview),
                 KeyCode::Char('c') => return ScreenAction::Push(TuiMode::CostDashboard),
                 KeyCode::Char('q') => return ScreenAction::Quit,
-                // Navigation
-                KeyCode::Char('j') | KeyCode::Down => {
-                    if self.selected_action < Self::NUM_ACTIONS - 1 {
-                        self.selected_action += 1;
+                KeyCode::Tab => {
+                    self.focus_section = match self.focus_section {
+                        HomeSection::QuickActions => HomeSection::Suggestions,
+                        HomeSection::Suggestions => HomeSection::QuickActions,
+                    };
+                }
+                KeyCode::Char('j') | KeyCode::Down => match self.focus_section {
+                    HomeSection::QuickActions => {
+                        if self.selected_action < Self::NUM_ACTIONS - 1 {
+                            self.selected_action += 1;
+                        }
                     }
-                }
-                KeyCode::Char('k') | KeyCode::Up => {
-                    self.selected_action = self.selected_action.saturating_sub(1);
-                }
-                // Enter executes the selected action
-                KeyCode::Enter => {
-                    return self.execute_selected_action();
-                }
+                    HomeSection::Suggestions => {
+                        if !self.suggestions.is_empty()
+                            && self.selected_suggestion < self.suggestions.len() - 1
+                        {
+                            self.selected_suggestion += 1;
+                        }
+                    }
+                },
+                KeyCode::Char('k') | KeyCode::Up => match self.focus_section {
+                    HomeSection::QuickActions => {
+                        self.selected_action = self.selected_action.saturating_sub(1);
+                    }
+                    HomeSection::Suggestions => {
+                        self.selected_suggestion = self.selected_suggestion.saturating_sub(1);
+                    }
+                },
+                KeyCode::Enter => match self.focus_section {
+                    HomeSection::QuickActions => {
+                        return self.execute_selected_action();
+                    }
+                    HomeSection::Suggestions => {
+                        if let Some(suggestion) = self.suggestions.get(self.selected_suggestion) {
+                            return ScreenAction::Push(suggestion.action);
+                        }
+                        return ScreenAction::None;
+                    }
+                },
                 KeyCode::Esc => return ScreenAction::None,
                 _ => {}
             }
@@ -126,11 +260,21 @@ impl HomeScreen {
 
         let bottom = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+            .constraints([
+                Constraint::Percentage(30),
+                Constraint::Percentage(35),
+                Constraint::Percentage(35),
+            ])
             .split(chunks[3]);
 
         self.draw_quick_actions(f, bottom[0]);
-        self.draw_recent_sessions(f, bottom[1]);
+        self.draw_suggestions(f, bottom[1]);
+        self.draw_recent_sessions(f, bottom[2]);
+    }
+
+    pub fn set_suggestions(&mut self, suggestions: Vec<Suggestion>) {
+        self.suggestions = suggestions;
+        self.selected_suggestion = 0;
     }
 
     pub fn tick(&mut self) {
@@ -204,10 +348,16 @@ impl HomeScreen {
     }
 
     fn draw_quick_actions(&self, f: &mut Frame, area: Rect) {
+        let is_focused = self.focus_section == HomeSection::QuickActions;
+        let border_color = if is_focused {
+            Color::Green
+        } else {
+            Color::DarkGray
+        };
         let block = Block::default()
             .title(" Quick Actions ")
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(Color::DarkGray));
+            .border_style(Style::default().fg(border_color));
 
         let selected_style = Style::default()
             .fg(Color::Black)
@@ -216,7 +366,7 @@ impl HomeScreen {
 
         let mut lines = Vec::new();
         for (idx, (label, key)) in QUICK_ACTIONS.iter().enumerate() {
-            let is_selected = idx == self.selected_action;
+            let is_selected = is_focused && idx == self.selected_action;
             let style = if is_selected {
                 selected_style
             } else {
@@ -230,6 +380,59 @@ impl HomeScreen {
             lines.push(Line::from(vec![
                 Span::styled(format!("  [{}]  ", key), key_style),
                 Span::styled(*label, style),
+            ]));
+        }
+
+        let para = Paragraph::new(lines).block(block);
+        f.render_widget(para, area);
+    }
+
+    fn draw_suggestions(&self, f: &mut Frame, area: Rect) {
+        let is_focused = self.focus_section == HomeSection::Suggestions;
+        let border_color = if is_focused {
+            Color::Green
+        } else {
+            Color::DarkGray
+        };
+        let block = Block::default()
+            .title(" Suggestions ")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(border_color));
+
+        if self.suggestions.is_empty() {
+            let para = Paragraph::new("  No suggestions — everything looks good!")
+                .style(Style::default().fg(Color::DarkGray))
+                .block(block);
+            f.render_widget(para, area);
+            return;
+        }
+
+        let mut lines = Vec::new();
+        for (idx, suggestion) in self.suggestions.iter().enumerate() {
+            let is_selected = is_focused && idx == self.selected_suggestion;
+            let icon = match &suggestion.kind {
+                SuggestionKind::ReadyIssues { .. } => ">>",
+                SuggestionKind::MilestoneProgress { .. } => "~~",
+                SuggestionKind::IdleSessions => "--",
+                SuggestionKind::FailedIssues { .. } => "!!",
+            };
+            let color = match &suggestion.kind {
+                SuggestionKind::ReadyIssues { .. } => Color::Green,
+                SuggestionKind::MilestoneProgress { .. } => Color::Cyan,
+                SuggestionKind::IdleSessions => Color::Yellow,
+                SuggestionKind::FailedIssues { .. } => Color::Red,
+            };
+            let style = if is_selected {
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(color)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::White)
+            };
+            lines.push(Line::from(vec![
+                Span::styled(format!("  {} ", icon), Style::default().fg(color)),
+                Span::styled(&suggestion.message, style),
             ]));
         }
 
@@ -479,5 +682,391 @@ mod tests {
         let info = make_project_info();
         let screen = HomeScreen::new(info, vec![], vec![]);
         assert!(screen.project_info.username.is_none());
+    }
+
+    // --- Tests for Work Suggestions (Issue #35) ---
+
+    fn make_home_with_suggestions(suggestions: Vec<Suggestion>) -> HomeScreen {
+        let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
+        screen.suggestions = suggestions;
+        screen
+    }
+
+    fn focus_suggestions(screen: &mut HomeScreen) {
+        screen.handle_input(&key_event(KeyCode::Tab));
+    }
+
+    // -- Suggestion::build_suggestions (pure logic) --
+
+    #[test]
+    fn build_suggestions_with_ready_issues_emits_ready_issues_suggestion() {
+        let result = Suggestion::build_suggestions(3, 0, &[], 1);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].kind, SuggestionKind::ReadyIssues { count: 3 });
+
+        assert_eq!(result[0].action, TuiMode::IssueBrowser);
+    }
+
+    #[test]
+    fn build_suggestions_with_zero_ready_issues_emits_no_ready_suggestion() {
+        let result = Suggestion::build_suggestions(0, 0, &[], 1);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn build_suggestions_with_failed_issues_emits_failed_issues_suggestion() {
+        let result = Suggestion::build_suggestions(0, 2, &[], 1);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].kind, SuggestionKind::FailedIssues { count: 2 });
+
+        assert_eq!(result[0].action, TuiMode::IssueBrowser);
+    }
+
+    #[test]
+    fn build_suggestions_with_milestone_emits_milestone_progress_suggestion() {
+        let result = Suggestion::build_suggestions(0, 0, &[("v1.0".to_string(), 3, 10)], 1);
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0].kind,
+            SuggestionKind::MilestoneProgress {
+                title: "v1.0".to_string(),
+                closed: 3,
+                total: 10,
+            }
+        );
+
+        assert_eq!(result[0].action, TuiMode::MilestoneView);
+    }
+
+    #[test]
+    fn build_suggestions_milestone_with_zero_total_is_skipped() {
+        let result = Suggestion::build_suggestions(0, 0, &[("empty".to_string(), 0, 0)], 1);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn build_suggestions_multiple_milestones_emits_one_per_nonzero() {
+        let milestones = vec![
+            ("v1".to_string(), 1u32, 5u32),
+            ("v2".to_string(), 0u32, 0u32),
+        ];
+        let result = Suggestion::build_suggestions(0, 0, &milestones, 1);
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0].kind,
+            SuggestionKind::MilestoneProgress {
+                title: "v1".to_string(),
+                closed: 1,
+                total: 5,
+            }
+        );
+    }
+
+    #[test]
+    fn build_suggestions_with_no_active_sessions_emits_idle_sessions_suggestion() {
+        let result = Suggestion::build_suggestions(0, 0, &[], 0);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].kind, SuggestionKind::IdleSessions);
+
+        assert_eq!(result[0].action, TuiMode::Overview);
+    }
+
+    #[test]
+    fn build_suggestions_with_active_sessions_does_not_emit_idle() {
+        let result = Suggestion::build_suggestions(0, 0, &[], 2);
+        assert!(
+            result
+                .iter()
+                .all(|s| s.kind != SuggestionKind::IdleSessions)
+        );
+    }
+
+    #[test]
+    fn build_suggestions_all_zeros_with_active_sessions_returns_empty() {
+        let result = Suggestion::build_suggestions(0, 0, &[], 1);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn build_suggestions_message_contains_count_for_ready_issues() {
+        let result = Suggestion::build_suggestions(5, 0, &[], 1);
+        assert!(result[0].message.contains("5"));
+    }
+
+    #[test]
+    fn build_suggestions_message_contains_percentage_for_milestone() {
+        let result = Suggestion::build_suggestions(0, 0, &[("v2".to_string(), 5, 10)], 1);
+        assert!(result[0].message.contains("50"));
+    }
+
+    #[test]
+    fn build_suggestions_order_is_ready_then_milestone_then_failed_then_idle() {
+        let milestones = vec![("v1".to_string(), 1u32, 2u32)];
+        let result = Suggestion::build_suggestions(1, 1, &milestones, 0);
+        assert_eq!(result.len(), 4);
+        assert!(matches!(result[0].kind, SuggestionKind::ReadyIssues { .. }));
+        assert!(matches!(
+            result[1].kind,
+            SuggestionKind::MilestoneProgress { .. }
+        ));
+        assert!(matches!(
+            result[2].kind,
+            SuggestionKind::FailedIssues { .. }
+        ));
+        assert_eq!(result[3].kind, SuggestionKind::IdleSessions);
+    }
+
+    // -- HomeSection focus and Tab toggle --
+
+    #[test]
+    fn home_initial_focus_section_is_quick_actions() {
+        let screen = HomeScreen::new(make_project_info(), vec![], vec![]);
+        assert_eq!(screen.focus_section, HomeSection::QuickActions);
+    }
+
+    #[test]
+    fn home_tab_toggles_focus_from_quick_actions_to_suggestions() {
+        let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
+        screen.handle_input(&key_event(KeyCode::Tab));
+        assert_eq!(screen.focus_section, HomeSection::Suggestions);
+    }
+
+    #[test]
+    fn home_tab_toggles_focus_back_to_quick_actions() {
+        let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
+        screen.handle_input(&key_event(KeyCode::Tab));
+        screen.handle_input(&key_event(KeyCode::Tab));
+        assert_eq!(screen.focus_section, HomeSection::QuickActions);
+    }
+
+    // -- Suggestion list navigation --
+
+    #[test]
+    fn home_suggestions_initial_selected_index_is_zero() {
+        let screen = HomeScreen::new(make_project_info(), vec![], vec![]);
+        assert_eq!(screen.selected_suggestion, 0);
+    }
+
+    #[test]
+    fn home_j_navigates_suggestions_when_focus_is_suggestions() {
+        let sug = Suggestion::build_suggestions(1, 0, &[("v1".to_string(), 1, 2)], 1);
+        let mut screen = make_home_with_suggestions(sug);
+        focus_suggestions(&mut screen);
+        screen.handle_input(&key_event(KeyCode::Char('j')));
+        assert_eq!(screen.selected_suggestion, 1);
+    }
+
+    #[test]
+    fn home_down_navigates_suggestions_when_focus_is_suggestions() {
+        let sug = Suggestion::build_suggestions(1, 0, &[("v1".to_string(), 1, 2)], 1);
+        let mut screen = make_home_with_suggestions(sug);
+        focus_suggestions(&mut screen);
+        screen.handle_input(&key_event(KeyCode::Down));
+        assert_eq!(screen.selected_suggestion, 1);
+    }
+
+    #[test]
+    fn home_k_navigates_suggestions_up_when_focus_is_suggestions() {
+        let sug = Suggestion::build_suggestions(1, 0, &[("v1".to_string(), 1, 2)], 1);
+        let mut screen = make_home_with_suggestions(sug);
+        focus_suggestions(&mut screen);
+        screen.handle_input(&key_event(KeyCode::Char('j')));
+        assert_eq!(screen.selected_suggestion, 1);
+        screen.handle_input(&key_event(KeyCode::Char('k')));
+        assert_eq!(screen.selected_suggestion, 0);
+    }
+
+    #[test]
+    fn home_suggestion_navigation_does_not_underflow() {
+        let sug = Suggestion::build_suggestions(1, 0, &[], 1);
+        let mut screen = make_home_with_suggestions(sug);
+        focus_suggestions(&mut screen);
+        screen.handle_input(&key_event(KeyCode::Char('k')));
+        screen.handle_input(&key_event(KeyCode::Char('k')));
+        assert_eq!(screen.selected_suggestion, 0);
+    }
+
+    #[test]
+    fn home_suggestion_navigation_does_not_overflow() {
+        let sug = Suggestion::build_suggestions(1, 0, &[("v1".to_string(), 1, 2)], 1);
+        let mut screen = make_home_with_suggestions(sug);
+        focus_suggestions(&mut screen);
+        for _ in 0..10 {
+            screen.handle_input(&key_event(KeyCode::Char('j')));
+        }
+        assert_eq!(screen.selected_suggestion, 1);
+    }
+
+    #[test]
+    fn home_j_navigates_quick_actions_when_focus_is_quick_actions() {
+        let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
+        screen.handle_input(&key_event(KeyCode::Char('j')));
+        assert_eq!(screen.selected_action, 1);
+        assert_eq!(screen.selected_suggestion, 0);
+    }
+
+    // -- Enter on a suggestion --
+
+    #[test]
+    fn home_enter_on_suggestion_returns_push_with_suggestion_action() {
+        let sug = Suggestion::build_suggestions(3, 0, &[], 1);
+        let mut screen = make_home_with_suggestions(sug);
+        focus_suggestions(&mut screen);
+        let action = screen.handle_input(&key_event(KeyCode::Enter));
+        assert_eq!(action, ScreenAction::Push(TuiMode::IssueBrowser));
+    }
+
+    #[test]
+    fn home_enter_on_milestone_suggestion_returns_push_milestone_view() {
+        let sug = Suggestion::build_suggestions(0, 0, &[("v1".to_string(), 1, 5)], 1);
+        let mut screen = make_home_with_suggestions(sug);
+        focus_suggestions(&mut screen);
+        let action = screen.handle_input(&key_event(KeyCode::Enter));
+        assert_eq!(action, ScreenAction::Push(TuiMode::MilestoneView));
+    }
+
+    #[test]
+    fn home_enter_on_idle_suggestion_returns_push_overview() {
+        let sug = Suggestion::build_suggestions(0, 0, &[], 0);
+        let mut screen = make_home_with_suggestions(sug);
+        focus_suggestions(&mut screen);
+        let action = screen.handle_input(&key_event(KeyCode::Enter));
+        assert_eq!(action, ScreenAction::Push(TuiMode::Overview));
+    }
+
+    #[test]
+    fn home_enter_when_suggestions_empty_and_focused_returns_none() {
+        let mut screen = make_home_with_suggestions(vec![]);
+        focus_suggestions(&mut screen);
+        let action = screen.handle_input(&key_event(KeyCode::Enter));
+        assert_eq!(action, ScreenAction::None);
+    }
+
+    // -- Shortcut keys always active regardless of focus --
+
+    #[test]
+    fn home_char_i_returns_issue_browser_when_focused_on_suggestions() {
+        let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
+        focus_suggestions(&mut screen);
+        let action = screen.handle_input(&key_event(KeyCode::Char('i')));
+        assert_eq!(action, ScreenAction::Push(TuiMode::IssueBrowser));
+    }
+
+    #[test]
+    fn home_char_m_returns_milestone_view_when_focused_on_suggestions() {
+        let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
+        focus_suggestions(&mut screen);
+        let action = screen.handle_input(&key_event(KeyCode::Char('m')));
+        assert_eq!(action, ScreenAction::Push(TuiMode::MilestoneView));
+    }
+
+    #[test]
+    fn home_char_q_returns_quit_when_focused_on_suggestions() {
+        let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
+        focus_suggestions(&mut screen);
+        let action = screen.handle_input(&key_event(KeyCode::Char('q')));
+        assert_eq!(action, ScreenAction::Quit);
+    }
+
+    // -- Edge cases --
+
+    #[test]
+    fn build_suggestions_singular_message_for_one_ready_issue() {
+        let result = Suggestion::build_suggestions(1, 0, &[], 1);
+        assert!(result[0].message.contains("1 issue labeled"));
+        assert!(!result[0].message.contains("issues"));
+    }
+
+    #[test]
+    fn build_suggestions_plural_message_for_multiple_ready_issues() {
+        let result = Suggestion::build_suggestions(3, 0, &[], 1);
+        assert!(result[0].message.contains("3 issues"));
+    }
+
+    #[test]
+    fn build_suggestions_singular_message_for_one_failed_issue() {
+        let result = Suggestion::build_suggestions(0, 1, &[], 1);
+        assert!(result[0].message.contains("1 issue labeled"));
+        assert!(!result[0].message.contains("issues"));
+    }
+
+    #[test]
+    fn build_suggestions_milestone_closed_exceeds_total_clamps_to_100() {
+        let result = Suggestion::build_suggestions(0, 0, &[("v1".to_string(), 15, 10)], 1);
+        assert!(result[0].message.contains("100%"));
+    }
+
+    #[test]
+    fn build_suggestions_milestone_fully_complete_shows_100() {
+        let result = Suggestion::build_suggestions(0, 0, &[("v1".to_string(), 10, 10)], 1);
+        assert!(result[0].message.contains("100%"));
+    }
+
+    #[test]
+    fn build_suggestions_milestone_zero_closed_shows_0() {
+        let result = Suggestion::build_suggestions(0, 0, &[("v1".to_string(), 0, 5)], 1);
+        assert!(result[0].message.contains("0%"));
+    }
+
+    #[test]
+    fn build_suggestions_multiple_nonzero_milestones_all_emitted() {
+        let milestones = vec![
+            ("v1".to_string(), 1u32, 5u32),
+            ("v2".to_string(), 3u32, 10u32),
+            ("v3".to_string(), 7u32, 7u32),
+        ];
+        let result = Suggestion::build_suggestions(0, 0, &milestones, 1);
+        assert_eq!(result.len(), 3);
+        for (i, (title, _, _)) in milestones.iter().enumerate() {
+            assert!(result[i].message.contains(title.as_str()));
+        }
+    }
+
+    #[test]
+    fn home_j_on_empty_suggestions_when_focused_does_not_panic() {
+        let mut screen = make_home_with_suggestions(vec![]);
+        focus_suggestions(&mut screen);
+        screen.handle_input(&key_event(KeyCode::Char('j')));
+        assert_eq!(screen.selected_suggestion, 0);
+    }
+
+    #[test]
+    fn home_k_on_empty_suggestions_when_focused_does_not_panic() {
+        let mut screen = make_home_with_suggestions(vec![]);
+        focus_suggestions(&mut screen);
+        screen.handle_input(&key_event(KeyCode::Char('k')));
+        assert_eq!(screen.selected_suggestion, 0);
+    }
+
+    #[test]
+    fn set_suggestions_resets_selected_index() {
+        let sug = Suggestion::build_suggestions(1, 1, &[("v1".to_string(), 1, 2)], 0);
+        let mut screen = make_home_with_suggestions(sug);
+        focus_suggestions(&mut screen);
+        // Navigate to index 2
+        screen.handle_input(&key_event(KeyCode::Char('j')));
+        screen.handle_input(&key_event(KeyCode::Char('j')));
+        assert_eq!(screen.selected_suggestion, 2);
+        // Replace with fewer suggestions
+        let new_sug = Suggestion::build_suggestions(1, 0, &[], 1);
+        screen.set_suggestions(new_sug);
+        assert_eq!(screen.selected_suggestion, 0);
+    }
+
+    #[test]
+    fn home_k_in_suggestions_does_not_move_quick_actions_selection() {
+        let sug = Suggestion::build_suggestions(1, 0, &[("v1".to_string(), 1, 2)], 1);
+        let mut screen = make_home_with_suggestions(sug);
+        // Move quick actions selection to 2
+        screen.handle_input(&key_event(KeyCode::Char('j')));
+        screen.handle_input(&key_event(KeyCode::Char('j')));
+        assert_eq!(screen.selected_action, 2);
+        // Switch to suggestions and navigate
+        focus_suggestions(&mut screen);
+        screen.handle_input(&key_event(KeyCode::Char('j')));
+        screen.handle_input(&key_event(KeyCode::Char('k')));
+        // Quick actions selection must be unchanged
+        assert_eq!(screen.selected_action, 2);
+        assert_eq!(screen.selected_suggestion, 0);
     }
 }


### PR DESCRIPTION
## Summary
- Add a **Suggestions** panel to the TUI dashboard showing context-aware next steps derived from live GitHub data (ready issues, milestone progress, failed issues, idle sessions)
- Fetch suggestion data concurrently via `tokio::join!` on dashboard startup (`FetchSuggestionData` command)
- Tab-based focus navigation between Quick Actions and Suggestions panels; j/k navigates, Enter activates

Closes #35

## Test plan
- [ ] 61 unit tests covering `build_suggestions` pure logic, navigation, focus toggle, Enter activation, and edge cases (empty list, overflow, underflow, stale index, singular/plural, percentage clamp)
- [ ] `cargo test` — 617 tests pass
- [ ] `cargo clippy` — no errors
- [ ] `cargo fmt -- --check` — clean