### PR TITLE
feat: maestro adapt — project onboarding pipeline

### DIFF
--- a/src/adapt/analyzer.rs
+++ b/src/adapt/analyzer.rs
@@ -1,0 +1,122 @@
+use async_trait::async_trait;
+
+use super::prompts::{build_analysis_prompt, parse_json_response, run_claude_print};
+use super::types::{AdaptReport, ProjectProfile};
+
+#[async_trait]
+pub trait ProjectAnalyzer: Send + Sync {
+    async fn analyze(&self, profile: &ProjectProfile) -> anyhow::Result<AdaptReport>;
+}
+
+pub struct ClaudeAnalyzer {
+    model: String,
+}
+
+impl ClaudeAnalyzer {
+    pub fn new(model: String) -> Self {
+        Self { model }
+    }
+}
+
+#[async_trait]
+impl ProjectAnalyzer for ClaudeAnalyzer {
+    async fn analyze(&self, profile: &ProjectProfile) -> anyhow::Result<AdaptReport> {
+        let profile_json = serde_json::to_string_pretty(profile)?;
+        let prompt = build_analysis_prompt(&profile_json);
+        let raw = run_claude_print(&self.model, &prompt, &profile.root).await?;
+        parse_json_response(&raw)
+    }
+}
+
+#[cfg(test)]
+pub struct MockProjectAnalyzer {
+    result: Option<AdaptReport>,
+}
+
+#[cfg(test)]
+impl MockProjectAnalyzer {
+    pub fn with_report(report: AdaptReport) -> Self {
+        Self {
+            result: Some(report),
+        }
+    }
+}
+
+#[cfg(test)]
+#[async_trait]
+impl ProjectAnalyzer for MockProjectAnalyzer {
+    async fn analyze(&self, _profile: &ProjectProfile) -> anyhow::Result<AdaptReport> {
+        self.result
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("mock analyzer: no report configured"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapt::types::*;
+    use std::path::PathBuf;
+
+    fn sample_profile() -> ProjectProfile {
+        ProjectProfile {
+            name: "test".into(),
+            root: PathBuf::from("/tmp/test"),
+            language: ProjectLanguage::Rust,
+            manifests: vec![PathBuf::from("Cargo.toml")],
+            config_files: vec![],
+            entry_points: vec![PathBuf::from("src/main.rs")],
+            source_stats: SourceStats {
+                total_files: 5,
+                total_lines: 200,
+                by_extension: vec![],
+            },
+            test_infra: TestInfraInfo {
+                has_tests: true,
+                framework: Some("cargo test".into()),
+                test_directories: vec![],
+                test_file_count: 2,
+            },
+            ci: CiInfo {
+                provider: None,
+                config_files: vec![],
+            },
+            git: GitInfo {
+                is_git_repo: true,
+                default_branch: Some("main".into()),
+                remote_url: None,
+                commit_count: 10,
+                recent_contributors: vec![],
+            },
+            dependencies: DependencySummary {
+                direct_count: 3,
+                dev_count: 1,
+                notable: vec![],
+            },
+            directory_tree: "src/\n  main.rs".into(),
+            has_maestro_config: false,
+        }
+    }
+
+    #[test]
+    fn analysis_prompt_contains_profile_data() {
+        let profile = sample_profile();
+        let json = serde_json::to_string_pretty(&profile).unwrap();
+        let prompt = build_analysis_prompt(&json);
+        assert!(prompt.contains("test"));
+        assert!(prompt.contains("Cargo.toml"));
+        assert!(prompt.contains("tech_debt_items"));
+    }
+
+    #[tokio::test]
+    async fn mock_analyzer_returns_configured_report() {
+        let report = AdaptReport {
+            summary: "Test project".into(),
+            modules: vec![],
+            tech_debt_items: vec![],
+        };
+        let analyzer = MockProjectAnalyzer::with_report(report);
+        let result = analyzer.analyze(&sample_profile()).await.unwrap();
+        assert_eq!(result.summary, "Test project");
+    }
+}

--- a/src/adapt/materializer.rs
+++ b/src/adapt/materializer.rs
@@ -1,0 +1,442 @@
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+
+use super::types::*;
+use crate::github::client::GitHubClient;
+
+#[async_trait]
+pub trait PlanMaterializer: Send + Sync {
+    async fn materialize(
+        &self,
+        plan: &AdaptPlan,
+        report: &AdaptReport,
+        dry_run: bool,
+    ) -> anyhow::Result<MaterializeResult>;
+}
+
+pub struct GhMaterializer<G: GitHubClient> {
+    github: G,
+}
+
+impl<G: GitHubClient> GhMaterializer<G> {
+    pub fn new(github: G) -> Self {
+        Self { github }
+    }
+}
+
+#[async_trait]
+impl<G: GitHubClient> PlanMaterializer for GhMaterializer<G> {
+    async fn materialize(
+        &self,
+        plan: &AdaptPlan,
+        report: &AdaptReport,
+        dry_run: bool,
+    ) -> anyhow::Result<MaterializeResult> {
+        if dry_run {
+            return Ok(build_dry_run_result(plan));
+        }
+
+        let mut milestones_created = Vec::new();
+        let mut issues_created = Vec::new();
+        let mut title_to_number: HashMap<String, u64> = HashMap::new();
+
+        for milestone in &plan.milestones {
+            let ms_number = self
+                .github
+                .create_milestone(&milestone.title, &milestone.description)
+                .await?;
+
+            milestones_created.push(CreatedMilestone {
+                number: ms_number,
+                title: milestone.title.clone(),
+            });
+
+            for issue in &milestone.issues {
+                let body =
+                    resolve_blocked_by(&issue.body, &issue.blocked_by_titles, &title_to_number);
+
+                let issue_number = self
+                    .github
+                    .create_issue(&issue.title, &body, &issue.labels, Some(ms_number))
+                    .await?;
+
+                title_to_number.insert(issue.title.clone(), issue_number);
+                issues_created.push(CreatedIssue {
+                    number: issue_number,
+                    title: issue.title.clone(),
+                    milestone_number: Some(ms_number),
+                });
+            }
+        }
+
+        // Generate tech debt catalog issue (#95)
+        let tech_debt_issue = if !report.tech_debt_items.is_empty() {
+            let body = build_tech_debt_catalog_body(&report.tech_debt_items);
+            let first_ms = milestones_created.first().map(|m| m.number);
+            let number = self
+                .github
+                .create_issue(
+                    "chore: Tech debt catalog",
+                    &body,
+                    &["tech-debt".to_string(), "enhancement".to_string()],
+                    first_ms,
+                )
+                .await?;
+            Some(CreatedIssue {
+                number,
+                title: "chore: Tech debt catalog".into(),
+                milestone_number: first_ms,
+            })
+        } else {
+            None
+        };
+
+        Ok(MaterializeResult {
+            milestones_created,
+            issues_created,
+            tech_debt_issue,
+            dry_run: false,
+        })
+    }
+}
+
+fn build_dry_run_result(plan: &AdaptPlan) -> MaterializeResult {
+    let mut milestones = Vec::new();
+    let mut issues = Vec::new();
+    let mut counter = 0u64;
+
+    for milestone in &plan.milestones {
+        counter += 1;
+        let ms_num = counter;
+        milestones.push(CreatedMilestone {
+            number: ms_num,
+            title: milestone.title.clone(),
+        });
+        for issue in &milestone.issues {
+            counter += 1;
+            issues.push(CreatedIssue {
+                number: counter,
+                title: issue.title.clone(),
+                milestone_number: Some(ms_num),
+            });
+        }
+    }
+
+    MaterializeResult {
+        milestones_created: milestones,
+        issues_created: issues,
+        tech_debt_issue: None,
+        dry_run: true,
+    }
+}
+
+fn resolve_blocked_by(
+    body: &str,
+    blocked_by_titles: &[String],
+    title_to_number: &HashMap<String, u64>,
+) -> String {
+    if blocked_by_titles.is_empty() {
+        return body.to_string();
+    }
+
+    let references: Vec<String> = blocked_by_titles
+        .iter()
+        .map(|title| {
+            if let Some(num) = title_to_number.get(title) {
+                format!("- #{} {}", num, title)
+            } else {
+                format!("- {}", title)
+            }
+        })
+        .collect();
+
+    let blocked_section = format!("\n\n## Blocked By\n\n{}", references.join("\n"));
+
+    // If body already has a Blocked By section, replace it
+    if let Some(idx) = body.find("## Blocked By") {
+        let before = &body[..idx];
+        // Find next section or end
+        let after = &body[idx..];
+        let end = after[14..] // skip "## Blocked By\n"
+            .find("## ")
+            .map(|i| idx + 14 + i)
+            .unwrap_or(body.len());
+        format!("{}{}{}", before.trim_end(), blocked_section, &body[end..])
+    } else {
+        format!("{}{}", body, blocked_section)
+    }
+}
+
+pub fn build_tech_debt_catalog_body(items: &[TechDebtItem]) -> String {
+    let mut sections: Vec<(TechDebtSeverity, Vec<&TechDebtItem>)> = vec![
+        (TechDebtSeverity::Critical, vec![]),
+        (TechDebtSeverity::High, vec![]),
+        (TechDebtSeverity::Medium, vec![]),
+        (TechDebtSeverity::Low, vec![]),
+    ];
+
+    for item in items {
+        for (sev, items_vec) in &mut sections {
+            if *sev == item.severity {
+                items_vec.push(item);
+                break;
+            }
+        }
+    }
+
+    let mut body = String::from(
+        "## Tech Debt Catalog\n\nAutomated catalog generated by `maestro adapt`. Items are ordered by severity.\n",
+    );
+
+    for (severity, items_vec) in &sections {
+        if items_vec.is_empty() {
+            continue;
+        }
+
+        let label = match severity {
+            TechDebtSeverity::Critical => "Critical",
+            TechDebtSeverity::High => "High",
+            TechDebtSeverity::Medium => "Medium",
+            TechDebtSeverity::Low => "Low",
+        };
+
+        body.push_str(&format!("\n### {}\n", label));
+        for item in items_vec {
+            let cat = format!("{:?}", item.category);
+            body.push_str(&format!(
+                "- [ ] **[{}]** `{}` — {} **Fix:** {}\n",
+                cat, item.location, item.description, item.suggested_fix
+            ));
+        }
+    }
+
+    body.push_str(&format!(
+        "\n---\n*Generated by `maestro adapt` on {}*\n",
+        chrono::Utc::now().format("%Y-%m-%d")
+    ));
+
+    body
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::github::client::mock::MockGitHubClient;
+
+    fn sample_plan() -> AdaptPlan {
+        AdaptPlan {
+            milestones: vec![PlannedMilestone {
+                title: "M0: Foundation".into(),
+                description: "Setup".into(),
+                issues: vec![
+                    PlannedIssue {
+                        title: "feat: setup".into(),
+                        body: "Setup the project".into(),
+                        labels: vec!["enhancement".into()],
+                        blocked_by_titles: vec![],
+                    },
+                    PlannedIssue {
+                        title: "test: add tests".into(),
+                        body: "Add tests".into(),
+                        labels: vec!["testing".into()],
+                        blocked_by_titles: vec!["feat: setup".into()],
+                    },
+                ],
+            }],
+            maestro_toml_patch: None,
+        }
+    }
+
+    fn sample_report() -> AdaptReport {
+        AdaptReport {
+            summary: "test".into(),
+            modules: vec![],
+            tech_debt_items: vec![],
+        }
+    }
+
+    fn sample_report_with_debt() -> AdaptReport {
+        AdaptReport {
+            summary: "test".into(),
+            modules: vec![],
+            tech_debt_items: vec![
+                TechDebtItem {
+                    title: "Missing tests".into(),
+                    description: "No tests for auth".into(),
+                    location: "src/auth.rs".into(),
+                    suggested_fix: "Add unit tests".into(),
+                    category: TechDebtCategory::MissingTests,
+                    severity: TechDebtSeverity::High,
+                },
+                TechDebtItem {
+                    title: "Dead code".into(),
+                    description: "Unused handler".into(),
+                    location: "src/legacy.rs".into(),
+                    suggested_fix: "Delete module".into(),
+                    category: TechDebtCategory::DeadCode,
+                    severity: TechDebtSeverity::Low,
+                },
+                TechDebtItem {
+                    title: "Hardcoded secret".into(),
+                    description: "API key in source".into(),
+                    location: "src/config.rs:42".into(),
+                    suggested_fix: "Use env var".into(),
+                    category: TechDebtCategory::SecurityConcern,
+                    severity: TechDebtSeverity::Critical,
+                },
+            ],
+        }
+    }
+
+    #[tokio::test]
+    async fn materialize_creates_milestones_before_issues() {
+        let client = MockGitHubClient::new();
+        let materializer = GhMaterializer::new(client.clone());
+        let plan = sample_plan();
+        let report = sample_report();
+
+        let result = materializer
+            .materialize(&plan, &report, false)
+            .await
+            .unwrap();
+
+        assert_eq!(result.milestones_created.len(), 1);
+        assert_eq!(result.issues_created.len(), 2);
+
+        // Milestone was created with number 1
+        assert_eq!(result.milestones_created[0].number, 1);
+        // Issues were assigned to milestone 1
+        assert_eq!(result.issues_created[0].milestone_number, Some(1));
+        assert_eq!(result.issues_created[1].milestone_number, Some(1));
+    }
+
+    #[tokio::test]
+    async fn materialize_resolves_blocked_by_titles() {
+        let client = MockGitHubClient::new();
+        let materializer = GhMaterializer::new(client.clone());
+        let plan = sample_plan();
+        let report = sample_report();
+
+        materializer
+            .materialize(&plan, &report, false)
+            .await
+            .unwrap();
+
+        let calls = client.create_issue_calls();
+        assert_eq!(calls.len(), 2);
+        // Second issue should have blocked_by reference to first issue (#1)
+        assert!(
+            calls[1].body.contains("#1"),
+            "Second issue body should contain reference to first issue: {}",
+            calls[1].body
+        );
+    }
+
+    #[tokio::test]
+    async fn materialize_dry_run_does_not_call_client() {
+        let client = MockGitHubClient::new();
+        let materializer = GhMaterializer::new(client.clone());
+        let plan = sample_plan();
+        let report = sample_report();
+
+        let result = materializer
+            .materialize(&plan, &report, true)
+            .await
+            .unwrap();
+
+        assert!(result.dry_run);
+        assert!(client.create_milestone_calls().is_empty());
+        assert!(client.create_issue_calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn materialize_creates_tech_debt_issue_when_items_exist() {
+        let client = MockGitHubClient::new();
+        let materializer = GhMaterializer::new(client.clone());
+        let plan = sample_plan();
+        let report = sample_report_with_debt();
+
+        let result = materializer
+            .materialize(&plan, &report, false)
+            .await
+            .unwrap();
+
+        assert!(result.tech_debt_issue.is_some());
+        let td = result.tech_debt_issue.unwrap();
+        assert_eq!(td.title, "chore: Tech debt catalog");
+    }
+
+    #[tokio::test]
+    async fn materialize_skips_tech_debt_issue_when_no_items() {
+        let client = MockGitHubClient::new();
+        let materializer = GhMaterializer::new(client.clone());
+        let plan = sample_plan();
+        let report = sample_report();
+
+        let result = materializer
+            .materialize(&plan, &report, false)
+            .await
+            .unwrap();
+
+        assert!(result.tech_debt_issue.is_none());
+    }
+
+    #[test]
+    fn tech_debt_catalog_body_groups_by_severity() {
+        let report = sample_report_with_debt();
+        let body = build_tech_debt_catalog_body(&report.tech_debt_items);
+
+        assert!(body.contains("### Critical"));
+        assert!(body.contains("### High"));
+        assert!(body.contains("### Low"));
+        // Medium should be omitted (no items)
+        assert!(!body.contains("### Medium"));
+    }
+
+    #[test]
+    fn tech_debt_catalog_body_critical_before_low() {
+        let report = sample_report_with_debt();
+        let body = build_tech_debt_catalog_body(&report.tech_debt_items);
+
+        let critical_pos = body.find("### Critical").unwrap();
+        let low_pos = body.find("### Low").unwrap();
+        assert!(
+            critical_pos < low_pos,
+            "Critical must appear before Low in the catalog"
+        );
+    }
+
+    #[test]
+    fn tech_debt_catalog_body_has_checkboxes() {
+        let report = sample_report_with_debt();
+        let body = build_tech_debt_catalog_body(&report.tech_debt_items);
+        assert!(body.contains("- [ ]"));
+    }
+
+    #[test]
+    fn tech_debt_catalog_body_empty_items_produces_no_sections() {
+        let body = build_tech_debt_catalog_body(&[]);
+        assert!(!body.contains("### Critical"));
+        assert!(!body.contains("### High"));
+    }
+
+    #[test]
+    fn resolve_blocked_by_appends_section() {
+        let body = "Some issue body";
+        let titles = vec!["feat: setup".into()];
+        let mut map = HashMap::new();
+        map.insert("feat: setup".to_string(), 5u64);
+
+        let result = resolve_blocked_by(body, &titles, &map);
+        assert!(result.contains("## Blocked By"));
+        assert!(result.contains("#5"));
+    }
+
+    #[test]
+    fn resolve_blocked_by_empty_titles_returns_original() {
+        let body = "Some body";
+        let result = resolve_blocked_by(body, &[], &HashMap::new());
+        assert_eq!(result, "Some body");
+    }
+}

--- a/src/adapt/mod.rs
+++ b/src/adapt/mod.rs
@@ -1,0 +1,116 @@
+pub mod analyzer;
+pub mod materializer;
+pub mod planner;
+mod prompts;
+pub mod scanner;
+pub mod types;
+
+/// Configuration for the `maestro adapt` command.
+#[derive(Debug, Clone)]
+pub struct AdaptConfig {
+    pub path: std::path::PathBuf,
+    pub dry_run: bool,
+    pub no_issues: bool,
+    pub scan_only: bool,
+    pub model: Option<String>,
+}
+
+impl Default for AdaptConfig {
+    fn default() -> Self {
+        Self {
+            path: std::path::PathBuf::from("."),
+            dry_run: false,
+            no_issues: false,
+            scan_only: false,
+            model: None,
+        }
+    }
+}
+
+pub async fn cmd_adapt(config: AdaptConfig) -> anyhow::Result<()> {
+    use analyzer::{ClaudeAnalyzer, ProjectAnalyzer};
+    use materializer::{GhMaterializer, PlanMaterializer};
+    use planner::{AdaptPlanner, ClaudePlanner};
+    use scanner::{LocalProjectScanner, ProjectScanner};
+
+    let model = config.model.as_deref().unwrap_or("sonnet").to_string();
+
+    // Phase 1: Scan
+    eprintln!("Phase 1: Scanning project...");
+    let scanner = LocalProjectScanner::new();
+    let profile = scanner.scan(&config.path).await?;
+    eprintln!(
+        "  Language: {:?}, {} source files, {} lines",
+        profile.language, profile.source_stats.total_files, profile.source_stats.total_lines
+    );
+
+    if config.scan_only {
+        let json = serde_json::to_string_pretty(&profile)?;
+        println!("{}", json);
+        return Ok(());
+    }
+
+    // Phase 2: Analyze
+    eprintln!("Phase 2: Analyzing with Claude...");
+    let analyzer = ClaudeAnalyzer::new(model.clone());
+    let report = match analyzer.analyze(&profile).await {
+        Ok(r) => {
+            eprintln!(
+                "  {} modules, {} tech debt items",
+                r.modules.len(),
+                r.tech_debt_items.len()
+            );
+            r
+        }
+        Err(e) => {
+            eprintln!("  Phase 2 failed: {}. Continuing with empty report.", e);
+            types::AdaptReport {
+                summary: String::new(),
+                modules: vec![],
+                tech_debt_items: vec![],
+            }
+        }
+    };
+
+    if config.no_issues {
+        let json = serde_json::to_string_pretty(&report)?;
+        println!("{}", json);
+        return Ok(());
+    }
+
+    // Phase 3: Plan
+    eprintln!("Phase 3: Planning milestones and issues...");
+    let planner = ClaudePlanner::new(model);
+    let plan = planner.plan(&profile, &report).await?;
+    eprintln!(
+        "  {} milestones, {} issues",
+        plan.milestones.len(),
+        plan.milestones
+            .iter()
+            .map(|m| m.issues.len())
+            .sum::<usize>()
+    );
+
+    if config.dry_run {
+        let json = serde_json::to_string_pretty(&plan)?;
+        println!("{}", json);
+        return Ok(());
+    }
+
+    // Phase 4: Materialize
+    eprintln!("Phase 4: Creating GitHub artifacts...");
+    let github = crate::github::client::GhCliClient::new();
+    let materializer = GhMaterializer::new(github);
+    let result = materializer.materialize(&plan, &report, false).await?;
+
+    eprintln!(
+        "  Created {} milestones, {} issues",
+        result.milestones_created.len(),
+        result.issues_created.len()
+    );
+    if let Some(ref td) = result.tech_debt_issue {
+        eprintln!("  Tech debt catalog: #{}", td.number);
+    }
+
+    Ok(())
+}

--- a/src/adapt/planner.rs
+++ b/src/adapt/planner.rs
@@ -1,0 +1,161 @@
+use async_trait::async_trait;
+
+use super::prompts::{build_planning_prompt, parse_json_response, run_claude_print};
+use super::types::{AdaptPlan, AdaptReport, ProjectProfile};
+
+#[async_trait]
+pub trait AdaptPlanner: Send + Sync {
+    async fn plan(
+        &self,
+        profile: &ProjectProfile,
+        report: &AdaptReport,
+    ) -> anyhow::Result<AdaptPlan>;
+}
+
+pub struct ClaudePlanner {
+    model: String,
+}
+
+impl ClaudePlanner {
+    pub fn new(model: String) -> Self {
+        Self { model }
+    }
+}
+
+#[async_trait]
+impl AdaptPlanner for ClaudePlanner {
+    async fn plan(
+        &self,
+        profile: &ProjectProfile,
+        report: &AdaptReport,
+    ) -> anyhow::Result<AdaptPlan> {
+        let profile_json = serde_json::to_string_pretty(profile)?;
+        let report_json = serde_json::to_string_pretty(report)?;
+        let prompt = build_planning_prompt(&profile_json, &report_json);
+        let raw = run_claude_print(&self.model, &prompt, &profile.root).await?;
+        parse_json_response(&raw)
+    }
+}
+
+#[cfg(test)]
+pub struct MockAdaptPlanner {
+    result: Option<AdaptPlan>,
+}
+
+#[cfg(test)]
+impl MockAdaptPlanner {
+    pub fn with_plan(plan: AdaptPlan) -> Self {
+        Self { result: Some(plan) }
+    }
+}
+
+#[cfg(test)]
+#[async_trait]
+impl AdaptPlanner for MockAdaptPlanner {
+    async fn plan(
+        &self,
+        _profile: &ProjectProfile,
+        _report: &AdaptReport,
+    ) -> anyhow::Result<AdaptPlan> {
+        self.result
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("mock planner: no plan configured"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapt::types::*;
+    use std::path::PathBuf;
+
+    fn sample_plan() -> AdaptPlan {
+        AdaptPlan {
+            milestones: vec![PlannedMilestone {
+                title: "M0: Foundation".into(),
+                description: "Initial setup".into(),
+                issues: vec![
+                    PlannedIssue {
+                        title: "feat: setup project".into(),
+                        body: "## Overview\n\nSetup the project.".into(),
+                        labels: vec!["enhancement".into()],
+                        blocked_by_titles: vec![],
+                    },
+                    PlannedIssue {
+                        title: "test: add unit tests".into(),
+                        body: "## Overview\n\nAdd tests.".into(),
+                        labels: vec!["testing".into()],
+                        blocked_by_titles: vec!["feat: setup project".into()],
+                    },
+                ],
+            }],
+            maestro_toml_patch: Some("[project]\nrepo = \"owner/repo\"".into()),
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_planner_returns_configured_plan() {
+        let plan = sample_plan();
+        let planner = MockAdaptPlanner::with_plan(plan.clone());
+
+        let profile = ProjectProfile {
+            name: "test".into(),
+            root: PathBuf::from("/tmp"),
+            language: ProjectLanguage::Rust,
+            manifests: vec![],
+            config_files: vec![],
+            entry_points: vec![],
+            source_stats: SourceStats {
+                total_files: 0,
+                total_lines: 0,
+                by_extension: vec![],
+            },
+            test_infra: TestInfraInfo {
+                has_tests: false,
+                framework: None,
+                test_directories: vec![],
+                test_file_count: 0,
+            },
+            ci: CiInfo {
+                provider: None,
+                config_files: vec![],
+            },
+            git: GitInfo {
+                is_git_repo: false,
+                default_branch: None,
+                remote_url: None,
+                commit_count: 0,
+                recent_contributors: vec![],
+            },
+            dependencies: DependencySummary {
+                direct_count: 0,
+                dev_count: 0,
+                notable: vec![],
+            },
+            directory_tree: String::new(),
+            has_maestro_config: false,
+        };
+
+        let report = AdaptReport {
+            summary: "test".into(),
+            modules: vec![],
+            tech_debt_items: vec![],
+        };
+
+        let result = planner.plan(&profile, &report).await.unwrap();
+        assert_eq!(result.milestones.len(), 1);
+        assert_eq!(result.milestones[0].issues.len(), 2);
+        assert_eq!(
+            result.milestones[0].issues[1].blocked_by_titles,
+            vec!["feat: setup project"]
+        );
+    }
+
+    #[test]
+    fn plan_json_round_trip_with_dependencies() {
+        let plan = sample_plan();
+        let json = serde_json::to_string(&plan).unwrap();
+        let rt: AdaptPlan = serde_json::from_str(&json).unwrap();
+        assert_eq!(rt.milestones[0].issues[1].blocked_by_titles.len(), 1);
+    }
+}

--- a/src/adapt/prompts.rs
+++ b/src/adapt/prompts.rs
@@ -1,0 +1,261 @@
+pub fn build_analysis_prompt(profile_json: &str) -> String {
+    format!(
+        r#"You are analyzing a software project to produce an adaptation report.
+
+## Project Profile
+
+{profile_json}
+
+## Instructions
+
+Based on the project profile above, analyze the codebase and produce a JSON report with this exact schema:
+
+```json
+{{
+  "summary": "A 2-3 sentence summary of the project's architecture and purpose",
+  "modules": [
+    {{
+      "path": "src/module_name",
+      "purpose": "What this module does",
+      "complexity": "low|medium|high"
+    }}
+  ],
+  "tech_debt_items": [
+    {{
+      "title": "Short title of the issue",
+      "description": "Detailed description",
+      "location": "src/file.rs:42 or src/module/",
+      "suggested_fix": "How to fix this",
+      "category": "dead_code|missing_tests|inconsistent_patterns|poor_abstractions|security_concern|documentation",
+      "severity": "critical|high|medium|low"
+    }}
+  ]
+}}
+```
+
+## Analysis Guidelines
+
+1. **Modules**: Identify the main modules/packages and their purposes. Focus on the top-level organization.
+2. **Tech Debt**: Look for:
+   - Dead code (unused functions, modules, imports)
+   - Missing tests (modules with no test coverage)
+   - Inconsistent patterns (different approaches to the same problem)
+   - Poor abstractions (god objects, tight coupling)
+   - Security concerns (hardcoded secrets, unsafe patterns)
+   - Missing documentation (public APIs without docs)
+
+3. Be specific about locations — reference actual file paths from the project profile.
+4. Be conservative with severity ratings — only use "critical" for genuine security or data-loss risks.
+
+Return ONLY the JSON object, no markdown fences, no commentary."#,
+    )
+}
+
+pub fn build_planning_prompt(profile_json: &str, report_json: &str) -> String {
+    format!(
+        r#"You are creating a project adaptation plan to onboard a project to the maestro workflow.
+
+## Project Profile
+
+{profile_json}
+
+## Analysis Report
+
+{report_json}
+
+## Instructions
+
+Create a structured plan with milestones and DOR-compliant issues. Return a JSON object with this exact schema:
+
+```json
+{{
+  "milestones": [
+    {{
+      "title": "M0: Foundation",
+      "description": "Description of the milestone goals",
+      "issues": [
+        {{
+          "title": "feat: descriptive title",
+          "body": "(DOR-compliant issue body with Overview, Expected Behavior, Acceptance Criteria, Files to Modify, Test Hints, Blocked By, Definition of Done sections)",
+          "labels": ["enhancement"],
+          "blocked_by_titles": []
+        }}
+      ]
+    }}
+  ],
+  "maestro_toml_patch": "(optional suggested maestro.toml content)"
+}}
+```
+
+## Planning Guidelines
+
+1. **Milestones**: Group work into logical phases (e.g., Foundation, Testing, CI/CD, Integration)
+2. **Issues**: Each issue should be:
+   - Small enough to complete in one session (1-2 hours of AI work)
+   - Self-contained with clear acceptance criteria
+   - Properly ordered with `blocked_by_titles` referencing other issue titles
+3. **Labels**: Use `enhancement`, `testing`, `documentation`, `tech-debt` as appropriate
+4. **maestro_toml_patch**: Suggest initial configuration based on the project analysis
+5. Prefix titles with `feat:`, `test:`, `chore:`, `fix:`, or `docs:` as appropriate
+
+Return ONLY the JSON object, no markdown fences, no commentary."#,
+    )
+}
+
+/// Run `claude --print` with the given prompt and return stdout.
+pub async fn run_claude_print(
+    model: &str,
+    prompt: &str,
+    cwd: &std::path::Path,
+) -> anyhow::Result<String> {
+    let output = tokio::process::Command::new("claude")
+        .args([
+            "--print",
+            "--output-format",
+            "text",
+            "--model",
+            model,
+            "-p",
+            prompt,
+        ])
+        .current_dir(cwd)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to spawn claude CLI: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("Claude CLI failed: {}", stderr.trim());
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Extract and parse a JSON block from Claude's response.
+pub fn parse_json_response<T: serde::de::DeserializeOwned>(raw: &str) -> anyhow::Result<T> {
+    let trimmed = raw.trim();
+
+    // Try direct parse first
+    if let Ok(v) = serde_json::from_str(trimmed) {
+        return Ok(v);
+    }
+
+    // Try extracting from markdown code block
+    if let Some(start) = trimmed.find("```json") {
+        let after = &trimmed[start + 7..];
+        if let Some(end) = after.find("```") {
+            let json_str = after[..end].trim();
+            if let Ok(v) = serde_json::from_str(json_str) {
+                return Ok(v);
+            }
+        }
+    }
+
+    // Try extracting from generic code block
+    if let Some(start) = trimmed.find("```") {
+        let after = &trimmed[start + 3..];
+        // Skip the language tag if present
+        let after = if let Some(nl) = after.find('\n') {
+            &after[nl + 1..]
+        } else {
+            after
+        };
+        if let Some(end) = after.find("```") {
+            let json_str = after[..end].trim();
+            if let Ok(v) = serde_json::from_str(json_str) {
+                return Ok(v);
+            }
+        }
+    }
+
+    // Try finding the first { to last }
+    if let (Some(start), Some(end)) = (trimmed.find('{'), trimmed.rfind('}')) {
+        let json_str = &trimmed[start..=end];
+        if let Ok(v) = serde_json::from_str(json_str) {
+            return Ok(v);
+        }
+    }
+
+    anyhow::bail!(
+        "Failed to parse JSON from Claude response. Raw response: {}",
+        &trimmed[..trimmed.len().min(200)]
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapt::types::{AdaptReport, ProjectProfile};
+
+    #[test]
+    fn build_analysis_prompt_contains_profile() {
+        let prompt = build_analysis_prompt(r#"{"name":"test"}"#);
+        assert!(prompt.contains(r#"{"name":"test"}"#));
+        assert!(prompt.contains("tech_debt_items"));
+        assert!(prompt.contains("modules"));
+    }
+
+    #[test]
+    fn build_planning_prompt_contains_both_inputs() {
+        let prompt = build_planning_prompt(r#"{"name":"test"}"#, r#"{"summary":"good"}"#);
+        assert!(prompt.contains(r#"{"name":"test"}"#));
+        assert!(prompt.contains(r#"{"summary":"good"}"#));
+        assert!(prompt.contains("milestones"));
+        assert!(prompt.contains("maestro_toml_patch"));
+    }
+
+    #[test]
+    fn parse_json_response_direct_json() {
+        let raw = r#"{"summary":"test","modules":[],"tech_debt_items":[]}"#;
+        let report: AdaptReport = parse_json_response(raw).unwrap();
+        assert_eq!(report.summary, "test");
+    }
+
+    #[test]
+    fn parse_json_response_markdown_fenced() {
+        let raw = r#"Here is the result:
+
+```json
+{"summary":"fenced","modules":[],"tech_debt_items":[]}
+```
+
+Done!"#;
+        let report: AdaptReport = parse_json_response(raw).unwrap();
+        assert_eq!(report.summary, "fenced");
+    }
+
+    #[test]
+    fn parse_json_response_generic_fence() {
+        let raw = r#"```
+{"summary":"generic","modules":[],"tech_debt_items":[]}
+```"#;
+        let report: AdaptReport = parse_json_response(raw).unwrap();
+        assert_eq!(report.summary, "generic");
+    }
+
+    #[test]
+    fn parse_json_response_with_surrounding_text() {
+        let raw = r#"Here is the analysis:
+{"summary":"embedded","modules":[],"tech_debt_items":[]}
+That's all."#;
+        let report: AdaptReport = parse_json_response(raw).unwrap();
+        assert_eq!(report.summary, "embedded");
+    }
+
+    #[test]
+    fn parse_json_response_invalid_returns_error() {
+        let raw = "This is not JSON at all";
+        let result: anyhow::Result<AdaptReport> = parse_json_response(raw);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_json_response_profile() {
+        let raw = r#"{"name":"p","root":"/tmp","language":"rust","manifests":[],"config_files":[],"entry_points":[],"source_stats":{"total_files":0,"total_lines":0,"by_extension":[]},"test_infra":{"has_tests":false,"framework":null,"test_directories":[],"test_file_count":0},"ci":{"provider":null,"config_files":[]},"git":{"is_git_repo":false,"default_branch":null,"remote_url":null,"commit_count":0,"recent_contributors":[]},"dependencies":{"direct_count":0,"dev_count":0,"notable":[]},"directory_tree":"","has_maestro_config":false}"#;
+        let profile: ProjectProfile = parse_json_response(raw).unwrap();
+        assert_eq!(profile.name, "p");
+    }
+}

--- a/src/adapt/scanner.rs
+++ b/src/adapt/scanner.rs
@@ -1,0 +1,799 @@
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use super::types::*;
+
+const IGNORED_DIRS: &[&str] = &[
+    "node_modules",
+    "target",
+    ".git",
+    "vendor",
+    "__pycache__",
+    ".venv",
+    "venv",
+    "dist",
+    "build",
+    ".next",
+];
+
+const MANIFEST_FILES: &[&str] = &[
+    "Cargo.toml",
+    "package.json",
+    "go.mod",
+    "pyproject.toml",
+    "requirements.txt",
+    "pom.xml",
+    "build.gradle",
+    "Gemfile",
+];
+
+const ENTRY_POINTS: &[(&str, &[&str])] = &[
+    ("rs", &["src/main.rs", "src/lib.rs"]),
+    ("ts", &["src/index.ts", "src/main.ts", "index.ts"]),
+    ("js", &["src/index.js", "index.js", "server.js", "app.js"]),
+    ("py", &["main.py", "app.py", "src/main.py", "__main__.py"]),
+    ("go", &["main.go", "cmd/main.go"]),
+];
+
+#[async_trait]
+pub trait ProjectScanner: Send + Sync {
+    async fn scan(&self, root: &Path) -> anyhow::Result<ProjectProfile>;
+}
+
+pub struct LocalProjectScanner;
+
+impl LocalProjectScanner {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl ProjectScanner for LocalProjectScanner {
+    async fn scan(&self, root: &Path) -> anyhow::Result<ProjectProfile> {
+        let root = root.to_path_buf();
+        tokio::task::spawn_blocking(move || scan_project(&root))
+            .await
+            .map_err(|e| anyhow::anyhow!("Scanner task failed: {}", e))?
+    }
+}
+
+fn scan_project(root: &Path) -> anyhow::Result<ProjectProfile> {
+    let name = root
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "unknown".into());
+
+    let language = detect_language(root);
+    let manifests = find_manifests(root);
+    let config_files = find_config_files(root);
+    let entry_points = find_entry_points(root);
+    let walk = walk_source_tree(root);
+    let source_stats = walk.source_stats;
+    let test_infra = detect_test_infra(root, language, walk.test_file_count);
+    let ci = detect_ci(root);
+    let git = gather_git_info(root);
+    let dependencies = parse_dependencies(root, language);
+    let directory_tree = build_directory_tree(root, 3);
+    let has_maestro_config =
+        root.join("maestro.toml").exists() || root.join(".claude/CLAUDE.md").exists();
+
+    Ok(ProjectProfile {
+        name,
+        root: root.to_path_buf(),
+        language,
+        manifests,
+        config_files,
+        entry_points,
+        source_stats,
+        test_infra,
+        ci,
+        git,
+        dependencies,
+        directory_tree,
+        has_maestro_config,
+    })
+}
+
+fn detect_language(root: &Path) -> ProjectLanguage {
+    if root.join("Cargo.toml").exists() {
+        ProjectLanguage::Rust
+    } else if root.join("package.json").exists() {
+        ProjectLanguage::TypeScript
+    } else if root.join("pyproject.toml").exists() || root.join("requirements.txt").exists() {
+        ProjectLanguage::Python
+    } else if root.join("go.mod").exists() {
+        ProjectLanguage::Go
+    } else if root.join("pom.xml").exists() || root.join("build.gradle").exists() {
+        ProjectLanguage::Java
+    } else if root.join("Gemfile").exists() {
+        ProjectLanguage::Ruby
+    } else {
+        ProjectLanguage::Unknown
+    }
+}
+
+fn is_ignored(entry: &walkdir::DirEntry) -> bool {
+    entry.file_type().is_dir()
+        && entry
+            .file_name()
+            .to_str()
+            .map(|name| IGNORED_DIRS.contains(&name))
+            .unwrap_or(false)
+}
+
+fn find_manifests(root: &Path) -> Vec<PathBuf> {
+    MANIFEST_FILES
+        .iter()
+        .filter_map(|name| {
+            let p = root.join(name);
+            p.exists().then_some(PathBuf::from(name))
+        })
+        .collect()
+}
+
+fn find_config_files(root: &Path) -> Vec<PathBuf> {
+    let candidates = [
+        ".env",
+        ".env.example",
+        "docker-compose.yml",
+        "docker-compose.yaml",
+        "Dockerfile",
+        ".eslintrc.json",
+        ".prettierrc",
+        "tsconfig.json",
+        "jest.config.js",
+        "jest.config.ts",
+        "vitest.config.ts",
+        "maestro.toml",
+    ];
+    candidates
+        .iter()
+        .filter_map(|name| {
+            let p = root.join(name);
+            p.exists().then_some(PathBuf::from(name))
+        })
+        .collect()
+}
+
+fn find_entry_points(root: &Path) -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    for (_ext, paths) in ENTRY_POINTS {
+        for path in *paths {
+            if root.join(path).exists() {
+                found.push(PathBuf::from(path));
+            }
+        }
+    }
+    found
+}
+
+/// Combined result of a single directory walk (source stats + test file count).
+struct WalkResult {
+    source_stats: SourceStats,
+    test_file_count: u32,
+}
+
+fn walk_source_tree(root: &Path) -> WalkResult {
+    let mut by_ext: HashMap<String, (u32, u64)> = HashMap::new();
+    let mut test_file_count: u32 = 0;
+
+    for entry in walkdir::WalkDir::new(root)
+        .into_iter()
+        .filter_entry(|e| !is_ignored(e))
+        .filter_map(|e| e.ok())
+    {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+
+        let file_name = entry.file_name().to_string_lossy();
+        if file_name.contains("test")
+            || file_name.contains("spec")
+            || file_name.ends_with("_test.go")
+        {
+            test_file_count += 1;
+        }
+
+        let ext = entry
+            .path()
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_string();
+
+        if !matches!(
+            ext.as_str(),
+            "rs" | "ts"
+                | "tsx"
+                | "js"
+                | "jsx"
+                | "py"
+                | "go"
+                | "java"
+                | "rb"
+                | "c"
+                | "cpp"
+                | "h"
+                | "hpp"
+                | "cs"
+                | "swift"
+                | "kt"
+        ) {
+            continue;
+        }
+
+        let lines = count_lines(entry.path());
+        let counter = by_ext.entry(ext).or_insert((0, 0));
+        counter.0 += 1;
+        counter.1 += lines;
+    }
+
+    let total_files: u32 = by_ext.values().map(|(f, _)| f).sum();
+    let total_lines: u64 = by_ext.values().map(|(_, l)| l).sum();
+
+    let mut by_extension: Vec<ExtensionStats> = by_ext
+        .into_iter()
+        .map(|(ext, (files, lines))| ExtensionStats {
+            extension: ext,
+            files,
+            lines,
+        })
+        .collect();
+    by_extension.sort_by(|a, b| b.files.cmp(&a.files));
+
+    WalkResult {
+        source_stats: SourceStats {
+            total_files,
+            total_lines,
+            by_extension,
+        },
+        test_file_count,
+    }
+}
+
+fn count_lines(path: &Path) -> u64 {
+    use std::io::Read;
+    let mut buf = [0u8; 8192];
+    let mut count = 0u64;
+    let Ok(mut file) = std::fs::File::open(path) else {
+        return 0;
+    };
+    loop {
+        let n = match file.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(_) => break,
+        };
+        count += buf[..n].iter().filter(|&&b| b == b'\n').count() as u64;
+    }
+    count
+}
+
+fn detect_test_infra(
+    root: &Path,
+    language: ProjectLanguage,
+    test_file_count: u32,
+) -> TestInfraInfo {
+    let mut test_dirs = Vec::new();
+
+    let test_dir_names = ["tests", "test", "__tests__", "spec"];
+    for name in &test_dir_names {
+        let p = root.join(name);
+        if p.is_dir() {
+            test_dirs.push(PathBuf::from(name));
+        }
+    }
+
+    let framework = match language {
+        ProjectLanguage::Rust => Some("cargo test".into()),
+        ProjectLanguage::TypeScript | ProjectLanguage::Java => {
+            if root.join("jest.config.js").exists()
+                || root.join("jest.config.ts").exists()
+                || root.join("jest.config.cjs").exists()
+            {
+                Some("jest".into())
+            } else if root.join("vitest.config.ts").exists() {
+                Some("vitest".into())
+            } else {
+                None
+            }
+        }
+        ProjectLanguage::Python => {
+            if root.join("pytest.ini").exists()
+                || root.join("pyproject.toml").exists()
+                || root.join("conftest.py").exists()
+            {
+                Some("pytest".into())
+            } else {
+                None
+            }
+        }
+        ProjectLanguage::Go => Some("go test".into()),
+        _ => None,
+    };
+
+    let has_tests = test_file_count > 0 || !test_dirs.is_empty();
+
+    TestInfraInfo {
+        has_tests,
+        framework,
+        test_directories: test_dirs,
+        test_file_count,
+    }
+}
+
+fn detect_ci(root: &Path) -> CiInfo {
+    let ga_dir = root.join(".github/workflows");
+    if ga_dir.is_dir() {
+        let config_files: Vec<PathBuf> = std::fs::read_dir(&ga_dir)
+            .ok()
+            .map(|entries| {
+                entries
+                    .filter_map(|e| e.ok())
+                    .filter(|e| {
+                        e.path()
+                            .extension()
+                            .map(|ext| ext == "yml" || ext == "yaml")
+                            .unwrap_or(false)
+                    })
+                    .map(|e| {
+                        PathBuf::from(format!(
+                            ".github/workflows/{}",
+                            e.file_name().to_string_lossy()
+                        ))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        if !config_files.is_empty() {
+            return CiInfo {
+                provider: Some("github_actions".into()),
+                config_files,
+            };
+        }
+    }
+
+    if root.join(".gitlab-ci.yml").exists() {
+        return CiInfo {
+            provider: Some("gitlab_ci".into()),
+            config_files: vec![PathBuf::from(".gitlab-ci.yml")],
+        };
+    }
+
+    if root.join("Jenkinsfile").exists() {
+        return CiInfo {
+            provider: Some("jenkins".into()),
+            config_files: vec![PathBuf::from("Jenkinsfile")],
+        };
+    }
+
+    if root.join(".circleci/config.yml").exists() {
+        return CiInfo {
+            provider: Some("circleci".into()),
+            config_files: vec![PathBuf::from(".circleci/config.yml")],
+        };
+    }
+
+    CiInfo {
+        provider: None,
+        config_files: vec![],
+    }
+}
+
+fn gather_git_info(root: &Path) -> GitInfo {
+    if !root.join(".git").exists() {
+        return GitInfo {
+            is_git_repo: false,
+            default_branch: None,
+            remote_url: None,
+            commit_count: 0,
+            recent_contributors: vec![],
+        };
+    }
+
+    let default_branch = run_git(root, &["rev-parse", "--abbrev-ref", "HEAD"]);
+    let remote_url = run_git(root, &["remote", "get-url", "origin"]);
+    let commit_count = run_git(root, &["rev-list", "--count", "HEAD"])
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(0);
+
+    let recent_contributors = run_git(root, &["log", "--format=%aN", "-20", "--no-merges"])
+        .map(|s| {
+            let mut names: Vec<String> = s.lines().map(|l| l.to_string()).collect();
+            names.sort();
+            names.dedup();
+            names
+        })
+        .unwrap_or_default();
+
+    GitInfo {
+        is_git_repo: true,
+        default_branch,
+        remote_url,
+        commit_count,
+        recent_contributors,
+    }
+}
+
+fn run_git(root: &Path, args: &[&str]) -> Option<String> {
+    std::process::Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+}
+
+fn parse_dependencies(root: &Path, language: ProjectLanguage) -> DependencySummary {
+    match language {
+        ProjectLanguage::Rust => parse_cargo_deps(root),
+        ProjectLanguage::TypeScript => parse_npm_deps(root),
+        _ => DependencySummary {
+            direct_count: 0,
+            dev_count: 0,
+            notable: vec![],
+        },
+    }
+}
+
+fn parse_cargo_deps(root: &Path) -> DependencySummary {
+    let path = root.join("Cargo.toml");
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => {
+            return DependencySummary::default();
+        }
+    };
+
+    let mut direct = 0u32;
+    let mut dev = 0u32;
+    let mut notable = Vec::new();
+    let mut in_deps = false;
+    let mut in_dev_deps = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed == "[dependencies]" {
+            in_deps = true;
+            in_dev_deps = false;
+            continue;
+        } else if trimmed == "[dev-dependencies]" {
+            in_deps = false;
+            in_dev_deps = true;
+            continue;
+        } else if trimmed.starts_with('[') {
+            in_deps = false;
+            in_dev_deps = false;
+            continue;
+        }
+
+        if (in_deps || in_dev_deps) && trimmed.contains('=') && !trimmed.starts_with('#') {
+            if in_deps {
+                direct += 1;
+            } else {
+                dev += 1;
+            }
+            if let Some(name) = trimmed.split('=').next().map(|s| s.trim()) {
+                let notable_crates = [
+                    "tokio",
+                    "serde",
+                    "clap",
+                    "actix-web",
+                    "axum",
+                    "rocket",
+                    "diesel",
+                    "sqlx",
+                    "reqwest",
+                    "tracing",
+                    "ratatui",
+                ];
+                if notable_crates.contains(&name) {
+                    notable.push(name.to_string());
+                }
+            }
+        }
+    }
+
+    DependencySummary {
+        direct_count: direct,
+        dev_count: dev,
+        notable,
+    }
+}
+
+fn parse_npm_deps(root: &Path) -> DependencySummary {
+    let path = root.join("package.json");
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => {
+            return DependencySummary::default();
+        }
+    };
+
+    let v: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => {
+            return DependencySummary::default();
+        }
+    };
+
+    let direct = v
+        .get("dependencies")
+        .and_then(|d| d.as_object())
+        .map(|o| o.len() as u32)
+        .unwrap_or(0);
+    let dev = v
+        .get("devDependencies")
+        .and_then(|d| d.as_object())
+        .map(|o| o.len() as u32)
+        .unwrap_or(0);
+
+    DependencySummary {
+        direct_count: direct,
+        dev_count: dev,
+        notable: vec![],
+    }
+}
+
+fn build_directory_tree(root: &Path, max_depth: usize) -> String {
+    let mut lines = Vec::new();
+    build_tree_recursive(root, 0, max_depth, &mut lines);
+    lines.join("\n")
+}
+
+const MAX_ENTRIES_PER_DIR: usize = 50;
+
+fn build_tree_recursive(current: &Path, depth: usize, max_depth: usize, lines: &mut Vec<String>) {
+    if depth > max_depth {
+        return;
+    }
+
+    let entries = match std::fs::read_dir(current) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+
+    let mut entries: Vec<_> = entries.filter_map(|e| e.ok()).collect();
+    entries.sort_by_key(|e| e.file_name());
+
+    let total = entries.len();
+    for entry in entries.into_iter().take(MAX_ENTRIES_PER_DIR) {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if IGNORED_DIRS.contains(&name.as_str()) || name.starts_with('.') {
+            continue;
+        }
+        let indent = "  ".repeat(depth);
+        let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+        if is_dir {
+            lines.push(format!("{}{}/", indent, name));
+            build_tree_recursive(&entry.path(), depth + 1, max_depth, lines);
+        } else {
+            lines.push(format!("{}{}", indent, name));
+        }
+    }
+    if total > MAX_ENTRIES_PER_DIR {
+        let indent = "  ".repeat(depth);
+        lines.push(format!(
+            "{}... ({} more entries)",
+            indent,
+            total - MAX_ENTRIES_PER_DIR
+        ));
+    }
+}
+
+#[cfg(test)]
+pub struct MockProjectScanner {
+    result: Option<ProjectProfile>,
+}
+
+#[cfg(test)]
+impl MockProjectScanner {
+    pub fn with_profile(profile: ProjectProfile) -> Self {
+        Self {
+            result: Some(profile),
+        }
+    }
+}
+
+#[cfg(test)]
+#[async_trait]
+impl ProjectScanner for MockProjectScanner {
+    async fn scan(&self, _path: &Path) -> anyhow::Result<ProjectProfile> {
+        self.result
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("mock scanner: no profile configured"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_language_rust() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("Cargo.toml"), "[package]").unwrap();
+        assert_eq!(detect_language(dir.path()), ProjectLanguage::Rust);
+    }
+
+    #[test]
+    fn detect_language_typescript() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("package.json"), "{}").unwrap();
+        assert_eq!(detect_language(dir.path()), ProjectLanguage::TypeScript);
+    }
+
+    #[test]
+    fn detect_language_python() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("pyproject.toml"), "").unwrap();
+        assert_eq!(detect_language(dir.path()), ProjectLanguage::Python);
+    }
+
+    #[test]
+    fn detect_language_go() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("go.mod"), "").unwrap();
+        assert_eq!(detect_language(dir.path()), ProjectLanguage::Go);
+    }
+
+    #[test]
+    fn detect_language_unknown() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(detect_language(dir.path()), ProjectLanguage::Unknown);
+    }
+
+    #[test]
+    fn find_manifests_detects_cargo_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("Cargo.toml"), "").unwrap();
+        let manifests = find_manifests(dir.path());
+        assert_eq!(manifests, vec![PathBuf::from("Cargo.toml")]);
+    }
+
+    #[test]
+    fn find_entry_points_detects_main_rs() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("src/main.rs"), "fn main() {}").unwrap();
+        let eps = find_entry_points(dir.path());
+        assert!(eps.contains(&PathBuf::from("src/main.rs")));
+    }
+
+    #[test]
+    fn source_stats_counts_files_and_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+        std::fs::write(
+            dir.path().join("src/lib.rs"),
+            "pub fn foo() {}\npub fn bar() {}\n",
+        )
+        .unwrap();
+        let stats = walk_source_tree(dir.path()).source_stats;
+        assert_eq!(stats.total_files, 2);
+        assert_eq!(stats.total_lines, 3);
+    }
+
+    #[test]
+    fn source_stats_ignores_vendor_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::create_dir_all(dir.path().join("node_modules/dep")).unwrap();
+        std::fs::write(dir.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+        std::fs::write(
+            dir.path().join("node_modules/dep/index.js"),
+            "module.exports = {};\n",
+        )
+        .unwrap();
+        let stats = walk_source_tree(dir.path()).source_stats;
+        assert_eq!(stats.total_files, 1, "node_modules files must be excluded");
+    }
+
+    #[test]
+    fn detect_ci_github_actions() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".github/workflows")).unwrap();
+        std::fs::write(dir.path().join(".github/workflows/ci.yml"), "on: push").unwrap();
+        let ci = detect_ci(dir.path());
+        assert_eq!(ci.provider, Some("github_actions".into()));
+        assert!(!ci.config_files.is_empty());
+    }
+
+    #[test]
+    fn detect_ci_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let ci = detect_ci(dir.path());
+        assert!(ci.provider.is_none());
+    }
+
+    #[test]
+    fn detect_test_infra_rust() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("tests")).unwrap();
+        std::fs::write(
+            dir.path().join("tests/integration_test.rs"),
+            "#[test]\nfn it_works() {}",
+        )
+        .unwrap();
+        let walk = walk_source_tree(dir.path());
+        let info = detect_test_infra(dir.path(), ProjectLanguage::Rust, walk.test_file_count);
+        assert!(info.has_tests);
+        assert_eq!(info.framework, Some("cargo test".into()));
+        assert!(info.test_file_count >= 1);
+    }
+
+    #[test]
+    fn git_info_non_git_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let info = gather_git_info(dir.path());
+        assert!(!info.is_git_repo);
+    }
+
+    #[test]
+    fn parse_cargo_deps_counts() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            r#"[package]
+name = "test"
+version = "0.1.0"
+
+[dependencies]
+tokio = "1"
+serde = "1"
+
+[dev-dependencies]
+tempfile = "3"
+"#,
+        )
+        .unwrap();
+        let deps = parse_cargo_deps(dir.path());
+        assert_eq!(deps.direct_count, 2);
+        assert_eq!(deps.dev_count, 1);
+        assert!(deps.notable.contains(&"tokio".to_string()));
+        assert!(deps.notable.contains(&"serde".to_string()));
+    }
+
+    #[test]
+    fn directory_tree_excludes_ignored_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::create_dir_all(dir.path().join("node_modules")).unwrap();
+        std::fs::write(dir.path().join("src/main.rs"), "").unwrap();
+        let tree = build_directory_tree(dir.path(), 2);
+        assert!(tree.contains("src/"));
+        assert!(!tree.contains("node_modules"));
+    }
+
+    #[tokio::test]
+    async fn local_scanner_scans_rust_project() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("Cargo.toml"), "[package]\nname = \"test\"").unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+
+        let scanner = LocalProjectScanner::new();
+        let profile = scanner.scan(dir.path()).await.unwrap();
+        assert_eq!(profile.language, ProjectLanguage::Rust);
+        assert_eq!(profile.source_stats.total_files, 1);
+        assert!(profile.manifests.contains(&PathBuf::from("Cargo.toml")));
+    }
+
+    #[test]
+    fn parse_npm_deps_counts() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("package.json"),
+            r#"{"dependencies":{"react":"18","next":"14"},"devDependencies":{"jest":"29"}}"#,
+        )
+        .unwrap();
+        let deps = parse_npm_deps(dir.path());
+        assert_eq!(deps.direct_count, 2);
+        assert_eq!(deps.dev_count, 1);
+    }
+}

--- a/src/adapt/types.rs
+++ b/src/adapt/types.rs
@@ -1,0 +1,361 @@
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectProfile {
+    pub name: String,
+    pub root: PathBuf,
+    pub language: ProjectLanguage,
+    pub manifests: Vec<PathBuf>,
+    pub config_files: Vec<PathBuf>,
+    pub entry_points: Vec<PathBuf>,
+    pub source_stats: SourceStats,
+    pub test_infra: TestInfraInfo,
+    pub ci: CiInfo,
+    pub git: GitInfo,
+    pub dependencies: DependencySummary,
+    pub directory_tree: String,
+    pub has_maestro_config: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectLanguage {
+    Rust,
+    TypeScript,
+    Python,
+    Go,
+    Java,
+    Ruby,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SourceStats {
+    pub total_files: u32,
+    pub total_lines: u64,
+    pub by_extension: Vec<ExtensionStats>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtensionStats {
+    pub extension: String,
+    pub files: u32,
+    pub lines: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TestInfraInfo {
+    pub has_tests: bool,
+    pub framework: Option<String>,
+    pub test_directories: Vec<PathBuf>,
+    pub test_file_count: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CiInfo {
+    pub provider: Option<String>,
+    pub config_files: Vec<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitInfo {
+    pub is_git_repo: bool,
+    pub default_branch: Option<String>,
+    pub remote_url: Option<String>,
+    pub commit_count: u64,
+    pub recent_contributors: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DependencySummary {
+    pub direct_count: u32,
+    pub dev_count: u32,
+    pub notable: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdaptReport {
+    pub summary: String,
+    pub modules: Vec<ModuleDescription>,
+    pub tech_debt_items: Vec<TechDebtItem>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModuleDescription {
+    pub path: String,
+    pub purpose: String,
+    pub complexity: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TechDebtItem {
+    pub title: String,
+    pub description: String,
+    pub location: String,
+    pub suggested_fix: String,
+    pub category: TechDebtCategory,
+    pub severity: TechDebtSeverity,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TechDebtCategory {
+    DeadCode,
+    MissingTests,
+    InconsistentPatterns,
+    PoorAbstractions,
+    SecurityConcern,
+    Documentation,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TechDebtSeverity {
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdaptPlan {
+    pub milestones: Vec<PlannedMilestone>,
+    pub maestro_toml_patch: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlannedMilestone {
+    pub title: String,
+    pub description: String,
+    pub issues: Vec<PlannedIssue>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlannedIssue {
+    pub title: String,
+    pub body: String,
+    pub labels: Vec<String>,
+    pub blocked_by_titles: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MaterializeResult {
+    pub milestones_created: Vec<CreatedMilestone>,
+    pub issues_created: Vec<CreatedIssue>,
+    pub tech_debt_issue: Option<CreatedIssue>,
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreatedMilestone {
+    pub number: u64,
+    pub title: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreatedIssue {
+    pub number: u64,
+    pub title: String,
+    pub milestone_number: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- ProjectLanguage serialization --
+
+    #[test]
+    fn project_language_serializes_as_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&ProjectLanguage::Rust).unwrap(),
+            r#""rust""#
+        );
+        assert_eq!(
+            serde_json::to_string(&ProjectLanguage::TypeScript).unwrap(),
+            r#""type_script""#
+        );
+        assert_eq!(
+            serde_json::to_string(&ProjectLanguage::Unknown).unwrap(),
+            r#""unknown""#
+        );
+    }
+
+    #[test]
+    fn project_language_deserializes_from_snake_case() {
+        let lang: ProjectLanguage = serde_json::from_str(r#""python""#).unwrap();
+        assert_eq!(lang, ProjectLanguage::Python);
+    }
+
+    // -- TechDebtCategory serialization --
+
+    #[test]
+    fn tech_debt_category_serializes_as_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&TechDebtCategory::DeadCode).unwrap(),
+            r#""dead_code""#
+        );
+        assert_eq!(
+            serde_json::to_string(&TechDebtCategory::MissingTests).unwrap(),
+            r#""missing_tests""#
+        );
+        assert_eq!(
+            serde_json::to_string(&TechDebtCategory::SecurityConcern).unwrap(),
+            r#""security_concern""#
+        );
+    }
+
+    // -- TechDebtSeverity serialization and ordering --
+
+    #[test]
+    fn tech_debt_severity_serializes_as_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&TechDebtSeverity::Critical).unwrap(),
+            r#""critical""#
+        );
+        assert_eq!(
+            serde_json::to_string(&TechDebtSeverity::Low).unwrap(),
+            r#""low""#
+        );
+    }
+
+    #[test]
+    fn tech_debt_severity_ordering() {
+        assert!(TechDebtSeverity::Critical > TechDebtSeverity::High);
+        assert!(TechDebtSeverity::High > TechDebtSeverity::Medium);
+        assert!(TechDebtSeverity::Medium > TechDebtSeverity::Low);
+    }
+
+    // -- ProjectProfile round-trip --
+
+    #[test]
+    fn project_profile_round_trips_through_json() {
+        let profile = ProjectProfile {
+            name: "test-project".into(),
+            root: PathBuf::from("/tmp/test"),
+            language: ProjectLanguage::Rust,
+            manifests: vec![PathBuf::from("Cargo.toml")],
+            config_files: vec![],
+            entry_points: vec![PathBuf::from("src/main.rs")],
+            source_stats: SourceStats {
+                total_files: 10,
+                total_lines: 500,
+                by_extension: vec![ExtensionStats {
+                    extension: "rs".into(),
+                    files: 10,
+                    lines: 500,
+                }],
+            },
+            test_infra: TestInfraInfo {
+                has_tests: true,
+                framework: Some("cargo test".into()),
+                test_directories: vec![],
+                test_file_count: 3,
+            },
+            ci: CiInfo {
+                provider: Some("github_actions".into()),
+                config_files: vec![PathBuf::from(".github/workflows/ci.yml")],
+            },
+            git: GitInfo {
+                is_git_repo: true,
+                default_branch: Some("main".into()),
+                remote_url: Some("https://github.com/owner/repo".into()),
+                commit_count: 42,
+                recent_contributors: vec!["alice".into()],
+            },
+            dependencies: DependencySummary {
+                direct_count: 5,
+                dev_count: 2,
+                notable: vec!["tokio".into(), "serde".into()],
+            },
+            directory_tree: "src/\n  main.rs".into(),
+            has_maestro_config: false,
+        };
+
+        let json = serde_json::to_string(&profile).unwrap();
+        let rt: ProjectProfile = serde_json::from_str(&json).unwrap();
+        assert_eq!(rt.name, "test-project");
+        assert_eq!(rt.language, ProjectLanguage::Rust);
+        assert_eq!(rt.source_stats.total_files, 10);
+    }
+
+    // -- AdaptReport round-trip --
+
+    #[test]
+    fn adapt_report_round_trips_through_json() {
+        let report = AdaptReport {
+            summary: "A Rust CLI tool".into(),
+            modules: vec![ModuleDescription {
+                path: "src/main.rs".into(),
+                purpose: "Entry point".into(),
+                complexity: "low".into(),
+            }],
+            tech_debt_items: vec![TechDebtItem {
+                title: "Missing tests".into(),
+                description: "No tests for auth module".into(),
+                location: "src/auth.rs".into(),
+                suggested_fix: "Add unit tests".into(),
+                category: TechDebtCategory::MissingTests,
+                severity: TechDebtSeverity::High,
+            }],
+        };
+
+        let json = serde_json::to_string(&report).unwrap();
+        let rt: AdaptReport = serde_json::from_str(&json).unwrap();
+        assert_eq!(rt.summary, "A Rust CLI tool");
+        assert_eq!(rt.modules.len(), 1);
+        assert_eq!(rt.tech_debt_items.len(), 1);
+        assert_eq!(rt.tech_debt_items[0].severity, TechDebtSeverity::High);
+    }
+
+    // -- AdaptPlan round-trip --
+
+    #[test]
+    fn adapt_plan_round_trips_through_json() {
+        let plan = AdaptPlan {
+            milestones: vec![PlannedMilestone {
+                title: "M0: Foundation".into(),
+                description: "Initial setup".into(),
+                issues: vec![PlannedIssue {
+                    title: "feat: setup project".into(),
+                    body: "## Overview\nSetup".into(),
+                    labels: vec!["enhancement".into()],
+                    blocked_by_titles: vec![],
+                }],
+            }],
+            maestro_toml_patch: Some("[project]\nrepo = \"owner/repo\"".into()),
+        };
+
+        let json = serde_json::to_string(&plan).unwrap();
+        let rt: AdaptPlan = serde_json::from_str(&json).unwrap();
+        assert_eq!(rt.milestones.len(), 1);
+        assert_eq!(rt.milestones[0].issues.len(), 1);
+        assert!(rt.maestro_toml_patch.is_some());
+    }
+
+    // -- MaterializeResult round-trip --
+
+    #[test]
+    fn materialize_result_round_trips_through_json() {
+        let result = MaterializeResult {
+            milestones_created: vec![CreatedMilestone {
+                number: 1,
+                title: "M0".into(),
+            }],
+            issues_created: vec![CreatedIssue {
+                number: 10,
+                title: "feat: thing".into(),
+                milestone_number: Some(1),
+            }],
+            tech_debt_issue: None,
+            dry_run: false,
+        };
+
+        let json = serde_json::to_string(&result).unwrap();
+        let rt: MaterializeResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(rt.milestones_created.len(), 1);
+        assert_eq!(rt.issues_created.len(), 1);
+        assert!(!rt.dry_run);
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -128,6 +128,28 @@ pub enum Commands {
     },
     /// Check environment setup and required tools
     Doctor,
+    /// Onboard an existing project to the maestro workflow
+    Adapt {
+        /// Path to the project to onboard (defaults to current directory)
+        #[arg(short, long, default_value = ".")]
+        path: std::path::PathBuf,
+
+        /// Preview what would be created without making changes
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Analyze and plan but do not create GitHub issues
+        #[arg(long)]
+        no_issues: bool,
+
+        /// Only run Phase 1 (project scanning), output profile as JSON
+        #[arg(long)]
+        scan_only: bool,
+
+        /// AI model to use for analysis and planning
+        #[arg(short, long)]
+        model: Option<String>,
+    },
     /// Analyze codebase for dead code and code smells
     Sanitize {
         /// Path to scan (defaults to current directory)
@@ -741,6 +763,148 @@ mod tests {
             assert_eq!(model.as_deref(), Some("haiku"));
         } else {
             panic!("Expected Commands::Sanitize");
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Adapt subcommand parsing
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn adapt_subcommand_parses_with_no_flags() {
+        let cli = Cli::try_parse_from(["maestro", "adapt"]).unwrap();
+        assert!(matches!(cli.command, Some(Commands::Adapt { .. })));
+    }
+
+    #[test]
+    fn adapt_path_defaults_to_current_dir() {
+        let cli = Cli::try_parse_from(["maestro", "adapt"]).unwrap();
+        if let Some(Commands::Adapt { path, .. }) = cli.command {
+            assert_eq!(path, PathBuf::from("."));
+        } else {
+            panic!("Expected Commands::Adapt");
+        }
+    }
+
+    #[test]
+    fn adapt_path_accepts_value() {
+        let cli = Cli::try_parse_from(["maestro", "adapt", "--path", "/project"]).unwrap();
+        if let Some(Commands::Adapt { path, .. }) = cli.command {
+            assert_eq!(path, PathBuf::from("/project"));
+        } else {
+            panic!("Expected Commands::Adapt");
+        }
+    }
+
+    #[test]
+    fn adapt_dry_run_defaults_to_false() {
+        let cli = Cli::try_parse_from(["maestro", "adapt"]).unwrap();
+        if let Some(Commands::Adapt { dry_run, .. }) = cli.command {
+            assert!(!dry_run);
+        } else {
+            panic!("Expected Commands::Adapt");
+        }
+    }
+
+    #[test]
+    fn adapt_dry_run_is_set_when_provided() {
+        let cli = Cli::try_parse_from(["maestro", "adapt", "--dry-run"]).unwrap();
+        if let Some(Commands::Adapt { dry_run, .. }) = cli.command {
+            assert!(dry_run);
+        } else {
+            panic!("Expected Commands::Adapt");
+        }
+    }
+
+    #[test]
+    fn adapt_no_issues_defaults_to_false() {
+        let cli = Cli::try_parse_from(["maestro", "adapt"]).unwrap();
+        if let Some(Commands::Adapt { no_issues, .. }) = cli.command {
+            assert!(!no_issues);
+        } else {
+            panic!("Expected Commands::Adapt");
+        }
+    }
+
+    #[test]
+    fn adapt_no_issues_is_set_when_provided() {
+        let cli = Cli::try_parse_from(["maestro", "adapt", "--no-issues"]).unwrap();
+        if let Some(Commands::Adapt { no_issues, .. }) = cli.command {
+            assert!(no_issues);
+        } else {
+            panic!("Expected Commands::Adapt");
+        }
+    }
+
+    #[test]
+    fn adapt_scan_only_defaults_to_false() {
+        let cli = Cli::try_parse_from(["maestro", "adapt"]).unwrap();
+        if let Some(Commands::Adapt { scan_only, .. }) = cli.command {
+            assert!(!scan_only);
+        } else {
+            panic!("Expected Commands::Adapt");
+        }
+    }
+
+    #[test]
+    fn adapt_scan_only_is_set_when_provided() {
+        let cli = Cli::try_parse_from(["maestro", "adapt", "--scan-only"]).unwrap();
+        if let Some(Commands::Adapt { scan_only, .. }) = cli.command {
+            assert!(scan_only);
+        } else {
+            panic!("Expected Commands::Adapt");
+        }
+    }
+
+    #[test]
+    fn adapt_model_defaults_to_none() {
+        let cli = Cli::try_parse_from(["maestro", "adapt"]).unwrap();
+        if let Some(Commands::Adapt { model, .. }) = cli.command {
+            assert!(model.is_none());
+        } else {
+            panic!("Expected Commands::Adapt");
+        }
+    }
+
+    #[test]
+    fn adapt_model_accepts_value() {
+        let cli = Cli::try_parse_from(["maestro", "adapt", "--model", "opus"]).unwrap();
+        if let Some(Commands::Adapt { model, .. }) = cli.command {
+            assert_eq!(model.as_deref(), Some("opus"));
+        } else {
+            panic!("Expected Commands::Adapt");
+        }
+    }
+
+    #[test]
+    fn adapt_all_flags_coexist() {
+        let cli = Cli::try_parse_from([
+            "maestro",
+            "adapt",
+            "--path",
+            "/project",
+            "--dry-run",
+            "--no-issues",
+            "--scan-only",
+            "--model",
+            "haiku",
+        ])
+        .unwrap();
+        if let Some(Commands::Adapt {
+            path,
+            dry_run,
+            no_issues,
+            scan_only,
+            model,
+        }) = cli.command
+        {
+            assert_eq!(path, PathBuf::from("/project"));
+            assert!(dry_run);
+            assert!(no_issues);
+            assert!(scan_only);
+            assert_eq!(model.as_deref(), Some("haiku"));
+        } else {
+            panic!("Expected Commands::Adapt");
         }
     }
 }

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -21,6 +21,18 @@ pub trait GitHubClient: Send + Sync {
     ) -> Result<u64>;
     /// List open PR numbers for a given head branch.
     async fn list_prs_for_branch(&self, head_branch: &str) -> Result<Vec<u64>>;
+
+    /// Create a GitHub milestone and return its number.
+    async fn create_milestone(&self, title: &str, description: &str) -> Result<u64>;
+
+    /// Create a GitHub issue and return its number.
+    async fn create_issue(
+        &self,
+        title: &str,
+        body: &str,
+        labels: &[String],
+        milestone: Option<u64>,
+    ) -> Result<u64>;
 }
 
 /// Parse JSON output from `gh issue list --json ...`.
@@ -142,6 +154,18 @@ impl<T: GitHubClient + ?Sized> GitHubClient for &T {
     }
     async fn list_prs_for_branch(&self, head_branch: &str) -> Result<Vec<u64>> {
         (**self).list_prs_for_branch(head_branch).await
+    }
+    async fn create_milestone(&self, title: &str, description: &str) -> Result<u64> {
+        (**self).create_milestone(title, description).await
+    }
+    async fn create_issue(
+        &self,
+        title: &str,
+        body: &str,
+        labels: &[String],
+        milestone: Option<u64>,
+    ) -> Result<u64> {
+        (**self).create_issue(title, body, labels, milestone).await
     }
 }
 
@@ -378,6 +402,61 @@ impl GitHubClient for GhCliClient {
             .filter_map(|v| v.get("number").and_then(|n| n.as_u64()))
             .collect())
     }
+
+    async fn create_milestone(&self, title: &str, description: &str) -> Result<u64> {
+        validate_gh_arg(title, "milestone title")?;
+        let json_str = self
+            .run_gh(&[
+                "api",
+                "repos/{owner}/{repo}/milestones",
+                "--method",
+                "POST",
+                "-f",
+                &format!("title={}", title),
+                "-f",
+                &format!("description={}", description),
+            ])
+            .await?;
+        let v: serde_json::Value =
+            serde_json::from_str(&json_str).context("Failed to parse milestone response")?;
+        v.get("number")
+            .and_then(|n| n.as_u64())
+            .ok_or_else(|| anyhow::anyhow!("Missing 'number' in milestone response"))
+    }
+
+    async fn create_issue(
+        &self,
+        title: &str,
+        body: &str,
+        labels: &[String],
+        milestone: Option<u64>,
+    ) -> Result<u64> {
+        validate_gh_arg(title, "issue title")?;
+        let mut args = vec!["issue", "create", "--title", title, "--body", body];
+        let label_str = labels.join(",");
+        if !label_str.is_empty() {
+            args.push("--label");
+            args.push(&label_str);
+        }
+        let ms_str;
+        if let Some(ms) = milestone {
+            ms_str = ms.to_string();
+            args.push("--milestone");
+            args.push(&ms_str);
+        }
+        let output = self.run_gh(&args).await?;
+        // gh issue create returns a URL like https://github.com/owner/repo/issues/123
+        // Extract the issue number from the URL
+        let number = output
+            .trim()
+            .rsplit('/')
+            .next()
+            .and_then(|s| s.parse::<u64>().ok())
+            .ok_or_else(|| {
+                anyhow::anyhow!("Failed to parse issue number from gh output: {}", output)
+            })?;
+        Ok(number)
+    }
 }
 
 #[cfg(test)]
@@ -404,6 +483,11 @@ pub mod mock {
         add_label_calls: Vec<(u64, String)>,
         remove_label_calls: Vec<(u64, String)>,
         create_pr_calls: Vec<CreatePrCallRecord>,
+
+        create_milestone_calls: Vec<(String, String)>,
+        create_milestone_counter: u64,
+        create_issue_calls: Vec<CreateIssueCallRecord>,
+        create_issue_counter: u64,
     }
 
     #[derive(Debug, Clone)]
@@ -413,6 +497,14 @@ pub mod mock {
         pub body: String,
         pub head_branch: String,
         pub base_branch: String,
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct CreateIssueCallRecord {
+        pub title: String,
+        pub body: String,
+        pub labels: Vec<String>,
+        pub milestone: Option<u64>,
     }
 
     impl MockGitHubClient {
@@ -470,6 +562,14 @@ pub mod mock {
 
         pub fn create_pr_calls(&self) -> Vec<CreatePrCallRecord> {
             self.inner.lock().unwrap().create_pr_calls.clone()
+        }
+
+        pub fn create_milestone_calls(&self) -> Vec<(String, String)> {
+            self.inner.lock().unwrap().create_milestone_calls.clone()
+        }
+
+        pub fn create_issue_calls(&self) -> Vec<CreateIssueCallRecord> {
+            self.inner.lock().unwrap().create_issue_calls.clone()
         }
     }
 
@@ -559,6 +659,33 @@ pub mod mock {
                 .get(head_branch)
                 .cloned()
                 .unwrap_or_default())
+        }
+
+        async fn create_milestone(&self, title: &str, description: &str) -> Result<u64> {
+            let mut state = self.inner.lock().unwrap();
+            state.create_milestone_counter += 1;
+            state
+                .create_milestone_calls
+                .push((title.to_string(), description.to_string()));
+            Ok(state.create_milestone_counter)
+        }
+
+        async fn create_issue(
+            &self,
+            title: &str,
+            body: &str,
+            labels: &[String],
+            milestone: Option<u64>,
+        ) -> Result<u64> {
+            let mut state = self.inner.lock().unwrap();
+            state.create_issue_counter += 1;
+            state.create_issue_calls.push(CreateIssueCallRecord {
+                title: title.to_string(),
+                body: body.to_string(),
+                labels: labels.to_vec(),
+                milestone,
+            });
+            Ok(state.create_issue_counter)
         }
     }
 }
@@ -910,5 +1037,52 @@ mod tests {
     fn is_gh_auth_error_returns_false_for_regular_error() {
         let err = anyhow::anyhow!("gh command failed: branch not found");
         assert!(!is_gh_auth_error(&err));
+    }
+
+    // -- create_milestone / create_issue mock tests --
+
+    #[tokio::test]
+    async fn mock_create_milestone_records_call_and_returns_number() {
+        let client = MockGitHubClient::new();
+        let n1 = client
+            .create_milestone("M0", "First milestone")
+            .await
+            .unwrap();
+        let n2 = client
+            .create_milestone("M1", "Second milestone")
+            .await
+            .unwrap();
+        assert_eq!(n1, 1);
+        assert_eq!(n2, 2);
+        let calls = client.create_milestone_calls();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].0, "M0");
+        assert_eq!(calls[1].0, "M1");
+    }
+
+    #[tokio::test]
+    async fn mock_create_issue_records_call_and_returns_number() {
+        let client = MockGitHubClient::new();
+        let n = client
+            .create_issue("feat: thing", "body", &["enhancement".into()], Some(1))
+            .await
+            .unwrap();
+        assert_eq!(n, 1);
+        let calls = client.create_issue_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].title, "feat: thing");
+        assert_eq!(calls[0].labels, vec!["enhancement"]);
+        assert_eq!(calls[0].milestone, Some(1));
+    }
+
+    #[tokio::test]
+    async fn mock_create_issue_increments_counter() {
+        let client = MockGitHubClient::new();
+        let n1 = client.create_issue("a", "", &[], None).await.unwrap();
+        let n2 = client.create_issue("b", "", &[], None).await.unwrap();
+        let n3 = client.create_issue("c", "", &[], None).await.unwrap();
+        assert_eq!(n1, 1);
+        assert_eq!(n2, 2);
+        assert_eq!(n3, 3);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod updater;
 mod util;
 mod work;
 
+mod adapt;
 mod sanitize;
 
 #[cfg(test)]
@@ -62,6 +63,22 @@ async fn main() -> anyhow::Result<()> {
         Some(Commands::Completions { shell }) => cli::cmd_completions(shell),
         Some(Commands::Mangen { out_dir }) => cli::cmd_mangen(&out_dir),
         Some(Commands::Doctor) => cmd_doctor(),
+        Some(Commands::Adapt {
+            path,
+            dry_run,
+            no_issues,
+            scan_only,
+            model,
+        }) => {
+            adapt::cmd_adapt(adapt::AdaptConfig {
+                path,
+                dry_run,
+                no_issues,
+                scan_only,
+                model,
+            })
+            .await
+        }
         Some(Commands::Sanitize {
             path,
             output,

--- a/src/provider/azure_devops.rs
+++ b/src/provider/azure_devops.rs
@@ -350,6 +350,20 @@ impl GitHubClient for AzDevOpsClient {
             .filter_map(|v| v.get("pullRequestId").and_then(|n| n.as_u64()))
             .collect())
     }
+
+    async fn create_milestone(&self, _title: &str, _description: &str) -> Result<u64> {
+        anyhow::bail!("create_milestone is not supported for Azure DevOps")
+    }
+
+    async fn create_issue(
+        &self,
+        _title: &str,
+        _body: &str,
+        _labels: &[String],
+        _milestone: Option<u64>,
+    ) -> Result<u64> {
+        anyhow::bail!("create_issue is not supported for Azure DevOps")
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Implement the full `maestro adapt` 4-phase pipeline: scan → analyze → plan → materialize
- Add `ProjectScanner`, `ProjectAnalyzer`, `AdaptPlanner`, and `PlanMaterializer` traits with production and mock implementations
- Extend `GitHubClient` trait with `create_issue()` and `create_milestone()` methods
- Wire `maestro adapt` CLI command with `--scan-only`, `--no-issues`, `--dry-run`, `--model`, and `--path` flags
- Generate tech debt catalog issues from analysis results

Closes #88
Closes #89
Closes #90
Closes #91
Closes #92
Closes #93
Closes #94
Closes #95

## Test plan
- [x] All 1792 tests passing (`cargo test`)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` applied
- [x] JSON round-trip tests for all adapt types
- [x] Scanner tests with tempfile mock projects
- [x] MockGitHubClient records create_issue/create_milestone calls
- [x] Materializer dependency resolution verified
- [x] Dry-run mode verified (no client calls)
- [x] Tech debt catalog body formatting verified
- [x] CLI parsing tests for all Adapt flags