### PR TITLE
feat: submit prompt with Enter key, use Shift+Enter for newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Submit Prompt with Enter Key, Shift+Enter for Newlines (#101)
+
+- `src/tui/screens/prompt_input.rs` — `Enter` now submits the prompt and launches a session (previously `Ctrl+S`); `Shift+Enter` inserts a newline in the prompt body (previously `Enter`); `Ctrl+S` removed as a submission keybinding; keybinds bar updated to show `Enter: Submit` and `Shift+Enter: New line`
+
 ### Dashboard Suggestion Refresh After Session Completion (#86)
 
 - `src/tui/screens/mod.rs` — `ScreenAction::RefreshSuggestions` variant added; triggers a suggestion reload from the dashboard without a full navigation round-trip

--- a/README.md
+++ b/README.md
@@ -391,6 +391,18 @@ Dependencies can also be declared in the issue body as `blocked-by: #N` (case-in
 | `r` | Run all open issues in selected milestone |
 | `Esc` | Go back |
 
+### Prompt Input
+
+| Key | Action |
+|-----|--------|
+| `Enter` | Submit prompt and launch session |
+| `Shift+Enter` | Insert newline |
+| `Ctrl+V` | Paste from clipboard (text or image) |
+| `Tab` / `Shift+Tab` | Move focus between fields |
+| `a` | Add image attachment (in attachment list) |
+| `d` | Remove selected attachment (in attachment list) |
+| `Esc` | Cancel and return to previous screen |
+
 ## How It Works
 
 1. Maestro spawns `claude --print --output-format stream-json --model <model> "<prompt>"`

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-06 22:00 (UTC)
+> Last updated: 2026-04-06 23:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -149,7 +149,8 @@ maestro/
 │   │       ├── mod.rs                     # Screen types: ScreenAction enum (+ RefreshSuggestions variant), SessionConfig; re-exports HomeScreen, IssueBrowserScreen, MilestoneScreen  [Issue #31-33, #86]
 │   │       ├── home.rs                    # HomeScreen: idle dashboard, logo, quick-actions menu, suggestions panel, recent activity panel; SuggestionKind enum, Suggestion struct, HomeSection enum; build_suggestions() derives contextual hints from GitHub data; draw_suggestions() renders Suggestions panel with "Loading..." placeholder when loading_suggestions=true; loading_suggestions: bool field; set_suggestions() clears loading flag on delivery; R key emits RefreshSuggestions; Tab-based focus navigation between QuickActions and Suggestions; ProjectInfo gains username field  [Issue #31, #49, #34, #35, #86]
 │   │       ├── issue_browser.rs           # IssueBrowserScreen: navigable issue list, multi-select, label/milestone filters, preview pane; set_issues() for async data delivery  [Issue #32, #46]
-│   │       └── milestone.rs               # MilestoneScreen: milestone list, progress gauge, issue detail pane, run-all action  [Issue #33]
+│   │       ├── milestone.rs               # MilestoneScreen: milestone list, progress gauge, issue detail pane, run-all action  [Issue #33]
+│   │       └── prompt_input.rs            # PromptInputScreen: free-text prompt entry; Enter submits, Shift+Enter inserts newline, Ctrl+V pastes from clipboard (image or text), Esc cancels; image attachment list with [a]/[d]; keybinds bar always visible  [Issue #101]
 │   ├── integration_tests/                 # End-to-end integration test suite (no external deps, all mocked)  [Issue #15]
 │   │   ├── mod.rs                         # Module declarations; shared helpers: make_pool(), make_pool_with_worktree(), make_session(), make_session_with_issue(), make_gh_issue()
 │   │   ├── session_lifecycle.rs           # 11 tests: enqueue/promote/complete lifecycle via handle_event()
@@ -262,10 +263,11 @@ maestro/
 | `src/tui/panels.rs` | Split-pane multi-session view; `GatesRunning` (Cyan), `NeedsReview` (LightYellow), and `CiFix` (LightMagenta) status colors (Issues #40, #41) |
 | `src/tui/ui.rs` | `draw_completion_overlay()`: centred overlay rendering PR links (underlined, full GitHub URL or `#N`), per-session error summaries in error color, and a keybindings bar with `[i]` Browse issues, `[r]` New prompt, `[l]` View logs, `[q]` Quit, `[Esc]` Dashboard; `ContinuousPause` render branch with pause overlay and status bar indicator (Issues #83, #84, #85) |
 | `src/tui/screens/` | Interactive TUI screen components (Issues #31-33) |
-| `src/tui/screens/mod.rs` | `ScreenAction` enum, `SessionConfig`; re-exports all screen types |
+| `src/tui/screens/mod.rs` | `ScreenAction` enum, `SessionConfig`; re-exports all screen types including `PromptInputScreen` |
 | `src/tui/screens/home.rs` | `HomeScreen`: idle dashboard with 3-column layout (Quick Actions 30% / Suggestions 35% / Recent Activity 35%); `SuggestionKind` enum (`ReadyIssues`, `MilestoneProgress`, `IdleSessions`, `FailedIssues`); `Suggestion` struct with `build_suggestions()` factory; `HomeSection` enum for Tab-based focus toggle; `draw_suggestions()` renderer; `@username` display in project info bar (Issues #31, #34, #35, #49) |
 | `src/tui/screens/issue_browser.rs` | `IssueBrowserScreen`: navigable issue list with multi-select, label/milestone filters; `set_issues()` (Issues #32, #46) |
 | `src/tui/screens/milestone.rs` | `MilestoneScreen`: milestone list with progress gauge and run-all action (Issue #33) |
+| `src/tui/screens/prompt_input.rs` | `PromptInputScreen`: free-text prompt entry; `Enter` submits, `Shift+Enter` inserts newline, `Ctrl+V` pastes from clipboard (image or text), `Esc` cancels; image attachment list with `[a]`/`[d]` (Issue #101) |
 | `src/tui/snapshot_tests/` | TUI snapshot test suite; 29 tests across 6 views using `insta`; run with `cargo test tui::snapshot_tests`; update with `INSTA_UPDATE=always cargo test` or `cargo insta review` (Issue #16) |
 | `src/tui/snapshot_tests/overview.rs` | 6 snapshot tests for `PanelView`: empty, single running, multiple, selected, context overflow, forked |
 | `src/tui/snapshot_tests/detail.rs` | 5 snapshot tests for `DetailView`: basic, progress, activity log, no files touched, files + retries |

--- a/src/tui/screens/prompt_input.rs
+++ b/src/tui/screens/prompt_input.rs
@@ -245,7 +245,8 @@ impl PromptInputScreen {
                 f,
                 chunks[2],
                 &[
-                    ("Ctrl+S", "Submit"),
+                    ("Enter", "Submit"),
+                    ("Shift+Enter", "New line"),
                     ("Ctrl+V", "Paste"),
                     ("Tab", "Switch"),
                     ("Esc", "Cancel"),
@@ -263,8 +264,12 @@ impl KeymapProvider for PromptInputScreen {
                 title: "Prompt Editor",
                 bindings: vec![
                     KeyBinding {
-                        key: "Ctrl+s",
+                        key: "Enter",
                         description: "Submit prompt",
+                    },
+                    KeyBinding {
+                        key: "Shift+Enter",
+                        description: "New line",
                     },
                     KeyBinding {
                         key: "Ctrl+v",
@@ -310,16 +315,6 @@ impl Screen for PromptInputScreen {
             ..
         }) = event
         {
-            if *modifiers == KeyModifiers::CONTROL && *code == KeyCode::Char('s') {
-                if self.prompt_text.trim().is_empty() {
-                    return ScreenAction::None;
-                }
-                return ScreenAction::LaunchPromptSession(PromptSessionConfig {
-                    prompt: self.prompt_text.clone(),
-                    image_paths: self.image_paths.clone(),
-                });
-            }
-
             if *modifiers == KeyModifiers::CONTROL && *code == KeyCode::Char('v') {
                 self.paste_from_clipboard();
                 return ScreenAction::None;
@@ -366,11 +361,22 @@ impl Screen for PromptInputScreen {
 
             if self.is_prompt_editor_focused() {
                 match code {
-                    KeyCode::Char(c) => {
-                        self.prompt_text.push(*c);
+                    KeyCode::Enter if *modifiers == KeyModifiers::SHIFT => {
+                        self.prompt_text.push('\n');
                     }
                     KeyCode::Enter => {
-                        self.prompt_text.push('\n');
+                        if !self.prompt_text.trim().is_empty() {
+                            return ScreenAction::LaunchPromptSession(PromptSessionConfig {
+                                prompt: self.prompt_text.clone(),
+                                image_paths: self.image_paths.clone(),
+                            });
+                        }
+                    }
+                    KeyCode::Char(c)
+                        if *modifiers == KeyModifiers::NONE
+                            || *modifiers == KeyModifiers::SHIFT =>
+                    {
+                        self.prompt_text.push(*c);
                     }
                     KeyCode::Backspace => {
                         self.prompt_text.pop();
@@ -426,8 +432,8 @@ impl Screen for PromptInputScreen {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tui::screens::test_helpers::key_event;
-    use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
+    use crate::tui::screens::test_helpers::{key_event, key_event_with_modifiers};
+    use crossterm::event::{KeyCode, KeyModifiers};
 
     /// Mock clipboard that returns a preconfigured response.
     struct MockClipboard {
@@ -464,13 +470,12 @@ mod tests {
         }
     }
 
-    fn ctrl_key(code: KeyCode) -> Event {
-        Event::Key(KeyEvent {
-            code,
-            modifiers: KeyModifiers::CONTROL,
-            kind: KeyEventKind::Press,
-            state: KeyEventState::NONE,
-        })
+    fn ctrl_key(code: KeyCode) -> crossterm::event::Event {
+        key_event_with_modifiers(code, KeyModifiers::CONTROL)
+    }
+
+    fn shift_key(code: KeyCode) -> crossterm::event::Event {
+        key_event_with_modifiers(code, KeyModifiers::SHIFT)
     }
 
     fn mock_screen() -> PromptInputScreen {
@@ -531,9 +536,9 @@ mod tests {
     }
 
     #[test]
-    fn prompt_input_enter_inserts_newline() {
+    fn prompt_input_shift_enter_inserts_newline() {
         let mut screen = screen_with_prompt("hello");
-        let action = screen.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
+        let action = screen.handle_input(&shift_key(KeyCode::Enter), InputMode::Normal);
         assert_eq!(screen.prompt_text, "hello\n");
         assert_eq!(action, ScreenAction::None);
     }
@@ -553,12 +558,12 @@ mod tests {
         assert_eq!(action, ScreenAction::None);
     }
 
-    // --- Group 3: Submit (Ctrl+S) ---
+    // --- Group 3: Submit (Enter) ---
 
     #[test]
-    fn prompt_input_ctrl_s_with_prompt_returns_launch_prompt_session() {
+    fn prompt_input_enter_with_prompt_returns_launch_prompt_session() {
         let mut screen = screen_with_prompt("fix the bug");
-        let action = screen.handle_input(&ctrl_key(KeyCode::Char('s')), InputMode::Normal);
+        let action = screen.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
         assert_eq!(
             action,
             ScreenAction::LaunchPromptSession(PromptSessionConfig {
@@ -569,10 +574,10 @@ mod tests {
     }
 
     #[test]
-    fn prompt_input_ctrl_s_with_prompt_and_images_includes_image_paths() {
+    fn prompt_input_enter_with_prompt_and_images_includes_image_paths() {
         let mut screen = screen_with_prompt("describe this");
         screen.image_paths = vec!["/tmp/a.png".to_string(), "/tmp/b.png".to_string()];
-        let action = screen.handle_input(&ctrl_key(KeyCode::Char('s')), InputMode::Normal);
+        let action = screen.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
         assert_eq!(
             action,
             ScreenAction::LaunchPromptSession(PromptSessionConfig {
@@ -583,17 +588,35 @@ mod tests {
     }
 
     #[test]
-    fn prompt_input_ctrl_s_with_empty_prompt_is_rejected() {
+    fn prompt_input_enter_with_empty_prompt_is_rejected() {
         let mut screen = mock_screen();
-        let action = screen.handle_input(&ctrl_key(KeyCode::Char('s')), InputMode::Normal);
+        let action = screen.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
         assert_eq!(action, ScreenAction::None);
     }
 
     #[test]
-    fn prompt_input_ctrl_s_with_whitespace_only_prompt_is_rejected() {
+    fn prompt_input_enter_with_whitespace_only_prompt_is_rejected() {
         let mut screen = screen_with_prompt("   \n  ");
+        let action = screen.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
+        assert_eq!(action, ScreenAction::None);
+    }
+
+    #[test]
+    fn prompt_input_ctrl_s_is_ignored() {
+        let mut screen = screen_with_prompt("fix the bug");
         let action = screen.handle_input(&ctrl_key(KeyCode::Char('s')), InputMode::Normal);
         assert_eq!(action, ScreenAction::None);
+        assert_eq!(screen.prompt_text, "fix the bug");
+    }
+
+    #[test]
+    fn prompt_input_enter_in_image_path_editing_does_not_submit_session() {
+        let mut screen = screen_in_image_list_focus();
+        screen.editing_image_path = true;
+        screen.image_path_input = "/tmp/shot.png".to_string();
+        let action = screen.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
+        assert_eq!(action, ScreenAction::None);
+        assert_eq!(screen.image_paths, vec!["/tmp/shot.png".to_string()]);
     }
 
     // --- Group 4: Esc ---


### PR DESCRIPTION
## Summary
- Swap keybindings: `Enter` now submits the prompt (was `Ctrl+S`), `Shift+Enter` inserts a newline (was `Enter`)
- Aligns with standard chat UX patterns (Slack, Discord, ChatGPT)
- Empty/whitespace-only prompt guard preserved, image path editing unaffected

Closes #101

## Test plan
- [x] `cargo test` — 966 tests pass (38 in prompt_input module)
- [x] `cargo clippy` — clean
- [ ] Manual: Enter submits prompt in TUI
- [ ] Manual: Shift+Enter inserts newline in TUI
- [ ] Manual: Enter still confirms image path when editing
- [ ] Manual: Uppercase letters and shifted symbols (!, @, #) work