### PR TITLE
feat: Nerd Font icons for status bar header

### DIFF
--- a/src/tui/icons.rs
+++ b/src/tui/icons.rs
@@ -84,6 +84,11 @@ pub enum IconId {
     CheckboxOff,
     Expand,
     Collapse,
+
+    // Header Metrics
+    Agents,
+    Cost,
+    Clock,
 }
 
 /// A Nerd Font / ASCII icon pair.
@@ -147,6 +152,11 @@ const fn icon_pair(id: IconId) -> IconPair {
         IconId::CheckboxOff => IconPair::new("\u{f096}", "[ ]"),
         IconId::Expand => IconPair::new("\u{f054}", ">"),
         IconId::Collapse => IconPair::new("\u{f078}", "v"),
+
+        // ── Header Metrics ─────────────────────────────────────────
+        IconId::Agents => IconPair::new("\u{f0c0}", "[U]"),
+        IconId::Cost => IconPair::new("\u{f155}", "[$]"),
+        IconId::Clock => IconPair::new("\u{f017}", "[T]"),
     }
 }
 
@@ -209,6 +219,10 @@ mod tests {
         IconId::CheckboxOff,
         IconId::Expand,
         IconId::Collapse,
+        // Header Metrics
+        IconId::Agents,
+        IconId::Cost,
+        IconId::Clock,
     ];
 
     // ── Existing tests (mode detection) ─────────────────────────────────
