### PR TITLE
docs: man page and shell completion installation guide

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,14 @@ jobs:
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           ARCHIVE="maestro-${TAG}-${{ matrix.target }}.tar.gz"
-          tar czf "${ARCHIVE}" -C target/${{ matrix.target }}/release maestro
+          OUT_DIR=$(find target/${{ matrix.target }}/release/build -path "*/maestro-*/out" -type d 2>/dev/null | head -1)
+          mkdir -p staging
+          cp target/${{ matrix.target }}/release/maestro staging/
+          if [ -n "${OUT_DIR}" ]; then
+            cp "${OUT_DIR}/man/maestro.1" staging/ 2>/dev/null || true
+            cp -r "${OUT_DIR}/completions" staging/ 2>/dev/null || true
+          fi
+          tar czf "${ARCHIVE}" -C staging .
           echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
 
       - name: Upload artifact

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
+clap_mangen = "0.2"
 crossterm = { version = "0.28", features = ["event-stream"] }
 ratatui = "0.29"
 tokio = { version = "1", features = ["full"] }
@@ -31,6 +32,12 @@ async-trait = "0.1"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 arboard = "3.6.1"
 image = { version = "0.25.10", features = ["png"], default-features = false }
+
+[build-dependencies]
+clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
+clap_mangen = "0.2"
+anyhow = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -105,6 +105,67 @@ cargo build --release
 # Binary at target/release/maestro
 ```
 
+## Shell Completions
+
+Maestro supports tab-completion for bash, zsh, and fish. Completions are pre-generated in every release tarball and installed automatically by Homebrew.
+
+### Generate on demand
+
+```bash
+maestro completions bash   # print bash completion script
+maestro completions zsh    # print zsh completion script
+maestro completions fish   # print fish completion script
+```
+
+### Bash
+
+```bash
+maestro completions bash > ~/.local/share/bash-completion/completions/maestro
+```
+
+Restart your shell or run `source ~/.bashrc` to activate.
+
+### Zsh
+
+```bash
+mkdir -p ~/.zfunc
+maestro completions zsh > ~/.zfunc/_maestro
+```
+
+Add the following line to your `~/.zshrc` **before** `compinit` is called:
+
+```zsh
+fpath+=~/.zfunc
+```
+
+Then reload:
+
+```zsh
+source ~/.zshrc
+```
+
+### Fish
+
+```bash
+maestro completions fish > ~/.config/fish/completions/maestro.fish
+```
+
+Fish picks up completions in that directory automatically — no shell restart required.
+
+### Homebrew
+
+Homebrew installs the man page and shell completions automatically when you run `brew install`. No manual steps are needed.
+
+### Pre-built releases
+
+Each release tarball on the [GitHub Releases page](https://github.com/CarlosDanielDev/maestro/releases) includes a `completions/` directory (containing `maestro.bash`, `_maestro` for zsh, and `maestro.fish`) and a `man/maestro.1` man page. Copy the files to the appropriate paths listed above.
+
+To read the man page from the tarball:
+
+```bash
+man ./man/maestro.1
+```
+
 ## Quick Start
 
 ```bash

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,27 @@
+// NOTE: cli.rs must remain self-contained (no imports from other src/ modules)
+// because build.rs includes it directly via #[path].
+#[path = "src/cli.rs"]
+mod cli;
+
+fn main() {
+    use clap::CommandFactory;
+
+    let out_dir =
+        std::path::PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR must be set by cargo"));
+
+    // Generate man page (reuses cli::cmd_mangen)
+    let man_dir = out_dir.join("man");
+    cli::cmd_mangen(&man_dir).expect("failed to generate man page");
+
+    // Generate shell completions
+    let comp_dir = out_dir.join("completions");
+    std::fs::create_dir_all(&comp_dir).unwrap();
+    for shell in [
+        clap_complete::Shell::Bash,
+        clap_complete::Shell::Zsh,
+        clap_complete::Shell::Fish,
+    ] {
+        let mut cmd = cli::Cli::command();
+        clap_complete::generate_to(shell, &mut cmd, "maestro", &comp_dir).unwrap();
+    }
+}

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-06 00:00 (UTC)
+> Last updated: 2026-04-06 12:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -60,8 +60,10 @@ maestro/
 │   └── workflows/
 │       ├── ci.yml                         # GitHub Actions CI pipeline
 │       └── release.yml                    # Release automation for cross-platform builds and Homebrew tap updates
