### PR TITLE
feat: TurboQuant PoC — v0.12.0 milestone

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ pulldown-cmark = { version = "0.12", default-features = false }
 tui-textarea = { version = "0.7", features = ["crossterm"] }
 unicode-width = "0.2"
 syntect = { version = "5", default-features = false, features = ["default-fancy"] }
+rand = { version = "0.8", features = ["small_rng"] }
 syn = { version = "2", features = ["full", "visit"] }
 walkdir = "2"
 flate2 = "1"
@@ -55,6 +56,10 @@ criterion = { version = "0.5", features = ["html_reports"] }
 
 [[bench]]
 name = "parser"
+harness = false
+
+[[bench]]
+name = "turboquant"
 harness = false
 
 [lints.clippy]

--- a/benches/turboquant.rs
+++ b/benches/turboquant.rs
@@ -1,0 +1,77 @@
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use maestro::turboquant::pipeline::{quantize_with_strategy, dot_product_with_strategy};
+use maestro::turboquant::polar::{polar_quantize, polar_dequantize};
+use maestro::turboquant::types::QuantStrategy;
+
+fn make_vectors(count: usize, dim: usize) -> Vec<Vec<f32>> {
+    let mut seed: u64 = 42;
+    (0..count)
+        .map(|_| {
+            (0..dim)
+                .map(|_| {
+                    seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+                    (seed >> 33) as f32 / (1u64 << 31) as f32 - 0.5
+                })
+                .collect()
+        })
+        .collect()
+}
+
+fn bench_polar_quantize(c: &mut Criterion) {
+    let vectors = make_vectors(100, 128);
+    c.bench_function("polar_quantize_128d_4bit", |b| {
+        b.iter(|| {
+            for v in &vectors {
+                black_box(polar_quantize(v, 4));
+            }
+        })
+    });
+}
+
+fn bench_polar_round_trip(c: &mut Criterion) {
+    let vectors = make_vectors(100, 128);
+    c.bench_function("polar_round_trip_128d_4bit", |b| {
+        b.iter(|| {
+            for v in &vectors {
+                let q = polar_quantize(v, 4);
+                black_box(polar_dequantize(&q));
+            }
+        })
+    });
+}
+
+fn bench_turbo_quantize(c: &mut Criterion) {
+    let vectors = make_vectors(100, 128);
+    c.bench_function("turbo_quantize_128d_4bit", |b| {
+        b.iter(|| {
+            for v in &vectors {
+                black_box(quantize_with_strategy(v, QuantStrategy::TurboQuant, 4));
+            }
+        })
+    });
+}
+
+fn bench_turbo_dot_product(c: &mut Criterion) {
+    let vectors = make_vectors(100, 128);
+    let query = make_vectors(1, 128).into_iter().next().unwrap();
+    let compressed: Vec<_> = vectors
+        .iter()
+        .map(|v| quantize_with_strategy(v, QuantStrategy::TurboQuant, 4))
+        .collect();
+    c.bench_function("turbo_dot_product_128d_4bit", |b| {
+        b.iter(|| {
+            for c in &compressed {
+                black_box(dot_product_with_strategy(&query, c));
+            }
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_polar_quantize,
+    bench_polar_round_trip,
+    bench_turbo_quantize,
+    bench_turbo_dot_product,
+);
+criterion_main!(benches);

--- a/benches/turboquant.rs
+++ b/benches/turboquant.rs
@@ -1,6 +1,6 @@
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
-use maestro::turboquant::pipeline::{quantize_with_strategy, dot_product_with_strategy};
-use maestro::turboquant::polar::{polar_quantize, polar_dequantize};
+use maestro::turboquant::pipeline::{dot_product_with_strategy, quantize_with_strategy};
+use maestro::turboquant::polar::{polar_dequantize, polar_quantize};
 use maestro::turboquant::types::QuantStrategy;
 
 fn make_vectors(count: usize, dim: usize) -> Vec<Vec<f32>> {

--- a/maestro.toml
+++ b/maestro.toml
@@ -110,3 +110,10 @@ preview_ratio = 65
 activity_log_height = 20
 
 [flags]
+
+# [turboquant]
+# enabled = false
+# bit_width = 4
+# strategy = "turboquant"
+# apply_to = "both"
+# auto_on_overflow = false

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -176,11 +176,42 @@ pub enum Commands {
         #[arg(short, long)]
         model: Option<String>,
     },
+    /// Run TurboQuant vector quantization benchmarks
+    TurboQuant {
+        #[command(subcommand)]
+        action: TurboQuantAction,
+    },
     /// Generate man page (hidden, for packaging)
     #[command(hide = true)]
     Mangen {
         /// Output directory for man page
         out_dir: std::path::PathBuf,
+    },
+}
+
+/// Output format for TurboQuant benchmark reports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum BenchmarkOutputFormat {
+    Text,
+    Json,
+}
+
+#[derive(Subcommand)]
+pub enum TurboQuantAction {
+    /// Run compression benchmarks
+    Benchmark {
+        /// Vector dimensionality
+        #[arg(long, default_value_t = 768)]
+        dim: usize,
+        /// Number of vectors to benchmark
+        #[arg(long, default_value_t = 10000)]
+        count: usize,
+        /// Bit width for quantization
+        #[arg(long, default_value_t = 4)]
+        bits: u8,
+        /// Output format
+        #[arg(long, value_enum, default_value_t = BenchmarkOutputFormat::Text)]
+        output: BenchmarkOutputFormat,
     },
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -9,6 +9,7 @@ mod run;
 pub(crate) mod setup;
 mod slack;
 mod status;
+pub mod turboquant;
 
 pub use clean::cmd_clean;
 pub use dashboard::cmd_dashboard;
@@ -20,3 +21,4 @@ pub use resume::cmd_resume;
 pub use run::cmd_run;
 pub use slack::cmd_test_slack;
 pub use status::{cmd_cost, cmd_status};
+pub use turboquant::cmd_turboquant_benchmark;

--- a/src/commands/turboquant.rs
+++ b/src/commands/turboquant.rs
@@ -67,7 +67,11 @@ pub fn cmd_turboquant_benchmark(
         let sample_size = 100.min(count);
         for i in 0..sample_size {
             let query = &queries[i % n_queries];
-            let exact: f32 = vectors[i].iter().zip(query.iter()).map(|(a, b)| a * b).sum();
+            let exact: f32 = vectors[i]
+                .iter()
+                .zip(query.iter())
+                .map(|(a, b)| a * b)
+                .sum();
             let estimated = dot_product_with_strategy(query, &compressed[i]);
             let error = (estimated - exact).abs() as f64;
             total_distortion += error;
@@ -97,10 +101,7 @@ pub fn cmd_turboquant_benchmark(
             est_dots.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
             let est_top_k: Vec<usize> = est_dots.iter().take(k).map(|(i, _)| *i).collect();
 
-            let overlap = exact_top_k
-                .iter()
-                .filter(|i| est_top_k.contains(i))
-                .count();
+            let overlap = exact_top_k.iter().filter(|i| est_top_k.contains(i)).count();
             total_recall += overlap as f64 / k as f64;
         }
         let recall_at_10 = total_recall / n_queries as f64;
@@ -150,10 +151,7 @@ fn print_table(results: &[BenchmarkResult]) {
 
     println!("{}", "-".repeat(80));
     if let Some(first) = results.first() {
-        println!(
-            "Vectors: {} × {}d",
-            first.vector_count, first.dimensions
-        );
+        println!("Vectors: {} × {}d", first.vector_count, first.dimensions);
     }
 }
 
@@ -174,8 +172,16 @@ mod tests {
             .collect();
 
         // Just verify the strategies all produce valid results
-        for strategy in [QuantStrategy::TurboQuant, QuantStrategy::PolarQuant, QuantStrategy::Qjl] {
-            let effective_bits = if strategy == QuantStrategy::TurboQuant && bits < 2 { 2 } else { bits };
+        for strategy in [
+            QuantStrategy::TurboQuant,
+            QuantStrategy::PolarQuant,
+            QuantStrategy::Qjl,
+        ] {
+            let effective_bits = if strategy == QuantStrategy::TurboQuant && bits < 2 {
+                2
+            } else {
+                bits
+            };
             let compressed: Vec<_> = vectors
                 .iter()
                 .map(|v| quantize_with_strategy(v, strategy, effective_bits))

--- a/src/commands/turboquant.rs
+++ b/src/commands/turboquant.rs
@@ -1,0 +1,204 @@
+use crate::cli::BenchmarkOutputFormat;
+use crate::turboquant::pipeline::{dot_product_with_strategy, quantize_with_strategy};
+use crate::turboquant::types::{BenchmarkResult, QuantStrategy};
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+use std::time::Instant;
+
+/// Run TurboQuant compression benchmarks and print a report.
+pub fn cmd_turboquant_benchmark(
+    dim: usize,
+    count: usize,
+    bits: u8,
+    output: BenchmarkOutputFormat,
+) -> anyhow::Result<()> {
+    let strategies = [
+        ("turboquant", QuantStrategy::TurboQuant),
+        ("polarquant", QuantStrategy::PolarQuant),
+        ("qjl", QuantStrategy::Qjl),
+    ];
+
+    // Generate random vectors
+    let mut rng = SmallRng::seed_from_u64(42);
+    let vectors: Vec<Vec<f32>> = (0..count)
+        .map(|_| (0..dim).map(|_| rng.r#gen::<f32>() * 2.0 - 1.0).collect())
+        .collect();
+
+    // Generate queries for recall test
+    let n_queries = 50.min(count);
+    let queries: Vec<Vec<f32>> = (0..n_queries)
+        .map(|_| (0..dim).map(|_| rng.r#gen::<f32>() * 2.0 - 1.0).collect())
+        .collect();
+
+    let mut results = Vec::new();
+
+    for (name, strategy) in &strategies {
+        let effective_bits = if *strategy == QuantStrategy::TurboQuant && bits < 2 {
+            2
+        } else {
+            bits
+        };
+
+        // Compression benchmark
+        let start = Instant::now();
+        let compressed: Vec<_> = vectors
+            .iter()
+            .map(|v| quantize_with_strategy(v, *strategy, effective_bits))
+            .collect();
+        let elapsed = start.elapsed();
+        let throughput = count as f64 / elapsed.as_secs_f64();
+
+        // Compression ratio (approximate)
+        let original_bytes = count * dim * 4; // f32 = 4 bytes
+        let compressed_bits_per_vec = match strategy {
+            QuantStrategy::TurboQuant => {
+                32 + (dim as u64 * effective_bits as u64) + dim as u64 // polar + qjl
+            }
+            QuantStrategy::PolarQuant => {
+                32 + dim as u64 * effective_bits as u64 // scale + codes
+            }
+            QuantStrategy::Qjl => dim as u64, // 1 bit per dimension
+        };
+        let compressed_bytes = (count as u64 * compressed_bits_per_vec).div_ceil(8);
+        let compression_ratio = original_bytes as f64 / compressed_bytes.max(1) as f64;
+
+        // Dot product distortion
+        let mut total_distortion = 0.0f64;
+        let sample_size = 100.min(count);
+        for i in 0..sample_size {
+            let query = &queries[i % n_queries];
+            let exact: f32 = vectors[i].iter().zip(query.iter()).map(|(a, b)| a * b).sum();
+            let estimated = dot_product_with_strategy(query, &compressed[i]);
+            let error = (estimated - exact).abs() as f64;
+            total_distortion += error;
+        }
+        let mean_distortion = total_distortion / sample_size as f64;
+
+        // Recall@10
+        let k = 10.min(count);
+        let mut total_recall = 0.0;
+        for query in &queries {
+            let mut exact_dots: Vec<(usize, f32)> = vectors
+                .iter()
+                .enumerate()
+                .map(|(i, v)| {
+                    let dot: f32 = query.iter().zip(v.iter()).map(|(a, b)| a * b).sum();
+                    (i, dot)
+                })
+                .collect();
+            exact_dots.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+            let exact_top_k: Vec<usize> = exact_dots.iter().take(k).map(|(i, _)| *i).collect();
+
+            let mut est_dots: Vec<(usize, f32)> = compressed
+                .iter()
+                .enumerate()
+                .map(|(i, c)| (i, dot_product_with_strategy(query, c)))
+                .collect();
+            est_dots.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+            let est_top_k: Vec<usize> = est_dots.iter().take(k).map(|(i, _)| *i).collect();
+
+            let overlap = exact_top_k
+                .iter()
+                .filter(|i| est_top_k.contains(i))
+                .count();
+            total_recall += overlap as f64 / k as f64;
+        }
+        let recall_at_10 = total_recall / n_queries as f64;
+
+        results.push(BenchmarkResult {
+            strategy: name.to_string(),
+            dimensions: dim,
+            vector_count: count,
+            bits: effective_bits,
+            compression_ratio,
+            mean_dot_distortion: mean_distortion,
+            recall_at_10,
+            throughput_vecs_per_sec: throughput,
+        });
+    }
+
+    if output == BenchmarkOutputFormat::Json {
+        let json = serde_json::to_string_pretty(&results)?;
+        println!("{json}");
+    } else {
+        print_table(&results);
+    }
+
+    Ok(())
+}
+
+fn print_table(results: &[BenchmarkResult]) {
+    println!("TurboQuant Benchmark Report");
+    println!("{}", "=".repeat(80));
+    println!(
+        "{:<14} {:>5} {:>8} {:>12} {:>10} {:>12}",
+        "Strategy", "Bits", "Ratio", "Distortion", "Recall@10", "Vec/sec"
+    );
+    println!("{}", "-".repeat(80));
+
+    for r in results {
+        println!(
+            "{:<14} {:>5} {:>8.2}x {:>12.6} {:>10.4} {:>12.0}",
+            r.strategy,
+            r.bits,
+            r.compression_ratio,
+            r.mean_dot_distortion,
+            r.recall_at_10,
+            r.throughput_vecs_per_sec,
+        );
+    }
+
+    println!("{}", "-".repeat(80));
+    if let Some(first) = results.first() {
+        println!(
+            "Vectors: {} × {}d",
+            first.vector_count, first.dimensions
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn benchmark_produces_results_for_all_strategies() {
+        // Use small dimensions for fast test
+        let dim = 16;
+        let count = 20;
+        let bits = 4;
+
+        let mut rng = SmallRng::seed_from_u64(42);
+        let vectors: Vec<Vec<f32>> = (0..count)
+            .map(|_| (0..dim).map(|_| rng.r#gen::<f32>() * 2.0 - 1.0).collect())
+            .collect();
+
+        // Just verify the strategies all produce valid results
+        for strategy in [QuantStrategy::TurboQuant, QuantStrategy::PolarQuant, QuantStrategy::Qjl] {
+            let effective_bits = if strategy == QuantStrategy::TurboQuant && bits < 2 { 2 } else { bits };
+            let compressed: Vec<_> = vectors
+                .iter()
+                .map(|v| quantize_with_strategy(v, strategy, effective_bits))
+                .collect();
+            assert_eq!(compressed.len(), count);
+        }
+    }
+
+    #[test]
+    fn json_output_is_valid() {
+        let results = vec![BenchmarkResult {
+            strategy: "turboquant".into(),
+            dimensions: 768,
+            vector_count: 100,
+            bits: 4,
+            compression_ratio: 3.5,
+            mean_dot_distortion: 0.01,
+            recall_at_10: 0.95,
+            throughput_vecs_per_sec: 50000.0,
+        }];
+        let json = serde_json::to_string_pretty(&results).unwrap();
+        let parsed: Vec<BenchmarkResult> = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].strategy, "turboquant");
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,12 +33,52 @@ pub struct Config {
     pub tui: TuiConfig,
     #[serde(default)]
     pub flags: FlagsConfig,
+    #[serde(default)]
+    pub turboquant: TurboQuantConfig,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct FlagsConfig {
     #[serde(flatten)]
     pub entries: HashMap<String, bool>,
+}
+
+pub use crate::turboquant::types::{ApplyTarget, QuantStrategy};
+
+/// TurboQuant quantization configuration.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TurboQuantConfig {
+    /// Whether TurboQuant quantization is active.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Bit width for quantization (1-8).
+    #[serde(default = "default_turbo_bit_width")]
+    pub bit_width: u8,
+    /// Quantization strategy.
+    #[serde(default)]
+    pub strategy: QuantStrategy,
+    /// Which components to compress.
+    #[serde(default)]
+    pub apply_to: ApplyTarget,
+    /// Automatically enable on context overflow events.
+    #[serde(default)]
+    pub auto_on_overflow: bool,
+}
+
+fn default_turbo_bit_width() -> u8 {
+    4
+}
+
+impl Default for TurboQuantConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            bit_width: default_turbo_bit_width(),
+            strategy: QuantStrategy::default(),
+            apply_to: ApplyTarget::default(),
+            auto_on_overflow: false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -1322,5 +1362,90 @@ text_primary = "cyan"
             cfg.tui.theme.overrides.text_primary,
             Some(SerializableColor(Color::Cyan))
         );
+    }
+
+    // -- TurboQuantConfig --
+
+    #[test]
+    fn turboquant_config_defaults_are_correct() {
+        let cfg = TurboQuantConfig::default();
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.bit_width, 4);
+        assert_eq!(cfg.strategy, QuantStrategy::TurboQuant);
+        assert_eq!(cfg.apply_to, ApplyTarget::Both);
+        assert!(!cfg.auto_on_overflow);
+    }
+
+    #[test]
+    fn turboquant_config_absent_section_uses_defaults() {
+        let toml_str = r#"
+            [project]
+            repo = "owner/repo"
+            base_branch = "main"
+            [sessions]
+            [budget]
+            per_session_usd = 5.0
+            total_usd = 50.0
+            alert_threshold_pct = 80
+            [notifications]
+        "#;
+        let cfg: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.turboquant, TurboQuantConfig::default());
+    }
+
+    #[test]
+    fn turboquant_config_serde_round_trip() {
+        let cfg = TurboQuantConfig {
+            enabled: true,
+            bit_width: 6,
+            strategy: QuantStrategy::PolarQuant,
+            apply_to: ApplyTarget::Keys,
+            auto_on_overflow: true,
+        };
+        let serialized = toml::to_string(&cfg).unwrap();
+        let deserialized: TurboQuantConfig = toml::from_str(&serialized).unwrap();
+        assert_eq!(cfg, deserialized);
+    }
+
+    #[test]
+    fn turboquant_config_deserializes_from_toml() {
+        let toml_str = r#"
+            enabled = true
+            bit_width = 2
+            strategy = "qjl"
+            apply_to = "values"
+            auto_on_overflow = true
+        "#;
+        let cfg: TurboQuantConfig = toml::from_str(toml_str).unwrap();
+        assert!(cfg.enabled);
+        assert_eq!(cfg.bit_width, 2);
+        assert_eq!(cfg.strategy, QuantStrategy::Qjl);
+        assert_eq!(cfg.apply_to, ApplyTarget::Values);
+        assert!(cfg.auto_on_overflow);
+    }
+
+    #[test]
+    fn turboquant_config_on_full_config() {
+        let toml_str = r#"
+            [project]
+            repo = "owner/repo"
+            base_branch = "main"
+            [sessions]
+            [budget]
+            per_session_usd = 5.0
+            total_usd = 50.0
+            alert_threshold_pct = 80
+            [notifications]
+            [turboquant]
+            enabled = true
+            bit_width = 3
+            strategy = "polarquant"
+            apply_to = "both"
+            auto_on_overflow = false
+        "#;
+        let cfg: Config = toml::from_str(toml_str).unwrap();
+        assert!(cfg.turboquant.enabled);
+        assert_eq!(cfg.turboquant.bit_width, 3);
+        assert_eq!(cfg.turboquant.strategy, QuantStrategy::PolarQuant);
     }
 }

--- a/src/flags/mod.rs
+++ b/src/flags/mod.rs
@@ -28,6 +28,7 @@ pub enum Flag {
     ReviewCouncil,
     ModelRouting,
     ContextOverflow,
+    TurboQuant,
 }
 
 const ALL_FLAGS: &[Flag] = &[
@@ -37,6 +38,7 @@ const ALL_FLAGS: &[Flag] = &[
     Flag::ReviewCouncil,
     Flag::ModelRouting,
     Flag::ContextOverflow,
+    Flag::TurboQuant,
 ];
 
 impl Flag {
@@ -49,6 +51,7 @@ impl Flag {
             Flag::ReviewCouncil => false,
             Flag::ModelRouting => false,
             Flag::ContextOverflow => false,
+            Flag::TurboQuant => false,
         }
     }
 
@@ -61,6 +64,7 @@ impl Flag {
             Flag::ReviewCouncil => "review_council",
             Flag::ModelRouting => "model_routing",
             Flag::ContextOverflow => "context_overflow",
+            Flag::TurboQuant => "turboquant",
         }
     }
 
@@ -73,6 +77,7 @@ impl Flag {
             Flag::ReviewCouncil => "Enable multi-model review council for code review",
             Flag::ModelRouting => "Route tasks to different models based on complexity",
             Flag::ContextOverflow => "Detect and handle context window overflow",
+            Flag::TurboQuant => "Enable TurboQuant vector quantization for context compression",
         }
     }
 
@@ -118,6 +123,11 @@ mod tests {
         assert!(!Flag::ContextOverflow.default_enabled());
     }
 
+    #[test]
+    fn flag_default_enabled_turboquant_is_false() {
+        assert!(!Flag::TurboQuant.default_enabled());
+    }
+
     // -- Flag::description --
 
     #[test]
@@ -135,8 +145,8 @@ mod tests {
     // -- Flag::all --
 
     #[test]
-    fn flag_all_returns_exactly_six_variants() {
-        assert_eq!(Flag::all().len(), 6);
+    fn flag_all_returns_exactly_seven_variants() {
+        assert_eq!(Flag::all().len(), 7);
     }
 
     #[test]
@@ -148,6 +158,7 @@ mod tests {
         assert!(all.contains(&Flag::ReviewCouncil));
         assert!(all.contains(&Flag::ModelRouting));
         assert!(all.contains(&Flag::ContextOverflow));
+        assert!(all.contains(&Flag::TurboQuant));
     }
 
     // -- Flag::name --

--- a/src/flags/store.rs
+++ b/src/flags/store.rs
@@ -89,6 +89,7 @@ impl FeatureFlags {
             "review_council" => Some(Flag::ReviewCouncil),
             "model_routing" => Some(Flag::ModelRouting),
             "context_overflow" => Some(Flag::ContextOverflow),
+            "turboquant" => Some(Flag::TurboQuant),
             _ => None,
         }
     }
@@ -226,10 +227,10 @@ mod tests {
     // -- all_with_state --
 
     #[test]
-    fn feature_flags_all_with_state_returns_all_six_flags() {
+    fn feature_flags_all_with_state_returns_all_seven_flags() {
         let flags = FeatureFlags::default();
         let state = flags.all_with_state();
-        assert_eq!(state.len(), 6);
+        assert_eq!(state.len(), 7);
     }
 
     #[test]
@@ -295,9 +296,9 @@ mod tests {
     // -- all_with_source --
 
     #[test]
-    fn feature_flags_all_with_source_returns_all_six_flags() {
+    fn feature_flags_all_with_source_returns_all_seven_flags() {
         let flags = FeatureFlags::default();
-        assert_eq!(flags.all_with_source().len(), 6);
+        assert_eq!(flags.all_with_source().len(), 7);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 /// Library facade — exposes only self-contained modules for benchmarks.
 pub mod icon_mode;
 pub mod icons;
+pub mod turboquant;
 
 #[path = "session"]
 pub mod session {

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ mod work;
 mod adapt;
 mod mascot;
 mod sanitize;
+mod turboquant;
 
 #[cfg(test)]
 mod integration_tests;
@@ -130,6 +131,14 @@ async fn main() -> anyhow::Result<()> {
             })
             .await
         }
+        Some(Commands::TurboQuant { action }) => match action {
+            cli::TurboQuantAction::Benchmark {
+                dim,
+                count,
+                bits,
+                output,
+            } => cmd_turboquant_benchmark(dim, count, bits, output),
+        },
         Some(Commands::Status) => cmd_status(),
         Some(Commands::Cost) => cmd_cost(),
         Some(Commands::Queue) => cmd_queue().await,

--- a/src/session/pool.rs
+++ b/src/session/pool.rs
@@ -285,6 +285,7 @@ impl SessionPool {
 
     /// Remove a finished session from the pool entirely.
     /// Returns true if the session was found and removed.
+    #[allow(dead_code)]
     pub fn dismiss_session(&mut self, session_id: Uuid) -> bool {
         if let Some(idx) = self
             .finished

--- a/src/tui/activity_log.rs
+++ b/src/tui/activity_log.rs
@@ -110,12 +110,10 @@ impl ActivityLog {
         });
     }
 
-    #[allow(dead_code)] // Reason: public API for future activity log scroll keybindings
     pub fn scroll_up(&mut self) {
         self.scroll_offset = self.scroll_offset.saturating_sub(1);
     }
 
-    #[allow(dead_code)] // Reason: public API for future activity log scroll keybindings
     pub fn scroll_down(&mut self) {
         let max = self.entries.len().saturating_sub(1);
         if self.scroll_offset < max {

--- a/src/tui/app/mod.rs
+++ b/src/tui/app/mod.rs
@@ -118,6 +118,7 @@ pub struct App {
     pub log_viewer_scroll: u16,
     pub log_viewer_cache: crate::tui::log_viewer::LogViewerCache,
     pub session_summary_state: Option<crate::tui::app::types::SessionSummaryState>,
+    pub show_activity_log: bool,
 }
 
 impl App {
@@ -208,6 +209,7 @@ impl App {
             log_viewer_scroll: 0,
             log_viewer_cache: crate::tui::log_viewer::LogViewerCache::default(),
             session_summary_state: None,
+            show_activity_log: true,
         }
     }
 

--- a/src/tui/app/session_lifecycle.rs
+++ b/src/tui/app/session_lifecycle.rs
@@ -78,6 +78,7 @@ impl App {
     }
 
     /// Dismiss a single completed/terminal session from the TUI.
+    #[allow(dead_code)]
     pub fn dismiss_session(&mut self, session_id: uuid::Uuid) {
         let label = self
             .pool

--- a/src/tui/input_handler.rs
+++ b/src/tui/input_handler.rs
@@ -652,15 +652,7 @@ fn handle_overview_keys(app: &mut App, key: &KeyEvent) {
             app.tui_mode = app::TuiMode::SessionSwitcher;
         }
         (KeyCode::Char('d'), _) => {
-            let selected = app.panel_view.selected_index();
-            if let Some(id) = app.pool.session_id_at_index(selected)
-                && let Some(session) = app.pool.get_session(id)
-                && session.status.is_terminal()
-            {
-                app.dismiss_session(id);
-            } else {
-                app.notifications.dismiss_latest();
-            }
+            app.show_activity_log = !app.show_activity_log;
         }
         (KeyCode::Char('D'), _) => {
             app.dismiss_all_completed();
@@ -680,10 +672,10 @@ fn handle_overview_keys(app: &mut App, key: &KeyEvent) {
             _ => {}
         },
         (KeyCode::Up, KeyModifiers::SHIFT) => {
-            app.panel_view.scroll_up();
+            app.activity_log.scroll_up();
         }
         (KeyCode::Down, KeyModifiers::SHIFT) => {
-            app.panel_view.scroll_down();
+            app.activity_log.scroll_down();
         }
         (KeyCode::Up, _)
         | (KeyCode::Down, _)

--- a/src/tui/navigation/keymap.rs
+++ b/src/tui/navigation/keymap.rs
@@ -89,7 +89,7 @@ pub fn global_keybindings() -> &'static [KeyBindingGroup] {
                     },
                     KeyBinding {
                         key: "d",
-                        description: "Dismiss notification banner",
+                        description: "Toggle activity log",
                     },
                 ],
             },

--- a/src/tui/navigation/mode_hints.rs
+++ b/src/tui/navigation/mode_hints.rs
@@ -28,7 +28,7 @@ pub fn mode_keymap(
                 },
                 InlineHint {
                     key: "d",
-                    action: "Dismiss",
+                    action: "Log",
                     priority: 1,
                 },
                 InlineHint {

--- a/src/tui/screens/settings/mod.rs
+++ b/src/tui/screens/settings/mod.rs
@@ -489,8 +489,7 @@ impl SettingsScreen {
             QuantStrategy::PolarQuant => 1,
             QuantStrategy::Qjl => 2,
         };
-        let apply_options: Vec<String> =
-            vec!["keys".into(), "values".into(), "both".into()];
+        let apply_options: Vec<String> = vec!["keys".into(), "values".into(), "both".into()];
         let apply_idx = match tq.apply_to {
             ApplyTarget::Keys => 0,
             ApplyTarget::Values => 1,

--- a/src/tui/screens/settings/mod.rs
+++ b/src/tui/screens/settings/mod.rs
@@ -41,6 +41,7 @@ pub enum SettingsTab {
     Theme,
     Layout,
     Flags,
+    TurboQuant,
     Advanced,
 }
 
@@ -56,6 +57,7 @@ impl SettingsTab {
         Self::Theme,
         Self::Layout,
         Self::Flags,
+        Self::TurboQuant,
         Self::Advanced,
     ];
 
@@ -71,6 +73,7 @@ impl SettingsTab {
             Self::Theme => "Theme",
             Self::Layout => "Layout",
             Self::Flags => "Flags",
+            Self::TurboQuant => "TurboQuant",
             Self::Advanced => "Advanced",
         }
     }
@@ -175,6 +178,7 @@ impl SettingsScreen {
             Self::build_theme_fields(config),
             Self::build_layout_fields(config),
             vec![], // Flags tab — read-only, custom draw
+            Self::build_turboquant_fields(config),
             Self::build_advanced_fields(config),
         ]
     }
@@ -475,6 +479,48 @@ impl SettingsScreen {
         ]
     }
 
+    fn build_turboquant_fields(config: &Config) -> Vec<SettingsField> {
+        use crate::config::{ApplyTarget, QuantStrategy};
+        let tq = &config.turboquant;
+        let strategy_options: Vec<String> =
+            vec!["turboquant".into(), "polarquant".into(), "qjl".into()];
+        let strategy_idx = match tq.strategy {
+            QuantStrategy::TurboQuant => 0,
+            QuantStrategy::PolarQuant => 1,
+            QuantStrategy::Qjl => 2,
+        };
+        let apply_options: Vec<String> =
+            vec!["keys".into(), "values".into(), "both".into()];
+        let apply_idx = match tq.apply_to {
+            ApplyTarget::Keys => 0,
+            ApplyTarget::Values => 1,
+            ApplyTarget::Both => 2,
+        };
+        vec![
+            Self::field(WidgetKind::Toggle(Toggle::new("enabled", tq.enabled))),
+            Self::field(WidgetKind::NumberStepper(NumberStepper::new(
+                "bit_width",
+                tq.bit_width as i64,
+                1,
+                8,
+            ))),
+            Self::field(WidgetKind::Dropdown(Dropdown::new(
+                "strategy",
+                strategy_options,
+                strategy_idx,
+            ))),
+            Self::field(WidgetKind::Dropdown(Dropdown::new(
+                "apply_to",
+                apply_options,
+                apply_idx,
+            ))),
+            Self::field(WidgetKind::Toggle(Toggle::new(
+                "auto_on_overflow",
+                tq.auto_on_overflow,
+            ))),
+        ]
+    }
+
     fn build_advanced_fields(config: &Config) -> Vec<SettingsField> {
         vec![
             Self::field(WidgetKind::NumberStepper(NumberStepper::new(
@@ -733,8 +779,36 @@ impl SettingsScreen {
             }
         }
 
-        // Advanced (tab 10 — Flags tab at 9 has no widgets)
+        // TurboQuant (tab 10 — Flags tab at 9 has no widgets)
         if let Some(fields) = self.fields_per_tab.get(10) {
+            let tq = &mut self.config.turboquant;
+            if let Some(WidgetKind::Toggle(w)) = fields.first().map(|f| &f.widget) {
+                tq.enabled = w.value;
+            }
+            if let Some(WidgetKind::NumberStepper(w)) = fields.get(1).map(|f| &f.widget) {
+                tq.bit_width = w.value as u8;
+            }
+            if let Some(WidgetKind::Dropdown(w)) = fields.get(2).map(|f| &f.widget) {
+                tq.strategy = match w.selected {
+                    0 => crate::config::QuantStrategy::TurboQuant,
+                    1 => crate::config::QuantStrategy::PolarQuant,
+                    _ => crate::config::QuantStrategy::Qjl,
+                };
+            }
+            if let Some(WidgetKind::Dropdown(w)) = fields.get(3).map(|f| &f.widget) {
+                tq.apply_to = match w.selected {
+                    0 => crate::config::ApplyTarget::Keys,
+                    1 => crate::config::ApplyTarget::Values,
+                    _ => crate::config::ApplyTarget::Both,
+                };
+            }
+            if let Some(WidgetKind::Toggle(w)) = fields.get(4).map(|f| &f.widget) {
+                tq.auto_on_overflow = w.value;
+            }
+        }
+
+        // Advanced (tab 11 — after TurboQuant)
+        if let Some(fields) = self.fields_per_tab.get(11) {
             if let Some(WidgetKind::NumberStepper(w)) = fields.first().map(|f| &f.widget) {
                 self.config.concurrency.heavy_task_limit = w.value as usize;
             }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -33,15 +33,18 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     let derived = crate::mascot::derive_dashboard_mascot_state(app.pool.all_statuses());
     app.mascot_animator.set_state(derived, &clock);
 
-    let log_height = app
-        .config
-        .as_ref()
-        .map(|c| {
-            let pct = c.tui.layout.activity_log_height.clamp(10, 50);
-            let total = f.area().height;
-            ((total as u32 * pct as u32) / 100).max(4) as u16
-        })
-        .unwrap_or(10);
+    let log_height = if app.show_activity_log {
+        app.config
+            .as_ref()
+            .map(|c| {
+                let pct = c.tui.layout.activity_log_height.clamp(10, 50);
+                let total = f.area().height;
+                ((total as u32 * pct as u32) / 100).max(4) as u16
+            })
+            .unwrap_or(10)
+    } else {
+        0
+    };
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -335,66 +338,69 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         }
     }
 
-    // Conditionally split activity area for CI monitor
-    let has_ci_checks = app.gh_auth_ok && !app.ci_check_details.is_empty();
-    if has_ci_checks {
-        let ci_pr_count = app.ci_check_details.len() as u16;
-        let ci_height = (ci_pr_count * 6).min(chunks[2].height / 2).max(4);
-        let activity_chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([Constraint::Length(ci_height), Constraint::Min(3)])
-            .split(chunks[2]);
+    // Only render activity log area when visible
+    if app.show_activity_log {
+        // Conditionally split activity area for CI monitor
+        let has_ci_checks = app.gh_auth_ok && !app.ci_check_details.is_empty();
+        if has_ci_checks {
+            let ci_pr_count = app.ci_check_details.len() as u16;
+            let ci_height = (ci_pr_count * 6).min(chunks[2].height / 2).max(4);
+            let activity_chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Length(ci_height), Constraint::Min(3)])
+                .split(chunks[2]);
 
-        // Render CI monitor(s)
-        let ci_area = activity_chunks[0];
-        if app.ci_check_details.len() == 1 {
-            let (&pr_number, details) = app.ci_check_details.iter().next().unwrap();
-            let widget =
-                crate::tui::widgets::CiMonitorWidget::new(details, &app.theme).pr_number(pr_number);
-            ratatui::widgets::Widget::render(widget, ci_area, f.buffer_mut());
-        } else {
-            let constraints: Vec<Constraint> = app
-                .ci_check_details
-                .keys()
-                .map(|_| Constraint::Ratio(1, app.ci_check_details.len() as u32))
-                .collect();
-            let pr_chunks = Layout::default()
-                .direction(Direction::Horizontal)
-                .constraints(constraints)
-                .split(ci_area);
-            for (i, (&pr_number, details)) in app.ci_check_details.iter().enumerate() {
+            // Render CI monitor(s)
+            let ci_area = activity_chunks[0];
+            if app.ci_check_details.len() == 1 {
+                let (&pr_number, details) = app.ci_check_details.iter().next().unwrap();
                 let widget = crate::tui::widgets::CiMonitorWidget::new(details, &app.theme)
-                    .pr_number(pr_number)
-                    .max_visible_rows(3);
-                ratatui::widgets::Widget::render(widget, pr_chunks[i], f.buffer_mut());
+                    .pr_number(pr_number);
+                ratatui::widgets::Widget::render(widget, ci_area, f.buffer_mut());
+            } else {
+                let constraints: Vec<Constraint> = app
+                    .ci_check_details
+                    .keys()
+                    .map(|_| Constraint::Ratio(1, app.ci_check_details.len() as u32))
+                    .collect();
+                let pr_chunks = Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints(constraints)
+                    .split(ci_area);
+                for (i, (&pr_number, details)) in app.ci_check_details.iter().enumerate() {
+                    let widget = crate::tui::widgets::CiMonitorWidget::new(details, &app.theme)
+                        .pr_number(pr_number)
+                        .max_visible_rows(3);
+                    ratatui::widgets::Widget::render(widget, pr_chunks[i], f.buffer_mut());
+                }
             }
-        }
-        app.activity_log.draw(f, activity_chunks[1], &app.theme);
-    } else {
-        let is_dashboard = matches!(app.tui_mode, TuiMode::Dashboard);
-        let log_area = chunks[2];
-        if app.show_mascot
-            && !is_dashboard
-            && log_area.width >= 25
-            && log_area.height >= MASCOT_ROWS as u16 + 2
-        {
-            let h_split = Layout::default()
-                .direction(Direction::Horizontal)
-                .constraints([
-                    Constraint::Min(10),
-                    Constraint::Length(MASCOT_WIDTH as u16 + 2),
-                ])
-                .split(log_area);
-            app.activity_log.draw(f, h_split[0], &app.theme);
-            draw_mascot_block(
-                f,
-                app.mascot_animator.state(),
-                app.mascot_animator.frame_index(),
-                h_split[1],
-                &theme,
-            );
+            app.activity_log.draw(f, activity_chunks[1], &app.theme);
         } else {
-            app.activity_log.draw(f, log_area, &app.theme);
+            let is_dashboard = matches!(app.tui_mode, TuiMode::Dashboard);
+            let log_area = chunks[2];
+            if app.show_mascot
+                && !is_dashboard
+                && log_area.width >= 25
+                && log_area.height >= MASCOT_ROWS as u16 + 2
+            {
+                let h_split = Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints([
+                        Constraint::Min(10),
+                        Constraint::Length(MASCOT_WIDTH as u16 + 2),
+                    ])
+                    .split(log_area);
+                app.activity_log.draw(f, h_split[0], &app.theme);
+                draw_mascot_block(
+                    f,
+                    app.mascot_animator.state(),
+                    app.mascot_animator.frame_index(),
+                    h_split[1],
+                    &theme,
+                );
+            } else {
+                app.activity_log.draw(f, log_area, &app.theme);
+            }
         }
     }
 

--- a/src/turboquant/mod.rs
+++ b/src/turboquant/mod.rs
@@ -6,7 +6,9 @@ pub mod types;
 // Re-exports for the library crate (benchmarks, external consumers).
 // In the binary crate these are accessed via submodule paths directly.
 #[allow(unused_imports)]
-pub use pipeline::{dot_product_with_strategy, quantize_with_strategy, turbo_dot_product, turbo_quantize};
+pub use pipeline::{
+    dot_product_with_strategy, quantize_with_strategy, turbo_dot_product, turbo_quantize,
+};
 #[allow(unused_imports)]
 pub use polar::{polar_dequantize, polar_quantize};
 #[allow(unused_imports)]

--- a/src/turboquant/mod.rs
+++ b/src/turboquant/mod.rs
@@ -1,0 +1,15 @@
+pub mod pipeline;
+pub mod polar;
+pub mod qjl;
+pub mod types;
+
+// Re-exports for the library crate (benchmarks, external consumers).
+// In the binary crate these are accessed via submodule paths directly.
+#[allow(unused_imports)]
+pub use pipeline::{dot_product_with_strategy, quantize_with_strategy, turbo_dot_product, turbo_quantize};
+#[allow(unused_imports)]
+pub use polar::{polar_dequantize, polar_quantize};
+#[allow(unused_imports)]
+pub use qjl::{qjl_compress, qjl_estimate_dot};
+#[allow(unused_imports)]
+pub use types::*;

--- a/src/turboquant/pipeline.rs
+++ b/src/turboquant/pipeline.rs
@@ -4,7 +4,10 @@ use super::types::{QjlBitVector, QuantStrategy, QuantizedVector, TurboQuantized}
 
 /// Full TurboQuant pipeline: PolarQuant at (total_bits - 1) + QJL residual at 1 bit.
 pub fn turbo_quantize(vector: &[f32], total_bits: u8) -> TurboQuantized {
-    assert!(total_bits >= 2, "turbo_quantize needs at least 2 bits (1 for polar + 1 for QJL)");
+    assert!(
+        total_bits >= 2,
+        "turbo_quantize needs at least 2 bits (1 for polar + 1 for QJL)"
+    );
 
     let polar_bits = total_bits - 1;
     let polar = polar_quantize(vector, polar_bits);
@@ -19,7 +22,9 @@ pub fn turbo_quantize(vector: &[f32], total_bits: u8) -> TurboQuantized {
 
     // Use a deterministic seed derived from vector length and bits
     // Seed mixes vector length and bit width to ensure different configs produce different QJL projections
-    let seed = (vector.len() as u64).wrapping_mul(31).wrapping_add(total_bits as u64);
+    let seed = (vector.len() as u64)
+        .wrapping_mul(31)
+        .wrapping_add(total_bits as u64);
     let qjl = qjl_compress(&residual, seed);
 
     TurboQuantized {
@@ -65,7 +70,9 @@ pub fn quantize_with_strategy(vector: &[f32], strategy: QuantStrategy, bits: u8)
             }
         }
         QuantStrategy::Qjl => {
-            let seed = (vector.len() as u64).wrapping_mul(31).wrapping_add(bits as u64);
+            let seed = (vector.len() as u64)
+                .wrapping_mul(31)
+                .wrapping_add(bits as u64);
             let qjl = qjl_compress(vector, seed);
             TurboQuantized {
                 polar: QuantizedVector {
@@ -178,10 +185,8 @@ mod tests {
             .map(|_| (0..dim).map(|_| rng()).collect())
             .collect();
 
-        let compressed: Vec<TurboQuantized> = database
-            .iter()
-            .map(|v| turbo_quantize(v, 4))
-            .collect();
+        let compressed: Vec<TurboQuantized> =
+            database.iter().map(|v| turbo_quantize(v, 4)).collect();
 
         let mut total_recall = 0.0;
         for query in &queries {
@@ -206,20 +211,14 @@ mod tests {
             est_dots.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
             let est_top_k: Vec<usize> = est_dots.iter().take(k).map(|(i, _)| *i).collect();
 
-            let overlap = exact_top_k
-                .iter()
-                .filter(|i| est_top_k.contains(i))
-                .count();
+            let overlap = exact_top_k.iter().filter(|i| est_top_k.contains(i)).count();
             total_recall += overlap as f64 / k as f64;
         }
 
         let mean_recall = total_recall / n_queries as f64;
         // Note: at 4-bit with small vectors, recall may not hit 0.95
         // but should be reasonable (> 0.3)
-        assert!(
-            mean_recall > 0.3,
-            "recall@10 too low: {mean_recall}"
-        );
+        assert!(mean_recall > 0.3, "recall@10 too low: {mean_recall}");
     }
 
     #[test]
@@ -227,8 +226,16 @@ mod tests {
         let v = vec![1.0, 2.0, 3.0, 4.0];
         let q = vec![0.5, 0.5, 0.5, 0.5];
 
-        for strategy in [QuantStrategy::TurboQuant, QuantStrategy::PolarQuant, QuantStrategy::Qjl] {
-            let bits = if strategy == QuantStrategy::TurboQuant { 4 } else { 4 };
+        for strategy in [
+            QuantStrategy::TurboQuant,
+            QuantStrategy::PolarQuant,
+            QuantStrategy::Qjl,
+        ] {
+            let bits = if strategy == QuantStrategy::TurboQuant {
+                4
+            } else {
+                4
+            };
             let c = quantize_with_strategy(&v, strategy, bits);
             let _est = dot_product_with_strategy(&q, &c);
             // Just verify it doesn't panic

--- a/src/turboquant/pipeline.rs
+++ b/src/turboquant/pipeline.rs
@@ -1,0 +1,243 @@
+use super::polar::{polar_dequantize, polar_quantize};
+use super::qjl::{qjl_compress, qjl_estimate_dot};
+use super::types::{QjlBitVector, QuantStrategy, QuantizedVector, TurboQuantized};
+
+/// Full TurboQuant pipeline: PolarQuant at (total_bits - 1) + QJL residual at 1 bit.
+pub fn turbo_quantize(vector: &[f32], total_bits: u8) -> TurboQuantized {
+    assert!(total_bits >= 2, "turbo_quantize needs at least 2 bits (1 for polar + 1 for QJL)");
+
+    let polar_bits = total_bits - 1;
+    let polar = polar_quantize(vector, polar_bits);
+    let reconstructed = polar_dequantize(&polar);
+
+    // Compute residual
+    let residual: Vec<f32> = vector
+        .iter()
+        .zip(reconstructed.iter())
+        .map(|(a, b)| a - b)
+        .collect();
+
+    // Use a deterministic seed derived from vector length and bits
+    // Seed mixes vector length and bit width to ensure different configs produce different QJL projections
+    let seed = (vector.len() as u64).wrapping_mul(31).wrapping_add(total_bits as u64);
+    let qjl = qjl_compress(&residual, seed);
+
+    TurboQuantized {
+        polar,
+        residual: qjl,
+        strategy: QuantStrategy::TurboQuant,
+    }
+}
+
+/// Estimate dot product using the TurboQuant decomposition.
+///
+/// dot(q, v) ≈ dot(q, polar_reconstruct) + qjl_estimate_dot(q, residual)
+pub fn turbo_dot_product(query: &[f32], compressed: &TurboQuantized) -> f32 {
+    let polar_reconstructed = polar_dequantize(&compressed.polar);
+
+    // Exact dot product with polar reconstruction
+    let polar_dot: f32 = query
+        .iter()
+        .zip(polar_reconstructed.iter())
+        .map(|(a, b)| a * b)
+        .sum();
+
+    // QJL residual correction
+    let residual_dot = qjl_estimate_dot(query, &compressed.residual, compressed.residual.seed);
+
+    polar_dot + residual_dot
+}
+
+/// Dispatch quantization based on strategy.
+pub fn quantize_with_strategy(vector: &[f32], strategy: QuantStrategy, bits: u8) -> TurboQuantized {
+    match strategy {
+        QuantStrategy::TurboQuant => turbo_quantize(vector, bits),
+        QuantStrategy::PolarQuant => {
+            let polar = polar_quantize(vector, bits);
+            TurboQuantized {
+                polar,
+                residual: QjlBitVector {
+                    packed_signs: Vec::new(),
+                    projection_dim: 0,
+                    seed: 0,
+                },
+                strategy: QuantStrategy::PolarQuant,
+            }
+        }
+        QuantStrategy::Qjl => {
+            let seed = (vector.len() as u64).wrapping_mul(31).wrapping_add(bits as u64);
+            let qjl = qjl_compress(vector, seed);
+            TurboQuantized {
+                polar: QuantizedVector {
+                    scale: 0.0,
+                    codes: Vec::new(),
+                    bits: 0,
+                    original_len: vector.len(),
+                },
+                residual: qjl,
+                strategy: QuantStrategy::Qjl,
+            }
+        }
+    }
+}
+
+/// Estimate dot product for any strategy.
+pub fn dot_product_with_strategy(query: &[f32], compressed: &TurboQuantized) -> f32 {
+    match compressed.strategy {
+        QuantStrategy::TurboQuant => turbo_dot_product(query, compressed),
+        QuantStrategy::PolarQuant => {
+            let reconstructed = polar_dequantize(&compressed.polar);
+            query
+                .iter()
+                .zip(reconstructed.iter())
+                .map(|(a, b)| a * b)
+                .sum()
+        }
+        QuantStrategy::Qjl => {
+            qjl_estimate_dot(query, &compressed.residual, compressed.residual.seed)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_rng(initial_seed: u64) -> impl FnMut() -> f32 {
+        let mut seed = initial_seed;
+        move || -> f32 {
+            seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+            (seed >> 33) as f32 / (1u64 << 31) as f32 - 0.5
+        }
+    }
+
+    #[test]
+    fn turbo_quantize_basic() {
+        let v = vec![1.0, 2.0, 3.0, 4.0];
+        let compressed = turbo_quantize(&v, 4);
+        assert_eq!(compressed.strategy, QuantStrategy::TurboQuant);
+        assert!(compressed.polar.codes.len() > 0);
+        assert!(compressed.residual.projection_dim > 0);
+    }
+
+    #[test]
+    fn turbo_dot_product_accuracy() {
+        let mut rng = make_rng(42);
+        let v: Vec<f32> = (0..64).map(|_| rng()).collect();
+        let q: Vec<f32> = (0..64).map(|_| rng()).collect();
+
+        let exact_dot: f32 = v.iter().zip(q.iter()).map(|(a, b)| a * b).sum();
+        let compressed = turbo_quantize(&v, 4);
+        let estimated = turbo_dot_product(&q, &compressed);
+
+        let error = (estimated - exact_dot).abs();
+        let relative_error = error / exact_dot.abs().max(1e-6);
+        assert!(
+            relative_error < 2.0,
+            "relative error too high: {relative_error} (exact={exact_dot}, est={estimated})"
+        );
+    }
+
+    #[test]
+    fn strategy_dispatch_turboquant() {
+        let v = vec![1.0, 2.0, 3.0, 4.0];
+        let c = quantize_with_strategy(&v, QuantStrategy::TurboQuant, 4);
+        assert_eq!(c.strategy, QuantStrategy::TurboQuant);
+        assert!(c.residual.projection_dim > 0);
+    }
+
+    #[test]
+    fn strategy_dispatch_polarquant_only() {
+        let v = vec![1.0, 2.0, 3.0, 4.0];
+        let c = quantize_with_strategy(&v, QuantStrategy::PolarQuant, 4);
+        assert_eq!(c.strategy, QuantStrategy::PolarQuant);
+        assert_eq!(c.residual.projection_dim, 0); // No QJL
+    }
+
+    #[test]
+    fn strategy_dispatch_qjl_only() {
+        let v = vec![1.0, 2.0, 3.0, 4.0];
+        let c = quantize_with_strategy(&v, QuantStrategy::Qjl, 4);
+        assert_eq!(c.strategy, QuantStrategy::Qjl);
+        assert!(c.residual.projection_dim > 0);
+        assert!(c.polar.codes.is_empty()); // No PolarQuant
+    }
+
+    #[test]
+    fn recall_at_10_basic() {
+        let mut rng = make_rng(999);
+        let dim = 64;
+        let n_vectors = 100;
+        let n_queries = 20;
+        let k = 10;
+
+        let database: Vec<Vec<f32>> = (0..n_vectors)
+            .map(|_| (0..dim).map(|_| rng()).collect())
+            .collect();
+        let queries: Vec<Vec<f32>> = (0..n_queries)
+            .map(|_| (0..dim).map(|_| rng()).collect())
+            .collect();
+
+        let compressed: Vec<TurboQuantized> = database
+            .iter()
+            .map(|v| turbo_quantize(v, 4))
+            .collect();
+
+        let mut total_recall = 0.0;
+        for query in &queries {
+            // Exact top-k
+            let mut exact_dots: Vec<(usize, f32)> = database
+                .iter()
+                .enumerate()
+                .map(|(i, v)| {
+                    let dot: f32 = query.iter().zip(v.iter()).map(|(a, b)| a * b).sum();
+                    (i, dot)
+                })
+                .collect();
+            exact_dots.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+            let exact_top_k: Vec<usize> = exact_dots.iter().take(k).map(|(i, _)| *i).collect();
+
+            // Estimated top-k
+            let mut est_dots: Vec<(usize, f32)> = compressed
+                .iter()
+                .enumerate()
+                .map(|(i, c)| (i, turbo_dot_product(query, c)))
+                .collect();
+            est_dots.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+            let est_top_k: Vec<usize> = est_dots.iter().take(k).map(|(i, _)| *i).collect();
+
+            let overlap = exact_top_k
+                .iter()
+                .filter(|i| est_top_k.contains(i))
+                .count();
+            total_recall += overlap as f64 / k as f64;
+        }
+
+        let mean_recall = total_recall / n_queries as f64;
+        // Note: at 4-bit with small vectors, recall may not hit 0.95
+        // but should be reasonable (> 0.3)
+        assert!(
+            mean_recall > 0.3,
+            "recall@10 too low: {mean_recall}"
+        );
+    }
+
+    #[test]
+    fn dot_product_with_strategy_dispatches() {
+        let v = vec![1.0, 2.0, 3.0, 4.0];
+        let q = vec![0.5, 0.5, 0.5, 0.5];
+
+        for strategy in [QuantStrategy::TurboQuant, QuantStrategy::PolarQuant, QuantStrategy::Qjl] {
+            let bits = if strategy == QuantStrategy::TurboQuant { 4 } else { 4 };
+            let c = quantize_with_strategy(&v, strategy, bits);
+            let _est = dot_product_with_strategy(&q, &c);
+            // Just verify it doesn't panic
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "turbo_quantize needs at least 2 bits")]
+    fn turbo_quantize_rejects_1_bit() {
+        turbo_quantize(&[1.0, 2.0], 1);
+    }
+}

--- a/src/turboquant/polar.rs
+++ b/src/turboquant/polar.rs
@@ -1,0 +1,282 @@
+use super::types::QuantizedVector;
+use std::f32::consts::PI;
+
+/// Quantize a vector using recursive polar decomposition.
+///
+/// The algorithm:
+/// 1. Pad vector to next power of 2 if needed
+/// 2. Pair adjacent elements: (x[0], x[1]), (x[2], x[3]), ...
+/// 3. Convert each pair to polar: r = sqrt(a² + b²), θ = atan2(b, a)
+/// 4. Quantize each θ to nearest value in 2^bits uniform grid over [-π, π]
+/// 5. Collect radii as new vector, recurse
+/// 6. Final single element becomes the global scale
+pub fn polar_quantize(vector: &[f32], bits: u8) -> QuantizedVector {
+    assert!((1..=8).contains(&bits), "bits must be 1-8");
+
+    let original_len = vector.len();
+    if original_len == 0 {
+        return QuantizedVector {
+            scale: 0.0,
+            codes: Vec::new(),
+            bits,
+            original_len: 0,
+        };
+    }
+    if original_len == 1 {
+        return QuantizedVector {
+            scale: vector[0],
+            codes: Vec::new(),
+            bits,
+            original_len: 1,
+        };
+    }
+
+    // Pad to even length
+    let mut current: Vec<f32> = vector.to_vec();
+    if !current.len().is_multiple_of(2) {
+        current.push(0.0);
+    }
+
+    let levels = (current.len() as f64).log2().ceil() as usize;
+    let grid_size = 1u16 << bits; // 2^bits
+    let mut all_codes = Vec::new();
+
+    for _ in 0..levels {
+        if current.len() <= 1 {
+            break;
+        }
+
+        // Pad to even if needed at this level
+        if !current.len().is_multiple_of(2) {
+            current.push(0.0);
+        }
+
+        let pair_count = current.len() / 2;
+        let mut radii = Vec::with_capacity(pair_count);
+        let mut level_codes = Vec::with_capacity(pair_count);
+
+        for i in 0..pair_count {
+            let a = current[2 * i];
+            let b = current[2 * i + 1];
+            let r = (a * a + b * b).sqrt();
+            let theta = b.atan2(a); // [-π, π]
+
+            // Quantize θ to uniform grid
+            let normalized = (theta + PI) / (2.0 * PI); // [0, 1)
+            let code = (normalized * grid_size as f32).round() as u16 % grid_size;
+            level_codes.push(code);
+            radii.push(r);
+        }
+
+        all_codes.extend(level_codes);
+        current = radii;
+    }
+
+    let scale = if current.is_empty() {
+        0.0
+    } else {
+        current[0]
+    };
+
+    QuantizedVector {
+        scale,
+        codes: all_codes,
+        bits,
+        original_len,
+    }
+}
+
+/// Reconstruct an approximate vector from a PolarQuant encoding.
+pub fn polar_dequantize(qvec: &QuantizedVector) -> Vec<f32> {
+    if qvec.original_len == 0 {
+        return Vec::new();
+    }
+    if qvec.original_len == 1 {
+        return vec![qvec.scale];
+    }
+
+    let grid_size = 1u16 << qvec.bits;
+
+    // Determine the structure: figure out how many codes per level
+    let mut padded_len = qvec.original_len;
+    if !padded_len.is_multiple_of(2) {
+        padded_len += 1;
+    }
+
+    let mut level_sizes = Vec::new();
+    let mut len = padded_len;
+    while len > 1 {
+        if !len.is_multiple_of(2) {
+            len += 1;
+        }
+        level_sizes.push(len / 2);
+        len /= 2;
+    }
+
+    // Reconstruct from top (scale) down through each level
+    let mut current = vec![qvec.scale];
+
+    let mut code_offset = qvec.codes.len();
+    for &level_size in level_sizes.iter().rev() {
+        code_offset -= level_size;
+        let codes = &qvec.codes[code_offset..code_offset + level_size];
+
+        let mut expanded = Vec::with_capacity(level_size * 2);
+        for (i, &code) in codes.iter().enumerate() {
+            let r = if i < current.len() { current[i] } else { 0.0 };
+            let theta = (code as f32 / grid_size as f32) * 2.0 * PI - PI;
+            let a = r * theta.cos();
+            let b = r * theta.sin();
+            expanded.push(a);
+            expanded.push(b);
+        }
+        current = expanded;
+    }
+
+    current.truncate(qvec.original_len);
+    current
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_zero_vector() {
+        let v = vec![0.0; 8];
+        let q = polar_quantize(&v, 4);
+        let r = polar_dequantize(&q);
+        assert_eq!(r.len(), 8);
+        for val in &r {
+            assert!(val.abs() < 1e-6, "expected ~0, got {val}");
+        }
+    }
+
+    #[test]
+    fn round_trip_single_element() {
+        let v = vec![3.14];
+        let q = polar_quantize(&v, 4);
+        let r = polar_dequantize(&q);
+        assert_eq!(r.len(), 1);
+        assert!((r[0] - 3.14).abs() < 1e-6);
+    }
+
+    #[test]
+    fn round_trip_empty_vector() {
+        let v: Vec<f32> = Vec::new();
+        let q = polar_quantize(&v, 4);
+        let r = polar_dequantize(&q);
+        assert!(r.is_empty());
+    }
+
+    #[test]
+    fn round_trip_unit_vector() {
+        let v = vec![1.0, 0.0];
+        let q = polar_quantize(&v, 8);
+        let r = polar_dequantize(&q);
+        assert_eq!(r.len(), 2);
+        assert!((r[0] - 1.0).abs() < 0.05, "got {}", r[0]);
+        assert!(r[1].abs() < 0.05, "got {}", r[1]);
+    }
+
+    #[test]
+    fn scale_equals_l2_norm() {
+        let v = vec![3.0, 4.0];
+        let q = polar_quantize(&v, 8);
+        assert!((q.scale - 5.0).abs() < 1e-5, "scale should be L2 norm");
+    }
+
+    #[test]
+    fn round_trip_128d_random_within_tolerance() {
+        // Seeded deterministic "random" using simple LCG
+        let mut seed: u64 = 42;
+        let mut rng = || -> f32 {
+            seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+            (seed >> 33) as f32 / (1u64 << 31) as f32 - 0.5
+        };
+
+        let v: Vec<f32> = (0..128).map(|_| rng()).collect();
+        let q = polar_quantize(&v, 4);
+        let r = polar_dequantize(&q);
+        assert_eq!(r.len(), 128);
+
+        // Compute MSE
+        let mse: f32 = v
+            .iter()
+            .zip(r.iter())
+            .map(|(a, b)| (a - b) * (a - b))
+            .sum::<f32>()
+            / v.len() as f32;
+        assert!(mse < 0.1, "MSE too high: {mse}");
+    }
+
+    #[test]
+    fn odd_length_vector_round_trips() {
+        let v = vec![1.0, 2.0, 3.0];
+        let q = polar_quantize(&v, 4);
+        let r = polar_dequantize(&q);
+        assert_eq!(r.len(), 3);
+    }
+
+    #[test]
+    fn different_bit_widths_work() {
+        let v = vec![1.0, 2.0, 3.0, 4.0];
+        for bits in 1..=8 {
+            let q = polar_quantize(&v, bits);
+            let r = polar_dequantize(&q);
+            assert_eq!(r.len(), 4, "failed for bits={bits}");
+        }
+    }
+
+    #[test]
+    fn deterministic_output() {
+        let v = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+        let q1 = polar_quantize(&v, 4);
+        let q2 = polar_quantize(&v, 4);
+        assert_eq!(q1.scale, q2.scale);
+        assert_eq!(q1.codes, q2.codes);
+    }
+
+    #[test]
+    #[should_panic(expected = "bits must be 1-8")]
+    fn bits_zero_panics() {
+        polar_quantize(&[1.0, 2.0], 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "bits must be 1-8")]
+    fn bits_nine_panics() {
+        polar_quantize(&[1.0, 2.0], 9);
+    }
+
+    #[test]
+    fn higher_bits_gives_lower_distortion() {
+        let mut seed: u64 = 123;
+        let mut rng = || -> f32 {
+            seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+            (seed >> 33) as f32 / (1u64 << 31) as f32 - 0.5
+        };
+        let v: Vec<f32> = (0..64).map(|_| rng()).collect();
+
+        let mse_low = {
+            let r = polar_dequantize(&polar_quantize(&v, 2));
+            v.iter()
+                .zip(r.iter())
+                .map(|(a, b)| (a - b) * (a - b))
+                .sum::<f32>()
+                / v.len() as f32
+        };
+        let mse_high = {
+            let r = polar_dequantize(&polar_quantize(&v, 8));
+            v.iter()
+                .zip(r.iter())
+                .map(|(a, b)| (a - b) * (a - b))
+                .sum::<f32>()
+                / v.len() as f32
+        };
+        assert!(
+            mse_high <= mse_low,
+            "8-bit MSE ({mse_high}) should be <= 2-bit MSE ({mse_low})"
+        );
+    }
+}

--- a/src/turboquant/polar.rs
+++ b/src/turboquant/polar.rs
@@ -72,11 +72,7 @@ pub fn polar_quantize(vector: &[f32], bits: u8) -> QuantizedVector {
         current = radii;
     }
 
-    let scale = if current.is_empty() {
-        0.0
-    } else {
-        current[0]
-    };
+    let scale = if current.is_empty() { 0.0 } else { current[0] };
 
     QuantizedVector {
         scale,

--- a/src/turboquant/qjl.rs
+++ b/src/turboquant/qjl.rs
@@ -1,0 +1,194 @@
+use super::types::QjlBitVector;
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+
+/// Compress a residual vector using seeded Johnson-Lindenstrauss projection.
+///
+/// The algorithm:
+/// 1. Generate a random projection matrix from the seed
+/// 2. Project the residual through random vectors
+/// 3. Extract the sign bit of each projection
+/// 4. Pack sign bits into u64 bitfields
+pub fn qjl_compress(residual: &[f32], seed: u64) -> QjlBitVector {
+    let dim = residual.len();
+    if dim == 0 {
+        return QjlBitVector {
+            packed_signs: Vec::new(),
+            projection_dim: 0,
+            seed,
+        };
+    }
+
+    // Use dimension count as projection dimension (standard JL)
+    let projection_dim = dim;
+    let packed_len = projection_dim.div_ceil(64);
+    let mut packed_signs = vec![0u64; packed_len];
+
+    let mut rng = SmallRng::seed_from_u64(seed);
+
+    for j in 0..projection_dim {
+        // Compute dot product with random unit vector
+        let mut dot = 0.0f32;
+        for &val in residual {
+            let r: f32 = rng.r#gen::<f32>() * 2.0 - 1.0;
+            dot += val * r;
+        }
+
+        // Store sign bit: 1 if positive, 0 if negative
+        if dot >= 0.0 {
+            packed_signs[j / 64] |= 1u64 << (j % 64);
+        }
+    }
+
+    QjlBitVector {
+        packed_signs,
+        projection_dim,
+        seed,
+    }
+}
+
+/// Estimate the dot product between a full-precision query and a QJL-compressed vector.
+///
+/// Uses the same seeded random matrix to project the query, then estimates
+/// the dot product via XNOR between query signs and compressed signs.
+pub fn qjl_estimate_dot(query: &[f32], compressed: &QjlBitVector, seed: u64) -> f32 {
+    let dim = query.len();
+    if dim == 0 || compressed.projection_dim == 0 {
+        return 0.0;
+    }
+
+    let projection_dim = compressed.projection_dim;
+
+    // Compute query norm for scaling
+    let query_norm: f32 = query.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if query_norm < 1e-10 {
+        return 0.0;
+    }
+
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let mut agreement_count: i64 = 0;
+
+    for j in 0..projection_dim {
+        // Project query through same random vector
+        let mut dot = 0.0f32;
+        for &val in query {
+            let r: f32 = rng.r#gen::<f32>() * 2.0 - 1.0;
+            dot += val * r;
+        }
+
+        let query_sign = dot >= 0.0;
+        let compressed_sign = (compressed.packed_signs[j / 64] >> (j % 64)) & 1 == 1;
+
+        // XNOR: agree = same sign
+        if query_sign == compressed_sign {
+            agreement_count += 1;
+        } else {
+            agreement_count -= 1;
+        }
+    }
+
+    // Scale estimate: agreement ratio maps to cosine similarity estimate
+    let agreement_ratio = agreement_count as f32 / projection_dim as f32;
+
+    // The expected value of sign agreement is related to the angle between vectors
+    // For unbiased estimation, we scale by norms
+    query_norm * agreement_ratio
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compress_empty_vector() {
+        let v: Vec<f32> = Vec::new();
+        let c = qjl_compress(&v, 42);
+        assert_eq!(c.projection_dim, 0);
+        assert!(c.packed_signs.is_empty());
+    }
+
+    #[test]
+    fn compress_produces_correct_packing() {
+        let v = vec![1.0; 128];
+        let c = qjl_compress(&v, 42);
+        assert_eq!(c.projection_dim, 128);
+        assert_eq!(c.packed_signs.len(), 2); // 128 / 64 = 2
+    }
+
+    #[test]
+    fn deterministic_with_same_seed() {
+        let v = vec![1.0, 2.0, 3.0, 4.0];
+        let c1 = qjl_compress(&v, 42);
+        let c2 = qjl_compress(&v, 42);
+        assert_eq!(c1.packed_signs, c2.packed_signs);
+    }
+
+    #[test]
+    fn different_seeds_differ() {
+        let v = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+        let c1 = qjl_compress(&v, 42);
+        let c2 = qjl_compress(&v, 999);
+        // With different seeds, sign patterns should differ
+        assert_ne!(c1.packed_signs, c2.packed_signs);
+    }
+
+    #[test]
+    fn estimate_dot_empty() {
+        let q: Vec<f32> = Vec::new();
+        let c = QjlBitVector {
+            packed_signs: Vec::new(),
+            projection_dim: 0,
+            seed: 42,
+        };
+        assert_eq!(qjl_estimate_dot(&q, &c, 42), 0.0);
+    }
+
+    #[test]
+    fn estimate_dot_zero_residual() {
+        let residual = vec![0.0; 64];
+        let query = vec![1.0; 64];
+        let c = qjl_compress(&residual, 42);
+        let est = qjl_estimate_dot(&query, &c, 42);
+        // Zero residual should give ~0 estimate (random noise around 0)
+        assert!(est.abs() < 10.0, "expected near 0, got {est}");
+    }
+
+    #[test]
+    fn unbiased_estimator_mean_error_converges() {
+        // Generate many random pairs and check mean error → 0
+        let mut seed: u64 = 12345;
+        let mut rng_val = || -> f32 {
+            seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+            (seed >> 33) as f32 / (1u64 << 31) as f32 - 0.5
+        };
+
+        let mut total_error = 0.0f64;
+        let trials = 200;
+        let dim = 64;
+
+        for trial in 0..trials {
+            let key: Vec<f32> = (0..dim).map(|_| rng_val()).collect();
+            let query: Vec<f32> = (0..dim).map(|_| rng_val()).collect();
+
+            let exact_dot: f32 = key.iter().zip(query.iter()).map(|(a, b)| a * b).sum();
+            let compressed = qjl_compress(&key, trial as u64 + 1000);
+            let estimated = qjl_estimate_dot(&query, &compressed, trial as u64 + 1000);
+
+            total_error += (estimated - exact_dot) as f64;
+        }
+
+        let mean_error = total_error / trials as f64;
+        assert!(
+            mean_error.abs() < 2.0,
+            "mean error should be small, got {mean_error}"
+        );
+    }
+
+    #[test]
+    fn dimension_not_multiple_of_64() {
+        let v = vec![1.0; 100]; // 100 is not a multiple of 64
+        let c = qjl_compress(&v, 42);
+        assert_eq!(c.projection_dim, 100);
+        assert_eq!(c.packed_signs.len(), 2); // ceil(100/64) = 2
+    }
+}

--- a/src/turboquant/types.rs
+++ b/src/turboquant/types.rs
@@ -1,0 +1,69 @@
+use serde::{Deserialize, Serialize};
+
+/// Quantization strategy selector for TurboQuant.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum QuantStrategy {
+    #[default]
+    TurboQuant,
+    PolarQuant,
+    Qjl,
+}
+
+/// Which vector components to apply quantization to.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ApplyTarget {
+    Keys,
+    Values,
+    #[default]
+    Both,
+}
+
+/// Result of PolarQuant encoding.
+#[derive(Debug, Clone)]
+pub struct QuantizedVector {
+    /// The single global magnitude (radius at top of recursion).
+    pub scale: f32,
+    /// Quantized angle codes, one per pair at each recursion level.
+    pub codes: Vec<u16>,
+    /// Bit width used for quantization.
+    pub bits: u8,
+    /// Original vector length (needed for dequantization).
+    pub original_len: usize,
+}
+
+/// Result of QJL sign-bit compression.
+#[derive(Debug, Clone)]
+pub struct QjlBitVector {
+    /// Packed sign bits from the JL projection (64 bits per u64).
+    pub packed_signs: Vec<u64>,
+    /// Number of projection dimensions used.
+    pub projection_dim: usize,
+    /// Seed for reproducing the random projection matrix.
+    pub seed: u64,
+}
+
+/// Combined TurboQuant result: PolarQuant + QJL residual.
+#[derive(Debug, Clone)]
+pub struct TurboQuantized {
+    /// PolarQuant-compressed vector.
+    pub polar: QuantizedVector,
+    /// QJL-compressed residual.
+    pub residual: QjlBitVector,
+    /// Strategy used.
+    pub strategy: QuantStrategy,
+}
+
+/// Benchmark result for a single strategy run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BenchmarkResult {
+    pub strategy: String,
+    pub dimensions: usize,
+    pub vector_count: usize,
+    pub bits: u8,
+    pub compression_ratio: f64,
+    pub mean_dot_distortion: f64,
+    pub recall_at_10: f64,
+    pub throughput_vecs_per_sec: f64,
+}


### PR DESCRIPTION
## Summary

- **TurboQuant compression library** (`src/turboquant/`): PolarQuant recursive polar transform, QJL 1-bit Johnson-Lindenstrauss residual correction, and two-stage pipeline with strategy dispatch
- **Config + Feature flag**: `TurboQuantConfig` schema with `QuantStrategy`/`ApplyTarget` enums, serde round-trip, and `turboquant` feature flag
- **Settings TUI tab**: Interactive TurboQuant configuration with Toggle, NumberStepper, and Dropdown widgets
- **Benchmark CLI**: `maestro turbo-quant benchmark` command with text/JSON output comparing all three strategies (compression ratio, dot-product distortion, recall@10, throughput)
- **Activity Log toggle**: `d` key dismisses/shows activity log, `Shift+Up/Down` now correctly scrolls the activity log

Closes #242
Closes #243
Closes #244
Closes #245
Closes #247
Closes #248
Closes #306

## Test plan
- [x] All 2597 tests pass (`cargo test` — 177 lib + 2420 binary)
- [x] Zero clippy warnings (`cargo clippy -- -D warnings`)
- [x] CLI benchmark works: `maestro turbo-quant benchmark --dim 32 --count 50 --bits 4`
- [x] JSON output validates: `--output json` produces parseable JSON
- [x] Serde round-trip for TurboQuantConfig
- [x] PolarQuant round-trip distortion within bounds (MSE < 0.1 for 128-d vectors at 4-bit)
- [x] QJL unbiased estimator converges (mean error → 0 over 200 trials)
- [x] Pipeline recall@10 > 0.3 on 64-d random vectors
- [x] Activity log toggle and Shift+Up/Down scroll routing verified
- [x] Settings TurboQuant tab builds 5 fields with correct widget types