### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Maestro are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] - 2026-04-06
 
 ### Release Workflow for Binary Build and Distribution (#17)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maestro"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 description = "Multi-session Claude Code orchestrator with Matrix-style TUI"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump version to 0.4.0 in Cargo.toml
- Move CHANGELOG [Unreleased] entries under [0.4.0] - 2026-04-06

Once merged, tag `v0.4.0` on main to trigger the release workflow.