### PR TITLE
feat: add --image CLI flag for visual context (#42)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,10 @@ enum Commands {
         /// Skip preflight doctor checks before launching sessions
         #[arg(long)]
         skip_doctor: bool,
+
+        /// Image file(s) to attach as visual context (can be repeated)
+        #[arg(long = "image")]
+        images: Vec<std::path::PathBuf>,
     },
     /// Show queued/pending issues from GitHub
     Queue,
@@ -162,6 +166,7 @@ async fn main() -> anyhow::Result<()> {
             max_concurrent,
             resume,
             skip_doctor,
+            images,
         }) => {
             cmd_run(
                 prompt,
@@ -172,6 +177,7 @@ async fn main() -> anyhow::Result<()> {
                 max_concurrent,
                 resume,
                 skip_doctor,
+                images,
             )
             .await
         }
@@ -684,6 +690,7 @@ async fn cmd_run(
     max_concurrent_override: Option<usize>,
     resume: bool,
     skip_doctor: bool,
+    images: Vec<std::path::PathBuf>,
 ) -> anyhow::Result<()> {
     let config = Config::find_and_load()?;
 
@@ -699,6 +706,11 @@ async fn cmd_run(
         for check in report.failed_checks() {
             tracing::warn!("Doctor: {} — {}", check.name, check.message);
         }
+    }
+
+    // Validate image paths upfront
+    for img in &images {
+        session::image::validate_image_path(img)?;
     }
 
     let model = model.unwrap_or(config.sessions.default_model.clone());
@@ -736,7 +748,8 @@ async fn cmd_run(
 
     // Determine what to run
     if let Some(prompt_text) = prompt {
-        let session = Session::new(prompt_text, model, session_mode.clone(), None);
+        let session = Session::new(prompt_text, model, session_mode.clone(), None)
+            .with_image_paths(images.clone());
         app.add_session(session).await?;
     } else if let Some(milestone_name) = milestone {
         // Fetch all issues in the milestone
@@ -766,8 +779,11 @@ async fn cmd_run(
             // Use mode from label (maestro:mode:X) or CLI --mode or config default
             let issue_mode = crate::modes::mode_from_labels(&gh_issue.labels)
                 .unwrap_or_else(|| session_mode.clone());
-            let prompt = crate::prompts::PromptBuilder::build_issue_prompt(&gh_issue, &config);
-            let mut session = Session::new(prompt, model.clone(), issue_mode, Some(num));
+            let prompt = crate::prompts::PromptBuilder::build_issue_prompt_with_images(
+                &gh_issue, &config, &images,
+            );
+            let mut session = Session::new(prompt, model.clone(), issue_mode, Some(num))
+                .with_image_paths(images.clone());
             session.issue_title = Some(gh_issue.title.clone());
 
             // Cache issue data

--- a/src/prompts.rs
+++ b/src/prompts.rs
@@ -1,6 +1,7 @@
 use crate::config::Config;
 use crate::github::types::GhIssue;
-use std::path::Path;
+use crate::session::image::image_section_for_prompt;
+use std::path::{Path, PathBuf};
 
 /// Detected project language for guardrail defaults.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -82,6 +83,19 @@ pub fn resolve_guardrail(custom: Option<&str>, project_dir: &Path) -> String {
 pub struct PromptBuilder;
 
 impl PromptBuilder {
+    /// Build a structured prompt for an issue-based session with optional image references.
+    pub fn build_issue_prompt_with_images(
+        issue: &GhIssue,
+        config: &Config,
+        image_relative_paths: &[PathBuf],
+    ) -> String {
+        let base = Self::build_issue_prompt(issue, config);
+        match image_section_for_prompt(image_relative_paths) {
+            Some(section) => format!("{base}\n\n{section}"),
+            None => base,
+        }
+    }
+
     /// Build a structured prompt for an issue-based session.
     pub fn build_issue_prompt(issue: &GhIssue, config: &Config) -> String {
         let task_type = Self::detect_task_type(issue);
@@ -449,6 +463,50 @@ mod tests {
         assert!(prompt.contains("Feature"));
         // Phrase that belongs exclusively to the old unattended_prompt — must NOT leak in
         assert!(!prompt.contains("Read relevant source files first, then implement"));
+    }
+
+    // --- image prompt tests (issue #42) ---
+
+    fn make_image_paths(names: &[&str]) -> Vec<std::path::PathBuf> {
+        names.iter().map(|n| std::path::PathBuf::from(n)).collect()
+    }
+
+    #[test]
+    fn build_issue_prompt_with_images_includes_image_section_when_paths_provided() {
+        let issue = make_issue(&[]);
+        let config = make_config();
+        let images = make_image_paths(&["screenshot.png"]);
+        let prompt = PromptBuilder::build_issue_prompt_with_images(&issue, &config, &images);
+        assert!(prompt.contains("Attached Images"));
+    }
+
+    #[test]
+    fn build_issue_prompt_with_images_lists_all_image_filenames() {
+        let issue = make_issue(&[]);
+        let config = make_config();
+        let images = make_image_paths(&["before.png", "after.jpg"]);
+        let prompt = PromptBuilder::build_issue_prompt_with_images(&issue, &config, &images);
+        assert!(prompt.contains("before.png"));
+        assert!(prompt.contains("after.jpg"));
+    }
+
+    #[test]
+    fn build_issue_prompt_with_images_omits_image_section_when_no_images() {
+        let issue = make_issue(&[]);
+        let config = make_config();
+        let prompt = PromptBuilder::build_issue_prompt_with_images(&issue, &config, &[]);
+        assert!(!prompt.contains("Attached Images"));
+    }
+
+    #[test]
+    fn build_issue_prompt_with_images_preserves_existing_prompt_content() {
+        let issue = make_issue(&[]);
+        let config = make_config();
+        let images = make_image_paths(&["ui.png"]);
+        let prompt = PromptBuilder::build_issue_prompt_with_images(&issue, &config, &images);
+        assert!(prompt.contains("#42"));
+        assert!(prompt.contains("unattended mode"));
+        assert!(prompt.contains("Attached Images"));
     }
 
     #[test]

--- a/src/session/image.rs
+++ b/src/session/image.rs
@@ -1,0 +1,191 @@
+use anyhow::{Result, bail};
+use std::path::{Path, PathBuf};
+
+pub const VALID_IMAGE_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "gif", "webp", "svg"];
+
+/// Validate that `path` exists on disk and has an allowed image extension.
+pub fn validate_image_path(path: &Path) -> Result<()> {
+    if !path.exists() {
+        bail!("image path does not exist: {}", path.display());
+    }
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+    if !VALID_IMAGE_EXTENSIONS.contains(&ext.as_str()) {
+        bail!(
+            "unsupported image extension '{}' for path: {}",
+            ext,
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+/// Copy each image into `worktree_dir` and return the relative filenames.
+pub fn copy_images_to_worktree(
+    image_paths: &[PathBuf],
+    worktree_dir: &Path,
+) -> Result<Vec<PathBuf>> {
+    let mut relative = Vec::with_capacity(image_paths.len());
+    for src in image_paths {
+        let filename = src
+            .file_name()
+            .ok_or_else(|| anyhow::anyhow!("image path has no filename: {}", src.display()))?;
+        let dest = worktree_dir.join(filename);
+        std::fs::copy(src, &dest)?;
+        relative.push(PathBuf::from(filename));
+    }
+    Ok(relative)
+}
+
+/// Build the image section for a prompt. Returns `None` when `paths` is empty.
+pub fn image_section_for_prompt(paths: &[PathBuf]) -> Option<String> {
+    if paths.is_empty() {
+        return None;
+    }
+    let list = paths
+        .iter()
+        .map(|p| format!("- {}", p.display()))
+        .collect::<Vec<_>>()
+        .join("\n");
+    Some(format!("## Attached Images\n\n{list}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    // --- validate_image_path ---
+
+    #[test]
+    fn validate_image_path_accepts_valid_extensions() {
+        let dir = tempdir().unwrap();
+        for ext in VALID_IMAGE_EXTENSIONS {
+            let path = dir.path().join(format!("test.{ext}"));
+            std::fs::write(&path, b"").unwrap();
+            assert!(
+                validate_image_path(&path).is_ok(),
+                "expected Ok for extension: {ext}",
+            );
+        }
+    }
+
+    #[test]
+    fn validate_image_path_rejects_invalid_extension() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("document.txt");
+        std::fs::write(&path, b"").unwrap();
+        let result = validate_image_path(&path);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("txt") || msg.contains("extension"),
+            "msg: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_image_path_rejects_nonexistent_file() {
+        let path = PathBuf::from("/nonexistent/ghost.png");
+        let result = validate_image_path(&path);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("does not exist") || msg.contains("ghost.png"),
+            "msg: {msg}"
+        );
+    }
+
+    #[test]
+    fn validate_image_path_rejects_path_with_no_extension() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("Makefile");
+        std::fs::write(&path, b"").unwrap();
+        assert!(validate_image_path(&path).is_err());
+    }
+
+    // --- copy_images_to_worktree ---
+
+    #[test]
+    fn copy_images_to_worktree_copies_files_to_destination() {
+        let src_dir = tempdir().unwrap();
+        let wt_dir = tempdir().unwrap();
+        let img1 = src_dir.path().join("photo.png");
+        let img2 = src_dir.path().join("diagram.jpg");
+        std::fs::write(&img1, b"png-data").unwrap();
+        std::fs::write(&img2, b"jpg-data").unwrap();
+
+        copy_images_to_worktree(&[img1, img2], wt_dir.path()).unwrap();
+
+        assert!(wt_dir.path().join("photo.png").exists());
+        assert!(wt_dir.path().join("diagram.jpg").exists());
+    }
+
+    #[test]
+    fn copy_images_to_worktree_returns_relative_paths() {
+        let src_dir = tempdir().unwrap();
+        let wt_dir = tempdir().unwrap();
+        let img = src_dir.path().join("photo.png");
+        std::fs::write(&img, b"data").unwrap();
+
+        let relative = copy_images_to_worktree(&[img], wt_dir.path()).unwrap();
+
+        assert_eq!(relative.len(), 1);
+        assert_eq!(relative[0], PathBuf::from("photo.png"));
+        assert!(!relative[0].is_absolute());
+    }
+
+    #[test]
+    fn copy_images_to_worktree_with_empty_slice_returns_empty_vec() {
+        let wt_dir = tempdir().unwrap();
+        let result = copy_images_to_worktree(&[], wt_dir.path()).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn copy_images_to_worktree_handles_duplicate_filenames_by_overwriting() {
+        let src1 = tempdir().unwrap();
+        let src2 = tempdir().unwrap();
+        let wt_dir = tempdir().unwrap();
+        let p1 = src1.path().join("logo.png");
+        let p2 = src2.path().join("logo.png");
+        std::fs::write(&p1, b"version-1").unwrap();
+        std::fs::write(&p2, b"version-2").unwrap();
+
+        copy_images_to_worktree(&[p1, p2], wt_dir.path()).unwrap();
+
+        let content = std::fs::read(wt_dir.path().join("logo.png")).unwrap();
+        assert_eq!(content, b"version-2");
+    }
+
+    // --- image_section_for_prompt ---
+
+    #[test]
+    fn image_section_for_prompt_returns_none_for_empty_slice() {
+        assert!(image_section_for_prompt(&[]).is_none());
+    }
+
+    #[test]
+    fn image_section_for_prompt_returns_some_with_single_image() {
+        let result = image_section_for_prompt(&[PathBuf::from("diagram.svg")]);
+        let section = result.unwrap();
+        assert!(section.contains("diagram.svg"));
+        assert!(section.contains("Attached Images"));
+    }
+
+    #[test]
+    fn image_section_for_prompt_formats_multiple_images_as_list() {
+        let paths = vec![
+            PathBuf::from("a.png"),
+            PathBuf::from("b.jpg"),
+            PathBuf::from("c.gif"),
+        ];
+        let section = image_section_for_prompt(&paths).unwrap();
+        assert!(section.contains("a.png"));
+        assert!(section.contains("b.jpg"));
+        assert!(section.contains("c.gif"));
+    }
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -2,6 +2,7 @@ pub mod cleanup;
 pub mod context_monitor;
 pub mod fork;
 pub mod health;
+pub mod image;
 pub mod logger;
 pub mod manager;
 pub mod parser;

--- a/src/session/pool.rs
+++ b/src/session/pool.rs
@@ -2,6 +2,7 @@ use std::collections::VecDeque;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
+use super::image::copy_images_to_worktree;
 use super::manager::{ManagedSession, SessionEvent};
 use super::types::{Session, SessionStatus};
 use super::worktree::WorktreeManager;
@@ -95,6 +96,24 @@ impl SessionPool {
                     (None, None)
                 }
             };
+
+            // Copy images to worktree if available
+            if let Some(ref wt_path) = worktree_path
+                && !session.image_paths.is_empty()
+            {
+                match copy_images_to_worktree(&session.image_paths, wt_path) {
+                    Ok(_) => {
+                        session.log_activity(format!(
+                            "Copied {} image(s) to worktree",
+                            session.image_paths.len()
+                        ));
+                    }
+                    Err(e) => {
+                        tracing::warn!("Failed to copy images to worktree: {}", e);
+                        session.log_activity(format!("Image copy failed (non-fatal): {}", e));
+                    }
+                }
+            }
 
             // Build system prompt with file claims and guardrails
             let mut system_prompt = self.file_claims.build_system_prompt(session.id);

--- a/src/session/types.rs
+++ b/src/session/types.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -108,6 +109,9 @@ pub struct Session {
     /// If this session is a CI fix, tracks the PR and attempt number.
     #[serde(default)]
     pub ci_fix_context: Option<CiFixContext>,
+    /// Image paths attached to this session for visual context.
+    #[serde(default)]
+    pub image_paths: Vec<PathBuf>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -141,7 +145,14 @@ impl Session {
             child_session_ids: Vec::new(),
             fork_depth: 0,
             ci_fix_context: None,
+            image_paths: Vec::new(),
         }
+    }
+
+    /// Builder method to attach image paths to a session.
+    pub fn with_image_paths(mut self, paths: Vec<PathBuf>) -> Self {
+        self.image_paths = paths;
+        self
     }
 
     pub fn log_activity(&mut self, message: String) {
@@ -305,6 +316,45 @@ mod tests {
             Some(10),
         );
         assert!(s.ci_fix_context.is_none());
+    }
+
+    // --- image_paths field tests (issue #42) ---
+
+    #[test]
+    fn session_new_initializes_image_paths_as_empty() {
+        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None);
+        assert!(s.image_paths.is_empty());
+    }
+
+    #[test]
+    fn session_with_image_paths_builder() {
+        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None)
+            .with_image_paths(vec![
+                std::path::PathBuf::from("/tmp/a.png"),
+                std::path::PathBuf::from("/tmp/b.jpg"),
+            ]);
+        assert_eq!(s.image_paths.len(), 2);
+    }
+
+    #[test]
+    fn session_with_image_paths_round_trips_via_serde() {
+        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None)
+            .with_image_paths(vec![
+                std::path::PathBuf::from("img/a.png"),
+                std::path::PathBuf::from("img/b.jpg"),
+            ]);
+        let json = serde_json::to_string(&s).unwrap();
+        let rt: Session = serde_json::from_str(&json).unwrap();
+        assert_eq!(rt.image_paths, s.image_paths);
+    }
+
+    #[test]
+    fn session_image_paths_deserializes_with_default_when_field_absent() {
+        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None);
+        let json = serde_json::to_string(&s).unwrap();
+        let stripped = json.replace(r#","image_paths":[]"#, "");
+        let rt: Session = serde_json::from_str(&stripped).unwrap();
+        assert!(rt.image_paths.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `--image` CLI flag to `maestro run` for attaching screenshots/images as visual context
- New `src/session/image.rs` module with image validation (extension allowlist) and worktree copy logic
- Images are validated upfront, copied to worktree on session promotion, and referenced in the prompt via `build_issue_prompt_with_images`

Closes #42

## Test plan

- [x] 19 new unit tests covering image validation, worktree copy, prompt construction, and Session serde
- [x] `cargo fmt` passes
- [x] `cargo clippy` — no new warnings (43 pre-existing)
- [x] `cargo test` — all 698+ tests pass