### PR TITLE
chore: document flags/state module boundary

### DIFF
--- a/src/flags/mod.rs
+++ b/src/flags/mod.rs
@@ -1,3 +1,15 @@
+//! Feature flag definitions and runtime store.
+//!
+//! Flags are **user-facing boolean toggles** that gate experimental or optional
+//! features (e.g. `CiAutoFix`, `ReviewCouncil`, `TurboQuant`). They are resolved
+//! once at startup from three layers (compiled defaults → `maestro.toml` → CLI
+//! arguments) and live in memory for the duration of the process.
+//!
+//! This is intentionally separate from [`crate::state`], which handles **persistent
+//! session data** (JSON state file, progress, file claims, prompt history) that is
+//! written to disk and survives across runs. Flags are ephemeral configuration;
+//! state is durable runtime data.
+
 pub mod store;
 
 use serde::{Deserialize, Serialize};

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,3 +1,13 @@
+//! Persistent session state.
+//!
+//! Manages **durable runtime data** that is written to disk (`maestro-state.json`)
+//! and survives across process restarts: active sessions, cost totals, pending PRs,
+//! file claims, progress tracking, and prompt history.
+//!
+//! This is intentionally separate from [`crate::flags`], which handles **ephemeral
+//! feature toggles** resolved at startup from config and CLI arguments. State is
+//! persisted; flags are not.
+
 pub mod file_claims;
 pub mod progress;
 pub mod prompt_history;


### PR DESCRIPTION
## Summary

- Add module-level `//!` doc comments to `src/flags/mod.rs` and `src/state/mod.rs`
- Documents the intentional separation: flags = ephemeral feature toggles (resolved at startup), state = persistent session data (written to disk)
- Chose documentation over consolidation because the modules have fundamentally different persistence semantics

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes
- [x] No code behavior changes

Closes #357