### PR TITLE
docs: document build.rs purpose and rerun-if-changed directives

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,19 @@
+//! Build script for maestro.
+//!
+//! **What it does:** Generates man pages and shell completions from the clap
+//! CLI definition so they stay in sync with the actual command structure.
+//!
+//! **Outputs** (written to `$OUT_DIR/`):
+//! - `man/maestro.1`            — roff man page
+//! - `completions/maestro.bash` — Bash completions
+//! - `completions/maestro.zsh`  — Zsh completions
+//! - `completions/maestro.fish` — Fish completions
+//!
+//! **Re-runs when:**
+//! - `build.rs` changes  (implicit, handled by Cargo)
+//! - `src/cli.rs` changes (explicit directive below — this file defines the CLI)
+//! - `Cargo.toml` changes (explicit directive below — version / dependency changes)
+
 #![allow(clippy::expect_used)] // Build scripts conventionally use expect()
 // NOTE: cli.rs must remain self-contained (no imports from other src/ modules)
 // because build.rs includes it directly via #[path].
@@ -6,6 +22,10 @@ mod cli;
 
 fn main() {
     use clap::CommandFactory;
+
+    // Tell Cargo when to re-run this script.
+    println!("cargo:rerun-if-changed=src/cli.rs");
+    println!("cargo:rerun-if-changed=Cargo.toml");
 
     let out_dir =
         std::path::PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR must be set by cargo"));


### PR DESCRIPTION
## Summary

- Add module-level `//!` documentation to `build.rs` explaining what it does (man page + shell completion generation), what it outputs, and when it re-runs
- Add explicit `cargo:rerun-if-changed` directives for `src/cli.rs` and `Cargo.toml`

## Test plan

- [x] `cargo build` completes without warnings
- [x] `cargo test` passes (2478 tests)
- [ ] Verify incremental build: `touch src/cli.rs && cargo build -vv 2>&1 | grep build.rs`

Closes #353