### PR TITLE
refactor: unify icon system across lib and binary crates

### DIFF
--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-13 19:00 (UTC)
+> Last updated: 2026-04-14 00:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -62,7 +62,9 @@ maestro/
 │       └── release.yml                    # Release automation for cross-platform builds and Homebrew tap updates
 ├── build.rs                               # Build script: generates man page (maestro.1) and shell completions (bash, zsh, fish) into OUT_DIR at build time using clap_mangen and clap_complete  [Issue #18]
 ├── src/
-│   ├── lib.rs                             # Library facade exposing session::parser and session::types for benchmark crates (no main.rs re-export)
+│   ├── lib.rs                             # Library facade; exposes session::parser and session::types for benchmark crates; pub mod icon_mode and pub mod icons added so shared icon modules are accessible as library crate items  [Issue #307, #308]
+│   ├── icon_mode.rs                       # Shared icon mode detection: AtomicBool global flag, init_from_config() reads tui.ascii_icons from Config and MAESTRO_ASCII_ICONS env var, use_nerd_font() returns current mode; extracted from tui/icons.rs so non-TUI crates can query the mode without pulling in the full TUI tree  [Issue #307]
+│   ├── icons.rs                           # Shared icon registry: IconId enum (38 variants across Navigation, Status, UI Chrome, Indicators categories, plus NeedsReview variant added in #308), IconPair struct (nerd: &'static str, ascii: &'static str), icon_pair() const fn compiles to a zero-allocation jump table, get(IconId) returns the correct variant based on global mode, get_for_mode(id, nerd_font) pure testable variant; extracted from tui/icons.rs  [Issue #308]
 │   ├── main.rs                            # CLI entry point (clap); Run, Queue, Add, Status, Cost, Init, Doctor; --skip-doctor flag on Run subcommand bypasses preflight; cmd_run() runs validate_preflight() before session launch and uses PromptBuilder::build_issue_prompt() for issue sessions; setup_app_from_config() shared helper wires budget, model router, notifications, plugins, and permission_mode/allowed_tools from config; propagates once_mode from parsed CLI flag into App; forces max_concurrent=1 when --continuous is set; cmd_dashboard() performs orphan worktree cleanup, log cleanup, fetches username from doctor report, delegates App construction to setup_app_from_config(), and queues FetchSuggestionData on startup; declares #[cfg(test)] mod integration_tests; declares mod updater; declares mod flags; propagates startup gh auth check result into App.gh_auth_ok; declares #[cfg(feature = "experimental-sanitizer")] mod sanitizer; constructs FeatureFlags from --enable-flag / --disable-flag CLI args merged with [flags] config  [Issue #15, #29, #49, #34, #36, #35, #52, #83, #85, #118, #141, #142, #143, #158]
 │   ├── cli.rs                             # CLI definition extracted from main.rs; Cli struct and Commands enum (clap derive); --once flag on Run subcommand (exits after all sessions complete, for CI/scripting); --continuous / -C flag on Run subcommand (auto-advance through issues, pause on failure); --enable-flag / --disable-flag repeatable args on Run subcommand for runtime feature flag overrides; generate_completions() and cmd_completions() for shell tab-completion output; cmd_mangen() for roff man page generation; Completions and Mangen subcommands  [Issue #18, #83, #85, #143]
 │   ├── config.rs                          # maestro.toml parsing; ModelsConfig, GatesConfig, ReviewConfig; ContextOverflowConfig; ProviderConfig (kind, organization, az_project); guardrail_prompt in SessionsConfig; CompletionGatesConfig and CompletionGateEntry; CiAutoFixConfig (enabled, max_retries, poll_interval_secs) under GatesConfig.ci_auto_fix; TuiConfig struct with optional theme field; Config gains tui field; FlagsConfig (flattened HashMap<String, bool>) loaded from [flags] table; Config gains flags field  [Issue #29, #40, #41, #43, #38, #143]
@@ -143,7 +145,7 @@ maestro/
 │   │   ├── detail.rs                      # Session detail view  [Phase 3]
 │   │   ├── fullscreen.rs                  # Fullscreen session view with phase progress overlay  [Phase 3]
 │   │   ├── help.rs                        # Help overlay widget with keybinding reference  [Phase 3]
-│   │   ├── icons.rs                       # Centralized icon registry: IconId enum (38 variants across Navigation, Status, UI Chrome, Indicators categories); IconPair struct holding nerd: &'static str and ascii: &'static str; icon_pair() const fn compiles to a jump table with zero heap allocation; get(IconId) public API returns the correct variant based on current global mode; get_for_mode(id, nerd_font) pure testable variant; init_from_config() sets ASCII mode from tui.ascii_icons config; MAESTRO_ASCII_ICONS=1 env var override  [Issue #286]
+│   │   ├── icons.rs                       # Thin re-export shim: re-exports IconId, IconPair, icon_pair(), get(), get_for_mode() from src/icons.rs and init_from_config(), use_nerd_font() from src/icon_mode.rs so existing tui:: import paths remain valid after the registry was extracted  [Issue #307, #308]
 │   │   ├── input_handler.rs               # Top-level key event dispatcher extracted from mod.rs; KeyAction enum (Consumed, Quit); handle_key() dispatches to overlay handlers, mode-specific input, global shortcuts, and screen dispatch in priority order
 │   │   ├── log_viewer.rs                  # Full-screen scrollable log viewer widget
 │   │   ├── markdown.rs                    # markdown-to-ratatui rendering module; convert Markdown content to terminal-friendly widgets; wrap_and_push_text() performs width-aware word wrapping when appending text spans to a line buffer