+├── build.rs                               # Build script: generates man page (maestro.1) and shell completions (bash, zsh, fish) into OUT_DIR at build time using clap_mangen and clap_complete  [Issue #18]
 ├── src/
 │   ├── main.rs                            # CLI entry point (clap); Run, Queue, Add, Status, Cost, Init, Doctor; --skip-doctor flag on Run subcommand bypasses preflight; cmd_run() runs validate_preflight() before session launch and uses PromptBuilder::build_issue_prompt() for issue sessions; setup_app_from_config() shared helper wires budget, model router, notifications, plugins, and permission_mode/allowed_tools from config; cmd_dashboard() performs orphan worktree cleanup, log cleanup, fetches username from doctor report, delegates App construction to setup_app_from_config(), and queues FetchSuggestionData on startup; declares #[cfg(test)] mod integration_tests  [Issue #15, #29, #49, #34, #36, #35, #52]
+│   ├── cli.rs                             # CLI definition extracted from main.rs; Cli struct and Commands enum (clap derive); generate_completions() and cmd_completions() for shell tab-completion output; cmd_mangen() for roff man page generation; Completions and Mangen subcommands  [Issue #18]
 │   ├── config.rs                          # maestro.toml parsing; ModelsConfig, GatesConfig, ReviewConfig; ContextOverflowConfig; ProviderConfig (kind, organization, az_project); guardrail_prompt in SessionsConfig; CompletionGatesConfig and CompletionGateEntry; CiAutoFixConfig (enabled, max_retries, poll_interval_secs) under GatesConfig.ci_auto_fix; TuiConfig struct with optional theme field; Config gains tui field  [Issue #29, #40, #41, #43, #38]
 │   ├── budget.rs                          # BudgetEnforcer: per-session and global budget checks  [Phase 3]
 │   ├── doctor.rs                          # Preflight checks: CheckSeverity, CheckResult, DoctorReport, run_all_checks(), print_report(); validate_preflight() (public, fails fast on required check failures); build_claude_cli_result() (pub(crate), pure/testable); check_claude_cli() elevated to Required severity; build_gh_auth_result() (pure, testable); check_az_identity(); 10 check functions  [Issue #49, #34, #52]
@@ -201,8 +203,10 @@ maestro/
 | `.claude/hooks/` | Pre/post command notification hooks |
 | `.claude/skills/` | Reusable knowledge bases for subagents |
 | `.claude/worktrees/` | Worktree checkouts managed by maestro |
