### PR TITLE
feat: thinking animation spinner with elapsed metadata

### DIFF
--- a/src/integration_tests/stream_parsing.rs
+++ b/src/integration_tests/stream_parsing.rs
@@ -557,6 +557,92 @@ fn assistant_message_does_not_add_to_activity_log() {
     );
 }
 
+// --- Issue #134: Thinking state transitions ---
+
+#[test]
+fn thinking_event_sets_is_thinking_and_started_at() {
+    let mut managed = ManagedSession::new(make_session("s"));
+
+    assert!(!managed.session.is_thinking);
+    assert!(managed.session.thinking_started_at.is_none());
+
+    managed.handle_event(&StreamEvent::Thinking {
+        text: "reasoning".to_string(),
+    });
+
+    assert!(managed.session.is_thinking);
+    assert!(managed.session.thinking_started_at.is_some());
+}
+
+#[test]
+fn non_thinking_event_clears_thinking_state() {
+    let mut managed = ManagedSession::new(make_session("s"));
+
+    // Start thinking
+    managed.handle_event(&StreamEvent::Thinking {
+        text: "reasoning".to_string(),
+    });
+    assert!(managed.session.is_thinking);
+
+    // Non-thinking event clears it
+    managed.handle_event(&StreamEvent::AssistantMessage {
+        text: "Hello".to_string(),
+    });
+    assert!(!managed.session.is_thinking);
+    assert!(managed.session.thinking_started_at.is_none());
+}
+
+#[test]
+fn multiple_thinking_events_keep_original_start_time() {
+    let mut managed = ManagedSession::new(make_session("s"));
+
+    managed.handle_event(&StreamEvent::Thinking {
+        text: "first".to_string(),
+    });
+    let first_start = managed.session.thinking_started_at;
+
+    managed.handle_event(&StreamEvent::Thinking {
+        text: "second".to_string(),
+    });
+    // Start time should not change on subsequent thinking events
+    assert_eq!(managed.session.thinking_started_at, first_start);
+}
+
+#[test]
+fn thinking_elapsed_increases_over_time() {
+    let mut managed = ManagedSession::new(make_session("s"));
+
+    managed.handle_event(&StreamEvent::Thinking {
+        text: "reasoning".to_string(),
+    });
+
+    let started_at = managed.session.thinking_started_at.unwrap();
+    let elapsed = started_at.elapsed();
+    // Elapsed should be very small (just created)
+    assert!(elapsed.as_secs() < 1);
+}
+
+#[test]
+fn thinking_stop_logs_elapsed_time() {
+    let mut managed = ManagedSession::new(make_session("s"));
+
+    managed.handle_event(&StreamEvent::Thinking {
+        text: "reasoning".to_string(),
+    });
+
+    managed.handle_event(&StreamEvent::AssistantMessage {
+        text: "done".to_string(),
+    });
+
+    // Should have logged "Thought for ..."
+    let has_thought_log = managed
+        .session
+        .activity_log
+        .iter()
+        .any(|e| e.message.starts_with("Thought for"));
+    assert!(has_thought_log);
+}
+
 // Regression: roundtrip through parser and handler
 #[test]
 fn roundtrip_tool_use_bash_command_preview_preserved_through_parse_and_handle() {

--- a/src/session/manager.rs
+++ b/src/session/manager.rs
@@ -214,6 +214,8 @@ impl ManagedSession {
         if !matches!(event, StreamEvent::Thinking { .. })
             && let Some(start) = self.thinking_start.take()
         {
+            self.session.is_thinking = false;
+            self.session.thinking_started_at = None;
             self.session
                 .log_activity(format!("Thought for {}", format_elapsed(start.elapsed())));
         }
@@ -312,7 +314,10 @@ impl ManagedSession {
             }
             StreamEvent::Thinking { .. } => {
                 if self.thinking_start.is_none() {
-                    self.thinking_start = Some(std::time::Instant::now());
+                    let now = std::time::Instant::now();
+                    self.thinking_start = Some(now);
+                    self.session.is_thinking = true;
+                    self.session.thinking_started_at = Some(now);
                     self.session.log_activity("Thinking...".into());
                 }
                 if self.session.current_activity != "Thinking..." {

--- a/src/session/types.rs
+++ b/src/session/types.rs
@@ -116,6 +116,12 @@ pub struct Session {
     /// Gate results from the last gate check run (empty if gates not configured or not run yet).
     #[serde(default)]
     pub gate_results: Vec<GateResultEntry>,
+    /// Whether this session is currently in a thinking state.
+    #[serde(skip)]
+    pub is_thinking: bool,
+    /// When the current thinking block started (for elapsed display).
+    #[serde(skip)]
+    pub thinking_started_at: Option<std::time::Instant>,
 }
 
 /// Lightweight gate result stored on a session for post-completion display.
@@ -178,6 +184,8 @@ impl Session {
             ci_fix_context: None,
             image_paths: Vec::new(),
             gate_results: Vec::new(),
+            is_thinking: false,
+            thinking_started_at: None,
         }
     }
 
@@ -390,6 +398,32 @@ mod tests {
         let stripped = json.replace(r#","image_paths":[]"#, "");
         let rt: Session = serde_json::from_str(&stripped).unwrap();
         assert!(rt.image_paths.is_empty());
+    }
+
+    // --- Issue #134: Thinking state fields ---
+
+    #[test]
+    fn session_is_thinking_defaults_to_false() {
+        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None);
+        assert!(!s.is_thinking);
+        assert!(s.thinking_started_at.is_none());
+    }
+
+    #[test]
+    fn session_thinking_fields_skipped_in_serde() {
+        let mut s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None);
+        s.is_thinking = true;
+        s.thinking_started_at = Some(std::time::Instant::now());
+
+        let json = serde_json::to_string(&s).unwrap();
+        // The skipped fields should not appear in JSON
+        assert!(!json.contains("is_thinking"));
+        assert!(!json.contains("thinking_started_at"));
+
+        // Deserialize should default them
+        let rt: Session = serde_json::from_str(&json).unwrap();
+        assert!(!rt.is_thinking);
+        assert!(rt.thinking_started_at.is_none());
     }
 
     // --- Issue #102: Enhanced real-time session activity feedback ---

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -227,6 +227,8 @@ pub struct App {
     pub continuous_mode: Option<ContinuousModeState>,
     /// Current state of the self-upgrade flow.
     pub upgrade_state: crate::updater::UpgradeState,
+    /// Tick counter for spinner animation (incremented each TUI draw cycle).
+    pub spinner_tick: usize,
 }
 
 impl App {
@@ -287,6 +289,7 @@ impl App {
             completion_summary: None,
             continuous_mode: None,
             upgrade_state: crate::updater::UpgradeState::Hidden,
+            spinner_tick: 0,
         }
     }
 

--- a/src/tui/fullscreen.rs
+++ b/src/tui/fullscreen.rs
@@ -1,5 +1,6 @@
 use crate::session::types::Session;
 use crate::state::progress::ProgressTracker;
+use crate::tui::spinner;
 use crate::tui::theme::Theme;
 use ratatui::{
     Frame,
@@ -16,6 +17,7 @@ pub fn draw_fullscreen(
     progress_tracker: &ProgressTracker,
     area: Rect,
     theme: &Theme,
+    spinner_tick: usize,
 ) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -28,7 +30,7 @@ pub fn draw_fullscreen(
 
     draw_session_header(f, session, chunks[0], theme);
     draw_session_output(f, session, chunks[1], theme);
-    draw_session_footer(f, session, progress_tracker, chunks[2], theme);
+    draw_session_footer(f, session, progress_tracker, chunks[2], theme, spinner_tick);
 }
 
 fn draw_session_header(f: &mut Frame, session: &Session, area: Rect, theme: &Theme) {
@@ -109,6 +111,7 @@ fn draw_session_footer(
     progress_tracker: &ProgressTracker,
     area: Rect,
     theme: &Theme,
+    spinner_tick: usize,
 ) {
     let elapsed = session.elapsed_display();
     let files_count = session.files_touched.len();
@@ -139,7 +142,15 @@ fn draw_session_footer(
         Span::raw("  "),
         Span::styled(" Activity: ", Style::default().fg(theme.text_secondary)),
         Span::styled(
-            &session.current_activity,
+            if session.is_thinking {
+                let elapsed = session
+                    .thinking_started_at
+                    .map(|t| t.elapsed())
+                    .unwrap_or_default();
+                spinner::thinking_activity(spinner_tick, elapsed)
+            } else {
+                session.current_activity.clone()
+            },
             Style::default().fg(theme.text_primary),
         ),
         Span::raw("    "),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -8,6 +8,7 @@ pub mod help;
 pub mod navigation;
 pub mod panels;
 pub mod screens;
+pub mod spinner;
 pub mod theme;
 pub mod ui;
 

--- a/src/tui/panels.rs
+++ b/src/tui/panels.rs
@@ -1,5 +1,6 @@
 use crate::session::types::Session;
 use crate::state::file_claims::FileClaimManager;
+use crate::tui::spinner;
 use crate::tui::theme::Theme;
 use ratatui::{
     Frame,
@@ -38,8 +39,15 @@ impl PanelView {
         self.selected.unwrap_or(0)
     }
 
-    pub fn draw(&self, f: &mut Frame, sessions: &[&Session], area: Rect, theme: &Theme) {
-        self.draw_with_claims(f, sessions, None, area, theme);
+    pub fn draw(
+        &self,
+        f: &mut Frame,
+        sessions: &[&Session],
+        area: Rect,
+        theme: &Theme,
+        spinner_tick: usize,
+    ) {
+        self.draw_with_claims(f, sessions, None, area, theme, spinner_tick);
     }
 
     pub fn draw_with_claims(
@@ -49,6 +57,7 @@ impl PanelView {
         file_claims: Option<&FileClaimManager>,
         area: Rect,
         theme: &Theme,
+        spinner_tick: usize,
     ) {
         if sessions.is_empty() {
             let block = Block::default()
@@ -86,11 +95,13 @@ impl PanelView {
                 has_conflict,
                 self.scroll_offset,
                 theme,
+                spinner_tick,
             );
         }
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn draw_single_panel(
     f: &mut Frame,
     session: &Session,
@@ -99,6 +110,7 @@ fn draw_single_panel(
     has_conflict: bool,
     scroll: u16,
     theme: &Theme,
+    spinner_tick: usize,
 ) {
     let status_color = theme.status_color(session.status);
 
@@ -207,9 +219,18 @@ fn draw_single_panel(
         .percent(ctx_pct as u16);
     f.render_widget(gauge, chunks[2]);
 
-    // Current activity
+    // Current activity (animated spinner when thinking)
+    let activity_text = if session.is_thinking {
+        let elapsed = session
+            .thinking_started_at
+            .map(|t| t.elapsed())
+            .unwrap_or_default();
+        format!("> {}", spinner::thinking_activity(spinner_tick, elapsed))
+    } else {
+        format!("> {}", session.current_activity)
+    };
     let activity = Line::from(Span::styled(
-        format!("> {}", session.current_activity),
+        activity_text,
         Style::default().fg(theme.accent_info),
     ));
     f.render_widget(Paragraph::new(activity), chunks[3]);

--- a/src/tui/snapshot_tests/overview.rs
+++ b/src/tui/snapshot_tests/overview.rs
@@ -12,7 +12,7 @@ fn panel_view_empty_sessions() {
 
     terminal
         .draw(|f| {
-            panel.draw(f, &[], f.area(), &theme);
+            panel.draw(f, &[], f.area(), &theme, 0);
         })
         .unwrap();
 
@@ -28,7 +28,7 @@ fn panel_view_single_running_session() {
 
     terminal
         .draw(|f| {
-            panel.draw(f, &[&session], f.area(), &theme);
+            panel.draw(f, &[&session], f.area(), &theme, 0);
         })
         .unwrap();
 
@@ -57,7 +57,7 @@ fn panel_view_multiple_sessions() {
 
     terminal
         .draw(|f| {
-            panel.draw(f, &[&s1, &s2, &s3], f.area(), &theme);
+            panel.draw(f, &[&s1, &s2, &s3], f.area(), &theme, 0);
         })
         .unwrap();
 
@@ -78,7 +78,7 @@ fn panel_view_selected_session() {
 
     terminal
         .draw(|f| {
-            panel.draw(f, &[&s1, &s2], f.area(), &theme);
+            panel.draw(f, &[&s1, &s2], f.area(), &theme, 0);
         })
         .unwrap();
 
@@ -96,7 +96,7 @@ fn panel_view_context_overflow() {
 
     terminal
         .draw(|f| {
-            panel.draw(f, &[&session], f.area(), &theme);
+            panel.draw(f, &[&session], f.area(), &theme, 0);
         })
         .unwrap();
 
@@ -115,7 +115,7 @@ fn panel_view_forked_session() {
 
     terminal
         .draw(|f| {
-            panel.draw(f, &[&session], f.area(), &theme);
+            panel.draw(f, &[&session], f.area(), &theme, 0);
         })
         .unwrap();
 

--- a/src/tui/spinner.rs
+++ b/src/tui/spinner.rs
@@ -1,0 +1,107 @@
+#![allow(dead_code)]
+
+const BRAILLE_FRAMES: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+/// Returns the braille spinner character for a given tick index.
+pub fn spinner_frame(tick: usize) -> char {
+    BRAILLE_FRAMES[tick % BRAILLE_FRAMES.len()]
+}
+
+/// Format elapsed thinking time for display.
+pub fn format_thinking_elapsed(d: std::time::Duration) -> String {
+    let secs = d.as_secs();
+    if secs >= 60 {
+        format!("{}m{:02}s", secs / 60, secs % 60)
+    } else {
+        format!("{:.1}s", d.as_secs_f64())
+    }
+}
+
+/// Build the full spinner activity string: `⠹ Thinking... 3.2s`
+pub fn thinking_activity(tick: usize, elapsed: std::time::Duration) -> String {
+    format!(
+        "{} Thinking... {}",
+        spinner_frame(tick),
+        format_thinking_elapsed(elapsed)
+    )
+}
+
+/// Total number of braille frames in the spinner cycle.
+pub const FRAME_COUNT: usize = 10;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn spinner_cycles_through_all_10_braille_frames() {
+        let expected = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+        for (i, &ch) in expected.iter().enumerate() {
+            assert_eq!(spinner_frame(i), ch, "frame {} mismatch", i);
+        }
+    }
+
+    #[test]
+    fn spinner_wraps_around_after_10_frames() {
+        assert_eq!(spinner_frame(0), spinner_frame(10));
+        assert_eq!(spinner_frame(3), spinner_frame(13));
+        assert_eq!(spinner_frame(9), spinner_frame(19));
+    }
+
+    #[test]
+    fn frame_count_matches_braille_frames_len() {
+        assert_eq!(FRAME_COUNT, BRAILLE_FRAMES.len());
+    }
+
+    #[test]
+    fn format_elapsed_sub_second() {
+        let d = Duration::from_millis(500);
+        assert_eq!(format_thinking_elapsed(d), "0.5s");
+    }
+
+    #[test]
+    fn format_elapsed_seconds() {
+        let d = Duration::from_secs_f64(3.2);
+        assert_eq!(format_thinking_elapsed(d), "3.2s");
+    }
+
+    #[test]
+    fn format_elapsed_zero() {
+        let d = Duration::from_secs(0);
+        assert_eq!(format_thinking_elapsed(d), "0.0s");
+    }
+
+    #[test]
+    fn format_elapsed_minutes_transition() {
+        let d = Duration::from_secs(65);
+        assert_eq!(format_thinking_elapsed(d), "1m05s");
+    }
+
+    #[test]
+    fn format_elapsed_exact_minute() {
+        let d = Duration::from_secs(60);
+        assert_eq!(format_thinking_elapsed(d), "1m00s");
+    }
+
+    #[test]
+    fn format_elapsed_multiple_minutes() {
+        let d = Duration::from_secs(185);
+        assert_eq!(format_thinking_elapsed(d), "3m05s");
+    }
+
+    #[test]
+    fn thinking_activity_combines_frame_and_elapsed() {
+        let d = Duration::from_secs_f64(3.2);
+        let result = thinking_activity(2, d);
+        assert_eq!(result, "⠹ Thinking... 3.2s");
+    }
+
+    #[test]
+    fn thinking_activity_with_different_tick() {
+        let d = Duration::from_secs(0);
+        let result = thinking_activity(0, d);
+        assert!(result.starts_with('⠋'));
+        assert!(result.contains("Thinking..."));
+    }
+}

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -18,6 +18,9 @@ use ratatui::{
 
 /// Render the entire TUI.
 pub fn draw(f: &mut Frame, app: &mut App) {
+    // Advance spinner animation on each draw cycle
+    app.spinner_tick = app.spinner_tick.wrapping_add(1);
+
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -31,6 +34,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     draw_status_bar(f, app, chunks[0]);
 
     // Render main content based on TUI mode
+    let spinner_tick = app.spinner_tick;
     match app.tui_mode {
         TuiMode::Overview => {
             let sessions = app.pool.all_sessions();
@@ -40,6 +44,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
                 Some(&app.pool.file_claims),
                 chunks[1],
                 &app.theme,
+                spinner_tick,
             );
         }
         TuiMode::Detail(idx) => {
@@ -60,6 +65,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
                     Some(&app.pool.file_claims),
                     chunks[1],
                     &app.theme,
+                    spinner_tick,
                 );
             }
         }
@@ -75,9 +81,11 @@ pub fn draw(f: &mut Frame, app: &mut App) {
                     &app.progress_tracker,
                     chunks[1],
                     &app.theme,
+                    spinner_tick,
                 );
             } else {
-                app.panel_view.draw(f, &sessions, chunks[1], &app.theme);
+                app.panel_view
+                    .draw(f, &sessions, chunks[1], &app.theme, spinner_tick);
             }
         }
         TuiMode::CostDashboard => {
@@ -121,6 +129,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
                 Some(&app.pool.file_claims),
                 chunks[1],
                 &app.theme,
+                spinner_tick,
             );
             // Draw overlay on top
             if let Some(ref summary) = app.completion_summary {
@@ -135,6 +144,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
                 Some(&app.pool.file_claims),
                 chunks[1],
                 &app.theme,
+                spinner_tick,
             );
             if let Some(ref cont) = app.continuous_mode {
                 draw_continuous_pause_overlay(f, cont, chunks[1], &app.theme);


### PR DESCRIPTION
## Summary

- Add animated braille spinner (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`) during thinking state with elapsed time display (e.g., `⠹ Thinking... 3.2s`)
- Track per-session thinking state via `is_thinking` and `thinking_started_at` fields on `Session`
- Spinner frame advances on each TUI draw cycle (~50ms), elapsed time updates in real-time

## Changes

- **New file**: `src/tui/spinner.rs` — spinner frame cycling, elapsed time formatting, activity string builder
- **`src/session/types.rs`** — added `is_thinking: bool` and `thinking_started_at: Option<Instant>` (serde-skipped) to `Session`
- **`src/session/manager.rs`** — propagate thinking state to `Session` on `Thinking`/non-`Thinking` events
- **`src/tui/app.rs`** — added `spinner_tick` counter incremented each draw
- **`src/tui/panels.rs`** — render animated spinner in activity line when session is thinking
- **`src/tui/fullscreen.rs`** — render animated spinner in footer activity when session is thinking
- **`src/tui/ui.rs`** — pass `spinner_tick` through render pipeline

## Test plan

- [x] Spinner cycles through all 10 braille frames correctly
- [x] Spinner wraps around after 10 frames
- [x] Elapsed time formatting: sub-second, seconds, minutes transition
- [x] Thinking event sets `is_thinking` and `thinking_started_at`
- [x] Non-thinking event clears thinking state
- [x] Multiple thinking events preserve original start time
- [x] Thinking stop logs elapsed duration
- [x] Serde skips thinking fields (no serialization issues)
- [x] All 1117 tests pass, clippy clean, fmt clean

Closes #134