### PR TITLE
feat: CI error detection and auto-fix loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### CI Error Detection and Auto-Fix Loop (#41)
+
+- `src/config.rs` — `CiAutoFixConfig` struct added under `GatesConfig.ci_auto_fix`: `enabled: bool` (default `true`), `max_retries: u32` (default `3`), `poll_interval_secs: u64` (default `90`); fully TOML-deserializable with sane defaults when the `[gates.ci_auto_fix]` section is absent
+- `src/github/ci.rs` — `CiPollAction` enum added with three variants: `Wait` (CI still running or fix session in progress), `SpawnFix { log: String }` (spawn a fix session with this failure log), `Abandon` (retries exhausted or auto-fix disabled); `PendingPrCheck` extended with `fix_attempt: u32` and `awaiting_fix_ci: bool` fields; `fetch_failure_log(pr_number, branch)` method added to `CiChecker`: calls `gh run list` then `gh run view --log-failed` and returns a truncated log (max 4 000 chars); `build_ci_fix_prompt(pr_number, issue_number, branch, attempt, failure_log)` helper builds the unattended fix prompt injected into the fix session; `truncate_log(log, max_chars)` helper trims long logs to the last `max_chars` bytes while preserving line boundaries; `parse_ci_json(json)` extracted to a `pub(crate)` free function for unit-test coverage; `decide_ci_action(check, max_retries, error_log)` free function encodes the state-machine decision: `Wait` if `awaiting_fix_ci`, `Abandon` if `fix_attempt >= max_retries`, otherwise `SpawnFix`
+- `src/session/types.rs` — `SessionStatus::CiFix` variant added: symbol `"🔧"`, label `"CI_FIX"`, non-terminal; `CiFixContext` struct added (`pr_number`, `issue_number`, `branch`, `attempt`) with `Serialize`/`Deserialize`; `ci_fix_context: Option<CiFixContext>` field added to `Session`
+- `src/tui/app.rs` — `poll_ci_status()` extended with auto-fix loop: on `CiStatus::Failed`, calls `fetch_failure_log()` and `decide_ci_action()` to choose between `Wait`, `SpawnFix`, or `Abandon`; sets `awaiting_fix_ci = true` when a fix session is spawned, and clears it when the fix session exits; `spawn_ci_fix_session(pr_number, issue_number, branch, attempt, failure_log)` added: builds a `Session` with status `CiFix` and a populated `ci_fix_context`, then adds it to the pool; `on_issue_session_completed()` updated to skip PR creation when `is_ci_fix` is true, treating a completed fix session as a signal to re-enter the CI polling cycle
+- `src/tui/panels.rs` — `CiFix` mapped to `Color::LightMagenta` in `status_color()`
+
 ### Auto-fmt, Clippy, and Test Completion Gates (#40)
 
 - `src/config.rs` — `CompletionGatesConfig` struct added to `SessionsConfig` with `enabled: bool` (default `true`) and `commands: Vec<CompletionGateEntry>`; `CompletionGateEntry` struct with `name`, `run`, and `required` (default `true`) fields; both are TOML-deserializable and serializable; `completion_gates` field replaces ad-hoc gate setup

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,6 +52,7 @@ Hardening, missing PRD features, test coverage, and distribution.
 | [#32] | Interactive issue browser with selection and launch | P1 | Done |
 | [#33] | Milestone overview with progress tracking | P1 | Done |
 | [#35] | Work suggestions and quick commands on home screen | P1 | Done |
+| [#41] | CI error detection and auto-fix loop | P1 | Done |
 
 ### Testing & Quality
 
@@ -107,6 +108,7 @@ v0.2.0 🔧 In Progress
   ├── #16 TUI snapshot tests ────────┤ Quality (parallel)
   ├── #19 Parser benchmarks ─────────┘
   ├── #17 Release workflow ─────────✅ Done
+  ├── #41 CI auto-fix loop ─────────✅ Done
   └── #18 Completion docs
 
 v0.3.0 🌐 Planned
@@ -145,6 +147,8 @@ v0.3.0 🌐 Planned
 [#31]: https://github.com/CarlosDanielDev/maestro/issues/31
 [#32]: https://github.com/CarlosDanielDev/maestro/issues/32
 [#33]: https://github.com/CarlosDanielDev/maestro/issues/33
+[#35]: https://github.com/CarlosDanielDev/maestro/issues/35
+[#41]: https://github.com/CarlosDanielDev/maestro/issues/41
 [#46]: https://github.com/CarlosDanielDev/maestro/issues/46
 [#47]: https://github.com/CarlosDanielDev/maestro/issues/47
 [#48]: https://github.com/CarlosDanielDev/maestro/issues/48

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-03 22:00 (UTC)
+> Last updated: 2026-04-03 23:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -62,7 +62,7 @@ maestro/
 │       └── release.yml                    # Release workflow: cross-platform builds, GitHub Release, Homebrew tap trigger
 ├── src/
 │   ├── main.rs                            # CLI entry point (clap); Run, Queue, Add, Status, Cost, Init, Doctor; setup_app_from_config() shared helper wires budget, model router, notifications, plugins, and permission_mode/allowed_tools from config; cmd_dashboard() performs orphan worktree cleanup, log cleanup, fetches username from doctor report, delegates App construction to setup_app_from_config(), and queues FetchSuggestionData on startup; cmd_run() refactored to use same helper  [Issue #29, #49, #34, #36, #35]
-│   ├── config.rs                          # maestro.toml parsing; ModelsConfig, GatesConfig, ReviewConfig; ContextOverflowConfig; ProviderConfig (kind, organization, az_project); guardrail_prompt in SessionsConfig; CompletionGatesConfig and CompletionGateEntry  [Issue #29, #40, #43]
+│   ├── config.rs                          # maestro.toml parsing; ModelsConfig, GatesConfig, ReviewConfig; ContextOverflowConfig; ProviderConfig (kind, organization, az_project); guardrail_prompt in SessionsConfig; CompletionGatesConfig and CompletionGateEntry; CiAutoFixConfig (enabled, max_retries, poll_interval_secs) under GatesConfig.ci_auto_fix  [Issue #29, #40, #41, #43]
 │   ├── budget.rs                          # BudgetEnforcer: per-session and global budget checks  [Phase 3]
 │   ├── doctor.rs                          # Preflight checks: CheckSeverity, CheckResult, DoctorReport, run_all_checks(), print_report(); build_gh_auth_result() (pure, testable); check_az_identity(); 10 check functions  [Issue #49, #34]
 │   ├── git.rs                             # GitOps trait, CliGitOps: commit and push operations  [Phase 3]
@@ -81,6 +81,7 @@ maestro/
 │   │   ├── mod.rs                         # Module exports
 │   │   ├── types.rs                       # GhIssue (+ milestone/assignees fields), GhMilestone, Priority, MaestroLabel, SessionMode; label/body blocker parsing  [Issue #31-33]
 │   │   ├── client.rs                      # GitHubClient trait + list_milestones(); GhCliClient; MockGitHubClient (set_milestones()); parse_issues_json; parse_milestones_json  [Issue #31-33, #46-48]
+│   │   ├── ci.rs                          # CiChecker: check_pr_status(), fetch_failure_log(); CiStatus enum (Pending, Passed, Failed, NoneConfigured); CiPollAction enum (Wait, SpawnFix, Abandon); PendingPrCheck (fix_attempt, awaiting_fix_ci); build_ci_fix_prompt(); truncate_log(); parse_ci_json(); decide_ci_action()  [Phase 3, Issue #41]
 │   │   ├── labels.rs                      # LabelManager: ready→in-progress→done/failed lifecycle transitions
 │   │   └── pr.rs                          # PrCreator: build_pr_body, create_for_issue auto-PR creation
 │   ├── modes/                             # Session mode definitions and resolution  [Phase 3]
@@ -102,7 +103,7 @@ maestro/
 │   │   ├── manager.rs                     # Claude CLI process management; handles ContextUpdate events  [Phase 3]
 │   │   ├── parser.rs                      # stream-json output parser; parses system events for context usage  [Phase 3]
 │   │   ├── pool.rs                        # Session pool: max_concurrent, queue, auto-promote; branch tracking; guardrail_prompt field; set_guardrail_prompt(); merged into system prompt in try_promote(); find_by_issue_mut()  [Phase 3, Issue #40, #43]
-│   │   ├── types.rs                       # Session state machine; fork fields (parent_session_id, child_session_ids, fork_depth); ContextUpdate StreamEvent; GatesRunning and NeedsReview status variants  [Phase 3, Issue #40]
+│   │   ├── types.rs                       # Session state machine; fork fields (parent_session_id, child_session_ids, fork_depth); ContextUpdate StreamEvent; GatesRunning and NeedsReview status variants; CiFix variant; CiFixContext struct (pr_number, issue_number, branch, attempt); ci_fix_context field on Session  [Phase 3, Issue #40, #41]
 │   │   ├── worktree.rs                    # Git worktree isolation: WorktreeManager trait, GitWorktreeManager, MockWorktreeManager  [Phase 1]
 │   │   ├── health.rs                      # HealthMonitor: stall detection, HealthCheck trait  [Phase 3]
 │   │   ├── retry.rs                       # RetryPolicy: configurable max retries and cooldown  [Phase 3]
@@ -118,14 +119,14 @@ maestro/
 │   │   └── types.rs                       # State types; fork_lineage HashMap; record_fork, fork_chain, fork_depth methods  [Issue #12]
 │   ├── tui/
 │   │   ├── mod.rs                         # Event loop; keybindings; handle_screen_action() rewritten; command processing loop; launch_session_from_config(); FetchSuggestionData async handler spawns background GitHub fetch for ready/failed counts and milestone progress  [Phase 3, Issue #31-33, #46-48, #35]
-│   │   ├── app.rs                         # App state; TuiMode; TuiCommand enum (FetchIssues, FetchMilestones, FetchSuggestionData, LaunchSession, LaunchSessions); TuiDataEvent enum (Issues, Milestones, Issue, SuggestionData); SuggestionDataPayload; handle_data_event(); data_tx/data_rx channel; pending_commands; check_completions() uses config-driven gates with per-gate activity logging  [Issue #12, #31-33, #40, #43, #46-48, #35]
+│   │   ├── app.rs                         # App state; TuiMode; TuiCommand enum (FetchIssues, FetchMilestones, FetchSuggestionData, LaunchSession, LaunchSessions); TuiDataEvent enum (Issues, Milestones, Issue, SuggestionData); SuggestionDataPayload; handle_data_event(); data_tx/data_rx channel; pending_commands; check_completions() uses config-driven gates with per-gate activity logging; poll_ci_status() with CI auto-fix loop; spawn_ci_fix_session(); on_issue_session_completed() skips PR creation for CI-fix sessions  [Issue #12, #31-33, #35, #40, #41, #43, #46-48]
 │   │   ├── activity_log.rs                # Scrollable activity log widget with LogLevel color coding  [Phase 1]
 │   │   ├── cost_dashboard.rs              # Cost dashboard widget: per-session and aggregate cost display  [Phase 3]
 │   │   ├── dep_graph.rs                   # ASCII dependency graph visualization  [Phase 3]
 │   │   ├── detail.rs                      # Session detail view  [Phase 3]
 │   │   ├── fullscreen.rs                  # Fullscreen session view with phase progress overlay  [Phase 3]
 │   │   ├── help.rs                        # Help overlay widget with keybinding reference  [Phase 3]
-│   │   ├── panels.rs                      # Split-pane panel view; fork depth indicator in title; overflow warning in context gauge; GatesRunning (Cyan) and NeedsReview (LightYellow) status colors  [Issue #12, #40]
+│   │   ├── panels.rs                      # Split-pane panel view; fork depth indicator in title; overflow warning in context gauge; GatesRunning (Cyan), NeedsReview (LightYellow), and CiFix (LightMagenta) status colors  [Issue #12, #40, #41]
 │   │   ├── ui.rs                          # ratatui rendering; budget display, TUI mode switching, notification banners, screen rendering branches  [Phase 3, Issue #31-33]
 │   │   └── screens/                       # Interactive screen components  [Issue #31-33]
 │   │       ├── mod.rs                     # Screen types: ScreenAction enum, SessionConfig; re-exports HomeScreen, IssueBrowserScreen, MilestoneScreen
@@ -194,6 +195,7 @@ maestro/
 | `src/github/` | GitHub API integration (Phase 2) |
 | `src/github/types.rs` | GhIssue (milestone, assignees fields added), GhMilestone, Priority, MaestroLabel, SessionMode |
 | `src/github/client.rs` | GitHubClient trait + `list_milestones()`; GhCliClient; MockGitHubClient; `parse_issues_json`; `parse_milestones_json` |
+| `src/github/ci.rs` | `CiChecker` (`check_pr_status`, `fetch_failure_log`); `CiStatus`; `CiPollAction`; `PendingPrCheck` (with `fix_attempt`, `awaiting_fix_ci`); `build_ci_fix_prompt`; `truncate_log`; `parse_ci_json`; `decide_ci_action` (Issue #41) |
 | `src/github/labels.rs` | Issue label lifecycle transitions |
 | `src/github/pr.rs` | Automated PR creation |
 | `src/modes/` | Session mode definitions: orchestrator, vibe, review (Phase 3) |
@@ -218,14 +220,14 @@ maestro/
 | `src/state/progress.rs` | Session phase tracking (Phase 3) |
 | `src/tui/` | Terminal UI (ratatui) |
 | `src/tui/mod.rs` | Event loop; `handle_screen_action()`; command processing; `launch_session_from_config()`; `FetchSuggestionData` async handler for GitHub ready/failed counts and milestone progress (Issues #31-33, #35, #46-48) |
-| `src/tui/app.rs` | `App` struct; `TuiMode`; `TuiCommand` (adds `FetchSuggestionData`); `TuiDataEvent` (adds `SuggestionData`); `SuggestionDataPayload`; `handle_data_event()`; `data_tx`/`data_rx` channel; `check_completions()` config-driven gates with per-gate logging (Issues #12, #31-33, #35, #40, #43, #46-48) |
+| `src/tui/app.rs` | `App` struct; `TuiMode`; `TuiCommand` (adds `FetchSuggestionData`); `TuiDataEvent` (adds `SuggestionData`); `SuggestionDataPayload`; `handle_data_event()`; `data_tx`/`data_rx` channel; `check_completions()` config-driven gates with per-gate logging; `poll_ci_status()` with CI auto-fix loop; `spawn_ci_fix_session()`; `on_issue_session_completed()` skips PR creation for CI-fix sessions (Issues #12, #31-33, #35, #40, #41, #43, #46-48) |
 | `src/tui/activity_log.rs` | Scrollable log widget |
 | `src/tui/cost_dashboard.rs` | Per-session and aggregate cost display (Phase 3) |
 | `src/tui/dep_graph.rs` | ASCII dependency graph visualization (Phase 3) |
 | `src/tui/detail.rs` | Session detail view (Phase 3) |
 | `src/tui/fullscreen.rs` | Fullscreen session view with phase progress overlay (Phase 3) |
 | `src/tui/help.rs` | Help overlay widget with keybinding reference (Phase 3) |
-| `src/tui/panels.rs` | Split-pane multi-session view; `GatesRunning` (Cyan) and `NeedsReview` (LightYellow) status colors (Issue #40) |
+| `src/tui/panels.rs` | Split-pane multi-session view; `GatesRunning` (Cyan), `NeedsReview` (LightYellow), and `CiFix` (LightMagenta) status colors (Issues #40, #41) |
 | `src/tui/screens/` | Interactive TUI screen components (Issues #31-33) |
 | `src/tui/screens/mod.rs` | `ScreenAction` enum, `SessionConfig`; re-exports all screen types |
 | `src/tui/screens/home.rs` | `HomeScreen`: idle dashboard with 3-column layout (Quick Actions 30% / Suggestions 35% / Recent Activity 35%); `SuggestionKind` enum (`ReadyIssues`, `MilestoneProgress`, `IdleSessions`, `FailedIssues`); `Suggestion` struct with `build_suggestions()` factory; `HomeSection` enum for Tab-based focus toggle; `draw_suggestions()` renderer; `@username` display in project info bar (Issues #31, #34, #35, #49) |

--- a/src/config.rs
+++ b/src/config.rs
@@ -316,6 +316,9 @@ pub struct GatesConfig {
     /// Maximum time in seconds to wait for CI to complete. Default: 1800 (30min).
     #[serde(default = "default_ci_max_wait")]
     pub ci_max_wait_secs: u64,
+    /// CI auto-fix loop configuration.
+    #[serde(default)]
+    pub ci_auto_fix: CiAutoFixConfig,
 }
 
 impl Default for GatesConfig {
@@ -325,8 +328,32 @@ impl Default for GatesConfig {
             test_command: default_test_command(),
             ci_poll_interval_secs: default_ci_poll_interval(),
             ci_max_wait_secs: default_ci_max_wait(),
+            ci_auto_fix: CiAutoFixConfig::default(),
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CiAutoFixConfig {
+    /// Whether CI auto-fix is enabled. Default: true.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Maximum number of fix attempts per PR. Default: 3.
+    #[serde(default = "default_ci_fix_max_retries")]
+    pub max_retries: u32,
+}
+
+impl Default for CiAutoFixConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            max_retries: default_ci_fix_max_retries(),
+        }
+    }
+}
+
+fn default_ci_fix_max_retries() -> u32 {
+    3
 }
 
 fn default_test_command() -> String {
@@ -650,5 +677,55 @@ run = "cargo clippy -- -D warnings"
         let cfg: CompletionGatesConfig = toml::from_str(toml_str).expect("parse failed");
         assert_eq!(cfg.commands[0].name, "fmt");
         assert_eq!(cfg.commands[1].name, "clippy");
+    }
+
+    #[test]
+    fn ci_auto_fix_config_defaults() {
+        let cfg = CiAutoFixConfig::default();
+        assert!(cfg.enabled);
+        assert_eq!(cfg.max_retries, 3);
+    }
+
+    #[test]
+    fn ci_auto_fix_config_deserializes_from_toml() {
+        let toml_str = r#"
+enabled = false
+max_retries = 5
+"#;
+        let cfg: CiAutoFixConfig = toml::from_str(toml_str).expect("parse failed");
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.max_retries, 5);
+    }
+
+    #[test]
+    fn gates_config_ci_auto_fix_defaults_when_absent() {
+        let cfg: GatesConfig = toml::from_str("").expect("parse failed");
+        assert!(cfg.ci_auto_fix.enabled);
+        assert_eq!(cfg.ci_auto_fix.max_retries, 3);
+    }
+
+    #[test]
+    fn full_config_load_propagates_ci_auto_fix() {
+        use std::io::Write;
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        write!(
+            f,
+            r#"
+[project]
+repo = "owner/repo"
+[sessions]
+[budget]
+per_session_usd = 5.0
+total_usd = 50.0
+alert_threshold_pct = 80
+[github]
+[notifications]
+[gates.ci_auto_fix]
+max_retries = 7
+"#
+        )
+        .unwrap();
+        let cfg = Config::load(f.path()).expect("load failed");
+        assert_eq!(cfg.gates.ci_auto_fix.max_retries, 7);
     }
 }

--- a/src/github/ci.rs
+++ b/src/github/ci.rs
@@ -14,6 +14,17 @@ pub enum CiStatus {
     NoneConfigured,
 }
 
+/// Action to take after evaluating CI failure for auto-fix.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CiPollAction {
+    /// CI still running or fix session in progress — keep waiting.
+    Wait,
+    /// Spawn a fix session with this failure log.
+    SpawnFix { log: String },
+    /// Retries exhausted or auto-fix disabled — give up.
+    Abandon,
+}
+
 /// Tracks a PR awaiting CI completion.
 #[derive(Debug, Clone)]
 pub struct PendingPrCheck {
@@ -22,6 +33,10 @@ pub struct PendingPrCheck {
     pub branch: String,
     pub created_at: std::time::Instant,
     pub check_count: u32,
+    /// Number of CI fix attempts already made for this PR.
+    pub fix_attempt: u32,
+    /// If true, a fix session is running — skip re-processing failures.
+    pub awaiting_fix_ci: bool,
 }
 
 /// Checks CI status for pull requests via `gh` CLI.
@@ -34,6 +49,7 @@ struct PrStatusJson {
     status_check_rollup: Vec<CheckRun>,
     #[serde(default)]
     #[serde(rename = "mergeStateStatus")]
+    #[allow(dead_code)]
     merge_state_status: String,
 }
 
@@ -71,36 +87,54 @@ impl CiChecker {
         }
 
         let json_str = String::from_utf8_lossy(&output.stdout);
-        let pr_status: PrStatusJson = serde_json::from_str(&json_str)?;
+        parse_ci_json(&json_str)
+    }
 
-        if pr_status.status_check_rollup.is_empty() {
-            return Ok(CiStatus::NoneConfigured);
+    /// Fetch the failed CI run log for a PR branch.
+    /// Returns a truncated log string (max ~4000 chars to fit in a prompt).
+    pub fn fetch_failure_log(&self, pr_number: u64, branch: &str) -> Result<String> {
+        let output = std::process::Command::new("gh")
+            .args([
+                "run",
+                "list",
+                "--branch",
+                branch,
+                "--status",
+                "failure",
+                "--limit",
+                "1",
+                "--json",
+                "databaseId",
+            ])
+            .output()?;
+
+        if !output.status.success() {
+            anyhow::bail!(
+                "gh run list failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
         }
 
-        let mut pending = false;
-        let mut failures = Vec::new();
+        let runs: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout)?;
+        let run_id = runs
+            .first()
+            .and_then(|r| r.get("databaseId"))
+            .and_then(|v| v.as_u64())
+            .ok_or_else(|| anyhow::anyhow!("No failed run found for PR #{}", pr_number))?;
 
-        for check in &pr_status.status_check_rollup {
-            match check.conclusion.as_str() {
-                "SUCCESS" | "NEUTRAL" | "SKIPPED" | "success" | "neutral" | "skipped" => {}
-                "" if check.status != "COMPLETED" && check.status != "completed" => {
-                    pending = true;
-                }
-                conclusion => {
-                    failures.push(format!("{}: {}", check.name, conclusion));
-                }
-            }
+        let log_output = std::process::Command::new("gh")
+            .args(["run", "view", &run_id.to_string(), "--log-failed"])
+            .output()?;
+
+        if !log_output.status.success() {
+            anyhow::bail!(
+                "gh run view --log-failed failed: {}",
+                String::from_utf8_lossy(&log_output.stderr).trim()
+            );
         }
 
-        if !failures.is_empty() {
-            Ok(CiStatus::Failed {
-                summary: failures.join("; "),
-            })
-        } else if pending {
-            Ok(CiStatus::Pending)
-        } else {
-            Ok(CiStatus::Passed)
-        }
+        let full_log = String::from_utf8_lossy(&log_output.stdout).to_string();
+        Ok(truncate_log(&full_log, 4000))
     }
 }
 
@@ -108,6 +142,99 @@ impl Default for CiChecker {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Parse CI status JSON from `gh pr view` output.
+pub(crate) fn parse_ci_json(json: &str) -> Result<CiStatus> {
+    let pr_status: PrStatusJson = serde_json::from_str(json)?;
+
+    if pr_status.status_check_rollup.is_empty() {
+        return Ok(CiStatus::NoneConfigured);
+    }
+
+    let mut pending = false;
+    let mut failures = Vec::new();
+
+    for check in &pr_status.status_check_rollup {
+        match check.conclusion.as_str() {
+            "SUCCESS" | "NEUTRAL" | "SKIPPED" | "success" | "neutral" | "skipped" => {}
+            "" if check.status != "COMPLETED" && check.status != "completed" => {
+                pending = true;
+            }
+            conclusion => {
+                failures.push(format!("{}: {}", check.name, conclusion));
+            }
+        }
+    }
+
+    if !failures.is_empty() {
+        Ok(CiStatus::Failed {
+            summary: failures.join("; "),
+        })
+    } else if pending {
+        Ok(CiStatus::Pending)
+    } else {
+        Ok(CiStatus::Passed)
+    }
+}
+
+/// Truncate a log to the last `max_chars` characters, keeping complete lines.
+pub(crate) fn truncate_log(log: &str, max_chars: usize) -> String {
+    if log.len() <= max_chars {
+        return log.to_string();
+    }
+    let raw_start = log.len() - max_chars;
+    // Walk forward to find a valid UTF-8 char boundary
+    let start = (raw_start..log.len())
+        .find(|&i| log.is_char_boundary(i))
+        .unwrap_or(log.len());
+    // Find the next newline after the cut point to keep lines intact
+    match log[start..].find('\n') {
+        Some(pos) => format!("...(truncated)\n{}", &log[start + pos + 1..]),
+        None => format!("...(truncated)\n{}", &log[start..]),
+    }
+}
+
+/// A deferred CI fix request, collected during polling and processed after the loop.
+pub struct CiFixRequest {
+    pub pr_number: u64,
+    pub issue_number: u64,
+    pub branch: String,
+    pub attempt: u32,
+    pub failure_log: String,
+}
+
+/// Decide what action to take when CI fails for a pending PR check.
+pub fn decide_ci_action(check: &PendingPrCheck, max_retries: u32, error_log: &str) -> CiPollAction {
+    if check.awaiting_fix_ci {
+        return CiPollAction::Wait;
+    }
+    if check.fix_attempt >= max_retries {
+        return CiPollAction::Abandon;
+    }
+    CiPollAction::SpawnFix {
+        log: error_log.to_string(),
+    }
+}
+
+/// Build a prompt for a CI fix session.
+pub(crate) fn build_ci_fix_prompt(
+    pr_number: u64,
+    issue_number: u64,
+    branch: &str,
+    attempt: u32,
+    failure_log: &str,
+) -> String {
+    format!(
+        "Fix the CI failure for PR #{pr_number} (issue #{issue_number}).\n\n\
+         This is auto-fix attempt {attempt}.\n\n\
+         CI FAILURE LOG:\n```\n{failure_log}\n```\n\n\
+         IMPORTANT: You are running in unattended mode. \
+         Do NOT use AskUserQuestion. \
+         Read the failing code, fix the issue, then commit and push to the branch '{branch}'. \
+         Run the failing command locally first to reproduce, then fix and verify. \
+         Keep the fix minimal — do NOT refactor unrelated code. Only fix the CI failure.",
+    )
 }
 
 #[cfg(test)]
@@ -138,10 +265,193 @@ mod tests {
             branch: "maestro/issue-10".into(),
             created_at: std::time::Instant::now(),
             check_count: 0,
+            fix_attempt: 0,
+            awaiting_fix_ci: false,
         };
         assert_eq!(check.pr_number, 42);
         assert_eq!(check.issue_number, 10);
         assert_eq!(check.branch, "maestro/issue-10");
         assert_eq!(check.check_count, 0);
+        assert_eq!(check.fix_attempt, 0);
+        assert!(!check.awaiting_fix_ci);
+    }
+
+    #[test]
+    fn ci_poll_action_wait_equals_wait() {
+        assert_eq!(CiPollAction::Wait, CiPollAction::Wait);
+    }
+
+    #[test]
+    fn ci_poll_action_abandon_ne_wait() {
+        assert_ne!(CiPollAction::Abandon, CiPollAction::Wait);
+    }
+
+    #[test]
+    fn truncate_log_returns_full_string_when_under_limit() {
+        let log = "error: type mismatch in assignment".to_string();
+        let result = truncate_log(&log, 4096);
+        assert_eq!(result, log);
+    }
+
+    #[test]
+    fn truncate_log_clips_long_input() {
+        let log = "x".repeat(10_000);
+        let result = truncate_log(&log, 2048);
+        // Result should be roughly max_chars + prefix length
+        assert!(result.len() <= 2048 + 20);
+    }
+
+    #[test]
+    fn truncate_log_preserves_line_boundaries() {
+        let log = "line1\nline2\nline3\nline4\n".repeat(500);
+        let result = truncate_log(&log, 100);
+        // Should start with truncation marker
+        assert!(result.starts_with("...(truncated)\n"));
+    }
+
+    #[test]
+    fn truncate_log_respects_utf8_char_boundaries() {
+        // 'é' is 2 bytes; a 2000-char string is 4000 bytes
+        let log = "é".repeat(2000);
+        let result = truncate_log(&log, 2048);
+        // Must be valid UTF-8 (would panic otherwise)
+        assert!(std::str::from_utf8(result.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn parse_ci_json_all_success_returns_passed() {
+        let json = r#"{
+            "statusCheckRollup": [
+                {"name":"build","status":"COMPLETED","conclusion":"SUCCESS"},
+                {"name":"test","status":"COMPLETED","conclusion":"success"}
+            ],
+            "mergeStateStatus": "CLEAN"
+        }"#;
+        assert_eq!(parse_ci_json(json).unwrap(), CiStatus::Passed);
+    }
+
+    #[test]
+    fn parse_ci_json_empty_rollup_returns_none_configured() {
+        let json = r#"{"statusCheckRollup":[],"mergeStateStatus":"CLEAN"}"#;
+        assert_eq!(parse_ci_json(json).unwrap(), CiStatus::NoneConfigured);
+    }
+
+    #[test]
+    fn parse_ci_json_failure_conclusion_returns_failed_with_summary() {
+        let json = r#"{
+            "statusCheckRollup": [
+                {"name":"build","status":"COMPLETED","conclusion":"FAILURE"},
+                {"name":"lint","status":"COMPLETED","conclusion":"TIMED_OUT"}
+            ],
+            "mergeStateStatus": "BLOCKED"
+        }"#;
+        let status = parse_ci_json(json).unwrap();
+        match status {
+            CiStatus::Failed { summary } => {
+                assert!(summary.contains("build"));
+                assert!(summary.contains("lint"));
+            }
+            other => panic!("Expected Failed, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_ci_json_in_progress_returns_pending() {
+        let json = r#"{
+            "statusCheckRollup": [
+                {"name":"build","status":"IN_PROGRESS","conclusion":""}
+            ],
+            "mergeStateStatus": "BLOCKED"
+        }"#;
+        assert_eq!(parse_ci_json(json).unwrap(), CiStatus::Pending);
+    }
+
+    #[test]
+    fn parse_ci_json_mixed_success_and_pending_returns_pending() {
+        let json = r#"{
+            "statusCheckRollup": [
+                {"name":"build","status":"COMPLETED","conclusion":"SUCCESS"},
+                {"name":"deploy","status":"QUEUED","conclusion":""}
+            ],
+            "mergeStateStatus": "BLOCKED"
+        }"#;
+        assert_eq!(parse_ci_json(json).unwrap(), CiStatus::Pending);
+    }
+
+    #[test]
+    fn decide_ci_action_spawn_fix_when_under_limit() {
+        let check = PendingPrCheck {
+            pr_number: 42,
+            issue_number: 7,
+            branch: "b".into(),
+            created_at: std::time::Instant::now(),
+            check_count: 0,
+            fix_attempt: 1,
+            awaiting_fix_ci: false,
+        };
+        let action = decide_ci_action(&check, 3, "CI failed: missing semicolon");
+        assert!(matches!(action, CiPollAction::SpawnFix { .. }));
+    }
+
+    #[test]
+    fn decide_ci_action_abandon_when_at_limit() {
+        let check = PendingPrCheck {
+            pr_number: 42,
+            issue_number: 7,
+            branch: "b".into(),
+            created_at: std::time::Instant::now(),
+            check_count: 0,
+            fix_attempt: 3,
+            awaiting_fix_ci: false,
+        };
+        let action = decide_ci_action(&check, 3, "CI failed");
+        assert_eq!(action, CiPollAction::Abandon);
+    }
+
+    #[test]
+    fn decide_ci_action_wait_when_awaiting_fix_ci() {
+        let check = PendingPrCheck {
+            pr_number: 1,
+            issue_number: 1,
+            branch: "b".into(),
+            created_at: std::time::Instant::now(),
+            check_count: 0,
+            fix_attempt: 0,
+            awaiting_fix_ci: true,
+        };
+        assert_eq!(decide_ci_action(&check, 3, ""), CiPollAction::Wait);
+    }
+
+    #[test]
+    fn decide_ci_action_abandon_when_max_retries_is_zero() {
+        let check = PendingPrCheck {
+            pr_number: 1,
+            issue_number: 1,
+            branch: "b".into(),
+            created_at: std::time::Instant::now(),
+            check_count: 0,
+            fix_attempt: 0,
+            awaiting_fix_ci: false,
+        };
+        assert_eq!(decide_ci_action(&check, 0, "error"), CiPollAction::Abandon);
+    }
+
+    #[test]
+    fn build_ci_fix_prompt_contains_pr_number_and_error_log() {
+        let prompt = build_ci_fix_prompt(42, 7, "feat/fix", 1, "error[E0308]: mismatched types");
+        assert!(prompt.contains("PR #42"));
+        assert!(prompt.contains("mismatched types"));
+        assert!(prompt.contains("attempt 1"));
+    }
+
+    #[test]
+    fn build_ci_fix_prompt_includes_fix_scope_guard() {
+        let prompt = build_ci_fix_prompt(1, 1, "branch", 1, "test failed");
+        let lower = prompt.to_lowercase();
+        assert!(
+            lower.contains("do not") || lower.contains("only fix"),
+            "Expected scope-limiting instruction in prompt, got: {}",
+            prompt
+        );
     }
 }

--- a/src/session/types.rs
+++ b/src/session/types.rs
@@ -16,6 +16,7 @@ pub enum SessionStatus {
     Killed,
     Stalled,
     Retrying,
+    CiFix,
 }
 
 impl SessionStatus {
@@ -32,6 +33,7 @@ impl SessionStatus {
             Self::Killed => "💀",
             Self::Stalled => "⚠",
             Self::Retrying => "🔁",
+            Self::CiFix => "🔧",
         }
     }
 
@@ -48,6 +50,7 @@ impl SessionStatus {
             Self::Killed => "KILLED",
             Self::Stalled => "STALLED",
             Self::Retrying => "RETRYING",
+            Self::CiFix => "CI_FIX",
         }
     }
 
@@ -57,6 +60,14 @@ impl SessionStatus {
             Self::Completed | Self::Errored | Self::Killed | Self::NeedsReview
         )
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CiFixContext {
+    pub pr_number: u64,
+    pub issue_number: u64,
+    pub branch: String,
+    pub attempt: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -94,6 +105,9 @@ pub struct Session {
     /// Fork depth in the chain (0 = original, 1 = first fork, etc.)
     #[serde(default)]
     pub fork_depth: u8,
+    /// If this session is a CI fix, tracks the PR and attempt number.
+    #[serde(default)]
+    pub ci_fix_context: Option<CiFixContext>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -126,6 +140,7 @@ impl Session {
             parent_session_id: None,
             child_session_ids: Vec::new(),
             fork_depth: 0,
+            ci_fix_context: None,
         }
     }
 
@@ -247,5 +262,69 @@ mod tests {
             }
             other => panic!("Expected ContextUpdate, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn ci_fix_status_is_not_terminal() {
+        assert!(!SessionStatus::CiFix.is_terminal());
+    }
+
+    #[test]
+    fn ci_fix_status_has_symbol_and_label() {
+        let status = SessionStatus::CiFix;
+        assert!(!status.symbol().is_empty());
+        assert_eq!(status.label(), "CI_FIX");
+    }
+
+    #[test]
+    fn ci_fix_status_serializes_as_snake_case() {
+        let json = serde_json::to_string(&SessionStatus::CiFix).unwrap();
+        assert_eq!(json, r#""ci_fix""#);
+    }
+
+    #[test]
+    fn ci_fix_context_stores_all_fields() {
+        let ctx = CiFixContext {
+            pr_number: 99,
+            issue_number: 42,
+            branch: "feat/fix".into(),
+            attempt: 1,
+        };
+        assert_eq!(ctx.pr_number, 99);
+        assert_eq!(ctx.issue_number, 42);
+        assert_eq!(ctx.branch, "feat/fix");
+        assert_eq!(ctx.attempt, 1);
+    }
+
+    #[test]
+    fn session_ci_fix_context_defaults_to_none() {
+        let s = Session::new(
+            "prompt".into(),
+            "opus".into(),
+            "orchestrator".into(),
+            Some(10),
+        );
+        assert!(s.ci_fix_context.is_none());
+    }
+
+    #[test]
+    fn session_with_ci_fix_context_round_trips_via_serde() {
+        let mut s = Session::new(
+            "prompt".into(),
+            "opus".into(),
+            "orchestrator".into(),
+            Some(1),
+        );
+        s.ci_fix_context = Some(CiFixContext {
+            pr_number: 5,
+            issue_number: 1,
+            branch: "feat/fix".into(),
+            attempt: 2,
+        });
+        let json = serde_json::to_string(&s).unwrap();
+        let round_tripped: Session = serde_json::from_str(&json).unwrap();
+        let ctx = round_tripped.ci_fix_context.unwrap();
+        assert_eq!(ctx.attempt, 2);
+        assert_eq!(ctx.pr_number, 5);
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -96,6 +96,7 @@ struct PendingIssueCompletion {
     files_touched: Vec<String>,
     worktree_branch: Option<String>,
     worktree_path: Option<std::path::PathBuf>,
+    is_ci_fix: bool,
 }
 
 pub struct App {
@@ -459,6 +460,7 @@ impl App {
                             files_touched: managed.session.files_touched.clone(),
                             worktree_branch: managed.branch_name.clone(),
                             worktree_path: managed.worktree_path.clone(),
+                            is_ci_fix: managed.session.ci_fix_context.is_some(),
                         });
                     }
                 }
@@ -483,6 +485,7 @@ impl App {
                             files_touched: managed.session.files_touched.clone(),
                             worktree_branch: managed.branch_name.clone(),
                             worktree_path: managed.worktree_path.clone(),
+                            is_ci_fix: managed.session.ci_fix_context.is_some(),
                         });
                     }
                 }
@@ -917,6 +920,7 @@ impl App {
                 completion.cost_usd,
                 completion.files_touched,
                 completion.worktree_branch,
+                completion.is_ci_fix,
             )
             .await;
         }
@@ -1198,6 +1202,7 @@ impl App {
         cost_usd: f64,
         files_touched: Vec<String>,
         worktree_branch: Option<String>,
+        is_ci_fix: bool,
     ) {
         // Update work assigner
         if let Some(ref mut assigner) = self.work_assigner {
@@ -1255,6 +1260,16 @@ impl App {
             }
         }
 
+        // CI fix sessions skip PR creation — the PR already exists
+        if is_ci_fix {
+            self.activity_log.push_simple(
+                format!("#{}", issue_number),
+                "CI fix pushed to existing PR branch".into(),
+                LogLevel::Info,
+            );
+            return;
+        }
+
         // Auto PR creation
         if let (Some(client), Some(config)) = (&self.github_client, &self.config)
             && success
@@ -1282,6 +1297,8 @@ impl App {
                             branch: branch_name.clone(),
                             created_at: Instant::now(),
                             check_count: 0,
+                            fix_attempt: 0,
+                            awaiting_fix_ci: false,
                         });
                     }
                     self.dispatch_review(pr_num, branch, issue_number);
@@ -1406,8 +1423,16 @@ impl App {
         }
         self.last_ci_poll = Instant::now();
 
+        let (auto_fix_enabled, max_retries) = self
+            .config
+            .as_ref()
+            .map(|c| (c.gates.ci_auto_fix.enabled, c.gates.ci_auto_fix.max_retries))
+            .unwrap_or((false, 3));
+
         let checker = CiChecker::new();
         let mut completed_indices = Vec::new();
+        // Collect fix requests to process after the loop (avoids borrow conflict)
+        let mut fix_requests: Vec<crate::github::ci::CiFixRequest> = Vec::new();
 
         for (i, check) in self.pending_pr_checks.iter_mut().enumerate() {
             check.check_count += 1;
@@ -1423,6 +1448,35 @@ impl App {
                     LogLevel::Error,
                 );
                 completed_indices.push(i);
+                continue;
+            }
+
+            // If awaiting a fix session's CI re-run, handle separately
+            if check.awaiting_fix_ci {
+                match checker.check_pr_status(check.pr_number) {
+                    Ok(CiStatus::Pending) => {
+                        // Fix was pushed, CI is re-running. Reset flag.
+                        check.awaiting_fix_ci = false;
+                    }
+                    Ok(CiStatus::Passed) => {
+                        check.awaiting_fix_ci = false;
+                        self.activity_log.push_simple(
+                            format!("PR #{}", check.pr_number),
+                            format!("CI passed after {} fix attempt(s)", check.fix_attempt),
+                            LogLevel::Info,
+                        );
+                        self.notifications.notify(
+                            crate::notifications::types::InterruptLevel::Info,
+                            &format!("PR #{}", check.pr_number),
+                            "CI checks passed after auto-fix",
+                        );
+                        completed_indices.push(i);
+                    }
+                    Ok(CiStatus::Failed { .. }) => {
+                        // Still showing old failure or fix didn't push yet. Keep waiting.
+                    }
+                    _ => {}
+                }
                 continue;
             }
 
@@ -1476,17 +1530,69 @@ impl App {
                     }
                 }
                 Ok(CiStatus::Failed { summary }) => {
-                    self.activity_log.push_simple(
-                        format!("PR #{}", check.pr_number),
-                        format!("CI failed: {}", summary),
-                        LogLevel::Error,
-                    );
-                    self.notifications.notify(
-                        crate::notifications::types::InterruptLevel::Critical,
-                        &format!("PR #{} CI failed", check.pr_number),
-                        &summary,
-                    );
-                    completed_indices.push(i);
+                    use crate::github::ci::{CiFixRequest, CiPollAction, decide_ci_action};
+
+                    let action = if auto_fix_enabled {
+                        decide_ci_action(check, max_retries, &summary)
+                    } else {
+                        CiPollAction::Abandon
+                    };
+
+                    match action {
+                        CiPollAction::SpawnFix { .. } => {
+                            match checker.fetch_failure_log(check.pr_number, &check.branch) {
+                                Ok(failure_log) => {
+                                    self.activity_log.push_simple(
+                                        format!("PR #{}", check.pr_number),
+                                        format!(
+                                            "CI failed (attempt {}/{}), spawning fix session",
+                                            check.fix_attempt + 1,
+                                            max_retries
+                                        ),
+                                        LogLevel::Warn,
+                                    );
+                                    fix_requests.push(CiFixRequest {
+                                        pr_number: check.pr_number,
+                                        issue_number: check.issue_number,
+                                        branch: check.branch.clone(),
+                                        attempt: check.fix_attempt + 1,
+                                        failure_log,
+                                    });
+                                    check.fix_attempt += 1;
+                                    check.awaiting_fix_ci = true;
+                                }
+                                Err(e) => {
+                                    self.activity_log.push_simple(
+                                        format!("PR #{}", check.pr_number),
+                                        format!("CI failed, could not fetch log: {}", e),
+                                        LogLevel::Error,
+                                    );
+                                    completed_indices.push(i);
+                                }
+                            }
+                        }
+                        CiPollAction::Abandon => {
+                            self.activity_log.push_simple(
+                                format!("PR #{}", check.pr_number),
+                                if auto_fix_enabled {
+                                    format!(
+                                        "CI failed after {} fix attempts: {}",
+                                        check.fix_attempt, summary
+                                    )
+                                } else {
+                                    format!("CI failed: {}", summary)
+                                },
+                                LogLevel::Error,
+                            );
+                            self.notifications.notify(
+                                crate::notifications::types::InterruptLevel::Critical,
+                                &format!("PR #{} CI failed", check.pr_number),
+                                &summary,
+                            );
+                            completed_indices.push(i);
+                        }
+                        CiPollAction::Wait => {} // awaiting_fix_ci handled above
+                    }
                 }
                 Ok(CiStatus::NoneConfigured) => {
                     self.activity_log.push_simple(
@@ -1510,11 +1616,60 @@ impl App {
             }
         }
 
+        // Spawn fix sessions after the loop to avoid borrow conflicts
+        for req in fix_requests {
+            self.spawn_ci_fix_session(
+                req.pr_number,
+                req.issue_number,
+                req.branch,
+                req.attempt,
+                &req.failure_log,
+            );
+        }
+
         // Remove completed checks in reverse order to preserve indices
         completed_indices.sort_unstable();
         for i in completed_indices.into_iter().rev() {
             self.pending_pr_checks.remove(i);
         }
+    }
+
+    /// Spawn a Claude session to fix a CI failure on an existing PR branch.
+    fn spawn_ci_fix_session(
+        &mut self,
+        pr_number: u64,
+        issue_number: u64,
+        branch: String,
+        attempt: u32,
+        failure_log: &str,
+    ) {
+        use crate::github::ci::build_ci_fix_prompt;
+        use crate::session::types::CiFixContext;
+
+        let model = self
+            .config
+            .as_ref()
+            .map(|c| c.sessions.default_model.clone())
+            .unwrap_or_else(|| "opus".to_string());
+        let mode = self
+            .config
+            .as_ref()
+            .map(|c| c.sessions.default_mode.clone())
+            .unwrap_or_else(|| "orchestrator".to_string());
+
+        let prompt = build_ci_fix_prompt(pr_number, issue_number, &branch, attempt, failure_log);
+
+        let mut session = Session::new(prompt, model, mode, Some(issue_number));
+        session.status = SessionStatus::CiFix;
+        session.issue_title = Some(format!("CI Fix #{} for PR #{}", attempt, pr_number));
+        session.ci_fix_context = Some(CiFixContext {
+            pr_number,
+            issue_number,
+            branch,
+            attempt,
+        });
+
+        self.pending_session_launches.push(session);
     }
 
     /// Fire a plugin hook asynchronously and log results.

--- a/src/tui/panels.rs
+++ b/src/tui/panels.rs
@@ -235,5 +235,6 @@ fn status_to_color(status: SessionStatus) -> Color {
         SessionStatus::Retrying => Color::Magenta,
         SessionStatus::GatesRunning => Color::Cyan,
         SessionStatus::NeedsReview => Color::LightYellow,
+        SessionStatus::CiFix => Color::LightMagenta,
     }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -140,7 +140,7 @@ fn draw_status_bar(f: &mut Frame, app: &App, area: Rect) {
 
     let text = Line::from(vec![
         Span::styled(
-            " MAESTRO v0.1.0 ",
+            concat!(" MAESTRO v", env!("CARGO_PKG_VERSION"), " "),
             Style::default()
                 .fg(Color::Black)
                 .bg(Color::Green)


### PR DESCRIPTION
## Summary

- After PR creation, maestro polls CI status and on failure fetches the error log, spawns a Claude fix session with failure context, and re-polls up to a configurable max retries (default 3)
- Adds `CiAutoFixConfig` under `GatesConfig`, `SessionStatus::CiFix` variant, `CiFixContext` tracking struct, and pure functions (`parse_ci_json`, `decide_ci_action`, `truncate_log`, `build_ci_fix_prompt`)
- Fix sessions push to the same PR branch and skip PR creation; the cycle repeats until CI passes or retries are exhausted

Closes #41

## Test plan
- [x] Unit tests for `CiAutoFixConfig` defaults and TOML deserialization (4 tests)
- [x] Unit tests for `parse_ci_json` covering passed, failed, pending, mixed, and none-configured (5 tests)
- [x] Unit tests for `truncate_log` including UTF-8 boundary safety (4 tests)
- [x] Unit tests for `decide_ci_action` covering spawn, abandon, wait, and zero-retries (4 tests)
- [x] Unit tests for `build_ci_fix_prompt` content and scope guard (2 tests)
- [x] Unit tests for `SessionStatus::CiFix` (terminal, symbol, label, serde) (3 tests)
- [x] Unit tests for `CiFixContext` and `Session.ci_fix_context` serde round-trip (3 tests)
- [x] All 665 tests passing, clippy clean, fmt clean