### PR TITLE
feat: self-hosting — preflight checks and structured prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Maestro spawns and monitors multiple [Claude Code](https://claude.ai/claude-code
 - **Interactive home screen** — launching `maestro` opens an idle dashboard with a quick-actions menu, repo/branch info, and a recent activity panel; navigate with `j`/`k` or direct shortcut keys
 - **Interactive issue browser** — browse, filter, and launch GitHub issues directly from the TUI; supports single-launch (`Enter`) and multi-select batch-launch (`Space` + `Enter`); filter by text (`/`) or milestone (`m`)
 - **Milestone overview** — inspect milestone progress with real-time completion gauges; drill into issues or run all open issues in a milestone with a single key (`r`)
+- **Automatic preflight checks** — `maestro run` validates that `claude`, `gh`/`az`, and `git` are correctly installed and authenticated before spending any API credits; use `--skip-doctor` to bypass when needed
 
 ### Roadmap
 
@@ -133,6 +134,12 @@ maestro status
 
 # View spending report
 maestro cost
+
+# Run preflight environment checks manually
+maestro doctor
+
+# Skip preflight checks (use when environment is already known-good)
+maestro run --issue 42 --skip-doctor
 ```
 
 ## Configuration

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-03 23:00 (UTC)
+> Last updated: 2026-04-03 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -61,10 +61,10 @@ maestro/
 │       ├── ci.yml                         # GitHub Actions CI pipeline
 │       └── release.yml                    # Release workflow: cross-platform builds, GitHub Release, Homebrew tap trigger
 ├── src/
-│   ├── main.rs                            # CLI entry point (clap); Run, Queue, Add, Status, Cost, Init, Doctor; setup_app_from_config() shared helper wires budget, model router, notifications, plugins, and permission_mode/allowed_tools from config; cmd_dashboard() performs orphan worktree cleanup, log cleanup, fetches username from doctor report, delegates App construction to setup_app_from_config(), and queues FetchSuggestionData on startup; cmd_run() refactored to use same helper  [Issue #29, #49, #34, #36, #35]
+│   ├── main.rs                            # CLI entry point (clap); Run, Queue, Add, Status, Cost, Init, Doctor; --skip-doctor flag on Run subcommand bypasses preflight; cmd_run() runs validate_preflight() before session launch and uses PromptBuilder::build_issue_prompt() for issue sessions; setup_app_from_config() shared helper wires budget, model router, notifications, plugins, and permission_mode/allowed_tools from config; cmd_dashboard() performs orphan worktree cleanup, log cleanup, fetches username from doctor report, delegates App construction to setup_app_from_config(), and queues FetchSuggestionData on startup  [Issue #29, #49, #34, #36, #35, #52]
 │   ├── config.rs                          # maestro.toml parsing; ModelsConfig, GatesConfig, ReviewConfig; ContextOverflowConfig; ProviderConfig (kind, organization, az_project); guardrail_prompt in SessionsConfig; CompletionGatesConfig and CompletionGateEntry; CiAutoFixConfig (enabled, max_retries, poll_interval_secs) under GatesConfig.ci_auto_fix  [Issue #29, #40, #41, #43]
 │   ├── budget.rs                          # BudgetEnforcer: per-session and global budget checks  [Phase 3]
-│   ├── doctor.rs                          # Preflight checks: CheckSeverity, CheckResult, DoctorReport, run_all_checks(), print_report(); build_gh_auth_result() (pure, testable); check_az_identity(); 10 check functions  [Issue #49, #34]
+│   ├── doctor.rs                          # Preflight checks: CheckSeverity, CheckResult, DoctorReport, run_all_checks(), print_report(); validate_preflight() (public, fails fast on required check failures); build_claude_cli_result() (pub(crate), pure/testable); check_claude_cli() elevated to Required severity; build_gh_auth_result() (pure, testable); check_az_identity(); 10 check functions  [Issue #49, #34, #52]
 │   ├── git.rs                             # GitOps trait, CliGitOps: commit and push operations  [Phase 3]
 │   ├── models.rs                          # ModelRouter: label-based model routing  [Phase 3]
 │   ├── prompts.rs                         # PromptBuilder: structured issue prompts with task-type detection; ProjectLanguage enum; detect_project_language(); default_guardrail(); resolve_guardrail()  [Phase 3, Issue #43]
@@ -119,7 +119,7 @@ maestro/
 │   │   └── types.rs                       # State types; fork_lineage HashMap; record_fork, fork_chain, fork_depth methods  [Issue #12]
 │   ├── tui/
 │   │   ├── mod.rs                         # Event loop; keybindings; handle_screen_action() rewritten; command processing loop; launch_session_from_config(); FetchSuggestionData async handler spawns background GitHub fetch for ready/failed counts and milestone progress  [Phase 3, Issue #31-33, #46-48, #35]
-│   │   ├── app.rs                         # App state; TuiMode; TuiCommand enum (FetchIssues, FetchMilestones, FetchSuggestionData, LaunchSession, LaunchSessions); TuiDataEvent enum (Issues, Milestones, Issue, SuggestionData); SuggestionDataPayload; handle_data_event(); data_tx/data_rx channel; pending_commands; check_completions() uses config-driven gates with per-gate activity logging; poll_ci_status() with CI auto-fix loop; spawn_ci_fix_session(); on_issue_session_completed() skips PR creation for CI-fix sessions  [Issue #12, #31-33, #35, #40, #41, #43, #46-48]
+│   │   ├── app.rs                         # App state; TuiMode; TuiCommand enum (FetchIssues, FetchMilestones, FetchSuggestionData, LaunchSession, LaunchSessions); TuiDataEvent enum (Issues, Milestones, Issue, SuggestionData); SuggestionDataPayload; handle_data_event(); data_tx/data_rx channel; pending_commands; check_completions() uses config-driven gates with per-gate activity logging; poll_ci_status() with CI auto-fix loop; spawn_ci_fix_session(); on_issue_session_completed() skips PR creation for CI-fix sessions; issue launch path uses PromptBuilder::build_issue_prompt()  [Issue #12, #31-33, #35, #40, #41, #43, #46-48, #52]
 │   │   ├── activity_log.rs                # Scrollable activity log widget with LogLevel color coding  [Phase 1]
 │   │   ├── cost_dashboard.rs              # Cost dashboard widget: per-session and aggregate cost display  [Phase 3]
 │   │   ├── dep_graph.rs                   # ASCII dependency graph visualization  [Phase 3]
@@ -181,9 +181,9 @@ maestro/
 | `.claude/skills/` | Reusable knowledge bases for subagents |
 | `.claude/worktrees/` | Worktree checkouts managed by maestro |
 | `src/` | Rust source code |
-| `src/main.rs` | CLI entry point; `setup_app_from_config()` shared App setup helper; `cmd_dashboard()` with startup cleanup, config-driven wiring, and `FetchSuggestionData` queued on startup; `cmd_run()` refactored to use shared helper (Issues #29, #34, #35, #36, #49) |
+| `src/main.rs` | CLI entry point; `--skip-doctor` flag on `run` subcommand; `cmd_run()` calls `validate_preflight()` before launch and uses `PromptBuilder::build_issue_prompt()` for issue sessions; `setup_app_from_config()` shared App setup helper; `cmd_dashboard()` with startup cleanup, config-driven wiring, and `FetchSuggestionData` queued on startup (Issues #29, #34, #35, #36, #49, #52) |
 | `src/budget.rs` | Per-session and global budget enforcement (Phase 3) |
-| `src/doctor.rs` | Preflight check system: `CheckSeverity`, `CheckResult`, `DoctorReport`, `run_all_checks()`, `print_report()`; `build_gh_auth_result()` (pure/testable); `check_az_identity()` for Azure DevOps (Issues #49, #34) |
+| `src/doctor.rs` | Preflight check system: `CheckSeverity`, `CheckResult`, `DoctorReport`, `run_all_checks()`, `print_report()`; `validate_preflight()` fails fast if any required check fails; `build_claude_cli_result()` (pub(crate), pure/testable); `check_claude_cli()` is Required severity; `build_gh_auth_result()` (pure/testable); `check_az_identity()` for Azure DevOps (Issues #49, #34, #52) |
 | `src/git.rs` | GitOps trait and CLI-backed commit+push (Phase 3) |
 | `src/models.rs` | Label-based model routing (Phase 3) |
 | `src/prompts.rs` | Structured issue prompt builder with task-type detection; ProjectLanguage detection; guardrail resolution (Phase 3, Issue #43) |
@@ -220,7 +220,7 @@ maestro/
 | `src/state/progress.rs` | Session phase tracking (Phase 3) |
 | `src/tui/` | Terminal UI (ratatui) |
 | `src/tui/mod.rs` | Event loop; `handle_screen_action()`; command processing; `launch_session_from_config()`; `FetchSuggestionData` async handler for GitHub ready/failed counts and milestone progress (Issues #31-33, #35, #46-48) |
-| `src/tui/app.rs` | `App` struct; `TuiMode`; `TuiCommand` (adds `FetchSuggestionData`); `TuiDataEvent` (adds `SuggestionData`); `SuggestionDataPayload`; `handle_data_event()`; `data_tx`/`data_rx` channel; `check_completions()` config-driven gates with per-gate logging; `poll_ci_status()` with CI auto-fix loop; `spawn_ci_fix_session()`; `on_issue_session_completed()` skips PR creation for CI-fix sessions (Issues #12, #31-33, #35, #40, #41, #43, #46-48) |
+| `src/tui/app.rs` | `App` struct; `TuiMode`; `TuiCommand` (adds `FetchSuggestionData`); `TuiDataEvent` (adds `SuggestionData`); `SuggestionDataPayload`; `handle_data_event()`; `data_tx`/`data_rx` channel; `check_completions()` config-driven gates with per-gate logging; `poll_ci_status()` with CI auto-fix loop; `spawn_ci_fix_session()`; `on_issue_session_completed()` skips PR creation for CI-fix sessions; issue launch uses `PromptBuilder::build_issue_prompt()` (Issues #12, #31-33, #35, #40, #41, #43, #46-48, #52) |
 | `src/tui/activity_log.rs` | Scrollable log widget |
 | `src/tui/cost_dashboard.rs` | Per-session and aggregate cost display (Phase 3) |
 | `src/tui/dep_graph.rs` | ASCII dependency graph visualization (Phase 3) |

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -143,6 +143,33 @@ fn sanitize(s: &str) -> String {
     s.chars().filter(|c| !c.is_control()).collect()
 }
 
+/// Validate preflight checks and return an error if required checks fail.
+pub fn validate_preflight(report: &DoctorReport) -> anyhow::Result<()> {
+    let failed: Vec<String> = report
+        .checks
+        .iter()
+        .filter(|c| !c.passed && c.severity == CheckSeverity::Required)
+        .map(|c| format!("{}: {}", c.name, c.message))
+        .collect();
+    if !failed.is_empty() {
+        anyhow::bail!("Preflight failed: {}", failed.join("; "));
+    }
+    Ok(())
+}
+
+/// Pure, testable core of the claude cli check.
+pub(crate) fn build_claude_cli_result(available: bool, version: &str) -> CheckResult {
+    if available {
+        CheckResult::pass("claude cli", version, CheckSeverity::Required)
+    } else {
+        CheckResult::fail(
+            "claude cli",
+            "not installed — sessions won't launch",
+            CheckSeverity::Required,
+        )
+    }
+}
+
 /// Pure, testable core of the gh auth check.
 /// Accepts the outputs of the external process calls as plain values.
 pub(crate) fn build_gh_auth_result(
@@ -302,13 +329,9 @@ fn check_claude_cli() -> CheckResult {
     match Command::new("claude").arg("--version").output() {
         Ok(out) if out.status.success() => {
             let version = sanitize(String::from_utf8_lossy(&out.stdout).trim());
-            CheckResult::pass("claude cli", version, CheckSeverity::Optional)
+            build_claude_cli_result(true, &version)
         }
-        _ => CheckResult::fail(
-            "claude cli",
-            "not installed — sessions won't launch",
-            CheckSeverity::Optional,
-        ),
+        _ => build_claude_cli_result(false, ""),
     }
 }
 
@@ -583,5 +606,101 @@ mod tests {
             )],
         };
         assert!(report.has_failures());
+    }
+
+    // --- Tests for build_claude_cli_result() and validate_preflight() (Issue #52) ---
+
+    #[test]
+    fn build_claude_cli_result_pass_returns_required_severity() {
+        let result = build_claude_cli_result(true, "claude/1.2.3");
+        assert!(result.passed);
+        assert_eq!(result.severity, CheckSeverity::Required);
+    }
+
+    #[test]
+    fn build_claude_cli_result_fail_returns_required_severity() {
+        let result = build_claude_cli_result(false, "");
+        assert!(!result.passed);
+        assert_eq!(result.severity, CheckSeverity::Required);
+    }
+
+    #[test]
+    fn build_claude_cli_result_fail_message_contains_not_installed() {
+        let result = build_claude_cli_result(false, "");
+        assert!(result.message.contains("not installed"));
+    }
+
+    #[test]
+    fn build_claude_cli_result_pass_includes_version_in_message() {
+        let result = build_claude_cli_result(true, "claude/1.2.3");
+        assert!(result.message.contains("claude/1.2.3"));
+    }
+
+    #[test]
+    fn validate_preflight_returns_ok_when_no_failures() {
+        let report = DoctorReport {
+            checks: vec![
+                CheckResult::pass("gh cli", "ok", CheckSeverity::Required),
+                CheckResult::pass("claude cli", "ok", CheckSeverity::Required),
+            ],
+        };
+        assert!(validate_preflight(&report).is_ok());
+    }
+
+    #[test]
+    fn validate_preflight_returns_error_when_required_check_fails() {
+        let report = DoctorReport {
+            checks: vec![
+                CheckResult::pass("gh cli", "ok", CheckSeverity::Required),
+                CheckResult::fail("claude cli", "not installed", CheckSeverity::Required),
+            ],
+        };
+        assert!(validate_preflight(&report).is_err());
+    }
+
+    #[test]
+    fn validate_preflight_error_message_names_the_failing_check() {
+        let report = DoctorReport {
+            checks: vec![CheckResult::fail(
+                "claude cli",
+                "not installed — sessions won't launch",
+                CheckSeverity::Required,
+            )],
+        };
+        let err = validate_preflight(&report).unwrap_err();
+        assert!(err.to_string().contains("claude cli"));
+    }
+
+    #[test]
+    fn validate_preflight_returns_ok_when_only_optional_fails() {
+        let report = DoctorReport {
+            checks: vec![
+                CheckResult::pass("gh cli", "ok", CheckSeverity::Required),
+                CheckResult::fail("az cli", "not installed", CheckSeverity::Optional),
+            ],
+        };
+        assert!(validate_preflight(&report).is_ok());
+    }
+
+    #[test]
+    fn validate_preflight_returns_ok_on_empty_report() {
+        let report = DoctorReport { checks: vec![] };
+        assert!(validate_preflight(&report).is_ok());
+    }
+
+    #[test]
+    fn validate_preflight_error_lists_all_failing_required_checks() {
+        let report = DoctorReport {
+            checks: vec![
+                CheckResult::fail("gh cli", "not installed", CheckSeverity::Required),
+                CheckResult::fail("claude cli", "not installed", CheckSeverity::Required),
+            ],
+        };
+        let err = validate_preflight(&report).unwrap_err().to_string();
+        assert!(err.contains("gh cli"), "expected 'gh cli' in: {err}");
+        assert!(
+            err.contains("claude cli"),
+            "expected 'claude cli' in: {err}"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,10 @@ enum Commands {
         /// Resume from previous state after a crash
         #[arg(long)]
         resume: bool,
+
+        /// Skip preflight doctor checks before launching sessions
+        #[arg(long)]
+        skip_doctor: bool,
     },
     /// Show queued/pending issues from GitHub
     Queue,
@@ -157,6 +161,7 @@ async fn main() -> anyhow::Result<()> {
             mode,
             max_concurrent,
             resume,
+            skip_doctor,
         }) => {
             cmd_run(
                 prompt,
@@ -166,6 +171,7 @@ async fn main() -> anyhow::Result<()> {
                 mode,
                 max_concurrent,
                 resume,
+                skip_doctor,
             )
             .await
         }
@@ -668,6 +674,7 @@ fn cmd_doctor() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn cmd_run(
     prompt: Option<String>,
     issue: Option<String>,
@@ -676,8 +683,24 @@ async fn cmd_run(
     mode: Option<String>,
     max_concurrent_override: Option<usize>,
     resume: bool,
+    skip_doctor: bool,
 ) -> anyhow::Result<()> {
     let config = Config::find_and_load()?;
+
+    // Preflight doctor check — fail fast before wasting API credits
+    if !skip_doctor {
+        let config_ref = config.clone();
+        let report =
+            tokio::task::spawn_blocking(move || doctor::run_all_checks(Some(&config_ref))).await?;
+        if let Err(e) = doctor::validate_preflight(&report) {
+            doctor::print_report(&report);
+            return Err(e.context("Fix the issues above or pass --skip-doctor to bypass"));
+        }
+        for check in report.failed_checks() {
+            tracing::warn!("Doctor: {} — {}", check.name, check.message);
+        }
+    }
+
     let model = model.unwrap_or(config.sessions.default_model.clone());
     let session_mode = mode.unwrap_or(config.sessions.default_mode.clone());
 
@@ -688,7 +711,8 @@ async fn cmd_run(
     let issue_filter_labels = config.github.issue_filter_labels.clone();
     let worktree_mgr = Box::new(GitWorktreeManager::new(repo_root));
 
-    let mut app = setup_app_from_config(config, store, worktree_mgr, max_concurrent_override);
+    let mut app =
+        setup_app_from_config(config.clone(), store, worktree_mgr, max_concurrent_override);
 
     // Resume from previous state if requested
     if resume {
@@ -742,12 +766,8 @@ async fn cmd_run(
             // Use mode from label (maestro:mode:X) or CLI --mode or config default
             let issue_mode = crate::modes::mode_from_labels(&gh_issue.labels)
                 .unwrap_or_else(|| session_mode.clone());
-            let mut session = Session::new(
-                gh_issue.unattended_prompt(),
-                model.clone(),
-                issue_mode,
-                Some(num),
-            );
+            let prompt = crate::prompts::PromptBuilder::build_issue_prompt(&gh_issue, &config);
+            let mut session = Session::new(prompt, model.clone(), issue_mode, Some(num));
             session.issue_title = Some(gh_issue.title.clone());
 
             // Cache issue data

--- a/src/prompts.rs
+++ b/src/prompts.rs
@@ -421,4 +421,42 @@ mod tests {
         let result = resolve_guardrail(Some(""), dir.path());
         assert!(result.contains("gofmt"));
     }
+
+    // --- Tests for PromptBuilder enrichment (Issue #52) ---
+
+    #[test]
+    fn build_issue_prompt_contains_model_from_config() {
+        let issue = make_issue(&[]);
+        let config = make_config();
+        let prompt = PromptBuilder::build_issue_prompt(&issue, &config);
+        assert!(prompt.contains("Model:"));
+        assert!(prompt.contains(&config.sessions.default_model));
+    }
+
+    #[test]
+    fn build_issue_prompt_contains_mode_from_config() {
+        let issue = make_issue(&[]);
+        let config = make_config();
+        let prompt = PromptBuilder::build_issue_prompt(&issue, &config);
+        assert!(prompt.contains("Mode:"));
+    }
+
+    #[test]
+    fn build_issue_prompt_supersedes_unattended_prompt_for_feature_issues() {
+        let issue = make_issue(&["type:feature"]);
+        let config = make_config();
+        let prompt = PromptBuilder::build_issue_prompt(&issue, &config);
+        assert!(prompt.contains("Feature"));
+        // Phrase that belongs exclusively to the old unattended_prompt — must NOT leak in
+        assert!(!prompt.contains("Read relevant source files first, then implement"));
+    }
+
+    #[test]
+    fn build_issue_prompt_structured_reasoning_section_present() {
+        let issue = make_issue(&[]);
+        let config = make_config();
+        let prompt = PromptBuilder::build_issue_prompt(&issue, &config);
+        assert!(prompt.contains("## Approach"));
+        assert!(prompt.contains("1. Read and understand"));
+    }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -751,12 +751,12 @@ impl App {
                 let issue_mode =
                     crate::modes::mode_from_labels(&gh_issue.labels).unwrap_or(default_mode);
                 let issue_number = gh_issue.number;
-                let mut session = Session::new(
-                    gh_issue.unattended_prompt(),
-                    model,
-                    issue_mode,
-                    Some(issue_number),
-                );
+                let prompt = self
+                    .config
+                    .as_ref()
+                    .map(|c| crate::prompts::PromptBuilder::build_issue_prompt(&gh_issue, c))
+                    .unwrap_or_else(|| gh_issue.unattended_prompt());
+                let mut session = Session::new(prompt, model, issue_mode, Some(issue_number));
                 session.issue_title = Some(gh_issue.title.clone());
                 self.state.issue_cache.insert(issue_number, gh_issue);
                 self.pending_session_launches.push(session);


### PR DESCRIPTION
## Summary

- Add preflight doctor validation to `cmd_run()` — fails fast before wasting API credits on misconfigured environments; bypass with `--skip-doctor`
- Replace basic `unattended_prompt()` with `PromptBuilder::build_issue_prompt()` for richer structured prompts with task-type detection, phase instructions, safety guards, and reasoning steps
- Elevate `claude cli` doctor check from Optional to Required severity, extracted into pure testable `build_claude_cli_result()` helper

Closes #52

## Test plan
- [x] 679 tests pass (14 new covering `validate_preflight`, `build_claude_cli_result`, prompt enrichment)
- [x] `cargo fmt --check` clean
- [x] No new clippy warnings introduced
- [x] Manual: `maestro run --issue <N>` on a simple issue produces a working PR
- [x] Manual: `maestro run --issue <N> --skip-doctor` bypasses preflight checks
- [x] Manual: `maestro doctor` reports `claude cli` as Required severity