@@ -343,7 +345,9 @@ maestro/
 | `src/tui/screens/hollow_retry.rs` | `HollowRetryScreen`: minimal retry prompt overlay for stalled sessions awaiting user confirmation |
 | `src/tui/screens/queue_confirmation.rs` | `QueueConfirmationScreen`: confirmation overlay before bulk-queuing selected issues from the issue browser |
 | `src/tui/screens/settings/mod.rs` | `SettingsScreen`: tabbed interactive settings UI; `Flags` tab shows all feature flags with name, state, source (`Default`/`Config`/`Cli`), and description; read-only display with green accent on focused fields (Issues #124, #146) |
-| `src/tui/icons.rs` | Centralized icon registry: `IconId` enum (38 variants), `IconPair` struct, `get(IconId)` public API, `get_for_mode(id, nerd_font)` pure testable variant; zero-allocation const jump table; `init_from_config()` and `MAESTRO_ASCII_ICONS` env var override (Issue #286) |
+| `src/icon_mode.rs` | Shared icon mode detection: `AtomicBool` global, `init_from_config()`, `use_nerd_font()`; reads `tui.ascii_icons` config and `MAESTRO_ASCII_ICONS` env var (Issue #307) |
+| `src/icons.rs` | Shared icon registry: `IconId` enum (38 variants + `NeedsReview`), `IconPair` struct, `icon_pair()` const jump table, `get(IconId)`, `get_for_mode(id, nerd_font)` (Issue #308) |
+| `src/tui/icons.rs` | Thin re-export shim: re-exports all public items from `src/icon_mode.rs` and `src/icons.rs` so existing `tui::icons::` import paths remain valid (Issues #307, #308) |
 | `src/tui/screens/adapt/` | Adapt wizard screen: multi-step TUI wizard for onboarding a project into maestro (Issue #88) |
 | `src/tui/screens/adapt/mod.rs` | `AdaptScreen` struct implementing the `Screen` trait; wizard entry point and step coordination |
 | `src/tui/screens/adapt/types.rs` | `AdaptStep`, `AdaptWizardConfig`, `AdaptResults`, `AdaptError` type definitions |

--- a/src/icon_mode.rs
+++ b/src/icon_mode.rs
@@ -1,31 +1,40 @@
 //! Shared icon mode detection — single source of truth for ASCII vs Nerd Font.
 //!
 //! This module lives in the lib crate so both `session::types` and `tui::icons`
-//! can read the same `AtomicBool` without duplication.
+//! can read the same atomic without duplication.
+//!
+//! A single `AtomicU8` encodes both "initialized?" and "which mode?" to avoid
+//! split-state races between two separate atomics.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicU8, Ordering};
 
-static ASCII_MODE: AtomicBool = AtomicBool::new(false);
-static INITIALIZED: AtomicBool = AtomicBool::new(false);
+/// 0 = not yet initialized (fall back to env var).
+const UNINITIALIZED: u8 = 0;
+/// 1 = initialized, Nerd Font mode (ascii_icons = false).
+const NERD_FONT: u8 = 1;
+/// 2 = initialized, ASCII mode (ascii_icons = true).
+const ASCII: u8 = 2;
+
+static MODE: AtomicU8 = AtomicU8::new(UNINITIALIZED);
 
 /// Initialize icon mode from config. Call once at startup.
 pub fn init_from_config(ascii_icons: bool) {
-    ASCII_MODE.store(ascii_icons, Ordering::Relaxed);
-    INITIALIZED.store(true, Ordering::Release);
+    let value = if ascii_icons { ASCII } else { NERD_FONT };
+    MODE.store(value, Ordering::Release);
 }
 
 /// Returns true if Nerd Font icons should be used.
 /// Checks (in order): config flag, `MAESTRO_ASCII_ICONS` env var.
 pub fn use_nerd_font() -> bool {
-    if INITIALIZED.load(Ordering::Acquire) {
-        return !ASCII_MODE.load(Ordering::Relaxed);
+    match MODE.load(Ordering::Acquire) {
+        NERD_FONT => true,
+        ASCII => false,
+        _ => use_nerd_font_from_env(|k| std::env::var(k).ok()),
     }
-    // Fallback: env var check (for lib crate / before config loads)
-    use_nerd_font_from_env(|k| std::env::var(k).ok())
 }
 
 /// Testable version: accepts an env-var reader closure.
-pub fn use_nerd_font_from_env(get_env: impl Fn(&str) -> Option<String>) -> bool {
+pub(crate) fn use_nerd_font_from_env(get_env: impl Fn(&str) -> Option<String>) -> bool {
     get_env("MAESTRO_ASCII_ICONS")
         .map(|v| v != "1")
         .unwrap_or(true)

--- a/src/icon_mode.rs
+++ b/src/icon_mode.rs
@@ -1,0 +1,78 @@
+//! Shared icon mode detection — single source of truth for ASCII vs Nerd Font.
+//!
+//! This module lives in the lib crate so both `session::types` and `tui::icons`
+//! can read the same `AtomicBool` without duplication.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static ASCII_MODE: AtomicBool = AtomicBool::new(false);
+static INITIALIZED: AtomicBool = AtomicBool::new(false);
+
+/// Initialize icon mode from config. Call once at startup.
+pub fn init_from_config(ascii_icons: bool) {
+    ASCII_MODE.store(ascii_icons, Ordering::Relaxed);
+    INITIALIZED.store(true, Ordering::Release);
+}
+
+/// Returns true if Nerd Font icons should be used.
+/// Checks (in order): config flag, `MAESTRO_ASCII_ICONS` env var.
+pub fn use_nerd_font() -> bool {
+    if INITIALIZED.load(Ordering::Acquire) {
+        return !ASCII_MODE.load(Ordering::Relaxed);
+    }
+    // Fallback: env var check (for lib crate / before config loads)
+    use_nerd_font_from_env(|k| std::env::var(k).ok())
+}
+
+/// Testable version: accepts an env-var reader closure.
+pub fn use_nerd_font_from_env(get_env: impl Fn(&str) -> Option<String>) -> bool {
+    get_env("MAESTRO_ASCII_ICONS")
+        .map(|v| v != "1")
+        .unwrap_or(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_absent_returns_nerd_font_true() {
+        assert!(use_nerd_font_from_env(|_| None));
+    }
+
+    #[test]
+    fn env_var_set_to_1_returns_nerd_font_false() {
+        assert!(!use_nerd_font_from_env(|_| Some("1".to_string())));
+    }
+
+    #[test]
+    fn env_var_set_to_0_returns_nerd_font_true() {
+        assert!(use_nerd_font_from_env(|_| Some("0".to_string())));
+    }
+
+    #[test]
+    fn env_var_arbitrary_value_returns_nerd_font_true() {
+        assert!(use_nerd_font_from_env(|_| Some("yes".to_string())));
+    }
+
+    #[test]
+    fn init_from_config_ascii_true_disables_nerd_font() {
+        init_from_config(true);
+        assert!(!use_nerd_font());
+        init_from_config(false); // restore
+    }
+
+    #[test]
+    fn init_from_config_ascii_false_enables_nerd_font() {
+        init_from_config(false);
+        assert!(use_nerd_font());
+    }
+
+    #[test]
+    fn use_nerd_font_reads_initialized_flag_not_env() {
+        init_from_config(true);
+        assert!(!use_nerd_font());
+        init_from_config(false);
+        assert!(use_nerd_font());
+    }
+}

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -1,0 +1,154 @@
+//! Shared icon registry: centralized Nerd Font / ASCII icon definitions.
+//!
+//! This module lives in the lib crate so both `session::types` and `tui::icons`
+//! can access the registry without cross-module dependency violations.
+
+use crate::icon_mode::use_nerd_font;
+
+/// Identifies every icon used in the TUI, grouped by semantic category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[allow(dead_code)] // Registry covers all icons; some only used in files not yet migrated
+pub enum IconId {
+    // Navigation
+    ChevronRight,
+    ChevronDown,
+    ArrowRight,
+    ArrowLeft,
+    ArrowUp,
+    ArrowDown,
+    AngleLeft,
+    AngleRight,
+
+    // Status
+    CheckCircle,
+    CheckCircleFill,
+    XCircle,
+    Circle,
+    DotFill,
+    Skip,
+    Hourglass,
+    Warning,
+    Play,
+    Pause,
+    Sync,
+    Skull,
+    Alert,
+    Refresh,
+    Wrench,
+    GitPr,
+    GitMerge,
+    Search,
+    IssueOpened,
+    IssueClosed,
+    Milestone,
+    NeedsReview,
+
+    // UI Chrome
+    GaugeFilled,
+    GaugeEmpty,
+    Selector,
+    SeparatorV,
+    SeparatorH,
+    Fisheye,
+
+    // Indicators
+    CheckboxOn,
+    CheckboxOff,
+    Expand,
+    Collapse,
+
+    // Header Metrics
+    Agents,
+    Cost,
+    Clock,
+
+    // Header Brand
+    Repo,
+    User,
+    Branch,
+}
+
+/// A Nerd Font / ASCII icon pair.
+pub struct IconPair {
+    pub nerd: &'static str,
+    pub ascii: &'static str,
+}
+
+impl IconPair {
+    const fn new(nerd: &'static str, ascii: &'static str) -> Self {
+        Self { nerd, ascii }
+    }
+}
+
+const fn icon_pair(id: IconId) -> IconPair {
+    match id {
+        // ── Navigation ──────────────────────────────────────────────
+        IconId::ChevronRight => IconPair::new("\u{f054}", ">"),
+        IconId::ChevronDown => IconPair::new("\u{f078}", "v"),
+        IconId::ArrowRight => IconPair::new("\u{f061}", "->"),
+        IconId::ArrowLeft => IconPair::new("\u{f060}", "<-"),
+        IconId::ArrowUp => IconPair::new("\u{2191}", "^"),
+        IconId::ArrowDown => IconPair::new("\u{2193}", "v"),
+        IconId::AngleLeft => IconPair::new("\u{f104}", "<"),
+        IconId::AngleRight => IconPair::new("\u{f105}", ">"),
+
+        // ── Status ──────────────────────────────────────────────────
+        IconId::CheckCircle => IconPair::new("\u{f42e}", "[+]"),
+        IconId::CheckCircleFill => IconPair::new("\u{f058}", "[*]"),
+        IconId::XCircle => IconPair::new("\u{f467}", "[X]"),
+        IconId::Circle => IconPair::new("\u{f4a3}", "( )"),
+        IconId::DotFill => IconPair::new("\u{f444}", "(*)"),
+        IconId::Skip => IconPair::new("\u{f4a7}", "[-]"),
+        IconId::Hourglass => IconPair::new("\u{f251}", "[~]"),
+        IconId::Warning => IconPair::new("\u{26A0}", "[!]"),
+        IconId::Play => IconPair::new("\u{f40a}", "[>]"),
+        IconId::Pause => IconPair::new("\u{f04c}", "[=]"),
+        IconId::Sync => IconPair::new("\u{f46a}", "[S]"),
+        IconId::Skull => IconPair::new("\u{f2d3}", "[D]"),
+        IconId::Alert => IconPair::new("\u{f421}", "[A]"),
+        IconId::Refresh => IconPair::new("\u{f363}", "[R]"),
+        IconId::Wrench => IconPair::new("\u{f7d9}", "[W]"),
+        IconId::GitPr => IconPair::new("\u{f407}", "[P]"),
+        IconId::GitMerge => IconPair::new("\u{f419}", "[M]"),
+        IconId::Search => IconPair::new("\u{f422}", "[?]"),
+        IconId::IssueOpened => IconPair::new("\u{f0766}", "[#]"), // nf-md-circle_outline
+        IconId::IssueClosed => IconPair::new("\u{f04d2}", "[+]"), // nf-md-check_circle
+        IconId::Milestone => IconPair::new("\u{f0431}", "[M]"),   // nf-md-flag
+        IconId::NeedsReview => IconPair::new("\u{f41b}", "[!]"),  // nf-oct-issue_opened
+
+        // ── UI Chrome ───────────────────────────────────────────────
+        IconId::GaugeFilled => IconPair::new("\u{2593}", "#"),
+        IconId::GaugeEmpty => IconPair::new("\u{2591}", "-"),
+        IconId::Selector => IconPair::new("\u{25b8}", ">"),
+        IconId::SeparatorV => IconPair::new("\u{2502}", "|"),
+        IconId::SeparatorH => IconPair::new("\u{2550}\u{2550}", "=="),
+        IconId::Fisheye => IconPair::new("\u{25C9}", "*"),
+
+        // ── Indicators ──────────────────────────────────────────────
+        IconId::CheckboxOn => IconPair::new("\u{f46c}", "[x]"),
+        IconId::CheckboxOff => IconPair::new("\u{f096}", "[ ]"),
+        IconId::Expand => IconPair::new("\u{f054}", ">"),
+        IconId::Collapse => IconPair::new("\u{f078}", "v"),
+
+        // ── Header Metrics ─────────────────────────────────────────
+        IconId::Agents => IconPair::new("\u{f064d}", "[U]"), // nf-md-account_group
+        IconId::Cost => IconPair::new("$", "$"),
+        IconId::Clock => IconPair::new("\u{f251}", "[T]"), // nf-fa-hourglass
+
+        // ── Header Brand ──────────────────────────────────────────
+        IconId::Repo => IconPair::new("\u{f408}", "(g)"), // nf-oct-repo
+        IconId::User => IconPair::new("\u{f007}", "@"),   // nf-fa-user
+        IconId::Branch => IconPair::new("\u{f418}", "(b)"), // nf-oct-git_branch
+    }
+}
+
+/// Returns the correct icon string for the current mode (Nerd Font or ASCII).
+pub fn get(id: IconId) -> &'static str {
+    get_for_mode(id, use_nerd_font())
+}
+
+/// Pure, testable variant of `get()`. Pass the mode explicitly.
+pub fn get_for_mode(id: IconId, nerd_font: bool) -> &'static str {
+    let pair = icon_pair(id);
+    if nerd_font { pair.nerd } else { pair.ascii }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
 /// Library facade — exposes only self-contained modules for benchmarks.
+pub mod icon_mode;
+pub mod icons;
+
 #[path = "session"]
 pub mod session {
     pub mod parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,8 @@ mod flags;
 mod gates;
 mod git;
 mod github;
+mod icon_mode;
+mod icons;
 mod models;
 mod modes;
 mod notifications;

--- a/src/session/types.rs
+++ b/src/session/types.rs
@@ -1,10 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-use std::sync::atomic::AtomicBool;
 use uuid::Uuid;
-
-static ASCII_ICONS: AtomicBool = AtomicBool::new(false);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -27,21 +24,27 @@ pub enum SessionStatus {
 
 impl SessionStatus {
     pub fn nerd_symbol(&self) -> &'static str {
+        crate::icons::get_for_mode(self.icon_id(), true)
+    }
+
+    /// Maps each status to its icon registry entry.
+    pub fn icon_id(&self) -> crate::icons::IconId {
+        use crate::icons::IconId;
         match self {
-            Self::Queued => "\u{f251}",       //  hourglass
-            Self::Spawning => "\u{f46a}",     //  sync
-            Self::Running => "\u{f40a}",      //  play
-            Self::Completed => "\u{f42e}",    //  check_circle
-            Self::GatesRunning => "\u{f422}", //  search
-            Self::NeedsReview => "\u{f41b}",  //  issue_opened
-            Self::Errored => "\u{f467}",      //  x_circle
-            Self::Paused => "\u{f04c}",       //  pause
-            Self::Killed => "\u{f2d3}",       //  skull
-            Self::Stalled => "\u{f421}",      //  alert
-            Self::Retrying => "\u{f363}",     //  refresh
-            Self::CiFix => "\u{f7d9}",        //  wrench
-            Self::NeedsPr => "\u{f407}",      //  git_pull_request
-            Self::ConflictFix => "\u{f419}",  //  git_merge
+            Self::Queued => IconId::Hourglass,
+            Self::Spawning => IconId::Sync,
+            Self::Running => IconId::Play,
+            Self::Completed => IconId::CheckCircle,
+            Self::GatesRunning => IconId::Search,
+            Self::NeedsReview => IconId::NeedsReview,
+            Self::Errored => IconId::XCircle,
+            Self::Paused => IconId::Pause,
+            Self::Killed => IconId::Skull,
+            Self::Stalled => IconId::Alert,
+            Self::Retrying => IconId::Refresh,
+            Self::CiFix => IconId::Wrench,
+            Self::NeedsPr => IconId::GitPr,
+            Self::ConflictFix => IconId::GitMerge,
         }
     }
 
@@ -65,22 +68,11 @@ impl SessionStatus {
     }
 
     pub fn symbol(&self) -> &'static str {
-        if Self::use_nerd_font() {
+        if crate::icon_mode::use_nerd_font() {
             self.nerd_symbol()
         } else {
             self.ascii_symbol()
         }
-    }
-
-    /// Set icon mode globally. Called from config init and settings changes.
-    pub fn set_ascii_icons(ascii: bool) {
-        use std::sync::atomic::Ordering;
-        ASCII_ICONS.store(ascii, Ordering::Relaxed);
-    }
-
-    fn use_nerd_font() -> bool {
-        use std::sync::atomic::Ordering;
-        !ASCII_ICONS.load(Ordering::Relaxed)
     }
 
     pub fn label(&self) -> &'static str {

--- a/src/tui/app/mod.rs
+++ b/src/tui/app/mod.rs
@@ -232,8 +232,7 @@ impl App {
                 LogLevel::Warn,
             );
         }
-        crate::session::types::SessionStatus::set_ascii_icons(config.tui.ascii_icons);
-        crate::tui::icons::init_from_config(config.tui.ascii_icons);
+        crate::icon_mode::init_from_config(config.tui.ascii_icons);
         self.show_mascot = config.tui.show_mascot;
         self.config = Some(config);
     }

--- a/src/tui/icons.rs
+++ b/src/tui/icons.rs
@@ -9,11 +9,10 @@
 
 pub use crate::icons::*;
 
-// Re-exported for backward compatibility (used by tests and callers
-// that previously imported mode detection from `tui::icons`).
-pub use crate::icon_mode::use_nerd_font;
 #[cfg(test)]
 pub use crate::icon_mode::init_from_config;
+// Re-exported for callers that import mode detection from `tui::icons`.
+pub use crate::icon_mode::use_nerd_font;
 
 #[cfg(test)]
 mod tests {

--- a/src/tui/icons.rs
+++ b/src/tui/icons.rs
@@ -1,187 +1,19 @@
-//! Icon registry: centralized Nerd Font / ASCII icon definitions.
+//! Icon registry: re-exports from the shared `crate::icons` module.
+//! Mode detection: re-exports from `crate::icon_mode`.
+//!
 //! Config: `tui.ascii_icons = true` in maestro.toml
 //! Env override: `MAESTRO_ASCII_ICONS=1`
 //!
 //! Usage: `icons::get(IconId::ChevronRight)` returns the correct variant
 //! based on the current mode (Nerd Font or ASCII).
 
-use std::sync::atomic::{AtomicBool, Ordering};
+pub use crate::icons::*;
 
-static ASCII_MODE: AtomicBool = AtomicBool::new(false);
-static INITIALIZED: AtomicBool = AtomicBool::new(false);
-
-/// Initialize icon mode from config. Call once at startup.
-pub fn init_from_config(ascii_icons: bool) {
-    ASCII_MODE.store(ascii_icons, Ordering::Relaxed);
-    INITIALIZED.store(true, Ordering::Relaxed);
-}
-
-/// Returns true if Nerd Font icons should be used.
-/// Checks (in order): config flag, MAESTRO_ASCII_ICONS env var.
-pub fn use_nerd_font() -> bool {
-    if INITIALIZED.load(Ordering::Relaxed) {
-        return !ASCII_MODE.load(Ordering::Relaxed);
-    }
-    // Fallback: env var check (for lib crate / before config loads)
-    use_nerd_font_from_env(|k| std::env::var(k).ok())
-}
-
-// Testable version: accepts an env-var reader closure.
-pub(crate) fn use_nerd_font_from_env(get_env: impl Fn(&str) -> Option<String>) -> bool {
-    get_env("MAESTRO_ASCII_ICONS")
-        .map(|v| v != "1")
-        .unwrap_or(true)
-}
-
-// ── Icon Registry ──────────────────────────────────────────────────────
-
-/// Identifies every icon used in the TUI, grouped by semantic category.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[allow(dead_code)] // Registry covers all icons; some only used in files not yet migrated
-pub enum IconId {
-    // Navigation
-    ChevronRight,
-    ChevronDown,
-    ArrowRight,
-    ArrowLeft,
-    ArrowUp,
-    ArrowDown,
-    AngleLeft,
-    AngleRight,
-
-    // Status
-    CheckCircle,
-    CheckCircleFill,
-    XCircle,
-    Circle,
-    DotFill,
-    Skip,
-    Hourglass,
-    Warning,
-    Play,
-    Pause,
-    Sync,
-    Skull,
-    Alert,
-    Refresh,
-    Wrench,
-    GitPr,
-    GitMerge,
-    Search,
-    IssueOpened,
-    IssueClosed,
-    Milestone,
-
-    // UI Chrome
-    GaugeFilled,
-    GaugeEmpty,
-    Selector,
-    SeparatorV,
-    SeparatorH,
-    Fisheye,
-
-    // Indicators
-    CheckboxOn,
-    CheckboxOff,
-    Expand,
-    Collapse,
-
-    // Header Metrics
-    Agents,
-    Cost,
-    Clock,
-
-    // Header Brand
-    Repo,
-    User,
-    Branch,
-}
-
-/// A Nerd Font / ASCII icon pair.
-pub struct IconPair {
-    pub nerd: &'static str,
-    pub ascii: &'static str,
-}
-
-impl IconPair {
-    const fn new(nerd: &'static str, ascii: &'static str) -> Self {
-        Self { nerd, ascii }
-    }
-}
-
-/// Maps each IconId to its Nerd Font and ASCII variants.
-/// Compiles to a jump table — zero heap allocation, zero runtime cost.
-const fn icon_pair(id: IconId) -> IconPair {
-    match id {
-        // ── Navigation ──────────────────────────────────────────────
-        IconId::ChevronRight => IconPair::new("\u{f054}", ">"),
-        IconId::ChevronDown => IconPair::new("\u{f078}", "v"),
-        IconId::ArrowRight => IconPair::new("\u{f061}", "->"),
-        IconId::ArrowLeft => IconPair::new("\u{f060}", "<-"),
-        IconId::ArrowUp => IconPair::new("\u{2191}", "^"),
-        IconId::ArrowDown => IconPair::new("\u{2193}", "v"),
-        IconId::AngleLeft => IconPair::new("\u{f104}", "<"),
-        IconId::AngleRight => IconPair::new("\u{f105}", ">"),
-
-        // ── Status ──────────────────────────────────────────────────
-        IconId::CheckCircle => IconPair::new("\u{f42e}", "[+]"),
-        IconId::CheckCircleFill => IconPair::new("\u{f058}", "[*]"),
-        IconId::XCircle => IconPair::new("\u{f467}", "[X]"),
-        IconId::Circle => IconPair::new("\u{f4a3}", "( )"),
-        IconId::DotFill => IconPair::new("\u{f444}", "(*)"),
-        IconId::Skip => IconPair::new("\u{f4a7}", "[-]"),
-        IconId::Hourglass => IconPair::new("\u{f251}", "[~]"),
-        IconId::Warning => IconPair::new("\u{26A0}", "[!]"),
-        IconId::Play => IconPair::new("\u{f40a}", "[>]"),
-        IconId::Pause => IconPair::new("\u{f04c}", "[=]"),
-        IconId::Sync => IconPair::new("\u{f46a}", "[S]"),
-        IconId::Skull => IconPair::new("\u{f2d3}", "[D]"),
-        IconId::Alert => IconPair::new("\u{f421}", "[A]"),
-        IconId::Refresh => IconPair::new("\u{f363}", "[R]"),
-        IconId::Wrench => IconPair::new("\u{f7d9}", "[W]"),
-        IconId::GitPr => IconPair::new("\u{f407}", "[P]"),
-        IconId::GitMerge => IconPair::new("\u{f419}", "[M]"),
-        IconId::Search => IconPair::new("\u{f422}", "[?]"),
-        IconId::IssueOpened => IconPair::new("\u{f0766}", "[#]"), // nf-md-circle_outline
-        IconId::IssueClosed => IconPair::new("\u{f04d2}", "[+]"), // nf-md-check_circle
-        IconId::Milestone => IconPair::new("\u{f0431}", "[M]"),   // nf-md-flag
-
-        // ── UI Chrome ───────────────────────────────────────────────
-        IconId::GaugeFilled => IconPair::new("\u{2593}", "#"),
-        IconId::GaugeEmpty => IconPair::new("\u{2591}", "-"),
-        IconId::Selector => IconPair::new("\u{25b8}", ">"),
-        IconId::SeparatorV => IconPair::new("\u{2502}", "|"),
-        IconId::SeparatorH => IconPair::new("\u{2550}\u{2550}", "=="),
-        IconId::Fisheye => IconPair::new("\u{25C9}", "*"),
-
-        // ── Indicators ──────────────────────────────────────────────
-        IconId::CheckboxOn => IconPair::new("\u{f46c}", "[x]"),
-        IconId::CheckboxOff => IconPair::new("\u{f096}", "[ ]"),
-        IconId::Expand => IconPair::new("\u{f054}", ">"),
-        IconId::Collapse => IconPair::new("\u{f078}", "v"),
-
-        // ── Header Metrics ─────────────────────────────────────────
-        IconId::Agents => IconPair::new("\u{f064d}", "[U]"), // nf-md-account_group
-        IconId::Cost => IconPair::new("$", "$"),
-        IconId::Clock => IconPair::new("\u{f251}", "[T]"), // nf-fa-hourglass (⏳)
-
-        // ── Header Brand ──────────────────────────────────────────
-        IconId::Repo => IconPair::new("\u{f408}", "(g)"), // nf-oct-repo
-        IconId::User => IconPair::new("\u{f007}", "@"),   // nf-fa-user
-        IconId::Branch => IconPair::new("\u{f418}", "(b)"), // nf-oct-git_branch
-    }
-}
-
-/// Returns the correct icon string for the current mode (Nerd Font or ASCII).
-pub fn get(id: IconId) -> &'static str {
-    get_for_mode(id, use_nerd_font())
-}
-
-/// Pure, testable variant of `get()`. Pass the mode explicitly.
-pub(crate) fn get_for_mode(id: IconId, nerd_font: bool) -> &'static str {
-    let pair = icon_pair(id);
-    if nerd_font { pair.nerd } else { pair.ascii }
-}
+// Re-exported for backward compatibility (used by tests and callers
+// that previously imported mode detection from `tui::icons`).
+pub use crate::icon_mode::use_nerd_font;
+#[cfg(test)]
+pub use crate::icon_mode::init_from_config;
 
 #[cfg(test)]
 mod tests {
@@ -220,6 +52,7 @@ mod tests {
         IconId::IssueOpened,
         IconId::IssueClosed,
         IconId::Milestone,
+        IconId::NeedsReview,
         // UI Chrome
         IconId::GaugeFilled,
         IconId::GaugeEmpty,
@@ -242,30 +75,7 @@ mod tests {
         IconId::Branch,
     ];
 
-    // ── Existing tests (mode detection) ─────────────────────────────────
-
-    #[test]
-    fn returns_true_when_env_var_absent() {
-        assert!(use_nerd_font_from_env(|_| None));
-    }
-
-    #[test]
-    fn returns_false_when_ascii_icons_set_to_1() {
-        assert!(!use_nerd_font_from_env(|_| Some("1".to_string())));
-    }
-
-    #[test]
-    fn returns_true_when_ascii_icons_set_to_0() {
-        assert!(use_nerd_font_from_env(|_| Some("0".to_string())));
-    }
-
-    #[test]
-    fn init_from_config_sets_ascii_mode() {
-        init_from_config(true);
-        assert!(!use_nerd_font());
-        // Reset for other tests
-        init_from_config(false);
-    }
+    // ── SessionStatus symbol tests ──────────────────────────────────────
 
     #[test]
     fn nerd_symbol_all_variants_are_nonempty() {
@@ -396,6 +206,7 @@ mod tests {
             (IssueOpened, "\u{f0766}"),
             (IssueClosed, "\u{f04d2}"),
             (Milestone, "\u{f0431}"),
+            (NeedsReview, "\u{f41b}"),
         ];
         for &(id, expected) in cases {
             assert_eq!(
@@ -422,6 +233,7 @@ mod tests {
             (Agents, "[U]"),
             (Cost, "$"),
             (Clock, "[T]"),
+            (NeedsReview, "[!]"),
         ];
         for &(id, expected) in cases {
             assert_eq!(
@@ -476,5 +288,61 @@ mod tests {
     fn icon_pair_returns_both_variants() {
         assert_eq!(get_for_mode(IconId::CheckCircle, true), "\u{f42e}");
         assert_eq!(get_for_mode(IconId::CheckCircle, false), "[+]");
+    }
+
+    // ── #308: SessionStatus delegates to icon registry ──────────────────
+
+    #[test]
+    fn nerd_symbol_delegates_to_icon_registry_for_all_variants() {
+        let cases: &[(SessionStatus, IconId)] = &[
+            (SessionStatus::Queued, IconId::Hourglass),
+            (SessionStatus::Spawning, IconId::Sync),
+            (SessionStatus::Running, IconId::Play),
+            (SessionStatus::Completed, IconId::CheckCircle),
+            (SessionStatus::GatesRunning, IconId::Search),
+            (SessionStatus::NeedsReview, IconId::NeedsReview),
+            (SessionStatus::Errored, IconId::XCircle),
+            (SessionStatus::Paused, IconId::Pause),
+            (SessionStatus::Killed, IconId::Skull),
+            (SessionStatus::Stalled, IconId::Alert),
+            (SessionStatus::Retrying, IconId::Refresh),
+            (SessionStatus::CiFix, IconId::Wrench),
+            (SessionStatus::NeedsPr, IconId::GitPr),
+            (SessionStatus::ConflictFix, IconId::GitMerge),
+        ];
+        for &(ref status, icon_id) in cases {
+            assert_eq!(
+                status.nerd_symbol(),
+                get_for_mode(icon_id, true),
+                "{status:?}.nerd_symbol() must equal registry get_for_mode({icon_id:?}, true)"
+            );
+        }
+    }
+
+    #[test]
+    fn ascii_symbol_queued_remains_q_not_registry_value() {
+        assert_eq!(SessionStatus::Queued.ascii_symbol(), "[Q]");
+        assert_ne!(SessionStatus::Queued.ascii_symbol(), "[~]");
+    }
+
+    #[test]
+    fn ascii_symbol_paused_remains_bracket_dash_not_registry_value() {
+        assert_eq!(SessionStatus::Paused.ascii_symbol(), "[-]");
+        assert_ne!(SessionStatus::Paused.ascii_symbol(), "[=]");
+    }
+
+    #[test]
+    fn symbol_reads_from_shared_icon_mode_not_local_atomic() {
+        use crate::icon_mode;
+        icon_mode::init_from_config(true); // ASCII
+        assert_eq!(
+            SessionStatus::Running.symbol(),
+            SessionStatus::Running.ascii_symbol()
+        );
+        icon_mode::init_from_config(false); // Nerd
+        assert_eq!(
+            SessionStatus::Running.symbol(),
+            SessionStatus::Running.nerd_symbol()
+        );
     }
 }

--- a/src/tui/screen_dispatch.rs
+++ b/src/tui/screen_dispatch.rs
@@ -174,8 +174,7 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
             crate::tui::background_tasks::spawn_version_check(app.data_tx.clone());
         }
         ScreenAction::UpdateConfig(config) => {
-            crate::session::types::SessionStatus::set_ascii_icons(config.tui.ascii_icons);
-            crate::tui::icons::init_from_config(config.tui.ascii_icons);
+            crate::icon_mode::init_from_config(config.tui.ascii_icons);
             app.config = Some(*config);
         }
         ScreenAction::PreviewTheme(theme_config) => {


### PR DESCRIPTION
## Summary

- Extract icon mode detection (`AtomicBool`, `init_from_config()`, `use_nerd_font()`) into shared `src/icon_mode.rs` module accessible from the lib crate
- Move icon registry (`IconId`, `IconPair`, `get()`, `get_for_mode()`) from `src/tui/icons.rs` into shared `src/icons.rs`, add `IconId::NeedsReview` variant
- `SessionStatus::nerd_symbol()` now delegates to the centralized registry via `icon_id()` mapping, eliminating 14 inline Nerd Font codepoints from `session/types.rs`
- Remove duplicated `AtomicBool` and `set_ascii_icons()` from `session/types.rs`, consolidate startup init to a single `icon_mode::init_from_config()` call

Closes #307
Closes #308

## Test plan

- [x] All 2384 tests pass (`cargo test -- --test-threads=1`)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [x] `grep -rn '\\u{f' src/session/types.rs` returns zero matches
- [x] No `set_ascii_icons` references remain
- [x] `MAESTRO_ASCII_ICONS=1` env var override still works
- [x] Single `init_from_config()` call at each startup path