### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-04-09
+
+### Added
+
+- Field-level validation with inline error messages for Settings screen (#75)
+- Persistent background sessions with multi-window navigation (#63)
+
 ## [0.8.0] - 2026-04-09
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maestro"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 description = "Multi-session Claude Code orchestrator with Matrix-style TUI"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump version to 0.9.0 in Cargo.toml
- Add v0.9.0 changelog entry (field-level validation #75, persistent sessions #63)

## Test plan

- [x] All 1855 tests passing
- [x] Clippy clean
- [x] Formatting clean
- [x] Tag `v0.9.0` already pushed — release workflow will trigger once this merges