### PR TITLE
feat: mandatory dependency chain and graph guardrail

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -73,7 +73,7 @@ A conforming issue contains these sections (enforced by GitHub issue templates):
 | Acceptance Criteria | Required | Required | Testable conditions |
 | Files to Modify | Required | Optional | Expected file changes |
 | Test Hints | Required | Optional | Mocking and edge-case guidance |
-| Blocked By | Optional | Optional | Dependency issues |
+| Blocked By | Required | Required | Dependency issues (issue numbers or "None") |
 | Definition of Done | Required | Required | Completion checklist |
 
 **If an issue is missing required DOR fields, the orchestrator MUST:**
@@ -81,7 +81,54 @@ A conforming issue contains these sections (enforced by GitHub issue templates):
 2. Apply the `needs-info` label
 3. NOT start implementation until the DOR is satisfied
 
-### 4. TDD IS MANDATORY — NON-NEGOTIABLE
+### 4. DEPENDENCY CHAIN AND GRAPH — NON-NEGOTIABLE
+
+**Every issue and milestone MUST include dependency information. No exceptions. This applies in ALL modes (Subagents Orchestrator, Vibe Coding, Training).**
+
+**Rules for Issues:**
+- Every `gh issue create` call MUST include a `## Blocked By` section with issue numbers (or "None")
+- This field is REQUIRED, not optional
+- Format:
+  ```markdown
+  ## Blocked By
+
+  - #106 feat: sanitize module scaffolding
+  - #107 feat: Phase 1 scanner
+  ```
+  Or if no dependencies:
+  ```markdown
+  ## Blocked By
+
+  - None
+  ```
+
+**Rules for Milestones:**
+- Every `gh api milestones` create/update MUST include a `## Dependency Graph` in the description
+- The dependency graph MUST use ASCII visualization showing the execution order
+- Required sections in milestone description:
+  1. A one-line summary
+  2. A `## Dependency Graph (Implementation Order)` section with levels (Level 0, Level 1, etc.)
+  3. A `Sequence:` line showing the linear/parallel execution order using `→` (sequential) and `∥` (parallel)
+- Format:
+  ```markdown
+  ## Dependency Graph (Implementation Order)
+
+  Level 0 — no dependencies:
+  • #106 feat: scaffolding and types
+
+  Level 1 — depends on #106 (can run in parallel):
+  • #107 feat: Phase 1 scanner
+  • #108 feat: Phase 2 analyzer
+
+  Level 2 — depends on #107, #108:
+  • #110 feat: Wire pipeline
+
+  Sequence: #106 → #107 ∥ #108 → #110
+  ```
+
+**Violation of this rule means the issue/milestone is malformed and MUST be corrected before proceeding.**
+
+### 5. TDD IS MANDATORY — NON-NEGOTIABLE
 
 **Every implementation MUST follow Test-Driven Development. No exceptions.**
 

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -118,9 +118,12 @@ body:
     id: blocked-by
     attributes:
       label: Blocked By
-      description: Any issues or PRs that block this fix.
+      description: Any issues or PRs that block this fix. Use "None" if no dependencies.
+      placeholder: |
+        - #42 (description)
+        - None
     validations:
-      required: false
+      required: true
 
   - type: textarea
     id: definition-of-done

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -65,10 +65,29 @@ body:
     id: blocked-by
     attributes:
       label: Blocked By
-      description: List any issues or PRs that must be completed before this one can start.
+      description: List any issues or PRs that must be completed before this one can start. Use "None" if no dependencies.
       placeholder: |
         - #42 (description)
         - None