@@ -355,6 +369,9 @@ mod tests {
             (GaugeEmpty, "\u{2591}"),
             (CheckboxOn, "\u{f46c}"),
             (CheckboxOff, "\u{f096}"),
+            (Agents, "\u{f0c0}"),
+            (Cost, "\u{f155}"),
+            (Clock, "\u{f017}"),
         ];
         for &(id, expected) in cases {
             assert_eq!(
@@ -376,6 +393,9 @@ mod tests {
             (GaugeEmpty, "-"),
             (Warning, "[!]"),
             (IssueOpened, ">>"),
+            (Agents, "[U]"),
+            (Cost, "[$]"),
+            (Clock, "[T]"),
         ];
         for &(id, expected) in cases {
             assert_eq!(

--- a/src/tui/icons.rs
+++ b/src/tui/icons.rs
@@ -154,9 +154,9 @@ const fn icon_pair(id: IconId) -> IconPair {
         IconId::Collapse => IconPair::new("\u{f078}", "v"),
 
         // ── Header Metrics ─────────────────────────────────────────
-        IconId::Agents => IconPair::new("\u{f544}", "[U]"),
-        IconId::Cost => IconPair::new("\u{f0d6}", "[$]"),
-        IconId::Clock => IconPair::new("\u{f253}", "[T]"),
+        IconId::Agents => IconPair::new("\u{f415}", "[U]"),
+        IconId::Cost => IconPair::new("\u{f155}", "[$]"),
+        IconId::Clock => IconPair::new("\u{f017}", "[T]"),
     }
 }
 
@@ -369,9 +369,9 @@ mod tests {
             (GaugeEmpty, "\u{2591}"),
             (CheckboxOn, "\u{f46c}"),
             (CheckboxOff, "\u{f096}"),
-            (Agents, "\u{f544}"),
-            (Cost, "\u{f0d6}"),
-            (Clock, "\u{f253}"),
+            (Agents, "\u{f415}"),
+            (Cost, "\u{f155}"),
+            (Clock, "\u{f017}"),
         ];
         for &(id, expected) in cases {
             assert_eq!(

--- a/src/tui/icons.rs
+++ b/src/tui/icons.rs
@@ -154,9 +154,9 @@ const fn icon_pair(id: IconId) -> IconPair {
         IconId::Collapse => IconPair::new("\u{f078}", "v"),
 
         // ── Header Metrics ─────────────────────────────────────────
-        IconId::Agents => IconPair::new("\u{f0c0}", "[U]"),
-        IconId::Cost => IconPair::new("\u{f155}", "[$]"),
-        IconId::Clock => IconPair::new("\u{f017}", "[T]"),
+        IconId::Agents => IconPair::new("\u{f544}", "[U]"),
+        IconId::Cost => IconPair::new("\u{f0d6}", "[$]"),
+        IconId::Clock => IconPair::new("\u{f253}", "[T]"),
     }
 }
 
@@ -369,9 +369,9 @@ mod tests {
             (GaugeEmpty, "\u{2591}"),
             (CheckboxOn, "\u{f46c}"),
             (CheckboxOff, "\u{f096}"),
-            (Agents, "\u{f0c0}"),
-            (Cost, "\u{f155}"),
-            (Clock, "\u{f017}"),
+            (Agents, "\u{f544}"),
+            (Cost, "\u{f0d6}"),
+            (Clock, "\u{f253}"),
         ];
         for &(id, expected) in cases {
             assert_eq!(

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -520,7 +520,8 @@ fn draw_status_bar(f: &mut Frame, app: &App, mode_km: &ModeKeyMap, area: Rect) {
         sep.clone(),
         Span::styled(
             format!(
-                "{} agent{} ({} active)",
+                "{} {} agent{} ({} active)",
+                icons::get(IconId::Agents),
                 total,
                 if total != 1 { "s" } else { "" },
                 active
@@ -528,9 +529,15 @@ fn draw_status_bar(f: &mut Frame, app: &App, mode_km: &ModeKeyMap, area: Rect) {
             Style::default().fg(theme.accent_info),
         ),
         sep.clone(),
-        Span::styled(budget_display, Style::default().fg(budget_color)),
+        Span::styled(
+            format!("{} {}", icons::get(IconId::Cost), budget_display),
+            Style::default().fg(budget_color),
+        ),
         sep.clone(),
-        Span::styled(elapsed_str, Style::default().fg(theme.text_primary)),
+        Span::styled(
+            format!("{} {}", icons::get(IconId::Clock), elapsed_str),
+            Style::default().fg(theme.text_primary),
+        ),
     ];
 
     if let Some(ref cont) = app.continuous_mode {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -488,8 +488,8 @@ fn draw_status_bar(f: &mut Frame, app: &App, mode_km: &ModeKeyMap, area: Rect) {
     let total = app.pool.total_count();
 
     let budget_display = match &app.budget_enforcer {
-        Some(enforcer) => format!("${:.2}/${:.2}", app.total_cost, enforcer.total_limit()),
-        None => format!("${:.2} spent", app.total_cost),
+        Some(enforcer) => format!("{:.2}/${:.2}", app.total_cost, enforcer.total_limit()),
+        None => format!("{:.2} spent", app.total_cost),
     };
 
     let budget_color = match &app.budget_enforcer {
@@ -530,7 +530,7 @@ fn draw_status_bar(f: &mut Frame, app: &App, mode_km: &ModeKeyMap, area: Rect) {
         ),
         sep.clone(),
         Span::styled(
-            format!("{} {}", icons::get(IconId::Cost), budget_display),
+            format!("{}{}", icons::get(IconId::Cost), budget_display),
             Style::default().fg(budget_color),
         ),
         sep.clone(),


### PR DESCRIPTION
## Summary

- Add Nerd Font icon prefixes to status bar header metrics: agents (fa-users `\u{f0c0}`), cost (fa-dollar `\u{f155}`), elapsed time (fa-clock `\u{f017}`)
- ASCII fallback renders `[U]`, `[$]`, `[T]` when `tui.ascii_icons` is enabled
- Icons inherit span color for visual consistency across all three themes (Dark, Light, Retro)

Closes #310

## Test plan
- [x] All 2292 tests pass (`cargo test`)
- [x] Clippy clean (`cargo clippy`)
- [ ] Manual: launch maestro → verify icons visible in header
- [ ] Manual: toggle `tui.ascii_icons = true` → verify ASCII fallback
- [ ] Manual: verify all three themes render icons correctly