### PR TITLE
feat: keyboard navigation system and focus management

### DIFF
--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-04 (UTC)
+> Last updated: 2026-04-04 18:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -129,6 +129,10 @@ maestro/
 │   │   ├── help.rs                        # Help overlay widget with keybinding reference  [Phase 3]
 │   │   ├── panels.rs                      # Split-pane panel view; fork depth indicator in title; overflow warning in context gauge; GatesRunning (Cyan), NeedsReview (LightYellow), and CiFix (LightMagenta) status colors  [Issue #12, #40, #41]
 │   │   ├── ui.rs                          # ratatui rendering; budget display, TUI mode switching, notification banners, screen rendering branches  [Phase 3, Issue #31-33]
+│   │   ├── navigation/                    # Keyboard navigation and focus management  [Issue #37]
+│   │   │   ├── mod.rs                     # Module exports for navigation subsystem
+│   │   │   ├── focus.rs                   # Focus management: FocusManager, focus ring, widget focus state
+│   │   │   └── keymap.rs                  # Keymap definitions: action-to-key bindings, context-sensitive keymaps
 │   │   └── screens/                       # Interactive screen components  [Issue #31-33]
 │   │       ├── mod.rs                     # Screen types: ScreenAction enum, SessionConfig; re-exports HomeScreen, IssueBrowserScreen, MilestoneScreen
 │   │       ├── home.rs                    # HomeScreen: idle dashboard, logo, quick-actions menu, suggestions panel, recent activity panel; SuggestionKind enum, Suggestion struct, HomeSection enum; build_suggestions() derives contextual hints from GitHub data; draw_suggestions() renders Suggestions panel; Tab-based focus navigation between QuickActions and Suggestions; ProjectInfo gains username field  [Issue #31, #49, #34, #35]
@@ -229,6 +233,10 @@ maestro/
 | `src/tui/detail.rs` | Session detail view (Phase 3) |
 | `src/tui/fullscreen.rs` | Fullscreen session view with phase progress overlay (Phase 3) |
 | `src/tui/help.rs` | Help overlay widget with keybinding reference (Phase 3) |
