### PR TITLE
chore: simplify TQ badge rendering and config cleanup

### DIFF
--- a/maestro.toml
+++ b/maestro.toml
@@ -97,6 +97,7 @@ work_tick_interval_secs = 10
 
 [tui]
 ascii_icons = false
+show_mascot = true
 
 [tui.theme]
 preset = "retro"
@@ -110,11 +111,10 @@ preview_ratio = 65
 activity_log_height = 20
 
 [flags]
-# turboquant = false  # Enable TurboQuant context compression (also toggle with Ctrl+q)
 
 [turboquant]
-enabled = false           # Master switch for TurboQuant compression
-bit_width = 4             # Quantization bits (2-8). Lower = more compression, less quality
-strategy = "turboquant"   # "turboquant" (best), "polarquant" (quality), "qjl" (fast)
-apply_to = "both"         # "keys", "values", or "both"
-auto_on_overflow = false  # Auto-enable when context approaches overflow threshold
+enabled = false
+bit_width = 4
+strategy = "turboquant"
+apply_to = "both"
+auto_on_overflow = false

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -300,7 +300,6 @@ pub fn draw(f: &mut Frame, app: &mut App) {
             }
         }
         TuiMode::ConfirmExit => {
-            // Render the screen the user was on before pressing [q]
             match app.confirm_exit_return_mode {
                 Some(TuiMode::Dashboard) => {
                     if let Some(ref mut screen) = app.home_screen {
@@ -339,7 +338,6 @@ pub fn draw(f: &mut Frame, app: &mut App) {
                     );
                 }
                 _ => {
-                    // Default: show overview panel
                     let sessions = app.pool.all_sessions();
                     app.panel_view.draw_with_claims(
                         f,
@@ -633,23 +631,19 @@ fn draw_status_bar(f: &mut Frame, app: &App, mode_km: &ModeKeyMap, area: Rect) {
 
     // TQ badge
     {
+        spans.push(sep.clone());
         let tq_enabled = app.flags.is_enabled(crate::flags::Flag::TurboQuant);
-        if tq_enabled {
-            spans.push(sep.clone());
-            spans.push(Span::styled(
+        spans.push(if tq_enabled {
+            Span::styled(
                 "TQ:ON",
                 Style::default()
                     .fg(theme.branding_fg)
                     .bg(theme.accent_success)
                     .add_modifier(Modifier::BOLD),
-            ));
+            )
         } else {
-            spans.push(sep.clone());
-            spans.push(Span::styled(
-                "TQ:OFF",
-                Style::default().fg(theme.text_secondary),
-            ));
-        }
+            Span::styled("TQ:OFF", Style::default().fg(theme.text_secondary))
+        });
     }
 
     if let Some(ref cont) = app.continuous_mode {


### PR DESCRIPTION
## Summary

- Hoist `sep.clone()` above if/else in TQ badge (remove duplication from /simplify review)
- Remove narrating comments in ConfirmExit render path
- Update maestro.toml: add `show_mascot = true`, clean config values

## Test plan
- [x] `cargo test` — 2450 passing
- [x] Zero clippy warnings