### PR TITLE
feat: auto-run completion gates (fmt/clippy/test) after session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Auto-fmt, Clippy, and Test Completion Gates (#40)
+
+- `src/config.rs` — `CompletionGatesConfig` struct added to `SessionsConfig` with `enabled: bool` (default `true`) and `commands: Vec<CompletionGateEntry>`; `CompletionGateEntry` struct with `name`, `run`, and `required` (default `true`) fields; both are TOML-deserializable and serializable; `completion_gates` field replaces ad-hoc gate setup
+- `src/gates/types.rs` — `Command` variant added to `CompletionGate` enum with `name: String`, `command: String`, and `required: bool` fields; `is_required()` method returns `true` for all legacy variants and the `required` field for `Command`; `display_name()` method returns the gate's log-friendly name; `from_config_entry(entry: &CompletionGateEntry) -> Self` constructor maps config entries to the new variant
+- `src/gates/runner.rs` — `Command` match arm added to `run_single_gate()`: splits the command string, executes it in the worktree directory, and produces a named `GateResult`; empty command guard returns a failing result; `all_required_gates_passed(results: &[(GateResult, bool)]) -> bool` added to evaluate gate results paired with their required flag — optional gate failures are advisory only
+- `src/session/types.rs` — `GatesRunning` variant added to `SessionStatus`: used while config-driven gates are executing after a session completes; `NeedsReview` variant added to `SessionStatus`: terminal state assigned when one or more required gates fail; both variants have `symbol()`, `label()`, and `is_terminal()` implementations (`NeedsReview` is terminal, `GatesRunning` is not)
+- `src/session/pool.rs` — `find_by_issue_mut(issue_number: u64) -> Option<&mut ManagedSession>` added: searches active sessions first, then finished sessions, by issue number; used by `check_completions()` to update session status during gate execution
+- `src/tui/app.rs` — `check_completions()` updated: when a session succeeds, it now loads `[sessions.completion_gates]` commands (falling back to the legacy `[gates].test_command` if the new section is absent or empty); transitions session to `GatesRunning`, runs each gate via `GateRunner`, logs per-gate `[gate_name]: message` entries to the activity log with `Info`/`Error` level, then transitions to `NeedsReview` and fires the `TestsFailed` plugin hook if any required gate fails; fires `TestsPassed` and logs "All required gates passed" on success
+- `src/tui/panels.rs` — `GatesRunning` mapped to `Color::Cyan`; `NeedsReview` mapped to `Color::LightYellow` in the `status_color()` function
+- `maestro.toml` — `[sessions.completion_gates]` section added with `enabled = true` and three default `[[sessions.completion_gates.commands]]` entries: `fmt` (`cargo fmt --check`, required), `clippy` (`cargo clippy -- -D warnings`, required), `test` (`cargo test`, required)
+
 ### Work Suggestions and Quick Commands (#35)
 
 - `src/tui/screens/home.rs` — `SuggestionKind` enum added with four variants: `ReadyIssues { count }`, `MilestoneProgress { title, closed, total }`, `IdleSessions`, and `FailedIssues { count }`

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Maestro spawns and monitors multiple [Claude Code](https://claude.ai/claude-code
 
 - **Single-session TUI** — spawn a Claude Code session and watch it work in real-time
 - **Live stream parsing** — parses Claude CLI `stream-json` output for tool usage, messages, and costs
-- **Session lifecycle** — QUEUED → SPAWNING → RUNNING → COMPLETED/ERRORED/PAUSED/KILLED
+- **Session lifecycle** — QUEUED → SPAWNING → RUNNING → GATES_RUNNING → COMPLETED/NEEDS_REVIEW/ERRORED/PAUSED/KILLED
 - **Keyboard controls** — pause (SIGSTOP), resume, kill sessions from the dashboard
 - **State persistence** — session history and costs saved to `maestro-state.json`
 - **Cost tracking** — per-session and total spending displayed in real-time
@@ -46,6 +46,7 @@ Maestro spawns and monitors multiple [Claude Code](https://claude.ai/claude-code
 - **Fork depth limiting** — configurable maximum fork chain depth prevents runaway continuation loops
 - **Multi-provider support** — works with GitHub (via `gh` CLI) or Azure DevOps (via `az` CLI); provider is auto-detected from the git remote or set explicitly in config
 - **Session prompt guardrails** — a language-specific pre-completion checklist (format, lint, test) is automatically detected from the project root and appended to every session's system prompt; can be overridden with a custom prompt via `guardrail_prompt` in `maestro.toml`
+- **Config-driven completion gates** — after a session finishes, maestro runs a configurable list of shell commands (fmt, clippy, test, or any custom command) before accepting the result; required gate failures transition the session to `NEEDS_REVIEW` and block PR creation; optional gates log warnings only; configured via `[sessions.completion_gates]` in `maestro.toml`
 - **Interactive home screen** — launching `maestro` opens an idle dashboard with a quick-actions menu, repo/branch info, and a recent activity panel; navigate with `j`/`k` or direct shortcut keys
 - **Interactive issue browser** — browse, filter, and launch GitHub issues directly from the TUI; supports single-launch (`Enter`) and multi-select batch-launch (`Space` + `Enter`); filter by text (`/`) or milestone (`m`)
 - **Milestone overview** — inspect milestone progress with real-time completion gauges; drill into issues or run all open issues in a milestone with a single key (`r`)
@@ -170,6 +171,25 @@ overflow_threshold_pct = 70  # Auto-fork when context reaches this % (default: 7
 auto_fork = true             # Spawn a continuation session on overflow
 commit_prompt_pct = 50       # Prompt an intermediate commit at this % (default: 50)
 max_fork_depth = 5           # Max chained forks before overflow is ignored
+
+# Completion gates — run after every session before PR creation
+[sessions.completion_gates]
+enabled = true               # Set to false to skip all gates
+
+[[sessions.completion_gates.commands]]
+name = "fmt"
+run = "cargo fmt --check"
+required = true              # true = failure blocks PR; false = warning only
+
+[[sessions.completion_gates.commands]]
+name = "clippy"
+run = "cargo clippy -- -D warnings"
+required = true
+
+[[sessions.completion_gates.commands]]
+name = "test"
+run = "cargo test"
+required = true
 
 # Optional: explicit provider configuration (auto-detected from git remote by default)
 [provider]

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-03 21:00 (UTC)
+> Last updated: 2026-04-03 22:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -62,17 +62,17 @@ maestro/
 │       └── release.yml                    # Release workflow: cross-platform builds, GitHub Release, Homebrew tap trigger
 ├── src/
 │   ├── main.rs                            # CLI entry point (clap); Run, Queue, Add, Status, Cost, Init, Doctor; setup_app_from_config() shared helper wires budget, model router, notifications, plugins, and permission_mode/allowed_tools from config; cmd_dashboard() performs orphan worktree cleanup, log cleanup, fetches username from doctor report, delegates App construction to setup_app_from_config(), and queues FetchSuggestionData on startup; cmd_run() refactored to use same helper  [Issue #29, #49, #34, #36, #35]
-│   ├── config.rs                          # maestro.toml parsing; ModelsConfig, GatesConfig, ReviewConfig; ContextOverflowConfig; ProviderConfig (kind, organization, az_project); guardrail_prompt in SessionsConfig  [Issue #29, #43]
+│   ├── config.rs                          # maestro.toml parsing; ModelsConfig, GatesConfig, ReviewConfig; ContextOverflowConfig; ProviderConfig (kind, organization, az_project); guardrail_prompt in SessionsConfig; CompletionGatesConfig and CompletionGateEntry  [Issue #29, #40, #43]
 │   ├── budget.rs                          # BudgetEnforcer: per-session and global budget checks  [Phase 3]
 │   ├── doctor.rs                          # Preflight checks: CheckSeverity, CheckResult, DoctorReport, run_all_checks(), print_report(); build_gh_auth_result() (pure, testable); check_az_identity(); 10 check functions  [Issue #49, #34]
 │   ├── git.rs                             # GitOps trait, CliGitOps: commit and push operations  [Phase 3]
 │   ├── models.rs                          # ModelRouter: label-based model routing  [Phase 3]
 │   ├── prompts.rs                         # PromptBuilder: structured issue prompts with task-type detection; ProjectLanguage enum; detect_project_language(); default_guardrail(); resolve_guardrail()  [Phase 3, Issue #43]
 │   ├── util.rs                            # Shared utilities (truncate, etc.)
-│   ├── gates/                             # Completion gates framework  [Phase 3]
+│   ├── gates/                             # Completion gates framework  [Phase 3, Issue #40]
 │   │   ├── mod.rs                         # Module exports
-│   │   ├── types.rs                       # Gate types: TestsPass, FileExists, FileContains, PrCreated
-│   │   └── runner.rs                      # Gate evaluation runner
+│   │   ├── types.rs                       # Gate types: TestsPass, FileExists, FileContains, PrCreated, Command; is_required(), display_name(), from_config_entry()
+│   │   └── runner.rs                      # Gate evaluation runner; all_required_gates_passed(); Command match arm
 │   ├── provider/                          # Multi-provider abstraction layer  [Issue #29]
 │   │   ├── mod.rs                         # create_provider factory, detect_provider_from_remote
 │   │   ├── types.rs                       # ProviderKind enum (Github, AzureDevops); re-exports Issue/Priority/MaestroLabel/SessionMode/Milestone  [Issue #31-33]
@@ -101,8 +101,8 @@ maestro/
 │   │   ├── mod.rs                         # Module exports (includes pool, worktree, health, retry, context_monitor, fork)
 │   │   ├── manager.rs                     # Claude CLI process management; handles ContextUpdate events  [Phase 3]
 │   │   ├── parser.rs                      # stream-json output parser; parses system events for context usage  [Phase 3]
-│   │   ├── pool.rs                        # Session pool: max_concurrent, queue, auto-promote; branch tracking; guardrail_prompt field; set_guardrail_prompt(); merged into system prompt in try_promote()  [Phase 3, Issue #43]
-│   │   ├── types.rs                       # Session state machine; fork fields (parent_session_id, child_session_ids, fork_depth); ContextUpdate StreamEvent  [Phase 3]
+│   │   ├── pool.rs                        # Session pool: max_concurrent, queue, auto-promote; branch tracking; guardrail_prompt field; set_guardrail_prompt(); merged into system prompt in try_promote(); find_by_issue_mut()  [Phase 3, Issue #40, #43]
+│   │   ├── types.rs                       # Session state machine; fork fields (parent_session_id, child_session_ids, fork_depth); ContextUpdate StreamEvent; GatesRunning and NeedsReview status variants  [Phase 3, Issue #40]
 │   │   ├── worktree.rs                    # Git worktree isolation: WorktreeManager trait, GitWorktreeManager, MockWorktreeManager  [Phase 1]
 │   │   ├── health.rs                      # HealthMonitor: stall detection, HealthCheck trait  [Phase 3]
 │   │   ├── retry.rs                       # RetryPolicy: configurable max retries and cooldown  [Phase 3]
@@ -118,14 +118,14 @@ maestro/
 │   │   └── types.rs                       # State types; fork_lineage HashMap; record_fork, fork_chain, fork_depth methods  [Issue #12]
 │   ├── tui/
 │   │   ├── mod.rs                         # Event loop; keybindings; handle_screen_action() rewritten; command processing loop; launch_session_from_config(); FetchSuggestionData async handler spawns background GitHub fetch for ready/failed counts and milestone progress  [Phase 3, Issue #31-33, #46-48, #35]
-│   │   ├── app.rs                         # App state; TuiMode; TuiCommand enum (FetchIssues, FetchMilestones, FetchSuggestionData, LaunchSession, LaunchSessions); TuiDataEvent enum (Issues, Milestones, Issue, SuggestionData); SuggestionDataPayload; handle_data_event(); data_tx/data_rx channel; pending_commands  [Issue #12, #31-33, #43, #46-48, #35]
+│   │   ├── app.rs                         # App state; TuiMode; TuiCommand enum (FetchIssues, FetchMilestones, FetchSuggestionData, LaunchSession, LaunchSessions); TuiDataEvent enum (Issues, Milestones, Issue, SuggestionData); SuggestionDataPayload; handle_data_event(); data_tx/data_rx channel; pending_commands; check_completions() uses config-driven gates with per-gate activity logging  [Issue #12, #31-33, #40, #43, #46-48, #35]
 │   │   ├── activity_log.rs                # Scrollable activity log widget with LogLevel color coding  [Phase 1]
 │   │   ├── cost_dashboard.rs              # Cost dashboard widget: per-session and aggregate cost display  [Phase 3]
 │   │   ├── dep_graph.rs                   # ASCII dependency graph visualization  [Phase 3]
 │   │   ├── detail.rs                      # Session detail view  [Phase 3]
 │   │   ├── fullscreen.rs                  # Fullscreen session view with phase progress overlay  [Phase 3]
 │   │   ├── help.rs                        # Help overlay widget with keybinding reference  [Phase 3]
-│   │   ├── panels.rs                      # Split-pane panel view; fork depth indicator in title; overflow warning in context gauge  [Issue #12]
+│   │   ├── panels.rs                      # Split-pane panel view; fork depth indicator in title; overflow warning in context gauge; GatesRunning (Cyan) and NeedsReview (LightYellow) status colors  [Issue #12, #40]
 │   │   ├── ui.rs                          # ratatui rendering; budget display, TUI mode switching, notification banners, screen rendering branches  [Phase 3, Issue #31-33]
 │   │   └── screens/                       # Interactive screen components  [Issue #31-33]
 │   │       ├── mod.rs                     # Screen types: ScreenAction enum, SessionConfig; re-exports HomeScreen, IssueBrowserScreen, MilestoneScreen
@@ -161,7 +161,7 @@ maestro/
 ├── ROADMAP.md                             # Project milestones and implementation order
 ├── directory-tree.md                      # This file — SINGLE SOURCE OF TRUTH for structure
 ├── maestro-state.json                     # Runtime state persistence file
-└── maestro.toml                           # Runtime configuration; [sessions.context_overflow] section; guardrail_prompt option (commented)  [Issue #12, #43]
+└── maestro.toml                           # Runtime configuration; [sessions.context_overflow] section; guardrail_prompt option (commented); [sessions.completion_gates] with fmt, clippy, test defaults  [Issue #12, #40, #43]
 ```
 
 ## Quick Reference
@@ -186,7 +186,7 @@ maestro/
 | `src/git.rs` | GitOps trait and CLI-backed commit+push (Phase 3) |
 | `src/models.rs` | Label-based model routing (Phase 3) |
 | `src/prompts.rs` | Structured issue prompt builder with task-type detection; ProjectLanguage detection; guardrail resolution (Phase 3, Issue #43) |
-| `src/gates/` | Completion gates: TestsPass, FileExists, FileContains, PrCreated (Phase 3) |
+| `src/gates/` | Completion gates: TestsPass, FileExists, FileContains, PrCreated, Command (Phase 3, Issue #40) |
 | `src/provider/` | Multi-provider abstraction layer (Issue #29) |
 | `src/provider/mod.rs` | create_provider factory; detect_provider_from_remote |
 | `src/provider/types.rs` | ProviderKind enum; re-exports Issue/Priority/MaestroLabel/SessionMode/Milestone |
@@ -207,7 +207,7 @@ maestro/
 | `src/session/` | Claude CLI process and session lifecycle management |
 | `src/session/health.rs` | Stall detection and HealthCheck trait (Phase 3) |
 | `src/session/retry.rs` | Configurable retry policy (Phase 3) |
-| `src/session/pool.rs` | Concurrent session pool with queue and auto-promote; guardrail_prompt merged into system prompt (Issue #43) |
+| `src/session/pool.rs` | Concurrent session pool with queue and auto-promote; guardrail_prompt merged into system prompt; `find_by_issue_mut()` (Issue #40, #43) |
 | `src/session/worktree.rs` | Git worktree isolation per session |
 | `src/session/cleanup.rs` | Orphaned worktree detection and removal (Phase 3) |
 | `src/session/logger.rs` | Per-session file logging to .maestro/logs/ (Phase 3) |
@@ -218,14 +218,14 @@ maestro/
 | `src/state/progress.rs` | Session phase tracking (Phase 3) |
 | `src/tui/` | Terminal UI (ratatui) |
 | `src/tui/mod.rs` | Event loop; `handle_screen_action()`; command processing; `launch_session_from_config()`; `FetchSuggestionData` async handler for GitHub ready/failed counts and milestone progress (Issues #31-33, #35, #46-48) |
-| `src/tui/app.rs` | `App` struct; `TuiMode`; `TuiCommand` (adds `FetchSuggestionData`); `TuiDataEvent` (adds `SuggestionData`); `SuggestionDataPayload`; `handle_data_event()`; `data_tx`/`data_rx` channel (Issues #12, #31-33, #35, #43, #46-48) |
+| `src/tui/app.rs` | `App` struct; `TuiMode`; `TuiCommand` (adds `FetchSuggestionData`); `TuiDataEvent` (adds `SuggestionData`); `SuggestionDataPayload`; `handle_data_event()`; `data_tx`/`data_rx` channel; `check_completions()` config-driven gates with per-gate logging (Issues #12, #31-33, #35, #40, #43, #46-48) |
 | `src/tui/activity_log.rs` | Scrollable log widget |
 | `src/tui/cost_dashboard.rs` | Per-session and aggregate cost display (Phase 3) |
 | `src/tui/dep_graph.rs` | ASCII dependency graph visualization (Phase 3) |
 | `src/tui/detail.rs` | Session detail view (Phase 3) |
 | `src/tui/fullscreen.rs` | Fullscreen session view with phase progress overlay (Phase 3) |
 | `src/tui/help.rs` | Help overlay widget with keybinding reference (Phase 3) |
-| `src/tui/panels.rs` | Split-pane multi-session view |
+| `src/tui/panels.rs` | Split-pane multi-session view; `GatesRunning` (Cyan) and `NeedsReview` (LightYellow) status colors (Issue #40) |
 | `src/tui/screens/` | Interactive TUI screen components (Issues #31-33) |
 | `src/tui/screens/mod.rs` | `ScreenAction` enum, `SessionConfig`; re-exports all screen types |
 | `src/tui/screens/home.rs` | `HomeScreen`: idle dashboard with 3-column layout (Quick Actions 30% / Suggestions 35% / Recent Activity 35%); `SuggestionKind` enum (`ReadyIssues`, `MilestoneProgress`, `IdleSessions`, `FailedIssues`); `Suggestion` struct with `build_suggestions()` factory; `HomeSection` enum for Tab-based focus toggle; `draw_suggestions()` renderer; `@username` display in project info bar (Issues #31, #34, #35, #49) |

--- a/maestro.toml
+++ b/maestro.toml
@@ -37,6 +37,24 @@ slack = false
 # Model routing rules: label pattern -> model name. First match wins.
 # routing = { "priority:P0" = "opus", "type:docs" = "haiku" }
 
+[sessions.completion_gates]
+enabled = true
+
+[[sessions.completion_gates.commands]]
+name = "fmt"
+run = "cargo fmt --check"
+required = true
+
+[[sessions.completion_gates.commands]]
+name = "clippy"
+run = "cargo clippy -- -D warnings"
+required = true
+
+[[sessions.completion_gates.commands]]
+name = "test"
+run = "cargo test"
+required = true
+
 [gates]
 enabled = true
 test_command = "cargo test"

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,6 +70,39 @@ pub struct SessionsConfig {
     /// If unset, a default is auto-detected based on project language.
     #[serde(default)]
     pub guardrail_prompt: Option<String>,
+    /// Completion gates that run after session finishes, before PR creation.
+    #[serde(default)]
+    pub completion_gates: CompletionGatesConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompletionGatesConfig {
+    /// Whether completion gates are enabled. Default: true.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Ordered list of gate commands to run.
+    #[serde(default)]
+    pub commands: Vec<CompletionGateEntry>,
+}
+
+impl Default for CompletionGatesConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            commands: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompletionGateEntry {
+    /// Display name for activity log (e.g., "fmt", "clippy").
+    pub name: String,
+    /// Shell command to execute. Exit code 0 = pass.
+    pub run: String,
+    /// If true, failure blocks PR creation. Default: true.
+    #[serde(default = "default_true")]
+    pub required: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -569,5 +602,53 @@ alert_threshold_pct = 80
         .unwrap();
         let cfg = Config::load(f.path()).expect("load failed");
         assert_eq!(cfg.sessions.context_overflow.overflow_threshold_pct, 70);
+    }
+
+    #[test]
+    fn completion_gates_config_defaults_when_section_absent() {
+        let cfg: CompletionGatesConfig = toml::from_str("").expect("parse failed");
+        assert!(cfg.enabled);
+        assert!(cfg.commands.is_empty());
+    }
+
+    #[test]
+    fn completion_gates_config_deserializes_full_entry() {
+        let toml_str = r#"
+enabled = true
+[[commands]]
+name = "fmt"
+run = "cargo fmt --check"
+required = false
+"#;
+        let cfg: CompletionGatesConfig = toml::from_str(toml_str).expect("parse failed");
+        assert_eq!(cfg.commands.len(), 1);
+        assert_eq!(cfg.commands[0].name, "fmt");
+        assert_eq!(cfg.commands[0].run, "cargo fmt --check");
+        assert!(!cfg.commands[0].required);
+    }
+
+    #[test]
+    fn completion_gate_entry_required_defaults_to_true() {
+        let toml_str = r#"
+name = "fmt"
+run = "cargo fmt --check"
+"#;
+        let entry: CompletionGateEntry = toml::from_str(toml_str).expect("parse failed");
+        assert!(entry.required);
+    }
+
+    #[test]
+    fn completion_gates_config_multiple_entries_parse_in_order() {
+        let toml_str = r#"
+[[commands]]
+name = "fmt"
+run = "cargo fmt --check"
+[[commands]]
+name = "clippy"
+run = "cargo clippy -- -D warnings"
+"#;
+        let cfg: CompletionGatesConfig = toml::from_str(toml_str).expect("parse failed");
+        assert_eq!(cfg.commands[0].name, "fmt");
+        assert_eq!(cfg.commands[1].name, "clippy");
     }
 }

--- a/src/gates/runner.rs
+++ b/src/gates/runner.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::process::Command;
 
 use super::types::{CompletionGate, GateResult};
+use crate::util::truncate_at_char_boundary;
 
 /// Trait for running completion gates, enabling mock injection in tests.
 pub trait GateCheck: Send {
@@ -39,12 +40,12 @@ fn run_single_gate(gate: &CompletionGate, worktree_path: &Path) -> GateResult {
                         GateResult::pass("tests_pass", "All tests passed")
                     } else {
                         let stderr = String::from_utf8_lossy(&output.stderr);
-                        let preview = if stderr.len() > 200 {
-                            format!("{}...", &stderr[..200])
-                        } else {
-                            stderr.to_string()
-                        };
-                        GateResult::fail("tests_pass", format!("Tests failed: {}", preview))
+                        let end = truncate_at_char_boundary(&stderr, 200);
+                        let suffix = if end < stderr.len() { "..." } else { "" };
+                        GateResult::fail(
+                            "tests_pass",
+                            format!("Tests failed: {}{}", &stderr[..end], suffix),
+                        )
                     }
                 }
                 Err(e) => GateResult::fail("tests_pass", format!("Failed to run tests: {}", e)),
@@ -85,12 +86,46 @@ fn run_single_gate(gate: &CompletionGate, worktree_path: &Path) -> GateResult {
             // If we reach here, it means PR hasn't been verified yet.
             GateResult::pass("pr_created", "PR gate deferred to pipeline")
         }
+
+        CompletionGate::Command { name, command, .. } => {
+            if command.trim().is_empty() {
+                return GateResult::fail(name, "Empty command");
+            }
+
+            let result = Command::new("sh")
+                .args(["-c", command])
+                .current_dir(worktree_path)
+                .output();
+
+            match result {
+                Ok(output) => {
+                    if output.status.success() {
+                        GateResult::pass(name, format!("{} passed", name))
+                    } else {
+                        let stderr = String::from_utf8_lossy(&output.stderr);
+                        let end = truncate_at_char_boundary(&stderr, 200);
+                        let suffix = if end < stderr.len() { "..." } else { "" };
+                        GateResult::fail(
+                            name,
+                            format!("{} failed: {}{}", name, &stderr[..end], suffix),
+                        )
+                    }
+                }
+                Err(e) => GateResult::fail(name, format!("Failed to run {}: {}", name, e)),
+            }
+        }
     }
 }
 
 /// Check if all gate results passed.
 pub fn all_gates_passed(results: &[GateResult]) -> bool {
     results.iter().all(|r| r.passed)
+}
+
+/// Check if all *required* gate results passed.
+/// Non-required gate failures are advisory only.
+pub fn all_required_gates_passed(results: &[(GateResult, bool)]) -> bool {
+    results.iter().all(|(r, required)| r.passed || !required)
 }
 
 #[cfg(test)]
@@ -263,5 +298,71 @@ mod tests {
         let runner = MockGateRunner::with_failure();
         let results = runner.run_gates(&[], Path::new("/tmp"));
         assert!(!all_gates_passed(&results));
+    }
+
+    #[test]
+    fn command_gate_passes_when_exit_code_is_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let gate = CompletionGate::Command {
+            name: "ok".into(),
+            command: "true".into(),
+            required: true,
+        };
+        let result = run_single_gate(&gate, dir.path());
+        assert!(result.passed);
+        assert_eq!(result.gate, "ok");
+    }
+
+    #[test]
+    fn command_gate_fails_when_exit_code_is_nonzero() {
+        let dir = tempfile::tempdir().unwrap();
+        let gate = CompletionGate::Command {
+            name: "bad".into(),
+            command: "false".into(),
+            required: true,
+        };
+        let result = run_single_gate(&gate, dir.path());
+        assert!(!result.passed);
+    }
+
+    #[test]
+    fn command_gate_fails_gracefully_with_empty_command() {
+        let dir = tempfile::tempdir().unwrap();
+        let gate = CompletionGate::Command {
+            name: "empty".into(),
+            command: "".into(),
+            required: true,
+        };
+        let result = run_single_gate(&gate, dir.path());
+        assert!(!result.passed);
+        assert!(result.message.contains("Empty"));
+    }
+
+    #[test]
+    fn all_required_gates_passed_ignores_optional_failure() {
+        let results = vec![
+            (GateResult::pass("required-ok", "ok"), true),
+            (GateResult::fail("optional-fail", "nope"), false),
+        ];
+        assert!(all_required_gates_passed(&results));
+    }
+
+    #[test]
+    fn all_required_gates_passed_fails_when_required_gate_fails() {
+        let results = vec![
+            (GateResult::pass("optional-ok", "ok"), false),
+            (GateResult::fail("required-fail", "nope"), true),
+        ];
+        assert!(!all_required_gates_passed(&results));
+    }
+
+    #[test]
+    fn all_required_gates_passed_true_when_all_required_pass() {
+        let results = vec![
+            (GateResult::pass("required-a", "ok"), true),
+            (GateResult::pass("required-b", "ok"), true),
+            (GateResult::fail("optional-c", "nope"), false),
+        ];
+        assert!(all_required_gates_passed(&results));
     }
 }

--- a/src/gates/types.rs
+++ b/src/gates/types.rs
@@ -1,3 +1,4 @@
+use crate::config::CompletionGateEntry;
 use serde::{Deserialize, Serialize};
 
 /// A gate that must pass before a session is considered truly complete.
@@ -12,6 +13,39 @@ pub enum CompletionGate {
     FileContains { path: String, pattern: String },
     /// Check that a PR was created (verified externally).
     PrCreated,
+    /// A named command gate from [sessions.completion_gates.commands].
+    Command {
+        name: String,
+        command: String,
+        required: bool,
+    },
+}
+
+impl CompletionGate {
+    pub fn from_config_entry(entry: &CompletionGateEntry) -> Self {
+        Self::Command {
+            name: entry.name.clone(),
+            command: entry.run.clone(),
+            required: entry.required,
+        }
+    }
+
+    pub fn is_required(&self) -> bool {
+        match self {
+            Self::Command { required, .. } => *required,
+            _ => true,
+        }
+    }
+
+    pub fn display_name(&self) -> &str {
+        match self {
+            Self::TestsPass { .. } => "tests",
+            Self::FileExists { .. } => "file_exists",
+            Self::FileContains { .. } => "file_contains",
+            Self::PrCreated => "pr_created",
+            Self::Command { name, .. } => name.as_str(),
+        }
+    }
 }
 
 /// Result of running a single gate.
@@ -94,5 +128,69 @@ mod tests {
             CompletionGate::TestsPass { command } => assert_eq!(command, "cargo test"),
             _ => panic!("expected TestsPass"),
         }
+    }
+
+    #[test]
+    fn command_gate_is_required_returns_true_when_required() {
+        let gate = CompletionGate::Command {
+            name: "fmt".into(),
+            command: "cargo fmt --check".into(),
+            required: true,
+        };
+        assert!(gate.is_required());
+    }
+
+    #[test]
+    fn command_gate_is_required_returns_false_when_optional() {
+        let gate = CompletionGate::Command {
+            name: "clippy".into(),
+            command: "cargo clippy".into(),
+            required: false,
+        };
+        assert!(!gate.is_required());
+    }
+
+    #[test]
+    fn command_gate_display_name_returns_name_field() {
+        let gate = CompletionGate::Command {
+            name: "lint".into(),
+            command: "cargo clippy".into(),
+            required: true,
+        };
+        assert_eq!(gate.display_name(), "lint");
+    }
+
+    #[test]
+    fn command_gate_from_config_entry_copies_all_fields() {
+        let entry = CompletionGateEntry {
+            name: "fmt".into(),
+            run: "cargo fmt --check".into(),
+            required: false,
+        };
+        let gate = CompletionGate::from_config_entry(&entry);
+        match gate {
+            CompletionGate::Command {
+                name,
+                command,
+                required,
+            } => {
+                assert_eq!(name, "fmt");
+                assert_eq!(command, "cargo fmt --check");
+                assert!(!required);
+            }
+            _ => panic!("expected Command variant"),
+        }
+    }
+
+    #[test]
+    fn command_gate_serializes_with_type_tag() {
+        let gate = CompletionGate::Command {
+            name: "fmt".into(),
+            command: "cargo fmt --check".into(),
+            required: true,
+        };
+        let json = serde_json::to_string(&gate).unwrap();
+        assert!(json.contains("command"));
+        assert!(json.contains("fmt"));
     }
 }

--- a/src/session/pool.rs
+++ b/src/session/pool.rs
@@ -155,6 +155,20 @@ impl SessionPool {
         self.active.iter_mut().find(|m| m.session.id == session_id)
     }
 
+    /// Mutable access to a managed session by issue number (active or finished).
+    pub fn find_by_issue_mut(&mut self, issue_number: u64) -> Option<&mut ManagedSession> {
+        if let Some(m) = self
+            .active
+            .iter_mut()
+            .find(|m| m.session.issue_number == Some(issue_number))
+        {
+            return Some(m);
+        }
+        self.finished
+            .iter_mut()
+            .find(|m| m.session.issue_number == Some(issue_number))
+    }
+
     /// Mutable access to a session by ID across all buckets.
     pub fn get_session_mut(&mut self, session_id: Uuid) -> Option<&mut Session> {
         if let Some(m) = self.active.iter_mut().find(|m| m.session.id == session_id) {

--- a/src/session/types.rs
+++ b/src/session/types.rs
@@ -9,6 +9,8 @@ pub enum SessionStatus {
     Spawning,
     Running,
     Completed,
+    GatesRunning,
+    NeedsReview,
     Errored,
     Paused,
     Killed,
@@ -23,6 +25,8 @@ impl SessionStatus {
             Self::Spawning => "🔄",
             Self::Running => "▶",
             Self::Completed => "✅",
+            Self::GatesRunning => "🔍",
+            Self::NeedsReview => "⚡",
             Self::Errored => "❌",
             Self::Paused => "⏸",
             Self::Killed => "💀",
@@ -37,6 +41,8 @@ impl SessionStatus {
             Self::Spawning => "SPAWNING",
             Self::Running => "RUNNING",
             Self::Completed => "COMPLETED",
+            Self::GatesRunning => "GATES_RUNNING",
+            Self::NeedsReview => "NEEDS_REVIEW",
             Self::Errored => "ERRORED",
             Self::Paused => "PAUSED",
             Self::Killed => "KILLED",
@@ -46,7 +52,10 @@ impl SessionStatus {
     }
 
     pub fn is_terminal(&self) -> bool {
-        matches!(self, Self::Completed | Self::Errored | Self::Killed)
+        matches!(
+            self,
+            Self::Completed | Self::Errored | Self::Killed | Self::NeedsReview
+        )
     }
 }
 
@@ -191,6 +200,42 @@ mod tests {
         assert_eq!(s.parent_session_id, None);
         assert!(s.child_session_ids.is_empty());
         assert_eq!(s.fork_depth, 0);
+    }
+
+    #[test]
+    fn needs_review_status_is_terminal() {
+        assert!(SessionStatus::NeedsReview.is_terminal());
+    }
+
+    #[test]
+    fn gates_running_status_is_not_terminal() {
+        assert!(!SessionStatus::GatesRunning.is_terminal());
+    }
+
+    #[test]
+    fn gates_running_has_symbol_and_label() {
+        let status = SessionStatus::GatesRunning;
+        assert!(!status.symbol().is_empty());
+        assert_eq!(status.label(), "GATES_RUNNING");
+    }
+
+    #[test]
+    fn needs_review_has_symbol_and_label() {
+        let status = SessionStatus::NeedsReview;
+        assert!(!status.symbol().is_empty());
+        assert_eq!(status.label(), "NEEDS_REVIEW");
+    }
+
+    #[test]
+    fn session_status_gates_running_serializes_as_snake_case() {
+        let json = serde_json::to_string(&SessionStatus::GatesRunning).unwrap();
+        assert_eq!(json, r#""gates_running""#);
+    }
+
+    #[test]
+    fn session_status_needs_review_serializes_as_snake_case() {
+        let json = serde_json::to_string(&SessionStatus::NeedsReview).unwrap();
+        assert_eq!(json, r#""needs_review""#);
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2,7 +2,7 @@ use crate::budget::{BudgetAction, BudgetCheck, BudgetEnforcer};
 use crate::config::Config;
 use crate::config::ConflictPolicy;
 use crate::gates::runner::{self, GateCheck, GateRunner};
-use crate::gates::types::CompletionGate;
+use crate::gates::types::{CompletionGate, GateResult};
 use crate::git::GitOps;
 use crate::github::ci::{CiChecker, CiStatus, PendingPrCheck};
 use crate::github::client::GitHubClient;
@@ -790,45 +790,94 @@ impl App {
 
         // Process pending issue completions (gates, git push, label updates, PR creation)
         let pending = std::mem::take(&mut self.pending_issue_completions);
-        let gates_config = self.config.as_ref().map(|c| c.gates.clone());
+
+        // Build gates once from config (independent of individual completions)
+        let gates: Vec<CompletionGate> = if let Some(ref cfg) = self.config
+            && cfg.sessions.completion_gates.enabled
+            && !cfg.sessions.completion_gates.commands.is_empty()
+        {
+            cfg.sessions
+                .completion_gates
+                .commands
+                .iter()
+                .map(CompletionGate::from_config_entry)
+                .collect()
+        } else if let Some(ref cfg) = self.config
+            && cfg.gates.enabled
+        {
+            vec![CompletionGate::TestsPass {
+                command: cfg.gates.test_command.clone(),
+            }]
+        } else {
+            vec![]
+        };
 
         for mut completion in pending {
+            let issue_label = format!("#{}", completion.issue_number);
+
             // Run completion gates before accepting the result
             if completion.success
-                && let (Some(gates_cfg), Some(wt_path)) = (&gates_config, &completion.worktree_path)
-                && gates_cfg.enabled
+                && !gates.is_empty()
+                && let Some(wt_path) = &completion.worktree_path
             {
-                let gates = vec![CompletionGate::TestsPass {
-                    command: gates_cfg.test_command.clone(),
-                }];
+                if let Some(managed) = self.pool.find_by_issue_mut(completion.issue_number) {
+                    managed.session.status = SessionStatus::GatesRunning;
+                }
+
                 let gate_runner = GateRunner;
                 let results = gate_runner.run_gates(&gates, wt_path);
 
-                if !runner::all_gates_passed(&results) {
-                    let failures: Vec<String> = results
-                        .iter()
-                        .filter(|r| !r.passed)
-                        .map(|r| r.message.clone())
-                        .collect();
+                let paired: Vec<(GateResult, bool)> = results
+                    .into_iter()
+                    .zip(gates.iter().map(|g| g.is_required()))
+                    .collect();
+
+                let all_required_passed = runner::all_required_gates_passed(&paired);
+
+                // Log individual gate results (failed-level differs by outcome)
+                let fail_level = if all_required_passed {
+                    LogLevel::Warn
+                } else {
+                    LogLevel::Error
+                };
+                for (result, _) in &paired {
+                    let level = if result.passed {
+                        LogLevel::Info
+                    } else {
+                        fail_level
+                    };
                     self.activity_log.push_simple(
-                        format!("#{}", completion.issue_number),
-                        format!("Gate failed: {}", failures.join("; ")),
-                        LogLevel::Error,
+                        issue_label.clone(),
+                        format!("Gate [{}]: {}", result.gate, result.message),
+                        level,
                     );
-                    // Mark as failed — retry system will pick it up
+                }
+
+                if !all_required_passed {
+                    let failures: Vec<String> = paired
+                        .iter()
+                        .filter(|(r, required)| !r.passed && *required)
+                        .map(|(r, _)| r.message.clone())
+                        .collect();
+
+                    if let Some(managed) = self.pool.find_by_issue_mut(completion.issue_number) {
+                        managed.session.status = SessionStatus::NeedsReview;
+                        managed
+                            .session
+                            .log_activity(format!("Gates failed: {}", failures.join("; ")));
+                    }
+
                     completion.success = false;
-                    // Fire tests_failed hook
                     let ctx = HookContext::new()
                         .with_session("", Some(completion.issue_number))
                         .with_var("MAESTRO_GATE_FAILURES", &failures.join("; "));
                     self.fire_plugin_hook(HookPoint::TestsFailed, ctx).await;
                 } else {
                     self.activity_log.push_simple(
-                        format!("#{}", completion.issue_number),
-                        "All gates passed".into(),
+                        issue_label.clone(),
+                        "All required gates passed".into(),
                         LogLevel::Info,
                     );
-                    // Fire tests_passed hook
                     let ctx = HookContext::new().with_session("", Some(completion.issue_number));
                     self.fire_plugin_hook(HookPoint::TestsPassed, ctx).await;
                 }

--- a/src/tui/panels.rs
+++ b/src/tui/panels.rs
@@ -233,5 +233,7 @@ fn status_to_color(status: SessionStatus) -> Color {
         SessionStatus::Spawning => Color::Cyan,
         SessionStatus::Stalled => Color::Yellow,
         SessionStatus::Retrying => Color::Magenta,
+        SessionStatus::GatesRunning => Color::Cyan,
+        SessionStatus::NeedsReview => Color::LightYellow,
     }
 }


### PR DESCRIPTION
## Summary

- Add configurable completion gates in `[sessions.completion_gates]` that run shell commands (fmt, clippy, test) after session completion and before PR creation
- Gate failures transition session to `NEEDS_REVIEW` status and block auto-PR; optional gates log warnings only
- Backward compatible: falls back to legacy `[gates].test_command` when new config section is absent

Closes #40

## Test plan
- [x] Config deserialization: defaults, full entry, required flag, ordering (4 tests)
- [x] Gate types: is_required, display_name, from_config_entry, serialization (5 tests)
- [x] Gate runner: command pass/fail, empty command, all_required_gates_passed (6 tests)
- [x] Session status: GatesRunning/NeedsReview terminal, symbol, label, serialization (6 tests)
- [x] All 638 tests pass, cargo fmt clean