+| `src/tui/navigation/` | Keyboard navigation system and focus management (Issue #37) |
+| `src/tui/navigation/mod.rs` | Module exports for navigation subsystem |
+| `src/tui/navigation/focus.rs` | `FocusManager`: focus ring, widget focus state tracking |
+| `src/tui/navigation/keymap.rs` | Keymap definitions: action-to-key bindings, context-sensitive keymaps |
 | `src/tui/panels.rs` | Split-pane multi-session view; `GatesRunning` (Cyan), `NeedsReview` (LightYellow), and `CiFix` (LightMagenta) status colors (Issues #40, #41) |
 | `src/tui/screens/` | Interactive TUI screen components (Issues #31-33) |
 | `src/tui/screens/mod.rs` | `ScreenAction` enum, `SessionConfig`; re-exports all screen types |

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -148,6 +148,8 @@ pub struct App {
     pub plugin_runner: Option<PluginRunner>,
     /// Whether the help overlay is visible.
     pub show_help: bool,
+    /// Scroll offset for the help overlay.
+    pub help_scroll: u16,
     /// Context overflow monitor.
     pub context_monitor: Box<dyn ContextMonitor>,
     /// Fork policy for auto-fork decisions.
@@ -214,6 +216,8 @@ impl App {
             last_work_tick: Instant::now(),
             plugin_runner: None,
             show_help: false,
+            help_scroll: 0,
+
             context_monitor: Box::new(ProductionContextMonitor::new()),
             fork_policy: None,
             home_screen: None,

--- a/src/tui/help.rs
+++ b/src/tui/help.rs
@@ -1,3 +1,5 @@
+use crate::tui::navigation::InputMode;
+use crate::tui::navigation::keymap::{KeyBindingGroup, global_keybindings};
 use crate::tui::theme::Theme;
 use ratatui::{
     Frame,
@@ -8,13 +10,21 @@ use ratatui::{
 };
 
 /// Draw the help overlay popup centered on the screen.
-pub fn draw_help_overlay(f: &mut Frame, area: Rect, theme: &Theme) {
+/// Shows global keybindings and context-sensitive screen keybindings.
+pub fn draw_help_overlay(
+    f: &mut Frame,
+    area: Rect,
+    screen_bindings: &[KeyBindingGroup],
+    input_mode: InputMode,
+    scroll: u16,
+    theme: &Theme,
+) {
     let popup = centered_rect(60, 70, area);
 
     // Clear background behind popup
     f.render_widget(Clear, popup);
 
-    let help_text = vec![
+    let mut help_text = vec![
         Line::from(vec![Span::styled(
             "Keyboard Shortcuts",
             Style::default()
@@ -22,40 +32,31 @@ pub fn draw_help_overlay(f: &mut Frame, area: Rect, theme: &Theme) {
                 .add_modifier(Modifier::BOLD),
         )]),
         Line::from(""),
-        section_header("Navigation", theme),
-        key_line(
-            "Tab",
-            "Cycle views (Overview → Dependencies → Overview)",
-            theme,
-        ),
-        key_line("Esc", "Return to Overview / Close help", theme),
-        key_line("Enter", "Open detail view for selected session", theme),
-        key_line("1-9", "Jump to session detail by index", theme),
-        key_line("?", "Toggle this help overlay", theme),
+        // Show current input mode
+        Line::from(vec![
+            Span::styled("  Mode: ", Style::default().fg(theme.text_secondary)),
+            Span::styled(
+                match input_mode {
+                    InputMode::Normal => "Normal",
+                    InputMode::Insert => "Insert",
+                },
+                Style::default()
+                    .fg(theme.accent_warning)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]),
         Line::from(""),
-        section_header("Views", theme),
-        key_line("f", "Full-screen view for selected session", theme),
-        key_line("$", "Cost dashboard view", theme),
-        Line::from(""),
-        section_header("Session Control", theme),
-        key_line("p", "Pause all running sessions (SIGSTOP)", theme),
-        key_line("r", "Resume all paused sessions (SIGCONT)", theme),
-        key_line("k", "Kill all sessions", theme),
-        key_line("d", "Dismiss notification banner", theme),
-        Line::from(""),
-        section_header("Scrolling", theme),
-        key_line("↑/↓", "Scroll agent panel output", theme),
-        key_line("Shift+↑/↓", "Scroll activity log", theme),
-        key_line("Mouse wheel", "Scroll focused panel", theme),
-        Line::from(""),
-        section_header("General", theme),
-        key_line("q / Ctrl+c", "Quit maestro", theme),
-        Line::from(""),
-        Line::from(vec![Span::styled(
-            "Press ? or Esc to close",
-            Style::default().fg(theme.text_secondary),
-        )]),
     ];
+
+    // Render screen-specific bindings first, then global bindings
+    render_binding_groups(&mut help_text, screen_bindings, theme);
+    let globals = global_keybindings();
+    render_binding_groups(&mut help_text, &globals, theme);
+
+    help_text.push(Line::from(vec![Span::styled(
+        "Press ? or Esc to close",
+        Style::default().fg(theme.text_secondary),
+    )]));
 
     let paragraph = Paragraph::new(help_text)
         .block(
@@ -65,7 +66,8 @@ pub fn draw_help_overlay(f: &mut Frame, area: Rect, theme: &Theme) {
                 .title(" Help ")
                 .title_alignment(Alignment::Center),
         )
-        .wrap(Wrap { trim: false });
+        .wrap(Wrap { trim: false })
+        .scroll((scroll, 0));
 
     f.render_widget(paragraph, popup);
 }
@@ -90,6 +92,20 @@ fn key_line<'a>(key: &'a str, desc: &'a str, theme: &Theme) -> Line<'a> {
         ),
         Span::styled(desc, Style::default().fg(theme.text_primary)),
     ])
+}
+
+fn render_binding_groups<'a>(
+    lines: &mut Vec<Line<'a>>,
+    groups: &'a [KeyBindingGroup],
+    theme: &Theme,
+) {
+    for group in groups {
+        lines.push(section_header(group.title, theme));
+        for binding in &group.bindings {
+            lines.push(key_line(binding.key, binding.description, theme));
+        }
+        lines.push(Line::from(""));
+    }
 }
 
 /// Create a centered rectangle within the given area.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -5,6 +5,7 @@ pub mod dep_graph;
 pub mod detail;
 pub mod fullscreen;
 pub mod help;
+pub mod navigation;
 pub mod panels;
 pub mod screens;
 pub mod theme;
@@ -12,6 +13,7 @@ pub mod ui;
 
 use crate::github::client::{GhCliClient, GitHubClient};
 use crate::tui::activity_log::LogLevel;
+use crate::tui::screens::Screen;
 use app::App;
 use crossterm::{
     event::{
@@ -85,53 +87,37 @@ async fn event_loop(
                     // Help overlay intercepts all keys when visible
                     if app.show_help {
                         match key.code {
-                            KeyCode::Char('?') | KeyCode::Esc => app.show_help = false,
+                            KeyCode::Char('?') | KeyCode::Esc => {
+                                app.show_help = false;
+                                app.help_scroll = 0;
+                            }
+                            KeyCode::Char('j') | KeyCode::Down => {
+                                app.help_scroll = app.help_scroll.saturating_add(1);
+                            }
+                            KeyCode::Char('k') | KeyCode::Up => {
+                                app.help_scroll = app.help_scroll.saturating_sub(1);
+                            }
                             _ => {}
                         }
                         continue;
                     }
 
+                    // Global hotkeys that must not be swallowed by screens
+                    if key.code == KeyCode::Char('?') {
+                        app.show_help = true;
+                        app.help_scroll = 0;
+                        continue;
+                    }
+
                     // Delegate to active screen when in screen-based modes
                     let event = Event::Key(key);
-                    let screen_handled = match app.tui_mode {
-                        app::TuiMode::Dashboard => {
-                            if let Some(ref mut screen) = app.home_screen {
-                                let action = screen.handle_input(&event);
-                                handle_screen_action(app, action);
-                                true
-                            } else {
-                                false
-                            }
-                        }
-                        app::TuiMode::IssueBrowser => {
-                            if let Some(ref mut screen) = app.issue_browser_screen {
-                                let action = screen.handle_input(&event);
-                                handle_screen_action(app, action);
-                                true
-                            } else {
-                                false
-                            }
-                        }
-                        app::TuiMode::MilestoneView => {
-                            if let Some(ref mut screen) = app.milestone_screen {
-                                let action = screen.handle_input(&event);
-                                handle_screen_action(app, action);
-                                true
-                            } else {
-                                false
-                            }
-                        }
-                        app::TuiMode::PromptInput => {
-                            if let Some(ref mut screen) = app.prompt_input_screen {
-                                let action = screen.handle_input(&event);
-                                handle_screen_action(app, action);
-                                true
-                            } else {
-                                false
-                            }
-                        }
-                        _ => false,
-                    };
+                    let screen_handled =
+                        if let Some(action) = dispatch_to_active_screen(app, &event) {
+                            handle_screen_action(app, action);
+                            true
+                        } else {
+                            false
+                        };
 
                     if screen_handled {
                         if !app.running {
@@ -155,10 +141,6 @@ async fn event_loop(
                         }
                         (KeyCode::Char('k'), _) => {
                             app.kill_all().await;
-                        }
-                        // Help overlay
-                        (KeyCode::Char('?'), _) => {
-                            app.show_help = true;
                         }
                         // Full-screen view for selected session
                         (KeyCode::Char('f'), _) => {
@@ -396,6 +378,22 @@ async fn event_loop(
             return Ok(());
         }
     }
+}
+
+/// Dispatch an input event to the active screen, if any.
+/// Returns `Some(action)` if a screen handled the event, `None` otherwise.
+fn dispatch_to_active_screen(app: &mut App, event: &Event) -> Option<ScreenAction> {
+    use crate::tui::navigation::InputMode;
+
+    let screen: &mut dyn Screen = match app.tui_mode {
+        app::TuiMode::Dashboard => app.home_screen.as_mut()?,
+        app::TuiMode::IssueBrowser => app.issue_browser_screen.as_mut()?,
+        app::TuiMode::MilestoneView => app.milestone_screen.as_mut()?,
+        app::TuiMode::PromptInput => app.prompt_input_screen.as_mut()?,
+        _ => return None,
+    };
+    let mode = screen.desired_input_mode().unwrap_or(InputMode::Normal);
+    Some(screen.handle_input(event, mode))
 }
 
 /// Process a ScreenAction returned by a screen's input handler.

--- a/src/tui/navigation/focus.rs
+++ b/src/tui/navigation/focus.rs
@@ -1,0 +1,201 @@
+use std::fmt;
+
+/// Unique identifier for a focusable pane within a screen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FocusId(pub &'static str);
+
+impl fmt::Display for FocusId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Manages focus cycling within a screen's declared panes.
+#[derive(Debug, Clone)]
+pub struct FocusRing {
+    panes: Vec<FocusId>,
+    current: usize,
+}
+
+impl FocusRing {
+    /// Create a new FocusRing. Panics if `panes` is empty.
+    pub fn new(panes: Vec<FocusId>) -> Self {
+        assert!(!panes.is_empty(), "FocusRing requires at least one pane");
+        Self { panes, current: 0 }
+    }
+
+    /// The currently focused pane.
+    pub fn current(&self) -> FocusId {
+        self.panes[self.current]
+    }
+
+    /// Cycle to the next pane (wraps around). Returns the new focus.
+    pub fn next(&mut self) -> FocusId {
+        if !self.panes.is_empty() {
+            self.current = (self.current + 1) % self.panes.len();
+        }
+        self.current()
+    }
+
+    /// Cycle to the previous pane (wraps around). Returns the new focus.
+    pub fn previous(&mut self) -> FocusId {
+        if !self.panes.is_empty() {
+            self.current = if self.current == 0 {
+                self.panes.len() - 1
+            } else {
+                self.current - 1
+            };
+        }
+        self.current()
+    }
+
+    /// Jump to a specific pane by id. Returns true if found.
+    pub fn set(&mut self, id: FocusId) -> bool {
+        if let Some(pos) = self.panes.iter().position(|p| *p == id) {
+            self.current = pos;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Check if a given pane is currently focused.
+    pub fn is_focused(&self, id: FocusId) -> bool {
+        self.current() == id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn focus_ring_new_sets_current_to_first_pane() {
+        let ring = FocusRing::new(vec![FocusId("a"), FocusId("b"), FocusId("c")]);
+        assert_eq!(ring.current(), FocusId("a"));
+    }
+
+    #[test]
+    fn focus_ring_new_with_single_pane_current_is_that_pane() {
+        let ring = FocusRing::new(vec![FocusId("only")]);
+        assert_eq!(ring.current(), FocusId("only"));
+    }
+
+    #[test]
+    fn focus_ring_next_advances_to_second_pane() {
+        let mut ring = FocusRing::new(vec![FocusId("a"), FocusId("b"), FocusId("c")]);
+        let next = ring.next();
+        assert_eq!(next, FocusId("b"));
+        assert_eq!(ring.current(), FocusId("b"));
+    }
+
+    #[test]
+    fn focus_ring_next_wraps_from_last_to_first() {
+        let mut ring = FocusRing::new(vec![FocusId("a"), FocusId("b"), FocusId("c")]);
+        ring.next(); // -> b
+        ring.next(); // -> c
+        let wrapped = ring.next(); // -> a
+        assert_eq!(wrapped, FocusId("a"));
+    }
+
+    #[test]
+    fn focus_ring_next_on_single_pane_stays_at_same_pane() {
+        let mut ring = FocusRing::new(vec![FocusId("only")]);
+        let next = ring.next();
+        assert_eq!(next, FocusId("only"));
+    }
+
+    #[test]
+    fn focus_ring_previous_wraps_from_first_to_last() {
+        let mut ring = FocusRing::new(vec![FocusId("a"), FocusId("b"), FocusId("c")]);
+        let prev = ring.previous();
+        assert_eq!(prev, FocusId("c"));
+    }
+
+    #[test]
+    fn focus_ring_previous_moves_back_one_step() {
+        let mut ring = FocusRing::new(vec![FocusId("a"), FocusId("b"), FocusId("c")]);
+        ring.next(); // -> b
+        ring.next(); // -> c
+        let prev = ring.previous(); // -> b
+        assert_eq!(prev, FocusId("b"));
+    }
+
+    #[test]
+    fn focus_ring_previous_on_single_pane_stays_at_same_pane() {
+        let mut ring = FocusRing::new(vec![FocusId("only")]);
+        assert_eq!(ring.previous(), FocusId("only"));
+    }
+
+    #[test]
+    fn focus_ring_next_then_previous_returns_to_origin() {
+        let mut ring = FocusRing::new(vec![FocusId("a"), FocusId("b"), FocusId("c")]);
+        ring.next();
+        ring.previous();
+        assert_eq!(ring.current(), FocusId("a"));
+    }
+
+    #[test]
+    fn focus_ring_set_valid_id_returns_true_and_updates_current() {
+        let mut ring = FocusRing::new(vec![FocusId("a"), FocusId("b"), FocusId("c")]);
+        let result = ring.set(FocusId("c"));
+        assert!(result);
+        assert_eq!(ring.current(), FocusId("c"));
+    }
+
+    #[test]
+    fn focus_ring_set_unknown_id_returns_false_and_leaves_current_unchanged() {
+        let mut ring = FocusRing::new(vec![FocusId("a"), FocusId("b")]);
+        let result = ring.set(FocusId("z"));
+        assert!(!result);
+        assert_eq!(ring.current(), FocusId("a"));
+    }
+
+    #[test]
+    fn focus_ring_is_focused_returns_true_for_current_pane() {
+        let ring = FocusRing::new(vec![FocusId("a"), FocusId("b")]);
+        assert!(ring.is_focused(FocusId("a")));
+    }
+
+    #[test]
+    fn focus_ring_is_focused_returns_false_for_non_current_pane() {
+        let ring = FocusRing::new(vec![FocusId("a"), FocusId("b")]);
+        assert!(!ring.is_focused(FocusId("b")));
+    }
+
+    #[test]
+    fn focus_ring_is_focused_updates_correctly_after_next() {
+        let mut ring = FocusRing::new(vec![FocusId("a"), FocusId("b")]);
+        ring.next();
+        assert!(!ring.is_focused(FocusId("a")));
+        assert!(ring.is_focused(FocusId("b")));
+    }
+
+    #[test]
+    fn focus_ring_full_cycle_returns_to_start() {
+        let panes = vec![FocusId("a"), FocusId("b"), FocusId("c"), FocusId("d")];
+        let len = panes.len();
+        let mut ring = FocusRing::new(panes);
+        for _ in 0..len {
+            ring.next();
+        }
+        assert_eq!(ring.current(), FocusId("a"));
+    }
+
+    #[test]
+    fn focus_ring_full_reverse_cycle_returns_to_start() {
+        let panes = vec![FocusId("a"), FocusId("b"), FocusId("c")];
+        let len = panes.len();
+        let mut ring = FocusRing::new(panes);
+        for _ in 0..len {
+            ring.previous();
+        }
+        assert_eq!(ring.current(), FocusId("a"));
+    }
+
+    #[test]
+    #[should_panic(expected = "FocusRing requires at least one pane")]
+    fn focus_ring_empty_panes_panics() {
+        FocusRing::new(vec![]);
+    }
+}

--- a/src/tui/navigation/keymap.rs
+++ b/src/tui/navigation/keymap.rs
@@ -1,0 +1,190 @@
+/// A single keybinding declaration for documentation and help overlay.
+#[derive(Debug, Clone)]
+pub struct KeyBinding {
+    /// Human-readable key label (e.g., "j/Down", "Tab", "Ctrl+s").
+    pub key: &'static str,
+    /// Short description of what this binding does.
+    pub description: &'static str,
+}
+
+/// A group of keybindings with a section label, for help overlay rendering.
+#[derive(Debug, Clone)]
+pub struct KeyBindingGroup {
+    pub title: &'static str,
+    pub bindings: Vec<KeyBinding>,
+}
+
+/// Trait for screens/components that declare their keybindings.
+/// This drives the context-sensitive help overlay.
+pub trait KeymapProvider {
+    fn keybindings(&self) -> Vec<KeyBindingGroup>;
+}
+
+/// Return the global keybindings that apply regardless of active screen.
+pub fn global_keybindings() -> Vec<KeyBindingGroup> {
+    vec![
+        KeyBindingGroup {
+            title: "Navigation",
+            bindings: vec![
+                KeyBinding {
+                    key: "Tab",
+                    description: "Cycle focus between panes",
+                },
+                KeyBinding {
+                    key: "Esc",
+                    description: "Return to previous screen / Close help",
+                },
+                KeyBinding {
+                    key: "Enter",
+                    description: "Open detail / Execute action",
+                },
+                KeyBinding {
+                    key: "1-9",
+                    description: "Jump to session detail by index",
+                },
+                KeyBinding {
+                    key: "?",
+                    description: "Toggle help overlay",
+                },
+            ],
+        },
+        KeyBindingGroup {
+            title: "Views",
+            bindings: vec![
+                KeyBinding {
+                    key: "f",
+                    description: "Full-screen view for selected session",
+                },
+                KeyBinding {
+                    key: "$",
+                    description: "Cost dashboard view",
+                },
+            ],
+        },
+        KeyBindingGroup {
+            title: "Session Control",
+            bindings: vec![
+                KeyBinding {
+                    key: "p",
+                    description: "Pause all running sessions (SIGSTOP)",
+                },
+                KeyBinding {
+                    key: "r",
+                    description: "Resume all paused sessions (SIGCONT)",
+                },
+                KeyBinding {
+                    key: "k",
+                    description: "Kill all sessions",
+                },
+                KeyBinding {
+                    key: "d",
+                    description: "Dismiss notification banner",
+                },
+            ],
+        },
+        KeyBindingGroup {
+            title: "Scrolling",
+            bindings: vec![
+                KeyBinding {
+                    key: "Up/Down",
+                    description: "Scroll agent panel output",
+                },
+                KeyBinding {
+                    key: "Shift+Up/Down",
+                    description: "Scroll activity log",
+                },
+                KeyBinding {
+                    key: "Mouse wheel",
+                    description: "Scroll focused panel",
+                },
+            ],
+        },
+        KeyBindingGroup {
+            title: "General",
+            bindings: vec![KeyBinding {
+                key: "q / Ctrl+c",
+                description: "Quit maestro",
+            }],
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_binding_has_correct_key_and_description() {
+        let binding = KeyBinding {
+            key: "Tab",
+            description: "Cycle focus",
+        };
+        assert_eq!(binding.key, "Tab");
+        assert_eq!(binding.description, "Cycle focus");
+    }
+
+    #[test]
+    fn key_binding_group_contains_all_provided_bindings() {
+        let group = KeyBindingGroup {
+            title: "Navigation",
+            bindings: vec![
+                KeyBinding {
+                    key: "j",
+                    description: "Down",
+                },
+                KeyBinding {
+                    key: "k",
+                    description: "Up",
+                },
+            ],
+        };
+        assert_eq!(group.bindings.len(), 2);
+        assert_eq!(group.title, "Navigation");
+    }
+
+    #[test]
+    fn global_keybindings_returns_non_empty_list() {
+        let groups = global_keybindings();
+        assert!(!groups.is_empty());
+    }
+
+    #[test]
+    fn global_keybindings_includes_quit_binding() {
+        let groups = global_keybindings();
+        let all_bindings: Vec<&KeyBinding> =
+            groups.iter().flat_map(|g| g.bindings.iter()).collect();
+        let has_quit = all_bindings
+            .iter()
+            .any(|b| b.description.to_lowercase().contains("quit"));
+        assert!(has_quit);
+    }
+
+    #[test]
+    fn global_keybindings_includes_tab_for_focus_cycling() {
+        let groups = global_keybindings();
+        let all_bindings: Vec<&KeyBinding> =
+            groups.iter().flat_map(|g| g.bindings.iter()).collect();
+        let has_tab = all_bindings.iter().any(|b| b.key.contains("Tab"));
+        assert!(has_tab);
+    }
+
+    #[test]
+    fn keymapprovider_implementor_returns_groups() {
+        struct MyScreen;
+        impl KeymapProvider for MyScreen {
+            fn keybindings(&self) -> Vec<KeyBindingGroup> {
+                vec![KeyBindingGroup {
+                    title: "Test",
+                    bindings: vec![KeyBinding {
+                        key: "x",
+                        description: "Do X",
+                    }],
+                }]
+            }
+        }
+        let screen = MyScreen;
+        let groups = screen.keybindings();
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].bindings[0].key, "x");
+    }
+}

--- a/src/tui/navigation/mod.rs
+++ b/src/tui/navigation/mod.rs
@@ -1,0 +1,35 @@
+pub mod focus;
+pub mod keymap;
+
+/// Vim-style input mode for the entire application.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum InputMode {
+    /// Normal mode: single-key shortcuts navigate and execute commands.
+    #[default]
+    Normal,
+    /// Insert mode: keystrokes go to a text input field (filter, prompt, etc.).
+    Insert,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn input_mode_default_is_normal() {
+        let mode = InputMode::default();
+        assert_eq!(mode, InputMode::Normal);
+    }
+
+    #[test]
+    fn input_mode_normal_and_insert_are_not_equal() {
+        assert_ne!(InputMode::Normal, InputMode::Insert);
+    }
+
+    #[test]
+    fn input_mode_clone_produces_equal_value() {
+        let a = InputMode::Insert;
+        let b = a;
+        assert_eq!(a, b);
+    }
+}

--- a/src/tui/screens/home.rs
+++ b/src/tui/screens/home.rs
@@ -1,5 +1,8 @@
-use super::ScreenAction;
+use super::{Screen, ScreenAction};
 use crate::tui::app::TuiMode;
+use crate::tui::navigation::InputMode;
+use crate::tui::navigation::focus::{FocusId, FocusRing};
+use crate::tui::navigation::keymap::{KeyBinding, KeyBindingGroup, KeymapProvider};
 use crate::tui::theme::Theme;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind};
 use ratatui::{
@@ -140,12 +143,6 @@ impl Suggestion {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum HomeSection {
-    QuickActions,
-    Suggestions,
-}
-
 pub struct HomeScreen {
     pub selected_action: usize,
     pub recent_sessions: Vec<SessionSummary>,
@@ -153,12 +150,14 @@ pub struct HomeScreen {
     pub warnings: Vec<String>,
     pub suggestions: Vec<Suggestion>,
     pub selected_suggestion: usize,
-    pub focus_section: HomeSection,
+    pub focus_ring: FocusRing,
 }
 
 impl HomeScreen {
     pub const NUM_ACTIONS: usize = QUICK_ACTIONS.len();
     pub const QUIT_ACTION_INDEX: usize = 5;
+    pub const QUICK_ACTIONS_PANE: FocusId = FocusId("home:quick_actions");
+    pub const SUGGESTIONS_PANE: FocusId = FocusId("home:suggestions");
 
     pub fn new(
         project_info: ProjectInfo,
@@ -172,71 +171,19 @@ impl HomeScreen {
             warnings,
             suggestions: Vec::new(),
             selected_suggestion: 0,
-            focus_section: HomeSection::QuickActions,
+            focus_ring: FocusRing::new(vec![Self::QUICK_ACTIONS_PANE, Self::SUGGESTIONS_PANE]),
         }
     }
 
-    pub fn handle_input(&mut self, event: &Event) -> ScreenAction {
-        if let Event::Key(KeyEvent {
-            code,
-            kind: KeyEventKind::Press,
-            ..
-        }) = event
-        {
-            match code {
-                KeyCode::Char('i') => return ScreenAction::Push(TuiMode::IssueBrowser),
-                KeyCode::Char('m') => return ScreenAction::Push(TuiMode::MilestoneView),
-                KeyCode::Char('r') => return ScreenAction::Push(TuiMode::PromptInput),
-                KeyCode::Char('s') => return ScreenAction::Push(TuiMode::Overview),
-                KeyCode::Char('c') => return ScreenAction::Push(TuiMode::CostDashboard),
-                KeyCode::Char('q') => return ScreenAction::Quit,
-                KeyCode::Tab => {
-                    self.focus_section = match self.focus_section {
-                        HomeSection::QuickActions => HomeSection::Suggestions,
-                        HomeSection::Suggestions => HomeSection::QuickActions,
-                    };
-                }
-                KeyCode::Char('j') | KeyCode::Down => match self.focus_section {
-                    HomeSection::QuickActions => {
-                        if self.selected_action < Self::NUM_ACTIONS - 1 {
-                            self.selected_action += 1;
-                        }
-                    }
-                    HomeSection::Suggestions => {
-                        if !self.suggestions.is_empty()
-                            && self.selected_suggestion < self.suggestions.len() - 1
-                        {
-                            self.selected_suggestion += 1;
-                        }
-                    }
-                },
-                KeyCode::Char('k') | KeyCode::Up => match self.focus_section {
-                    HomeSection::QuickActions => {
-                        self.selected_action = self.selected_action.saturating_sub(1);
-                    }
-                    HomeSection::Suggestions => {
-                        self.selected_suggestion = self.selected_suggestion.saturating_sub(1);
-                    }
-                },
-                KeyCode::Enter => match self.focus_section {
-                    HomeSection::QuickActions => {
-                        return self.execute_selected_action();
-                    }
-                    HomeSection::Suggestions => {
-                        if let Some(suggestion) = self.suggestions.get(self.selected_suggestion) {
-                            return ScreenAction::Push(suggestion.action);
-                        }
-                        return ScreenAction::None;
-                    }
-                },
-                KeyCode::Esc => return ScreenAction::None,
-                _ => {}
-            }
-        }
-        ScreenAction::None
+    fn is_quick_actions_focused(&self) -> bool {
+        self.focus_ring.is_focused(Self::QUICK_ACTIONS_PANE)
     }
 
-    pub fn draw(&self, f: &mut Frame, area: Rect, theme: &Theme) {
+    fn is_suggestions_focused(&self) -> bool {
+        self.focus_ring.is_focused(Self::SUGGESTIONS_PANE)
+    }
+
+    fn draw_impl(&self, f: &mut Frame, area: Rect, theme: &Theme) {
         let warning_height = if self.warnings.is_empty() {
             0
         } else {
@@ -353,7 +300,7 @@ impl HomeScreen {
     }
 
     fn draw_quick_actions(&self, f: &mut Frame, area: Rect, theme: &Theme) {
-        let is_focused = self.focus_section == HomeSection::QuickActions;
+        let is_focused = self.is_quick_actions_focused();
         let border_color = if is_focused {
             theme.border_active
         } else {
@@ -393,7 +340,7 @@ impl HomeScreen {
     }
 
     fn draw_suggestions(&self, f: &mut Frame, area: Rect, theme: &Theme) {
-        let is_focused = self.focus_section == HomeSection::Suggestions;
+        let is_focused = self.is_suggestions_focused();
         let border_color = if is_focused {
             theme.border_active
         } else {
@@ -496,6 +443,125 @@ impl HomeScreen {
     }
 }
 
+impl KeymapProvider for HomeScreen {
+    fn keybindings(&self) -> Vec<KeyBindingGroup> {
+        vec![
+            KeyBindingGroup {
+                title: "Navigation",
+                bindings: vec![
+                    KeyBinding {
+                        key: "j/Down",
+                        description: "Move down",
+                    },
+                    KeyBinding {
+                        key: "k/Up",
+                        description: "Move up",
+                    },
+                    KeyBinding {
+                        key: "Tab",
+                        description: "Cycle focus between panes",
+                    },
+                ],
+            },
+            KeyBindingGroup {
+                title: "Actions",
+                bindings: vec![
+                    KeyBinding {
+                        key: "Enter",
+                        description: "Execute selected action",
+                    },
+                    KeyBinding {
+                        key: "i",
+                        description: "Browse Issues",
+                    },
+                    KeyBinding {
+                        key: "m",
+                        description: "Browse Milestones",
+                    },
+                    KeyBinding {
+                        key: "r",
+                        description: "Run Prompt",
+                    },
+                    KeyBinding {
+                        key: "q",
+                        description: "Quit",
+                    },
+                ],
+            },
+        ]
+    }
+}
+
+impl Screen for HomeScreen {
+    fn handle_input(&mut self, event: &Event, mode: InputMode) -> ScreenAction {
+        if let Event::Key(KeyEvent {
+            code,
+            kind: KeyEventKind::Press,
+            ..
+        }) = event
+        {
+            if mode == InputMode::Insert {
+                return ScreenAction::None;
+            }
+
+            match code {
+                KeyCode::Char('i') => return ScreenAction::Push(TuiMode::IssueBrowser),
+                KeyCode::Char('m') => return ScreenAction::Push(TuiMode::MilestoneView),
+                KeyCode::Char('r') => return ScreenAction::Push(TuiMode::PromptInput),
+                KeyCode::Char('s') => return ScreenAction::Push(TuiMode::Overview),
+                KeyCode::Char('c') => return ScreenAction::Push(TuiMode::CostDashboard),
+                KeyCode::Char('q') => return ScreenAction::Quit,
+                KeyCode::Tab => {
+                    self.focus_ring.next();
+                }
+                KeyCode::BackTab => {
+                    self.focus_ring.previous();
+                }
+                KeyCode::Char('j') | KeyCode::Down => {
+                    if self.is_quick_actions_focused() {
+                        if self.selected_action < Self::NUM_ACTIONS - 1 {
+                            self.selected_action += 1;
+                        }
+                    } else if self.is_suggestions_focused()
+                        && !self.suggestions.is_empty()
+                        && self.selected_suggestion < self.suggestions.len() - 1
+                    {
+                        self.selected_suggestion += 1;
+                    }
+                }
+                KeyCode::Char('k') | KeyCode::Up => {
+                    if self.is_quick_actions_focused() {
+                        self.selected_action = self.selected_action.saturating_sub(1);
+                    } else if self.is_suggestions_focused() {
+                        self.selected_suggestion = self.selected_suggestion.saturating_sub(1);
+                    }
+                }
+                KeyCode::Enter => {
+                    if self.is_quick_actions_focused() {
+                        return self.execute_selected_action();
+                    } else if self.is_suggestions_focused() {
+                        if let Some(suggestion) = self.suggestions.get(self.selected_suggestion) {
+                            return ScreenAction::Push(suggestion.action);
+                        }
+                        return ScreenAction::None;
+                    }
+                }
+                KeyCode::Esc => return ScreenAction::None,
+                _ => {}
+            }
+        }
+        ScreenAction::None
+    }
+
+    fn draw(&mut self, f: &mut Frame, area: Rect, theme: &Theme) {
+        self.draw_impl(f, area, theme);
+    }
+
+    fn desired_input_mode(&self) -> Option<InputMode> {
+        Some(InputMode::Normal)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -536,7 +602,7 @@ mod tests {
     #[test]
     fn home_key_j_moves_selection_down() {
         let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
-        let action = screen.handle_input(&key_event(KeyCode::Char('j')));
+        let action = screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
         assert_eq!(action, ScreenAction::None);
         assert_eq!(screen.selected_action, 1);
     }
@@ -544,25 +610,25 @@ mod tests {
     #[test]
     fn home_key_down_moves_selection_down() {
         let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
-        screen.handle_input(&key_event(KeyCode::Down));
+        screen.handle_input(&key_event(KeyCode::Down), InputMode::Normal);
         assert_eq!(screen.selected_action, 1);
     }
 
     #[test]
     fn home_key_k_moves_selection_up() {
         let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
-        screen.handle_input(&key_event(KeyCode::Char('j')));
-        screen.handle_input(&key_event(KeyCode::Char('j')));
+        screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
         assert_eq!(screen.selected_action, 2);
-        screen.handle_input(&key_event(KeyCode::Char('k')));
+        screen.handle_input(&key_event(KeyCode::Char('k')), InputMode::Normal);
         assert_eq!(screen.selected_action, 1);
     }
 
     #[test]
     fn home_key_k_does_not_underflow_at_zero() {
         let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
-        screen.handle_input(&key_event(KeyCode::Char('k')));
-        screen.handle_input(&key_event(KeyCode::Char('k')));
+        screen.handle_input(&key_event(KeyCode::Char('k')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Char('k')), InputMode::Normal);
         assert_eq!(screen.selected_action, 0);
     }
 
@@ -571,7 +637,7 @@ mod tests {
         let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
         let num_actions = HomeScreen::NUM_ACTIONS;
         for _ in 0..num_actions + 5 {
-            screen.handle_input(&key_event(KeyCode::Char('j')));
+            screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
         }
         assert_eq!(screen.selected_action, num_actions - 1);
     }
@@ -579,44 +645,44 @@ mod tests {
     #[test]
     fn home_key_up_moves_selection_up() {
         let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
-        screen.handle_input(&key_event(KeyCode::Down));
-        screen.handle_input(&key_event(KeyCode::Up));
+        screen.handle_input(&key_event(KeyCode::Down), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Up), InputMode::Normal);
         assert_eq!(screen.selected_action, 0);
     }
 
     #[test]
     fn home_key_i_returns_push_issue_browser() {
         let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
-        let action = screen.handle_input(&key_event(KeyCode::Char('i')));
+        let action = screen.handle_input(&key_event(KeyCode::Char('i')), InputMode::Normal);
         assert_eq!(action, ScreenAction::Push(TuiMode::IssueBrowser));
     }
 
     #[test]
     fn home_key_m_returns_push_milestone_view() {
         let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
-        let action = screen.handle_input(&key_event(KeyCode::Char('m')));
+        let action = screen.handle_input(&key_event(KeyCode::Char('m')), InputMode::Normal);
         assert_eq!(action, ScreenAction::Push(TuiMode::MilestoneView));
     }
 
     #[test]
     fn home_key_q_returns_quit() {
         let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
-        let action = screen.handle_input(&key_event(KeyCode::Char('q')));
+        let action = screen.handle_input(&key_event(KeyCode::Char('q')), InputMode::Normal);
         assert_eq!(action, ScreenAction::Quit);
     }
 
     #[test]
     fn home_enter_on_issues_action_returns_push_issue_browser() {
         let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
-        let action = screen.handle_input(&key_event(KeyCode::Enter));
+        let action = screen.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
         assert_eq!(action, ScreenAction::Push(TuiMode::IssueBrowser));
     }
 
     #[test]
     fn home_enter_on_milestones_action_returns_push_milestone_view() {
         let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
-        screen.handle_input(&key_event(KeyCode::Down));
-        let action = screen.handle_input(&key_event(KeyCode::Enter));
+        screen.handle_input(&key_event(KeyCode::Down), InputMode::Normal);
+        let action = screen.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
         assert_eq!(action, ScreenAction::Push(TuiMode::MilestoneView));
     }
 
@@ -624,16 +690,16 @@ mod tests {
     fn home_enter_on_quit_action_returns_quit() {
         let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
         for _ in 0..HomeScreen::QUIT_ACTION_INDEX {
-            screen.handle_input(&key_event(KeyCode::Down));
+            screen.handle_input(&key_event(KeyCode::Down), InputMode::Normal);
         }
-        let action = screen.handle_input(&key_event(KeyCode::Enter));
+        let action = screen.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
         assert_eq!(action, ScreenAction::Quit);
     }
 
     #[test]
     fn home_esc_returns_none() {
         let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
-        let action = screen.handle_input(&key_event(KeyCode::Esc));
+        let action = screen.handle_input(&key_event(KeyCode::Esc), InputMode::Normal);
         assert_eq!(action, ScreenAction::None);
     }
 
@@ -657,7 +723,7 @@ mod tests {
     #[test]
     fn home_unknown_key_returns_none() {
         let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
-        let action = screen.handle_input(&key_event(KeyCode::Char('x')));
+        let action = screen.handle_input(&key_event(KeyCode::Char('x')), InputMode::Normal);
         assert_eq!(action, ScreenAction::None);
     }
 
@@ -698,7 +764,7 @@ mod tests {
     }
 
     fn focus_suggestions(screen: &mut HomeScreen) {
-        screen.handle_input(&key_event(KeyCode::Tab));
+        screen.handle_input(&key_event(KeyCode::Tab), InputMode::Normal);
     }
 
     // -- Suggestion::build_suggestions (pure logic) --
@@ -821,27 +887,58 @@ mod tests {
         assert_eq!(result[3].kind, SuggestionKind::IdleSessions);
     }
 
-    // -- HomeSection focus and Tab toggle --
+    // -- FocusRing focus and Tab toggle --
 
     #[test]
-    fn home_initial_focus_section_is_quick_actions() {
+    fn home_initial_focus_is_quick_actions() {
         let screen = HomeScreen::new(make_project_info(), vec![], vec![]);
-        assert_eq!(screen.focus_section, HomeSection::QuickActions);
+        assert!(screen.focus_ring.is_focused(HomeScreen::QUICK_ACTIONS_PANE));
     }
 
     #[test]
     fn home_tab_toggles_focus_from_quick_actions_to_suggestions() {
         let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
-        screen.handle_input(&key_event(KeyCode::Tab));
-        assert_eq!(screen.focus_section, HomeSection::Suggestions);
+        screen.handle_input(&key_event(KeyCode::Tab), InputMode::Normal);
+        assert!(screen.focus_ring.is_focused(HomeScreen::SUGGESTIONS_PANE));
     }
 
     #[test]
     fn home_tab_toggles_focus_back_to_quick_actions() {
         let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
-        screen.handle_input(&key_event(KeyCode::Tab));
-        screen.handle_input(&key_event(KeyCode::Tab));
-        assert_eq!(screen.focus_section, HomeSection::QuickActions);
+        screen.handle_input(&key_event(KeyCode::Tab), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Tab), InputMode::Normal);
+        assert!(screen.focus_ring.is_focused(HomeScreen::QUICK_ACTIONS_PANE));
+    }
+
+    #[test]
+    fn home_shift_tab_cycles_focus_in_reverse() {
+        use crate::tui::screens::test_helpers::key_event_with_modifiers;
+        use crossterm::event::KeyModifiers;
+        let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
+        let shift_tab = key_event_with_modifiers(KeyCode::BackTab, KeyModifiers::SHIFT);
+        screen.handle_input(&shift_tab, InputMode::Normal);
+        assert!(screen.focus_ring.is_focused(HomeScreen::SUGGESTIONS_PANE));
+    }
+
+    // -- Screen trait tests --
+
+    #[test]
+    fn home_desired_input_mode_is_normal() {
+        let screen = HomeScreen::new(make_project_info(), vec![], vec![]);
+        assert_eq!(screen.desired_input_mode(), Some(InputMode::Normal));
+    }
+
+    #[test]
+    fn home_keybindings_returns_at_least_one_group() {
+        let screen = HomeScreen::new(make_project_info(), vec![], vec![]);
+        assert!(!screen.keybindings().is_empty());
+    }
+
+    #[test]
+    fn home_handle_input_navigation_keys_ignored_in_insert_mode() {
+        let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
+        let action = screen.handle_input(&key_event(KeyCode::Char('q')), InputMode::Insert);
+        assert_ne!(action, ScreenAction::Quit);
     }
 
     // -- Suggestion list navigation --
@@ -857,7 +954,7 @@ mod tests {
         let sug = Suggestion::build_suggestions(1, 0, &[("v1".to_string(), 1, 2)], 1);
         let mut screen = make_home_with_suggestions(sug);
         focus_suggestions(&mut screen);
-        screen.handle_input(&key_event(KeyCode::Char('j')));
+        screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
         assert_eq!(screen.selected_suggestion, 1);
     }
 
@@ -866,7 +963,7 @@ mod tests {
         let sug = Suggestion::build_suggestions(1, 0, &[("v1".to_string(), 1, 2)], 1);
         let mut screen = make_home_with_suggestions(sug);
         focus_suggestions(&mut screen);
-        screen.handle_input(&key_event(KeyCode::Down));
+        screen.handle_input(&key_event(KeyCode::Down), InputMode::Normal);
         assert_eq!(screen.selected_suggestion, 1);
     }
 
@@ -875,9 +972,9 @@ mod tests {
         let sug = Suggestion::build_suggestions(1, 0, &[("v1".to_string(), 1, 2)], 1);
         let mut screen = make_home_with_suggestions(sug);
         focus_suggestions(&mut screen);
-        screen.handle_input(&key_event(KeyCode::Char('j')));
+        screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
         assert_eq!(screen.selected_suggestion, 1);
-        screen.handle_input(&key_event(KeyCode::Char('k')));
+        screen.handle_input(&key_event(KeyCode::Char('k')), InputMode::Normal);
         assert_eq!(screen.selected_suggestion, 0);
     }
 
@@ -886,8 +983,8 @@ mod tests {
         let sug = Suggestion::build_suggestions(1, 0, &[], 1);
         let mut screen = make_home_with_suggestions(sug);
         focus_suggestions(&mut screen);
-        screen.handle_input(&key_event(KeyCode::Char('k')));
-        screen.handle_input(&key_event(KeyCode::Char('k')));
+        screen.handle_input(&key_event(KeyCode::Char('k')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Char('k')), InputMode::Normal);
         assert_eq!(screen.selected_suggestion, 0);
     }
 
@@ -897,7 +994,7 @@ mod tests {
         let mut screen = make_home_with_suggestions(sug);
         focus_suggestions(&mut screen);
         for _ in 0..10 {
-            screen.handle_input(&key_event(KeyCode::Char('j')));
+            screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
         }
         assert_eq!(screen.selected_suggestion, 1);
     }
@@ -905,7 +1002,7 @@ mod tests {
     #[test]
     fn home_j_navigates_quick_actions_when_focus_is_quick_actions() {
         let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
-        screen.handle_input(&key_event(KeyCode::Char('j')));
+        screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
         assert_eq!(screen.selected_action, 1);
         assert_eq!(screen.selected_suggestion, 0);
     }
@@ -917,7 +1014,7 @@ mod tests {
         let sug = Suggestion::build_suggestions(3, 0, &[], 1);
         let mut screen = make_home_with_suggestions(sug);
         focus_suggestions(&mut screen);
-        let action = screen.handle_input(&key_event(KeyCode::Enter));
+        let action = screen.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
         assert_eq!(action, ScreenAction::Push(TuiMode::IssueBrowser));
     }
 
@@ -926,7 +1023,7 @@ mod tests {
         let sug = Suggestion::build_suggestions(0, 0, &[("v1".to_string(), 1, 5)], 1);
         let mut screen = make_home_with_suggestions(sug);
         focus_suggestions(&mut screen);
-        let action = screen.handle_input(&key_event(KeyCode::Enter));
+        let action = screen.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
         assert_eq!(action, ScreenAction::Push(TuiMode::MilestoneView));
     }
 
@@ -935,7 +1032,7 @@ mod tests {
         let sug = Suggestion::build_suggestions(0, 0, &[], 0);
         let mut screen = make_home_with_suggestions(sug);
         focus_suggestions(&mut screen);
-        let action = screen.handle_input(&key_event(KeyCode::Enter));
+        let action = screen.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
         assert_eq!(action, ScreenAction::Push(TuiMode::Overview));
     }
 
@@ -943,7 +1040,7 @@ mod tests {
     fn home_enter_when_suggestions_empty_and_focused_returns_none() {
         let mut screen = make_home_with_suggestions(vec![]);
         focus_suggestions(&mut screen);
-        let action = screen.handle_input(&key_event(KeyCode::Enter));
+        let action = screen.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
         assert_eq!(action, ScreenAction::None);
     }
 
@@ -953,7 +1050,7 @@ mod tests {
     fn home_char_i_returns_issue_browser_when_focused_on_suggestions() {
         let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
         focus_suggestions(&mut screen);
-        let action = screen.handle_input(&key_event(KeyCode::Char('i')));
+        let action = screen.handle_input(&key_event(KeyCode::Char('i')), InputMode::Normal);
         assert_eq!(action, ScreenAction::Push(TuiMode::IssueBrowser));
     }
 
@@ -961,7 +1058,7 @@ mod tests {
     fn home_char_m_returns_milestone_view_when_focused_on_suggestions() {
         let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
         focus_suggestions(&mut screen);
-        let action = screen.handle_input(&key_event(KeyCode::Char('m')));
+        let action = screen.handle_input(&key_event(KeyCode::Char('m')), InputMode::Normal);
         assert_eq!(action, ScreenAction::Push(TuiMode::MilestoneView));
     }
 
@@ -969,7 +1066,7 @@ mod tests {
     fn home_char_q_returns_quit_when_focused_on_suggestions() {
         let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
         focus_suggestions(&mut screen);
-        let action = screen.handle_input(&key_event(KeyCode::Char('q')));
+        let action = screen.handle_input(&key_event(KeyCode::Char('q')), InputMode::Normal);
         assert_eq!(action, ScreenAction::Quit);
     }
 
@@ -1031,7 +1128,7 @@ mod tests {
     fn home_j_on_empty_suggestions_when_focused_does_not_panic() {
         let mut screen = make_home_with_suggestions(vec![]);
         focus_suggestions(&mut screen);
-        screen.handle_input(&key_event(KeyCode::Char('j')));
+        screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
         assert_eq!(screen.selected_suggestion, 0);
     }
 
@@ -1039,7 +1136,7 @@ mod tests {
     fn home_k_on_empty_suggestions_when_focused_does_not_panic() {
         let mut screen = make_home_with_suggestions(vec![]);
         focus_suggestions(&mut screen);
-        screen.handle_input(&key_event(KeyCode::Char('k')));
+        screen.handle_input(&key_event(KeyCode::Char('k')), InputMode::Normal);
         assert_eq!(screen.selected_suggestion, 0);
     }
 
@@ -1049,8 +1146,8 @@ mod tests {
         let mut screen = make_home_with_suggestions(sug);
         focus_suggestions(&mut screen);
         // Navigate to index 2
-        screen.handle_input(&key_event(KeyCode::Char('j')));
-        screen.handle_input(&key_event(KeyCode::Char('j')));
+        screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
         assert_eq!(screen.selected_suggestion, 2);
         // Replace with fewer suggestions
         let new_sug = Suggestion::build_suggestions(1, 0, &[], 1);
@@ -1063,13 +1160,13 @@ mod tests {
         let sug = Suggestion::build_suggestions(1, 0, &[("v1".to_string(), 1, 2)], 1);
         let mut screen = make_home_with_suggestions(sug);
         // Move quick actions selection to 2
-        screen.handle_input(&key_event(KeyCode::Char('j')));
-        screen.handle_input(&key_event(KeyCode::Char('j')));
+        screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
         assert_eq!(screen.selected_action, 2);
         // Switch to suggestions and navigate
         focus_suggestions(&mut screen);
-        screen.handle_input(&key_event(KeyCode::Char('j')));
-        screen.handle_input(&key_event(KeyCode::Char('k')));
+        screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Char('k')), InputMode::Normal);
         // Quick actions selection must be unchanged
         assert_eq!(screen.selected_action, 2);
         assert_eq!(screen.selected_suggestion, 0);

--- a/src/tui/screens/issue_browser.rs
+++ b/src/tui/screens/issue_browser.rs
@@ -1,5 +1,7 @@
-use super::{ScreenAction, SessionConfig, draw_keybinds_bar, sanitize_for_terminal};
+use super::{Screen, ScreenAction, SessionConfig, draw_keybinds_bar, sanitize_for_terminal};
 use crate::github::types::GhIssue;
+use crate::tui::navigation::InputMode;
+use crate::tui::navigation::keymap::{KeyBinding, KeyBindingGroup, KeymapProvider};
 use crate::tui::theme::Theme;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind};
 use ratatui::{
@@ -57,56 +59,7 @@ impl IssueBrowserScreen {
         self.loading = false;
     }
 
-    pub fn handle_input(&mut self, event: &Event) -> ScreenAction {
-        if let Event::Key(KeyEvent {
-            code,
-            kind: KeyEventKind::Press,
-            ..
-        }) = event
-        {
-            // In filter mode, handle text input
-            if self.filter_mode != FilterMode::None {
-                return self.handle_filter_input(*code);
-            }
-
-            match code {
-                KeyCode::Esc => return ScreenAction::Pop,
-                KeyCode::Char('j') | KeyCode::Down => {
-                    if !self.filtered_indices.is_empty()
-                        && self.selected < self.filtered_indices.len() - 1
-                    {
-                        self.selected += 1;
-                        self.sync_scroll();
-                    }
-                }
-                KeyCode::Char('k') | KeyCode::Up => {
-                    self.selected = self.selected.saturating_sub(1);
-                    self.sync_scroll();
-                }
-                KeyCode::Char(' ') => {
-                    if let Some(&idx) = self.filtered_indices.get(self.selected) {
-                        let number = self.issues[idx].number;
-                        if !self.selected_set.remove(&number) {
-                            self.selected_set.insert(number);
-                        }
-                    }
-                }
-                KeyCode::Char('/') => {
-                    self.filter_mode = FilterMode::Label;
-                }
-                KeyCode::Char('m') => {
-                    self.filter_mode = FilterMode::Milestone;
-                }
-                KeyCode::Enter => {
-                    return self.handle_enter();
-                }
-                _ => {}
-            }
-        }
-        ScreenAction::None
-    }
-
-    pub fn draw(&mut self, f: &mut Frame, area: Rect, theme: &Theme) {
+    fn draw_impl(&mut self, f: &mut Frame, area: Rect, theme: &Theme) {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
@@ -355,6 +308,114 @@ impl IssueBrowserScreen {
     }
 }
 
+impl KeymapProvider for IssueBrowserScreen {
+    fn keybindings(&self) -> Vec<KeyBindingGroup> {
+        vec![
+            KeyBindingGroup {
+                title: "Navigation",
+                bindings: vec![
+                    KeyBinding {
+                        key: "j/Down",
+                        description: "Move down",
+                    },
+                    KeyBinding {
+                        key: "k/Up",
+                        description: "Move up",
+                    },
+                    KeyBinding {
+                        key: "Space",
+                        description: "Toggle multi-select",
+                    },
+                ],
+            },
+            KeyBindingGroup {
+                title: "Actions",
+                bindings: vec![
+                    KeyBinding {
+                        key: "Enter",
+                        description: "Run selected issue(s)",
+                    },
+                    KeyBinding {
+                        key: "/",
+                        description: "Filter by label/title",
+                    },
+                    KeyBinding {
+                        key: "m",
+                        description: "Filter by milestone",
+                    },
+                    KeyBinding {
+                        key: "Esc",
+                        description: "Back / Cancel filter",
+                    },
+                ],
+            },
+        ]
+    }
+}
+
+impl Screen for IssueBrowserScreen {
+    fn handle_input(&mut self, event: &Event, _mode: InputMode) -> ScreenAction {
+        if let Event::Key(KeyEvent {
+            code,
+            kind: KeyEventKind::Press,
+            ..
+        }) = event
+        {
+            // In filter mode, handle text input (acts like Insert mode)
+            if self.filter_mode != FilterMode::None {
+                return self.handle_filter_input(*code);
+            }
+
+            match code {
+                KeyCode::Esc => return ScreenAction::Pop,
+                KeyCode::Char('j') | KeyCode::Down => {
+                    if !self.filtered_indices.is_empty()
+                        && self.selected < self.filtered_indices.len() - 1
+                    {
+                        self.selected += 1;
+                        self.sync_scroll();
+                    }
+                }
+                KeyCode::Char('k') | KeyCode::Up => {
+                    self.selected = self.selected.saturating_sub(1);
+                    self.sync_scroll();
+                }
+                KeyCode::Char(' ') => {
+                    if let Some(&idx) = self.filtered_indices.get(self.selected) {
+                        let number = self.issues[idx].number;
+                        if !self.selected_set.remove(&number) {
+                            self.selected_set.insert(number);
+                        }
+                    }
+                }
+                KeyCode::Char('/') => {
+                    self.filter_mode = FilterMode::Label;
+                }
+                KeyCode::Char('m') => {
+                    self.filter_mode = FilterMode::Milestone;
+                }
+                KeyCode::Enter => {
+                    return self.handle_enter();
+                }
+                _ => {}
+            }
+        }
+        ScreenAction::None
+    }
+
+    fn draw(&mut self, f: &mut Frame, area: Rect, theme: &Theme) {
+        self.draw_impl(f, area, theme);
+    }
+
+    fn desired_input_mode(&self) -> Option<InputMode> {
+        if self.filter_mode != FilterMode::None {
+            Some(InputMode::Insert)
+        } else {
+            Some(InputMode::Normal)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -420,38 +481,38 @@ mod tests {
     #[test]
     fn issue_browser_key_j_advances_cursor() {
         let mut screen = IssueBrowserScreen::new(make_three_issues());
-        screen.handle_input(&key_event(KeyCode::Char('j')));
+        screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
         assert_eq!(screen.selected, 1);
     }
 
     #[test]
     fn issue_browser_key_down_advances_cursor() {
         let mut screen = IssueBrowserScreen::new(make_three_issues());
-        screen.handle_input(&key_event(KeyCode::Down));
+        screen.handle_input(&key_event(KeyCode::Down), InputMode::Normal);
         assert_eq!(screen.selected, 1);
     }
 
     #[test]
     fn issue_browser_key_k_moves_cursor_up() {
         let mut screen = IssueBrowserScreen::new(make_three_issues());
-        screen.handle_input(&key_event(KeyCode::Char('j')));
-        screen.handle_input(&key_event(KeyCode::Char('j')));
-        screen.handle_input(&key_event(KeyCode::Char('k')));
+        screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Char('k')), InputMode::Normal);
         assert_eq!(screen.selected, 1);
     }
 
     #[test]
     fn issue_browser_key_up_moves_cursor_up() {
         let mut screen = IssueBrowserScreen::new(make_three_issues());
-        screen.handle_input(&key_event(KeyCode::Down));
-        screen.handle_input(&key_event(KeyCode::Up));
+        screen.handle_input(&key_event(KeyCode::Down), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Up), InputMode::Normal);
         assert_eq!(screen.selected, 0);
     }
 
     #[test]
     fn issue_browser_cursor_does_not_underflow() {
         let mut screen = IssueBrowserScreen::new(make_three_issues());
-        screen.handle_input(&key_event(KeyCode::Char('k')));
+        screen.handle_input(&key_event(KeyCode::Char('k')), InputMode::Normal);
         assert_eq!(screen.selected, 0);
     }
 
@@ -459,7 +520,7 @@ mod tests {
     fn issue_browser_cursor_does_not_overflow() {
         let mut screen = IssueBrowserScreen::new(make_three_issues());
         for _ in 0..10 {
-            screen.handle_input(&key_event(KeyCode::Char('j')));
+            screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
         }
         assert_eq!(screen.selected, 2);
     }
@@ -469,15 +530,15 @@ mod tests {
     #[test]
     fn issue_browser_esc_returns_pop() {
         let mut screen = IssueBrowserScreen::new(make_three_issues());
-        let action = screen.handle_input(&key_event(KeyCode::Esc));
+        let action = screen.handle_input(&key_event(KeyCode::Esc), InputMode::Normal);
         assert_eq!(action, ScreenAction::Pop);
     }
 
     #[test]
     fn issue_browser_enter_on_single_issue_returns_launch_session() {
         let mut screen = IssueBrowserScreen::new(make_three_issues());
-        screen.handle_input(&key_event(KeyCode::Char('j'))); // move to issue 2 (number=2)
-        let action = screen.handle_input(&key_event(KeyCode::Enter));
+        screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal); // move to issue 2 (number=2)
+        let action = screen.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
         match action {
             ScreenAction::LaunchSession(config) => {
                 assert_eq!(config.issue_number, Some(2));
@@ -489,11 +550,11 @@ mod tests {
     #[test]
     fn issue_browser_enter_with_multi_select_returns_launch_sessions() {
         let mut screen = IssueBrowserScreen::new(make_three_issues());
-        screen.handle_input(&key_event(KeyCode::Char(' '))); // select issue #1
-        screen.handle_input(&key_event(KeyCode::Char('j')));
-        screen.handle_input(&key_event(KeyCode::Char('j')));
-        screen.handle_input(&key_event(KeyCode::Char(' '))); // select issue #3
-        let action = screen.handle_input(&key_event(KeyCode::Enter));
+        screen.handle_input(&key_event(KeyCode::Char(' ')), InputMode::Normal); // select issue #1
+        screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Char(' ')), InputMode::Normal); // select issue #3
+        let action = screen.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
         match action {
             ScreenAction::LaunchSessions(configs) => {
                 assert_eq!(configs.len(), 2);
@@ -505,7 +566,7 @@ mod tests {
     #[test]
     fn issue_browser_empty_issue_list_enter_returns_none() {
         let mut screen = IssueBrowserScreen::new(vec![]);
-        let action = screen.handle_input(&key_event(KeyCode::Enter));
+        let action = screen.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
         assert_eq!(action, ScreenAction::None);
     }
 
@@ -516,7 +577,7 @@ mod tests {
         let issues = make_three_issues();
         let issue_number = issues[0].number;
         let mut screen = IssueBrowserScreen::new(issues);
-        screen.handle_input(&key_event(KeyCode::Char(' ')));
+        screen.handle_input(&key_event(KeyCode::Char(' ')), InputMode::Normal);
         assert!(screen.selected_set.contains(&issue_number));
     }
 
@@ -525,8 +586,8 @@ mod tests {
         let issues = make_three_issues();
         let issue_number = issues[0].number;
         let mut screen = IssueBrowserScreen::new(issues);
-        screen.handle_input(&key_event(KeyCode::Char(' ')));
-        screen.handle_input(&key_event(KeyCode::Char(' ')));
+        screen.handle_input(&key_event(KeyCode::Char(' ')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Char(' ')), InputMode::Normal);
         assert!(!screen.selected_set.contains(&issue_number));
     }
 
@@ -535,7 +596,7 @@ mod tests {
     #[test]
     fn issue_browser_slash_enters_filter_mode() {
         let mut screen = IssueBrowserScreen::new(make_three_issues());
-        screen.handle_input(&key_event(KeyCode::Char('/')));
+        screen.handle_input(&key_event(KeyCode::Char('/')), InputMode::Normal);
         assert_eq!(screen.filter_mode, FilterMode::Label);
     }
 
@@ -547,10 +608,10 @@ mod tests {
             make_issue(3, "Add logout"),
         ];
         let mut screen = IssueBrowserScreen::new(issues);
-        screen.handle_input(&key_event(KeyCode::Char('/')));
-        screen.handle_input(&key_event(KeyCode::Char('A')));
-        screen.handle_input(&key_event(KeyCode::Char('d')));
-        screen.handle_input(&key_event(KeyCode::Char('d')));
+        screen.handle_input(&key_event(KeyCode::Char('/')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Char('A')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Char('d')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Char('d')), InputMode::Normal);
         assert_eq!(screen.filtered_indices.len(), 2);
     }
 
@@ -558,20 +619,20 @@ mod tests {
     fn issue_browser_filter_text_is_case_insensitive() {
         let issues = vec![make_issue(1, "Implement Feature")];
         let mut screen = IssueBrowserScreen::new(issues);
-        screen.handle_input(&key_event(KeyCode::Char('/')));
-        screen.handle_input(&key_event(KeyCode::Char('i')));
-        screen.handle_input(&key_event(KeyCode::Char('m')));
-        screen.handle_input(&key_event(KeyCode::Char('p')));
+        screen.handle_input(&key_event(KeyCode::Char('/')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Char('i')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Char('m')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Char('p')), InputMode::Normal);
         assert_eq!(screen.filtered_indices.len(), 1);
     }
 
     #[test]
     fn issue_browser_esc_in_filter_mode_clears_filter_and_exits() {
         let mut screen = IssueBrowserScreen::new(make_three_issues());
-        screen.handle_input(&key_event(KeyCode::Char('/')));
-        screen.handle_input(&key_event(KeyCode::Char('F')));
-        screen.handle_input(&key_event(KeyCode::Char('i')));
-        screen.handle_input(&key_event(KeyCode::Esc));
+        screen.handle_input(&key_event(KeyCode::Char('/')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Char('F')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Char('i')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Esc), InputMode::Normal);
         assert!(screen.filter_text.is_empty());
         assert_eq!(screen.filter_mode, FilterMode::None);
         assert_eq!(screen.filtered_indices.len(), 3);
@@ -580,19 +641,19 @@ mod tests {
     #[test]
     fn issue_browser_backspace_in_filter_mode_deletes_last_char() {
         let mut screen = IssueBrowserScreen::new(make_three_issues());
-        screen.handle_input(&key_event(KeyCode::Char('/')));
-        screen.handle_input(&key_event(KeyCode::Char('a')));
-        screen.handle_input(&key_event(KeyCode::Char('b')));
-        screen.handle_input(&key_event(KeyCode::Backspace));
+        screen.handle_input(&key_event(KeyCode::Char('/')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Char('a')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Char('b')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Backspace), InputMode::Normal);
         assert_eq!(screen.filter_text, "a");
     }
 
     #[test]
     fn issue_browser_filter_no_match_results_in_empty_filtered_indices() {
         let mut screen = IssueBrowserScreen::new(make_three_issues());
-        screen.handle_input(&key_event(KeyCode::Char('/')));
+        screen.handle_input(&key_event(KeyCode::Char('/')), InputMode::Normal);
         for c in "zzznomatch".chars() {
-            screen.handle_input(&key_event(KeyCode::Char(c)));
+            screen.handle_input(&key_event(KeyCode::Char(c)), InputMode::Normal);
         }
         assert_eq!(screen.filtered_indices.len(), 0);
     }
@@ -602,7 +663,7 @@ mod tests {
     #[test]
     fn issue_browser_key_m_enters_milestone_filter_mode() {
         let mut screen = IssueBrowserScreen::new(make_three_issues());
-        screen.handle_input(&key_event(KeyCode::Char('m')));
+        screen.handle_input(&key_event(KeyCode::Char('m')), InputMode::Normal);
         assert_eq!(screen.filter_mode, FilterMode::Milestone);
     }
 
@@ -645,12 +706,12 @@ mod tests {
         ];
         let mut screen = IssueBrowserScreen::new(issues);
         for _ in 0..4 {
-            screen.handle_input(&key_event(KeyCode::Char('j')));
+            screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
         }
         assert_eq!(screen.selected, 4);
-        screen.handle_input(&key_event(KeyCode::Char('/')));
+        screen.handle_input(&key_event(KeyCode::Char('/')), InputMode::Normal);
         for c in "Alpha".chars() {
-            screen.handle_input(&key_event(KeyCode::Char(c)));
+            screen.handle_input(&key_event(KeyCode::Char(c)), InputMode::Normal);
         }
         assert!(screen.selected <= 1);
     }
@@ -660,8 +721,8 @@ mod tests {
     #[test]
     fn issue_browser_set_issues_replaces_and_resets() {
         let mut screen = IssueBrowserScreen::new(make_three_issues());
-        screen.handle_input(&key_event(KeyCode::Char('j')));
-        screen.handle_input(&key_event(KeyCode::Char('j')));
+        screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
         assert_eq!(screen.selected, 2);
 
         screen.loading = true;

--- a/src/tui/screens/milestone.rs
+++ b/src/tui/screens/milestone.rs
@@ -1,6 +1,8 @@
-use super::{ScreenAction, SessionConfig, draw_keybinds_bar, sanitize_for_terminal};
+use super::{Screen, ScreenAction, SessionConfig, draw_keybinds_bar, sanitize_for_terminal};
 use crate::github::types::{GhIssue, GhMilestone};
 use crate::tui::app::TuiMode;
+use crate::tui::navigation::InputMode;
+use crate::tui::navigation::keymap::{KeyBinding, KeyBindingGroup, KeymapProvider};
 use crate::tui::theme::Theme;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind};
 use ratatui::{
@@ -70,41 +72,7 @@ impl MilestoneScreen {
         }
     }
 
-    pub fn handle_input(&mut self, event: &Event) -> ScreenAction {
-        if let Event::Key(KeyEvent {
-            code,
-            kind: KeyEventKind::Press,
-            ..
-        }) = event
-        {
-            match code {
-                KeyCode::Esc => return ScreenAction::Pop,
-                KeyCode::Char('j') | KeyCode::Down => {
-                    if !self.milestones.is_empty() && self.selected < self.milestones.len() - 1 {
-                        self.selected += 1;
-                        self.sync_scroll();
-                    }
-                }
-                KeyCode::Char('k') | KeyCode::Up => {
-                    self.selected = self.selected.saturating_sub(1);
-                    self.sync_scroll();
-                }
-                KeyCode::Enter => {
-                    if self.milestones.is_empty() {
-                        return ScreenAction::None;
-                    }
-                    return ScreenAction::Push(TuiMode::IssueBrowser);
-                }
-                KeyCode::Char('r') => {
-                    return self.handle_run_all();
-                }
-                _ => {}
-            }
-        }
-        ScreenAction::None
-    }
-
-    pub fn draw(&mut self, f: &mut Frame, area: Rect, theme: &Theme) {
+    fn draw_impl(&mut self, f: &mut Frame, area: Rect, theme: &Theme) {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
@@ -306,6 +274,80 @@ impl MilestoneScreen {
     }
 }
 
+impl KeymapProvider for MilestoneScreen {
+    fn keybindings(&self) -> Vec<KeyBindingGroup> {
+        vec![KeyBindingGroup {
+            title: "Milestones",
+            bindings: vec![
+                KeyBinding {
+                    key: "j/Down",
+                    description: "Move down",
+                },
+                KeyBinding {
+                    key: "k/Up",
+                    description: "Move up",
+                },
+                KeyBinding {
+                    key: "Enter",
+                    description: "View issues",
+                },
+                KeyBinding {
+                    key: "r",
+                    description: "Run all open issues",
+                },
+                KeyBinding {
+                    key: "Esc",
+                    description: "Back",
+                },
+            ],
+        }]
+    }
+}
+
+impl Screen for MilestoneScreen {
+    fn handle_input(&mut self, event: &Event, _mode: InputMode) -> ScreenAction {
+        if let Event::Key(KeyEvent {
+            code,
+            kind: KeyEventKind::Press,
+            ..
+        }) = event
+        {
+            match code {
+                KeyCode::Esc => return ScreenAction::Pop,
+                KeyCode::Char('j') | KeyCode::Down => {
+                    if !self.milestones.is_empty() && self.selected < self.milestones.len() - 1 {
+                        self.selected += 1;
+                        self.sync_scroll();
+                    }
+                }
+                KeyCode::Char('k') | KeyCode::Up => {
+                    self.selected = self.selected.saturating_sub(1);
+                    self.sync_scroll();
+                }
+                KeyCode::Enter => {
+                    if self.milestones.is_empty() {
+                        return ScreenAction::None;
+                    }
+                    return ScreenAction::Push(TuiMode::IssueBrowser);
+                }
+                KeyCode::Char('r') => {
+                    return self.handle_run_all();
+                }
+                _ => {}
+            }
+        }
+        ScreenAction::None
+    }
+
+    fn draw(&mut self, f: &mut Frame, area: Rect, theme: &Theme) {
+        self.draw_impl(f, area, theme);
+    }
+
+    fn desired_input_mode(&self) -> Option<InputMode> {
+        Some(InputMode::Normal)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -373,14 +415,14 @@ mod tests {
             make_entry(2, 0, 0),
             make_entry(3, 0, 0),
         ]);
-        screen.handle_input(&key_event(KeyCode::Char('j')));
+        screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
         assert_eq!(screen.selected, 1);
     }
 
     #[test]
     fn milestone_screen_key_down_advances_cursor() {
         let mut screen = MilestoneScreen::new(vec![make_entry(1, 0, 0), make_entry(2, 0, 0)]);
-        screen.handle_input(&key_event(KeyCode::Down));
+        screen.handle_input(&key_event(KeyCode::Down), InputMode::Normal);
         assert_eq!(screen.selected, 1);
     }
 
@@ -391,24 +433,24 @@ mod tests {
             make_entry(2, 0, 0),
             make_entry(3, 0, 0),
         ]);
-        screen.handle_input(&key_event(KeyCode::Char('j')));
-        screen.handle_input(&key_event(KeyCode::Char('j')));
-        screen.handle_input(&key_event(KeyCode::Char('k')));
+        screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Char('k')), InputMode::Normal);
         assert_eq!(screen.selected, 1);
     }
 
     #[test]
     fn milestone_screen_key_up_moves_cursor_up() {
         let mut screen = MilestoneScreen::new(vec![make_entry(1, 0, 0), make_entry(2, 0, 0)]);
-        screen.handle_input(&key_event(KeyCode::Down));
-        screen.handle_input(&key_event(KeyCode::Up));
+        screen.handle_input(&key_event(KeyCode::Down), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Up), InputMode::Normal);
         assert_eq!(screen.selected, 0);
     }
 
     #[test]
     fn milestone_screen_cursor_does_not_underflow() {
         let mut screen = MilestoneScreen::new(vec![make_entry(1, 0, 0), make_entry(2, 0, 0)]);
-        screen.handle_input(&key_event(KeyCode::Char('k')));
+        screen.handle_input(&key_event(KeyCode::Char('k')), InputMode::Normal);
         assert_eq!(screen.selected, 0);
     }
 
@@ -420,7 +462,7 @@ mod tests {
             make_entry(3, 0, 0),
         ]);
         for _ in 0..10 {
-            screen.handle_input(&key_event(KeyCode::Char('j')));
+            screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
         }
         assert_eq!(screen.selected, 2);
     }
@@ -430,15 +472,15 @@ mod tests {
     #[test]
     fn milestone_screen_esc_returns_pop() {
         let mut screen = MilestoneScreen::new(vec![make_entry(1, 0, 0)]);
-        let action = screen.handle_input(&key_event(KeyCode::Esc));
+        let action = screen.handle_input(&key_event(KeyCode::Esc), InputMode::Normal);
         assert_eq!(action, ScreenAction::Pop);
     }
 
     #[test]
     fn milestone_screen_enter_returns_push_issue_browser_with_milestone_number() {
         let mut screen = MilestoneScreen::new(vec![make_entry(7, 3, 0), make_entry(12, 1, 5)]);
-        screen.handle_input(&key_event(KeyCode::Char('j')));
-        let action = screen.handle_input(&key_event(KeyCode::Enter));
+        screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
+        let action = screen.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
         match action {
             ScreenAction::Push(TuiMode::IssueBrowser) => {}
             other => panic!("Expected Push(IssueBrowser), got {:?}", other),
@@ -448,7 +490,7 @@ mod tests {
     #[test]
     fn milestone_screen_empty_list_enter_returns_none() {
         let mut screen = MilestoneScreen::new(vec![]);
-        let action = screen.handle_input(&key_event(KeyCode::Enter));
+        let action = screen.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
         assert_eq!(action, ScreenAction::None);
     }
 
@@ -456,7 +498,7 @@ mod tests {
     fn milestone_screen_key_r_on_milestone_returns_launch_sessions_for_all_open_issues() {
         let issues = vec![make_issue(10), make_issue(11)];
         let mut screen = MilestoneScreen::new(vec![make_entry_with_issues(1, issues)]);
-        let action = screen.handle_input(&key_event(KeyCode::Char('r')));
+        let action = screen.handle_input(&key_event(KeyCode::Char('r')), InputMode::Normal);
         match action {
             ScreenAction::LaunchSessions(configs) => {
                 assert_eq!(configs.len(), 2);
@@ -468,7 +510,7 @@ mod tests {
     #[test]
     fn milestone_screen_key_r_on_empty_milestone_returns_none() {
         let mut screen = MilestoneScreen::new(vec![make_entry(1, 0, 5)]);
-        let action = screen.handle_input(&key_event(KeyCode::Char('r')));
+        let action = screen.handle_input(&key_event(KeyCode::Char('r')), InputMode::Normal);
         assert_eq!(action, ScreenAction::None);
     }
 

--- a/src/tui/screens/mod.rs
+++ b/src/tui/screens/mod.rs
@@ -9,7 +9,10 @@ pub use milestone::MilestoneScreen;
 pub use prompt_input::PromptInputScreen;
 
 use crate::tui::app::TuiMode;
+use crate::tui::navigation::InputMode;
+use crate::tui::navigation::keymap::KeymapProvider;
 use crate::tui::theme::Theme;
+use crossterm::event::Event;
 use ratatui::{
     Frame,
     layout::Rect,
@@ -17,6 +20,21 @@ use ratatui::{
     text::{Line, Span},
     widgets::Paragraph,
 };
+
+/// Trait that all interactive screens implement.
+pub trait Screen: KeymapProvider {
+    /// Handle an input event. Returns a ScreenAction describing what the event loop should do.
+    fn handle_input(&mut self, event: &Event, mode: InputMode) -> ScreenAction;
+
+    /// Render the screen into the given area.
+    fn draw(&mut self, f: &mut Frame, area: Rect, theme: &Theme);
+
+    /// What input mode this screen wants to be in, given its current state.
+    /// Returns None to leave the mode unchanged (defer to current global mode).
+    fn desired_input_mode(&self) -> Option<InputMode> {
+        None
+    }
+}
 
 /// Sanitize strings from external sources (GitHub API, git) for safe terminal rendering.
 /// Strips control characters that could be interpreted as terminal escape sequences.
@@ -84,6 +102,15 @@ pub(crate) mod test_helpers {
         Event::Key(KeyEvent {
             code,
             modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        })
+    }
+
+    pub fn key_event_with_modifiers(code: KeyCode, modifiers: KeyModifiers) -> Event {
+        Event::Key(KeyEvent {
+            code,
+            modifiers,
             kind: KeyEventKind::Press,
             state: KeyEventState::NONE,
         })

--- a/src/tui/screens/prompt_input.rs
+++ b/src/tui/screens/prompt_input.rs
@@ -1,4 +1,7 @@
-use super::{PromptSessionConfig, ScreenAction, draw_keybinds_bar};
+use super::{PromptSessionConfig, Screen, ScreenAction, draw_keybinds_bar};
+use crate::tui::navigation::InputMode;
+use crate::tui::navigation::focus::{FocusId, FocusRing};
+use crate::tui::navigation::keymap::{KeyBinding, KeyBindingGroup, KeymapProvider};
 use crate::tui::theme::Theme;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use ratatui::{
@@ -67,17 +70,11 @@ fn save_clipboard_image(img: &arboard::ImageData) -> Option<PathBuf> {
     Some(path)
 }
 
-#[derive(Debug, PartialEq)]
-pub enum PromptInputFocus {
-    PromptEditor,
-    ImageList,
-}
-
 pub struct PromptInputScreen {
     pub(crate) prompt_text: String,
     pub(crate) cursor_position: (usize, usize),
     pub(crate) image_paths: Vec<String>,
-    pub(crate) focus: PromptInputFocus,
+    pub(crate) focus_ring: FocusRing,
     pub(crate) image_path_input: String,
     pub(crate) editing_image_path: bool,
     pub(crate) selected_image: usize,
@@ -92,12 +89,15 @@ impl PromptInputScreen {
         Self::with_clipboard(Box::new(SystemClipboard))
     }
 
+    pub const PROMPT_EDITOR_PANE: FocusId = FocusId("prompt:editor");
+    pub const IMAGE_LIST_PANE: FocusId = FocusId("prompt:images");
+
     pub fn with_clipboard(clipboard: Box<dyn ClipboardProvider>) -> Self {
         Self {
             prompt_text: String::new(),
             cursor_position: (0, 0),
             image_paths: Vec::new(),
-            focus: PromptInputFocus::PromptEditor,
+            focus_ring: FocusRing::new(vec![Self::PROMPT_EDITOR_PANE, Self::IMAGE_LIST_PANE]),
             image_path_input: String::new(),
             editing_image_path: false,
             selected_image: 0,
@@ -105,6 +105,14 @@ impl PromptInputScreen {
             clipboard,
             status_message: None,
         }
+    }
+
+    fn is_prompt_editor_focused(&self) -> bool {
+        self.focus_ring.is_focused(Self::PROMPT_EDITOR_PANE)
+    }
+
+    fn is_image_list_focused(&self) -> bool {
+        self.focus_ring.is_focused(Self::IMAGE_LIST_PANE)
     }
 
     fn paste_from_clipboard(&mut self) {
@@ -124,117 +132,7 @@ impl PromptInputScreen {
         }
     }
 
-    pub fn handle_input(&mut self, event: &Event) -> ScreenAction {
-        if let Event::Key(KeyEvent {
-            code,
-            modifiers,
-            kind: KeyEventKind::Press,
-            ..
-        }) = event
-        {
-            // Ctrl+S: submit prompt
-            if *modifiers == KeyModifiers::CONTROL && *code == KeyCode::Char('s') {
-                if self.prompt_text.trim().is_empty() {
-                    return ScreenAction::None;
-                }
-                return ScreenAction::LaunchPromptSession(PromptSessionConfig {
-                    prompt: self.prompt_text.clone(),
-                    image_paths: self.image_paths.clone(),
-                });
-            }
-
-            // Ctrl+V: paste from clipboard (adds image/path to attachments)
-            if *modifiers == KeyModifiers::CONTROL && *code == KeyCode::Char('v') {
-                self.paste_from_clipboard();
-                return ScreenAction::None;
-            }
-
-            // Esc: cancel image path editing or pop screen
-            if *code == KeyCode::Esc {
-                if self.editing_image_path {
-                    self.editing_image_path = false;
-                    self.image_path_input.clear();
-                    return ScreenAction::None;
-                }
-                return ScreenAction::Pop;
-            }
-
-            // Tab: toggle focus
-            if *code == KeyCode::Tab {
-                self.focus = match self.focus {
-                    PromptInputFocus::PromptEditor => PromptInputFocus::ImageList,
-                    PromptInputFocus::ImageList => PromptInputFocus::PromptEditor,
-                };
-                return ScreenAction::None;
-            }
-
-            // Route input based on focus and editing state
-            if self.editing_image_path {
-                match code {
-                    KeyCode::Enter => {
-                        if !self.image_path_input.is_empty() {
-                            self.image_paths.push(self.image_path_input.clone());
-                        }
-                        self.editing_image_path = false;
-                        self.image_path_input.clear();
-                    }
-                    KeyCode::Backspace => {
-                        self.image_path_input.pop();
-                    }
-                    KeyCode::Char(c) => {
-                        self.image_path_input.push(*c);
-                    }
-                    _ => {}
-                }
-                return ScreenAction::None;
-            }
-
-            match self.focus {
-                PromptInputFocus::PromptEditor => match code {
-                    KeyCode::Char(c) => {
-                        self.prompt_text.push(*c);
-                    }
-                    KeyCode::Enter => {
-                        self.prompt_text.push('\n');
-                    }
-                    KeyCode::Backspace => {
-                        self.prompt_text.pop();
-                    }
-                    _ => {}
-                },
-                PromptInputFocus::ImageList => match code {
-                    KeyCode::Char('a') => {
-                        self.editing_image_path = true;
-                        self.image_path_input.clear();
-                    }
-                    KeyCode::Char('d') => {
-                        if !self.image_paths.is_empty() {
-                            self.image_paths.remove(self.selected_image);
-                            if self.selected_image > 0
-                                && self.selected_image >= self.image_paths.len()
-                            {
-                                self.selected_image = self.image_paths.len().saturating_sub(1);
-                            }
-                        }
-                    }
-                    KeyCode::Char('j') | KeyCode::Down => {
-                        if !self.image_paths.is_empty()
-                            && self.selected_image < self.image_paths.len() - 1
-                        {
-                            self.selected_image += 1;
-                        }
-                    }
-                    KeyCode::Char('k') | KeyCode::Up => {
-                        self.selected_image = self.selected_image.saturating_sub(1);
-                    }
-                    _ => {}
-                },
-            }
-        }
-        ScreenAction::None
-    }
-
-    pub fn draw(&self, f: &mut Frame, area: Rect, theme: &Theme) {
+    fn draw_impl(&self, f: &mut Frame, area: Rect, theme: &Theme) {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
@@ -245,7 +143,7 @@ impl PromptInputScreen {
             .split(area);
 
         // Prompt editor
-        let editor_border_color = if self.focus == PromptInputFocus::PromptEditor {
+        let editor_border_color = if self.is_prompt_editor_focused() {
             theme.border_active
         } else {
             theme.border_inactive
@@ -277,7 +175,7 @@ impl PromptInputScreen {
         f.render_widget(editor, chunks[0]);
 
         // Image list
-        let image_border_color = if self.focus == PromptInputFocus::ImageList {
+        let image_border_color = if self.is_image_list_focused() {
             theme.border_active
         } else {
             theme.border_inactive
@@ -298,14 +196,14 @@ impl PromptInputScreen {
             )));
         }
         for (i, path) in self.image_paths.iter().enumerate() {
-            let style = if i == self.selected_image && self.focus == PromptInputFocus::ImageList {
+            let style = if i == self.selected_image && self.is_image_list_focused() {
                 Style::default()
                     .fg(theme.accent_success)
                     .add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(theme.text_primary)
             };
-            let prefix = if i == self.selected_image && self.focus == PromptInputFocus::ImageList {
+            let prefix = if i == self.selected_image && self.is_image_list_focused() {
                 " > "
             } else {
                 "   "
@@ -325,7 +223,7 @@ impl PromptInputScreen {
                 Span::styled("_", Style::default().fg(theme.accent_success)),
             ]));
         }
-        if self.focus == PromptInputFocus::ImageList && !self.editing_image_path {
+        if self.is_image_list_focused() && !self.editing_image_path {
             lines.push(Line::from(Span::styled(
                 "  [a] Add   [d] Remove   [Ctrl+V] Paste",
                 Style::default().fg(theme.text_secondary),
@@ -354,6 +252,173 @@ impl PromptInputScreen {
                 ],
                 theme,
             );
+        }
+    }
+}
+
+impl KeymapProvider for PromptInputScreen {
+    fn keybindings(&self) -> Vec<KeyBindingGroup> {
+        vec![
+            KeyBindingGroup {
+                title: "Prompt Editor",
+                bindings: vec![
+                    KeyBinding {
+                        key: "Ctrl+s",
+                        description: "Submit prompt",
+                    },
+                    KeyBinding {
+                        key: "Ctrl+v",
+                        description: "Paste from clipboard",
+                    },
+                    KeyBinding {
+                        key: "Tab",
+                        description: "Toggle focus (editor/images)",
+                    },
+                    KeyBinding {
+                        key: "Esc",
+                        description: "Back",
+                    },
+                ],
+            },
+            KeyBindingGroup {
+                title: "Image List",
+                bindings: vec![
+                    KeyBinding {
+                        key: "a",
+                        description: "Add image path",
+                    },
+                    KeyBinding {
+                        key: "d",
+                        description: "Delete selected image",
+                    },
+                    KeyBinding {
+                        key: "j/k",
+                        description: "Navigate images",
+                    },
+                ],
+            },
+        ]
+    }
+}
+
+impl Screen for PromptInputScreen {
+    fn handle_input(&mut self, event: &Event, _mode: InputMode) -> ScreenAction {
+        if let Event::Key(KeyEvent {
+            code,
+            modifiers,
+            kind: KeyEventKind::Press,
+            ..
+        }) = event
+        {
+            if *modifiers == KeyModifiers::CONTROL && *code == KeyCode::Char('s') {
+                if self.prompt_text.trim().is_empty() {
+                    return ScreenAction::None;
+                }
+                return ScreenAction::LaunchPromptSession(PromptSessionConfig {
+                    prompt: self.prompt_text.clone(),
+                    image_paths: self.image_paths.clone(),
+                });
+            }
+
+            if *modifiers == KeyModifiers::CONTROL && *code == KeyCode::Char('v') {
+                self.paste_from_clipboard();
+                return ScreenAction::None;
+            }
+
+            if *code == KeyCode::Esc {
+                if self.editing_image_path {
+                    self.editing_image_path = false;
+                    self.image_path_input.clear();
+                    return ScreenAction::None;
+                }
+                return ScreenAction::Pop;
+            }
+
+            if *code == KeyCode::Tab {
+                self.focus_ring.next();
+                return ScreenAction::None;
+            }
+            if *code == KeyCode::BackTab {
+                self.focus_ring.previous();
+                return ScreenAction::None;
+            }
+
+            // Route input based on focus and editing state
+            if self.editing_image_path {
+                match code {
+                    KeyCode::Enter => {
+                        if !self.image_path_input.is_empty() {
+                            self.image_paths.push(self.image_path_input.clone());
+                        }
+                        self.editing_image_path = false;
+                        self.image_path_input.clear();
+                    }
+                    KeyCode::Backspace => {
+                        self.image_path_input.pop();
+                    }
+                    KeyCode::Char(c) => {
+                        self.image_path_input.push(*c);
+                    }
+                    _ => {}
+                }
+                return ScreenAction::None;
+            }
+
+            if self.is_prompt_editor_focused() {
+                match code {
+                    KeyCode::Char(c) => {
+                        self.prompt_text.push(*c);
+                    }
+                    KeyCode::Enter => {
+                        self.prompt_text.push('\n');
+                    }
+                    KeyCode::Backspace => {
+                        self.prompt_text.pop();
+                    }
+                    _ => {}
+                }
+            } else if self.is_image_list_focused() {
+                match code {
+                    KeyCode::Char('a') => {
+                        self.editing_image_path = true;
+                        self.image_path_input.clear();
+                    }
+                    KeyCode::Char('d') => {
+                        if !self.image_paths.is_empty() {
+                            self.image_paths.remove(self.selected_image);
+                            if self.selected_image > 0
+                                && self.selected_image >= self.image_paths.len()
+                            {
+                                self.selected_image = self.image_paths.len().saturating_sub(1);
+                            }
+                        }
+                    }
+                    KeyCode::Char('j') | KeyCode::Down => {
+                        if !self.image_paths.is_empty()
+                            && self.selected_image < self.image_paths.len() - 1
+                        {
+                            self.selected_image += 1;
+                        }
+                    }
+                    KeyCode::Char('k') | KeyCode::Up => {
+                        self.selected_image = self.selected_image.saturating_sub(1);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        ScreenAction::None
+    }
+
+    fn draw(&mut self, f: &mut Frame, area: Rect, theme: &Theme) {
+        self.draw_impl(f, area, theme);
+    }
+
+    fn desired_input_mode(&self) -> Option<InputMode> {
+        if self.is_prompt_editor_focused() {
+            Some(InputMode::Insert)
+        } else {
+            Some(InputMode::Normal)
         }
     }
 }
@@ -420,7 +485,7 @@ mod tests {
 
     fn screen_in_image_list_focus() -> PromptInputScreen {
         let mut s = mock_screen();
-        s.handle_input(&key_event(KeyCode::Tab));
+        s.handle_input(&key_event(KeyCode::Tab), InputMode::Normal);
         s
     }
 
@@ -441,7 +506,11 @@ mod tests {
     #[test]
     fn prompt_input_initial_focus_is_prompt_editor() {
         let screen = mock_screen();
-        assert_eq!(screen.focus, PromptInputFocus::PromptEditor);
+        assert!(
+            screen
+                .focus_ring
+                .is_focused(PromptInputScreen::PROMPT_EDITOR_PANE)
+        );
     }
 
     #[test]
@@ -455,16 +524,16 @@ mod tests {
     #[test]
     fn prompt_input_typing_appends_character() {
         let mut screen = mock_screen();
-        screen.handle_input(&key_event(KeyCode::Char('h')));
-        screen.handle_input(&key_event(KeyCode::Char('i')));
-        screen.handle_input(&key_event(KeyCode::Char('!')));
+        screen.handle_input(&key_event(KeyCode::Char('h')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Char('i')), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Char('!')), InputMode::Normal);
         assert_eq!(screen.prompt_text, "hi!");
     }
 
     #[test]
     fn prompt_input_enter_inserts_newline() {
         let mut screen = screen_with_prompt("hello");
-        let action = screen.handle_input(&key_event(KeyCode::Enter));
+        let action = screen.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
         assert_eq!(screen.prompt_text, "hello\n");
         assert_eq!(action, ScreenAction::None);
     }
@@ -472,14 +541,14 @@ mod tests {
     #[test]
     fn prompt_input_backspace_removes_last_character() {
         let mut screen = screen_with_prompt("abc");
-        screen.handle_input(&key_event(KeyCode::Backspace));
+        screen.handle_input(&key_event(KeyCode::Backspace), InputMode::Normal);
         assert_eq!(screen.prompt_text, "ab");
     }
 
     #[test]
     fn prompt_input_backspace_on_empty_prompt_is_noop() {
         let mut screen = mock_screen();
-        let action = screen.handle_input(&key_event(KeyCode::Backspace));
+        let action = screen.handle_input(&key_event(KeyCode::Backspace), InputMode::Normal);
         assert_eq!(screen.prompt_text, "");
         assert_eq!(action, ScreenAction::None);
     }
@@ -489,7 +558,7 @@ mod tests {
     #[test]
     fn prompt_input_ctrl_s_with_prompt_returns_launch_prompt_session() {
         let mut screen = screen_with_prompt("fix the bug");
-        let action = screen.handle_input(&ctrl_key(KeyCode::Char('s')));
+        let action = screen.handle_input(&ctrl_key(KeyCode::Char('s')), InputMode::Normal);
         assert_eq!(
             action,
             ScreenAction::LaunchPromptSession(PromptSessionConfig {
@@ -503,7 +572,7 @@ mod tests {
     fn prompt_input_ctrl_s_with_prompt_and_images_includes_image_paths() {
         let mut screen = screen_with_prompt("describe this");
         screen.image_paths = vec!["/tmp/a.png".to_string(), "/tmp/b.png".to_string()];
-        let action = screen.handle_input(&ctrl_key(KeyCode::Char('s')));
+        let action = screen.handle_input(&ctrl_key(KeyCode::Char('s')), InputMode::Normal);
         assert_eq!(
             action,
             ScreenAction::LaunchPromptSession(PromptSessionConfig {
@@ -516,14 +585,14 @@ mod tests {
     #[test]
     fn prompt_input_ctrl_s_with_empty_prompt_is_rejected() {
         let mut screen = mock_screen();
-        let action = screen.handle_input(&ctrl_key(KeyCode::Char('s')));
+        let action = screen.handle_input(&ctrl_key(KeyCode::Char('s')), InputMode::Normal);
         assert_eq!(action, ScreenAction::None);
     }
 
     #[test]
     fn prompt_input_ctrl_s_with_whitespace_only_prompt_is_rejected() {
         let mut screen = screen_with_prompt("   \n  ");
-        let action = screen.handle_input(&ctrl_key(KeyCode::Char('s')));
+        let action = screen.handle_input(&ctrl_key(KeyCode::Char('s')), InputMode::Normal);
         assert_eq!(action, ScreenAction::None);
     }
 
@@ -532,14 +601,14 @@ mod tests {
     #[test]
     fn prompt_input_esc_returns_pop() {
         let mut screen = mock_screen();
-        let action = screen.handle_input(&key_event(KeyCode::Esc));
+        let action = screen.handle_input(&key_event(KeyCode::Esc), InputMode::Normal);
         assert_eq!(action, ScreenAction::Pop);
     }
 
     #[test]
     fn prompt_input_esc_in_image_list_focus_returns_pop() {
         let mut screen = screen_in_image_list_focus();
-        let action = screen.handle_input(&key_event(KeyCode::Esc));
+        let action = screen.handle_input(&key_event(KeyCode::Esc), InputMode::Normal);
         assert_eq!(action, ScreenAction::Pop);
     }
 
@@ -548,17 +617,25 @@ mod tests {
     #[test]
     fn prompt_input_tab_switches_focus_to_image_list() {
         let mut screen = mock_screen();
-        let action = screen.handle_input(&key_event(KeyCode::Tab));
-        assert_eq!(screen.focus, PromptInputFocus::ImageList);
+        let action = screen.handle_input(&key_event(KeyCode::Tab), InputMode::Normal);
+        assert!(
+            screen
+                .focus_ring
+                .is_focused(PromptInputScreen::IMAGE_LIST_PANE)
+        );
         assert_eq!(action, ScreenAction::None);
     }
 
     #[test]
     fn prompt_input_tab_toggles_back_to_prompt_editor() {
         let mut screen = mock_screen();
-        screen.handle_input(&key_event(KeyCode::Tab));
-        screen.handle_input(&key_event(KeyCode::Tab));
-        assert_eq!(screen.focus, PromptInputFocus::PromptEditor);
+        screen.handle_input(&key_event(KeyCode::Tab), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Tab), InputMode::Normal);
+        assert!(
+            screen
+                .focus_ring
+                .is_focused(PromptInputScreen::PROMPT_EDITOR_PANE)
+        );
     }
 
     // --- Group 6: ImageList add image path ---
@@ -566,7 +643,7 @@ mod tests {
     #[test]
     fn prompt_input_key_a_in_image_list_enters_editing_mode() {
         let mut screen = screen_in_image_list_focus();
-        screen.handle_input(&key_event(KeyCode::Char('a')));
+        screen.handle_input(&key_event(KeyCode::Char('a')), InputMode::Normal);
         assert!(screen.editing_image_path);
         assert_eq!(screen.image_path_input, "");
     }
@@ -574,10 +651,10 @@ mod tests {
     #[test]
     fn prompt_input_typing_in_image_path_input_accumulates_text() {
         let mut screen = screen_in_image_list_focus();
-        screen.handle_input(&key_event(KeyCode::Char('a'))); // enter editing mode
+        screen.handle_input(&key_event(KeyCode::Char('a')), InputMode::Normal); // enter editing mode
         let original_prompt = screen.prompt_text.clone();
         for ch in ['/', 't', 'm', 'p'] {
-            screen.handle_input(&key_event(KeyCode::Char(ch)));
+            screen.handle_input(&key_event(KeyCode::Char(ch)), InputMode::Normal);
         }
         assert_eq!(screen.image_path_input, "/tmp");
         assert_eq!(screen.prompt_text, original_prompt);
@@ -588,7 +665,7 @@ mod tests {
         let mut screen = screen_in_image_list_focus();
         screen.editing_image_path = true;
         screen.image_path_input = "/tmp/shot.png".to_string();
-        screen.handle_input(&key_event(KeyCode::Enter));
+        screen.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
         assert_eq!(screen.image_paths, vec!["/tmp/shot.png".to_string()]);
         assert!(!screen.editing_image_path);
         assert_eq!(screen.image_path_input, "");
@@ -599,7 +676,7 @@ mod tests {
         let mut screen = screen_in_image_list_focus();
         screen.editing_image_path = true;
         screen.image_path_input = "".to_string();
-        screen.handle_input(&key_event(KeyCode::Enter));
+        screen.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
         assert!(screen.image_paths.is_empty());
         assert!(!screen.editing_image_path);
     }
@@ -609,7 +686,7 @@ mod tests {
         let mut screen = screen_in_image_list_focus();
         screen.editing_image_path = true;
         screen.image_path_input = "/tmp/partial".to_string();
-        let action = screen.handle_input(&key_event(KeyCode::Esc));
+        let action = screen.handle_input(&key_event(KeyCode::Esc), InputMode::Normal);
         assert!(screen.image_paths.is_empty());
         assert!(!screen.editing_image_path);
         assert_eq!(screen.image_path_input, "");
@@ -622,14 +699,14 @@ mod tests {
     fn prompt_input_key_d_removes_selected_image() {
         let mut screen = screen_with_images(&["/a.png", "/b.png"]);
         screen.selected_image = 0;
-        screen.handle_input(&key_event(KeyCode::Char('d')));
+        screen.handle_input(&key_event(KeyCode::Char('d')), InputMode::Normal);
         assert_eq!(screen.image_paths, vec!["/b.png".to_string()]);
     }
 
     #[test]
     fn prompt_input_key_d_on_empty_image_list_is_noop() {
         let mut screen = screen_in_image_list_focus();
-        let action = screen.handle_input(&key_event(KeyCode::Char('d')));
+        let action = screen.handle_input(&key_event(KeyCode::Char('d')), InputMode::Normal);
         assert!(screen.image_paths.is_empty());
         assert_eq!(action, ScreenAction::None);
     }
@@ -638,7 +715,7 @@ mod tests {
     fn prompt_input_selected_image_clamps_after_deletion() {
         let mut screen = screen_with_images(&["/only.png"]);
         screen.selected_image = 0;
-        screen.handle_input(&key_event(KeyCode::Char('d')));
+        screen.handle_input(&key_event(KeyCode::Char('d')), InputMode::Normal);
         assert!(screen.image_paths.is_empty());
         assert_eq!(screen.selected_image, 0);
     }
@@ -649,7 +726,7 @@ mod tests {
     fn prompt_input_key_j_in_image_list_advances_selected_image() {
         let mut screen = screen_with_images(&["/a.png", "/b.png"]);
         screen.selected_image = 0;
-        screen.handle_input(&key_event(KeyCode::Char('j')));
+        screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
         assert_eq!(screen.selected_image, 1);
     }
 
@@ -658,7 +735,7 @@ mod tests {
         let mut screen = screen_with_images(&["/a.png"]);
         screen.selected_image = 0;
         for _ in 0..3 {
-            screen.handle_input(&key_event(KeyCode::Char('j')));
+            screen.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
         }
         assert_eq!(screen.selected_image, 0);
     }
@@ -667,7 +744,7 @@ mod tests {
     fn prompt_input_key_k_in_image_list_moves_selection_up() {
         let mut screen = screen_with_images(&["/a.png", "/b.png"]);
         screen.selected_image = 1;
-        screen.handle_input(&key_event(KeyCode::Char('k')));
+        screen.handle_input(&key_event(KeyCode::Char('k')), InputMode::Normal);
         assert_eq!(screen.selected_image, 0);
     }
 
@@ -675,7 +752,7 @@ mod tests {
     fn prompt_input_key_k_in_image_list_does_not_underflow() {
         let mut screen = screen_with_images(&["/a.png", "/b.png"]);
         screen.selected_image = 0;
-        screen.handle_input(&key_event(KeyCode::Char('k')));
+        screen.handle_input(&key_event(KeyCode::Char('k')), InputMode::Normal);
         assert_eq!(screen.selected_image, 0);
     }
 
@@ -687,7 +764,7 @@ mod tests {
         screen.prompt_text = "existing".to_string();
         screen.image_paths = vec!["/x.png".to_string()];
         for code in [KeyCode::Char('j'), KeyCode::Char('k'), KeyCode::Char('d')] {
-            screen.handle_input(&key_event(code));
+            screen.handle_input(&key_event(code), InputMode::Normal);
         }
         assert_eq!(screen.prompt_text, "existing");
     }
@@ -722,7 +799,7 @@ mod tests {
         let mut screen = PromptInputScreen::with_clipboard(MockClipboard::with_image(
             "/tmp/maestro-clips/clip-abc.png",
         ));
-        let action = screen.handle_input(&ctrl_key(KeyCode::Char('v')));
+        let action = screen.handle_input(&ctrl_key(KeyCode::Char('v')), InputMode::Normal);
         assert_eq!(action, ScreenAction::None);
         assert_eq!(
             screen.image_paths,
@@ -736,7 +813,7 @@ mod tests {
         let mut screen = PromptInputScreen::with_clipboard(MockClipboard::with_text(
             "/home/user/screenshot.png",
         ));
-        let action = screen.handle_input(&ctrl_key(KeyCode::Char('v')));
+        let action = screen.handle_input(&ctrl_key(KeyCode::Char('v')), InputMode::Normal);
         assert_eq!(action, ScreenAction::None);
         assert_eq!(
             screen.image_paths,
@@ -748,7 +825,7 @@ mod tests {
     #[test]
     fn prompt_input_ctrl_v_with_empty_clipboard_shows_message() {
         let mut screen = PromptInputScreen::with_clipboard(MockClipboard::empty());
-        screen.handle_input(&ctrl_key(KeyCode::Char('v')));
+        screen.handle_input(&ctrl_key(KeyCode::Char('v')), InputMode::Normal);
         assert!(screen.image_paths.is_empty());
         assert_eq!(screen.status_message.unwrap(), "Clipboard is empty");
     }
@@ -758,8 +835,12 @@ mod tests {
         let mut screen =
             PromptInputScreen::with_clipboard(MockClipboard::with_text("/tmp/shot.png"));
         // Default focus is PromptEditor — Ctrl+V should still work
-        assert_eq!(screen.focus, PromptInputFocus::PromptEditor);
-        screen.handle_input(&ctrl_key(KeyCode::Char('v')));
+        assert!(
+            screen
+                .focus_ring
+                .is_focused(PromptInputScreen::PROMPT_EDITOR_PANE)
+        );
+        screen.handle_input(&ctrl_key(KeyCode::Char('v')), InputMode::Normal);
         assert_eq!(screen.image_paths, vec!["/tmp/shot.png".to_string()]);
     }
 
@@ -768,7 +849,7 @@ mod tests {
         let mut screen =
             PromptInputScreen::with_clipboard(MockClipboard::with_text("/tmp/new.png"));
         screen.image_paths = vec!["/tmp/existing.png".to_string()];
-        screen.handle_input(&ctrl_key(KeyCode::Char('v')));
+        screen.handle_input(&ctrl_key(KeyCode::Char('v')), InputMode::Normal);
         assert_eq!(
             screen.image_paths,
             vec!["/tmp/existing.png".to_string(), "/tmp/new.png".to_string()]
@@ -780,7 +861,7 @@ mod tests {
         let mut screen =
             PromptInputScreen::with_clipboard(MockClipboard::with_text("/tmp/img.png"));
         screen.prompt_text = "my prompt".to_string();
-        screen.handle_input(&ctrl_key(KeyCode::Char('v')));
+        screen.handle_input(&ctrl_key(KeyCode::Char('v')), InputMode::Normal);
         assert_eq!(screen.prompt_text, "my prompt");
     }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -4,6 +4,8 @@ use crate::tui::dep_graph;
 use crate::tui::detail;
 use crate::tui::fullscreen;
 use crate::tui::help;
+use crate::tui::navigation::keymap::KeymapProvider;
+use crate::tui::screens::Screen;
 use chrono::Utc;
 use ratatui::{
     Frame,
@@ -90,7 +92,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
             );
         }
         TuiMode::Dashboard => {
-            if let Some(ref screen) = app.home_screen {
+            if let Some(ref mut screen) = app.home_screen {
                 screen.draw(f, chunks[1], &app.theme);
             }
         }
@@ -105,7 +107,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
             }
         }
         TuiMode::PromptInput => {
-            if let Some(ref screen) = app.prompt_input_screen {
+            if let Some(ref mut screen) = app.prompt_input_screen {
                 screen.draw(f, chunks[1], &app.theme);
             }
         }
@@ -124,7 +126,36 @@ pub fn draw(f: &mut Frame, app: &mut App) {
 
     // Draw help overlay on top of everything if active
     if app.show_help {
-        help::draw_help_overlay(f, f.area(), &app.theme);
+        use crate::tui::navigation::InputMode;
+        let (screen_bindings, input_mode) = match app.tui_mode {
+            TuiMode::Dashboard => app
+                .home_screen
+                .as_ref()
+                .map(|s| (s.keybindings(), s.desired_input_mode())),
+            TuiMode::IssueBrowser => app
+                .issue_browser_screen
+                .as_ref()
+                .map(|s| (s.keybindings(), s.desired_input_mode())),
+            TuiMode::MilestoneView => app
+                .milestone_screen
+                .as_ref()
+                .map(|s| (s.keybindings(), s.desired_input_mode())),
+            TuiMode::PromptInput => app
+                .prompt_input_screen
+                .as_ref()
+                .map(|s| (s.keybindings(), s.desired_input_mode())),
+            _ => None,
+        }
+        .map(|(b, m)| (b, m.unwrap_or(InputMode::Normal)))
+        .unwrap_or_default();
+        help::draw_help_overlay(
+            f,
+            f.area(),
+            &screen_bindings,
+            input_mode,
+            app.help_scroll,
+            &app.theme,
+        );
     }
 }
 


### PR DESCRIPTION
## Summary
- Add unified navigation module with `FocusRing`, `InputMode` (Normal/Insert), and `KeymapProvider` trait for consistent keyboard handling across all TUI screens
- Introduce formal `Screen` trait implemented by all 4 screens (Home, IssueBrowser, Milestone, PromptInput), replacing ad-hoc focus enums with `FocusRing` abstraction
- Refactor help overlay to show context-sensitive keybindings per screen, display current input mode, and support j/k scrolling

Closes #37

## Test plan
- [x] All 811 tests pass (`cargo test`)
- [x] No new clippy warnings from changed code
- [x] Tab cycles focus between panes on Home and PromptInput screens
- [x] Shift+Tab reverses focus cycle
- [x] `?` opens help overlay from any screen with screen-specific keybindings
- [x] j/k scrolls help overlay content
- [x] IssueBrowser filter mode (`/`) enters Insert-like input handling
- [x] PromptInput editor focus uses Insert mode semantics