### PR TITLE
fix: milestone text filter and --bare session spawn (#155)

### DIFF
--- a/src/session/manager.rs
+++ b/src/session/manager.rs
@@ -411,8 +411,14 @@ mod tests {
         let prompt = "do something";
         let ms = make_managed(prompt);
         let args = ms.build_args();
-        let bare_pos = args.iter().position(|a| a == "--bare").expect("--bare must be present");
-        let prompt_pos = args.iter().position(|a| a == prompt).expect("prompt must be present");
+        let bare_pos = args
+            .iter()
+            .position(|a| a == "--bare")
+            .expect("--bare must be present");
+        let prompt_pos = args
+            .iter()
+            .position(|a| a == prompt)
+            .expect("prompt must be present");
         assert!(
             bare_pos < prompt_pos,
             "--bare must appear before the prompt positional arg"
@@ -423,7 +429,13 @@ mod tests {
     fn spawn_args_include_required_base_flags() {
         let ms = make_managed("test prompt");
         let args = ms.build_args();
-        for flag in &["--print", "--verbose", "--output-format", "stream-json", "--bare"] {
+        for flag in &[
+            "--print",
+            "--verbose",
+            "--output-format",
+            "stream-json",
+            "--bare",
+        ] {
             assert!(
                 args.iter().any(|a| a == flag),
                 "args must contain {}; got: {:?}",

--- a/src/tui/screens/issue_browser.rs
+++ b/src/tui/screens/issue_browser.rs
@@ -221,13 +221,12 @@ impl IssueBrowserScreen {
         let filter_lower = self.filter_text.to_lowercase();
 
         // When in milestone filter mode, parse typed text as milestone number
-        let typed_milestone: Option<u64> = if self.filter_mode == FilterMode::Milestone
-            && !self.filter_text.is_empty()
-        {
-            self.filter_text.trim().parse::<u64>().ok()
-        } else {
-            None
-        };
+        let typed_milestone: Option<u64> =
+            if self.filter_mode == FilterMode::Milestone && !self.filter_text.is_empty() {
+                self.filter_text.trim().parse::<u64>().ok()
+            } else {
+                None
+            };
 
         self.filtered_indices = self
             .issues


### PR DESCRIPTION
## Summary

- **Milestone filter (`m` key)** now filters by `issue.milestone` number instead of searching titles. Non-numeric input shows no results, Esc restores all issues.
- **Session spawn** adds `--bare` flag to skip CLAUDE.md auto-discovery, preventing `AskUserQuestion` from intercepting unattended sessions.
- Extracted `build_args()` from `spawn()` for testability.

## Test plan

- [x] 4 new milestone filter tests (typed number, invalid text, Esc clear, label regression)
- [x] 5 new `build_args()` tests (bare flag, position, base flags, permission mode, default exclusion)
- [x] All 1262 tests pass
- [x] `cargo clippy` clean

Closes #155