### PR TITLE
fix: include milestone field in gh issue list JSON queries

### DIFF
--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -191,7 +191,7 @@ impl GitHubClient for GhCliClient {
             "--limit",
             "100",
             "--json",
-            "number,title,body,labels,state,url",
+            "number,title,body,labels,state,url,milestone",
         ];
         if !label_arg.is_empty() {
             args.push("--label");
@@ -214,7 +214,7 @@ impl GitHubClient for GhCliClient {
                 "--limit",
                 "100",
                 "--json",
-                "number,title,body,labels,state,url",
+                "number,title,body,labels,state,url,milestone",
             ])
             .await?;
         parse_issues_json(&json_str)


### PR DESCRIPTION
Both list_issues and list_issues_by_milestone were fetching "number,title,body,labels,state,url" without "milestone", so issue.milestone was always None and the typed milestone filter could never match anything.

Closes #155 