+| `build.rs` | Build script: generates `maestro.1` man page and bash/zsh/fish completions into `OUT_DIR` at build time (Issue #18) |
 | `src/` | Rust source code |
 | `src/main.rs` | CLI entry point; `--skip-doctor` flag on `run` subcommand; `cmd_run()` calls `validate_preflight()` before launch and uses `PromptBuilder::build_issue_prompt()` for issue sessions; `setup_app_from_config()` shared App setup helper; `cmd_dashboard()` with startup cleanup, config-driven wiring, and `FetchSuggestionData` queued on startup (Issues #29, #34, #35, #36, #49, #52) |
+| `src/cli.rs` | CLI struct and subcommand definitions; `generate_completions()`, `cmd_completions()`, `cmd_mangen()`; `Completions` and `Mangen` subcommands (Issue #18) |
 | `src/budget.rs` | Per-session and global budget enforcement (Phase 3) |
 | `src/doctor.rs` | Preflight check system: `CheckSeverity`, `CheckResult`, `DoctorReport`, `run_all_checks()`, `print_report()`; `validate_preflight()` fails fast if any required check fails; `build_claude_cli_result()` (pub(crate), pure/testable); `check_claude_cli()` is Required severity; `build_gh_auth_result()` (pure/testable); `check_az_identity()` for Azure DevOps (Issues #49, #34, #52) |
 | `src/git.rs` | GitOps trait and CLI-backed commit+push (Phase 3) |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,280 @@
+use clap::{Parser, Subcommand};
+use clap_complete::Shell;
+
+#[derive(Parser)]
+#[command(
+    name = "maestro",
+    version,
+    about = "Multi-session Claude Code orchestrator"
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Run sessions from GitHub issues or a prompt
+    Run {
+        /// Prompt to send to Claude
+        #[arg(short, long)]
+        prompt: Option<String>,
+
+        /// GitHub issue number(s), comma-separated
+        #[arg(short, long)]
+        issue: Option<String>,
+
+        /// Milestone to fetch all issues from
+        #[arg(short = 'M', long)]
+        milestone: Option<String>,
+
+        /// Model to use (opus, sonnet, haiku)
+        #[arg(short, long)]
+        model: Option<String>,
+
+        /// Session mode (orchestrator, vibe, review, or custom)
+        #[arg(long)]
+        mode: Option<String>,
+
+        /// Max concurrent sessions (overrides config)
+        #[arg(long)]
+        max_concurrent: Option<usize>,
+
+        /// Resume from previous state after a crash
+        #[arg(long)]
+        resume: bool,
+
+        /// Skip preflight doctor checks before launching sessions
+        #[arg(long)]
+        skip_doctor: bool,
+
+        /// Image file(s) to attach as visual context (can be repeated)
+        #[arg(long = "image")]
+        images: Vec<std::path::PathBuf>,
+    },
+    /// Show queued/pending issues from GitHub
+    Queue,
+    /// Add an issue to the work queue manually
+    Add {
+        /// Issue number to add
+        issue_number: u64,
+    },
+    /// Show current state without TUI
+    Status,
+    /// Show spending report
+    Cost,
+    /// Initialize maestro.toml in current directory
+    Init,
+    /// Clean orphaned worktrees left by crashed sessions
+    Clean {
+        /// Show what would be cleaned without actually doing it
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Show session transcript logs
+    Logs {
+        /// Show full log for a specific session ID
+        #[arg(long)]
+        session: Option<String>,
+        /// Export as JSON
+        #[arg(long)]
+        export: Option<String>,
+    },
+    /// Resume interrupted sessions from saved state
+    Resume {
+        /// Resume a specific session by ID
+        #[arg(long)]
+        session: Option<String>,
+    },
+    /// Test Slack webhook configuration
+    TestSlack,
+    /// Generate shell completions
+    Completions {
+        /// Shell to generate completions for
+        #[arg(value_enum)]
+        shell: Shell,
+    },
+    /// Check environment setup and required tools
+    Doctor,
+    /// Generate man page (hidden, for packaging)
+    #[command(hide = true)]
+    Mangen {
+        /// Output directory for man page
+        out_dir: std::path::PathBuf,
+    },
+}
+
+pub fn generate_completions<W: std::io::Write>(shell: Shell, out: &mut W) {
+    use clap::CommandFactory;
+    use clap_complete::generate;
+
+    let mut cmd = Cli::command();
+    generate(shell, &mut cmd, "maestro", out);
+}
+
+pub fn cmd_completions(shell: Shell) -> anyhow::Result<()> {
+    generate_completions(shell, &mut std::io::stdout());
+    Ok(())
+}
+
+pub fn cmd_mangen(out_dir: &std::path::Path) -> anyhow::Result<()> {
+    use clap::CommandFactory;
+
+    std::fs::create_dir_all(out_dir)?;
+    let cmd = Cli::command();
+    let man = clap_mangen::Man::new(cmd);
+    let mut buffer = Vec::new();
+    man.render(&mut buffer)?;
+    std::fs::write(out_dir.join("maestro.1"), buffer)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    use std::path::{Path, PathBuf};
+
+    // ------------------------------------------------------------------
+    // Clap struct integrity
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn cli_debug_assert() {
+        <Cli as clap::CommandFactory>::command().debug_assert();
+    }
+
+    // ------------------------------------------------------------------
+    // Completions subcommand parsing
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn completions_subcommand_accepts_bash() {
+        let cli = Cli::try_parse_from(["maestro", "completions", "bash"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Completions { shell: Shell::Bash })
+        ));
+    }
+
+    #[test]
+    fn completions_subcommand_accepts_zsh() {
+        let cli = Cli::try_parse_from(["maestro", "completions", "zsh"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Completions { shell: Shell::Zsh })
+        ));
+    }
+
+    #[test]
+    fn completions_subcommand_accepts_fish() {
+        let cli = Cli::try_parse_from(["maestro", "completions", "fish"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Completions { shell: Shell::Fish })
+        ));
+    }
+
+    #[test]
+    fn completions_subcommand_rejects_invalid_shell() {
+        let result = Cli::try_parse_from(["maestro", "completions", "invalid-shell"]);
+        assert!(result.is_err(), "invalid shell must be rejected by clap");
+    }
+
+    // ------------------------------------------------------------------
+    // Mangen subcommand parsing
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn mangen_subcommand_parses_out_dir() {
+        let cli = Cli::try_parse_from(["maestro", "mangen", "/tmp/man"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Mangen { out_dir }) if out_dir == PathBuf::from("/tmp/man")
+        ));
+    }
+
+    #[test]
+    fn mangen_subcommand_requires_out_dir_argument() {
+        let result = Cli::try_parse_from(["maestro", "mangen"]);
+        assert!(result.is_err(), "mangen without out_dir must fail");
+    }
+
+    #[test]
+    fn mangen_is_hidden_from_help() {
+        let help = <Cli as clap::CommandFactory>::command()
+            .render_help()
+            .to_string();
+        assert!(
+            !help.contains("mangen"),
+            "mangen must not appear in --help output"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // generate_completions output
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn completions_bash_output_contains_program_name() {
+        let mut buf = Vec::<u8>::new();
+        generate_completions(Shell::Bash, &mut buf);
+        let script = String::from_utf8(buf).expect("bash output must be valid UTF-8");
+        assert!(
+            script.contains("maestro"),
+            "bash completion must reference the binary name 'maestro'"
+        );
+    }
+
+    #[test]
+    fn completions_zsh_output_is_non_empty() {
+        let mut buf = Vec::<u8>::new();
+        generate_completions(Shell::Zsh, &mut buf);
+        assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn completions_fish_output_is_valid_utf8() {
+        let mut buf = Vec::<u8>::new();
+        generate_completions(Shell::Fish, &mut buf);
+        assert!(
+            String::from_utf8(buf).is_ok(),
+            "fish completion output must be valid UTF-8"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // cmd_mangen filesystem behavior
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn mangen_file_is_named_after_binary() {
+        let dir = tempfile::TempDir::new().unwrap();
+        cmd_mangen(dir.path()).unwrap();
+        assert!(
+            dir.path().join("maestro.1").exists(),
+            "man page file must be named maestro.1"
+        );
+    }
+
+    #[test]
+    fn mangen_output_contains_roff_title_heading() {
+        let dir = tempfile::TempDir::new().unwrap();
+        cmd_mangen(dir.path()).unwrap();
+        let contents = std::fs::read_to_string(dir.path().join("maestro.1")).unwrap();
+        assert!(!contents.is_empty(), "man page must not be empty");
+        assert!(
+            contents.contains(".TH"),
+            "man page must contain roff .TH macro"
+        );
+    }
+
+    #[test]
+    fn mangen_fails_on_unwritable_path() {
+        let result = cmd_mangen(Path::new("/nonexistent/path/maestro-test-qa-9f3a"));
+        assert!(
+            result.is_err(),
+            "mangen must fail when out_dir cannot be created"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod budget;
+mod cli;
 mod config;
 mod doctor;
 mod gates;
@@ -20,7 +21,8 @@ mod work;
 #[cfg(test)]
 mod integration_tests;
 
-use clap::{Parser, Subcommand};
+use clap::Parser;
+use cli::{Cli, Commands};
 use config::{Config, NotificationsConfig};
 use github::client::{GhCliClient, GitHubClient};
 use notifications::dispatcher::NotificationDispatcher;
@@ -30,102 +32,6 @@ use state::store::StateStore;
 use tui::app::App;
 use work::assigner::WorkAssigner;
 use work::types::WorkItem;
-
-#[derive(Parser)]
-#[command(
-    name = "maestro",
-    version,
-    about = "Multi-session Claude Code orchestrator"
-)]
-struct Cli {
-    #[command(subcommand)]
-    command: Option<Commands>,
-}
-
-#[derive(Subcommand)]
-enum Commands {
-    /// Run sessions from GitHub issues or a prompt
-    Run {
-        /// Prompt to send to Claude
-        #[arg(short, long)]
-        prompt: Option<String>,
-
-        /// GitHub issue number(s), comma-separated
-        #[arg(short, long)]
-        issue: Option<String>,
-
-        /// Milestone to fetch all issues from
-        #[arg(short = 'M', long)]
-        milestone: Option<String>,
-
-        /// Model to use (opus, sonnet, haiku)
-        #[arg(short, long)]
-        model: Option<String>,
-
-        /// Session mode (orchestrator, vibe, review, or custom)
-        #[arg(long)]
-        mode: Option<String>,
-
-        /// Max concurrent sessions (overrides config)
-        #[arg(long)]
-        max_concurrent: Option<usize>,
-
-        /// Resume from previous state after a crash
-        #[arg(long)]
-        resume: bool,
-
-        /// Skip preflight doctor checks before launching sessions
-        #[arg(long)]
-        skip_doctor: bool,
-
-        /// Image file(s) to attach as visual context (can be repeated)
-        #[arg(long = "image")]
-        images: Vec<std::path::PathBuf>,
-    },
-    /// Show queued/pending issues from GitHub
-    Queue,
-    /// Add an issue to the work queue manually
-    Add {
-        /// Issue number to add
-        issue_number: u64,
-    },
-    /// Show current state without TUI
-    Status,
-    /// Show spending report
-    Cost,
-    /// Initialize maestro.toml in current directory
-    Init,
-    /// Clean orphaned worktrees left by crashed sessions
-    Clean {
-        /// Show what would be cleaned without actually doing it
-        #[arg(long)]
-        dry_run: bool,
-    },
-    /// Show session transcript logs
-    Logs {
-        /// Show full log for a specific session ID
-        #[arg(long)]
-        session: Option<String>,
-        /// Export as JSON
-        #[arg(long)]
-        export: Option<String>,
-    },
-    /// Resume interrupted sessions from saved state
-    Resume {
-        /// Resume a specific session by ID
-        #[arg(long)]
-        session: Option<String>,
-    },
-    /// Test Slack webhook configuration
-    TestSlack,
-    /// Generate shell completions
-    Completions {
-        /// Shell to generate completions for (bash, zsh, fish)
-        shell: String,
-    },
-    /// Check environment setup and required tools
-    Doctor,
-}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -154,7 +60,8 @@ async fn main() -> anyhow::Result<()> {
         Some(Commands::Logs { session, export }) => cmd_logs(session, export),
         Some(Commands::Resume { session }) => cmd_resume(session).await,
         Some(Commands::TestSlack) => cmd_test_slack().await,
-        Some(Commands::Completions { shell }) => cmd_completions(&shell),
+        Some(Commands::Completions { shell }) => cli::cmd_completions(shell),
+        Some(Commands::Mangen { out_dir }) => cli::cmd_mangen(&out_dir),
         Some(Commands::Doctor) => cmd_doctor(),
         Some(Commands::Status) => cmd_status(),
         Some(Commands::Cost) => cmd_cost(),
@@ -654,22 +561,6 @@ async fn cmd_test_slack() -> anyhow::Result<()> {
             anyhow::bail!("Slack webhook test failed: {}", e)
         }
     }
-}
-
-fn cmd_completions(shell: &str) -> anyhow::Result<()> {
-    use clap::CommandFactory;
-    use clap_complete::{Shell, generate};
-
-    let shell = match shell.to_lowercase().as_str() {
-        "bash" => Shell::Bash,
-        "zsh" => Shell::Zsh,
-        "fish" => Shell::Fish,
-        other => anyhow::bail!("Unsupported shell: {}. Use bash, zsh, or fish.", other),
-    };
-
-    let mut cmd = Cli::command();
-    generate(shell, &mut cmd, "maestro", &mut std::io::stdout());
-    Ok(())
 }
 
 fn cmd_doctor() -> anyhow::Result<()> {


### PR DESCRIPTION
## Summary
- Extract CLI definition to `src/cli.rs` with `Completions` using `clap_complete::Shell` enum (replaces raw string) and hidden `Mangen` subcommand for packaging
- Add `build.rs` with `clap_mangen` to generate man page and bash/zsh/fish completions at build time, included in release tarballs
- Add shell completion installation guide to README for bash, zsh, fish, and Homebrew

Closes #18

## Test plan
- [x] 14 new tests in `src/cli.rs` covering CLI parsing, completion output, and man page generation
- [x] Full test suite passes (902 tests)
- [x] `cargo build` generates `maestro.1` man page and shell completions in `OUT_DIR`
- [x] `cargo clippy` and `cargo fmt` clean