+    validations:
+      required: true
+
+  - type: textarea
+    id: dependency-graph
+    attributes:
+      label: Dependency Graph
+      description: For epic/multi-issue features, provide an ASCII dependency graph showing implementation order. Optional for single standalone issues.
+      placeholder: |
+        ## Dependency Graph (Implementation Order)
+
+        Level 0 — no dependencies:
+        • #106 feat: scaffolding and types
+
+        Level 1 — depends on #106 (can run in parallel):
+        • #107 feat: Phase 1 scanner
+        • #108 feat: Phase 2 analyzer
+
+        Sequence: #106 → #107 ∥ #108
     validations:
       required: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Mandatory Dependency Chain and Graph Guardrail for Issue and Milestone Creation (#113)
+
+- `.claude/CLAUDE.md` — Critical Premise #5 added: "DEPENDENCY CHAIN AND GRAPH — NON-NEGOTIABLE"; rules require an explicit dependency graph for issues that have blockers, and for milestones consisting of multiple issues; DOR table updated to mark `Blocked By` as required for both Feature and Bug issues
+- `.github/ISSUE_TEMPLATE/feature.yml` — `Blocked By` field set to `required: true`; new `Dependency Graph` textarea field added (optional) for documenting ASCII dependency graphs when creating multi-issue features or epics
+- `.github/ISSUE_TEMPLATE/bug.yml` — `Blocked By` field set to `required: true` with placeholder guidance to use "None" if there are no dependencies
+- GitHub v1.0.0 milestone updated via API to include dependency graph section in its description
+
 ### Add [f] Fix Action to Completion Overlay for Failed Gates (#104)
 
 - `src/gates/types.rs` — `GateResult` derives `Serialize`/`Deserialize` (round-trip support for persisting gate results on the session)

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-06 23:55 (UTC)
+> Last updated: 2026-04-06 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -55,8 +55,8 @@ maestro/
 ├── .github/
 │   ├── ISSUE_TEMPLATE/
 │   │   ├── config.yml                     # Template chooser config (blank issues disabled)
-│   │   ├── feature.yml                    # Feature request issue form with DOR
-│   │   └── bug.yml                        # Bug report issue form with DOR
+│   │   ├── feature.yml                    # Feature request issue form with DOR; Blocked By required; Dependency Graph field
+│   │   └── bug.yml                        # Bug report issue form with DOR; Blocked By required
 │   └── workflows/
 │       ├── ci.yml                         # GitHub Actions CI pipeline
 │       └── release.yml                    # Release automation for cross-platform builds and Homebrew tap updates
@@ -198,8 +198,8 @@ maestro/
 | Path | Description |
 |------|-------------|
 | `.github/ISSUE_TEMPLATE/config.yml` | Template chooser config — blank issues disabled |
-| `.github/ISSUE_TEMPLATE/feature.yml` | Feature request issue form with Definition of Ready fields |
-| `.github/ISSUE_TEMPLATE/bug.yml` | Bug report issue form with Definition of Ready fields |
+| `.github/ISSUE_TEMPLATE/feature.yml` | Feature request issue form with DOR fields; `Blocked By` required; `Dependency Graph` textarea for epic/multi-issue ordering |
+| `.github/ISSUE_TEMPLATE/bug.yml` | Bug report issue form with DOR fields; `Blocked By` required |
 | `.github/workflows/ci.yml` | GitHub Actions CI pipeline |
 | `.github/workflows/release.yml` | Release automation: cross-platform builds, GitHub Release with SHA256 checksums, Homebrew tap update |
 | `.claude/` | Claude Code agent configuration |


### PR DESCRIPTION
## Summary

- Added Critical Premise #4 to CLAUDE.md enforcing mandatory `Blocked By` on all issues and `Dependency Graph` on all milestones
- Made `Blocked By` required in both feature and bug issue templates; added optional `Dependency Graph` field to feature template
- Updated v1.0.0 milestone to include dependency graph section
- Updated DOR table, CHANGELOG, and directory-tree.md

Closes #113

## Test plan
- [x] Create a test feature issue — verify `Blocked By` is required
- [x] Create a test bug issue — verify `Blocked By` is required
- [x] Verify all open milestones (v0.5.0, v0.6.0, v0.7.0, v1.0.0) have dependency graphs