### PR TITLE
test: add unit tests for src/adapt/ pipeline modules

### DIFF
--- a/src/adapt/analyzer.rs
+++ b/src/adapt/analyzer.rs
@@ -40,6 +40,10 @@ impl MockProjectAnalyzer {
             result: Some(report),
         }
     }
+
+    pub fn without_report() -> Self {
+        Self { result: None }
+    }
 }
 
 #[cfg(test)]
@@ -118,5 +122,43 @@ mod tests {
         let analyzer = MockProjectAnalyzer::with_report(report);
         let result = analyzer.analyze(&sample_profile()).await.unwrap();
         assert_eq!(result.summary, "Test project");
+    }
+
+    #[tokio::test]
+    async fn mock_analyzer_returns_report_with_modules_and_debt() {
+        let report = AdaptReport {
+            summary: "Complex project".into(),
+            modules: vec![
+                ModuleDescription {
+                    path: "src/auth.rs".into(),
+                    purpose: "Authentication".into(),
+                    complexity: "high".into(),
+                },
+                ModuleDescription {
+                    path: "src/db.rs".into(),
+                    purpose: "Database layer".into(),
+                    complexity: "medium".into(),
+                },
+            ],
+            tech_debt_items: vec![TechDebtItem {
+                title: "Missing auth tests".into(),
+                description: "No tests for auth module".into(),
+                location: "src/auth.rs".into(),
+                suggested_fix: "Add unit tests".into(),
+                category: TechDebtCategory::MissingTests,
+                severity: TechDebtSeverity::High,
+            }],
+        };
+        let analyzer = MockProjectAnalyzer::with_report(report);
+        let result = analyzer.analyze(&sample_profile()).await.unwrap();
+        assert_eq!(result.modules.len(), 2);
+        assert_eq!(result.tech_debt_items.len(), 1);
+        assert_eq!(result.tech_debt_items[0].severity, TechDebtSeverity::High);
+    }
+
+    #[tokio::test]
+    async fn mock_analyzer_without_report_returns_error() {
+        let analyzer = MockProjectAnalyzer::without_report();
+        assert!(analyzer.analyze(&sample_profile()).await.is_err());
     }
 }

--- a/src/adapt/planner.rs
+++ b/src/adapt/planner.rs
@@ -47,6 +47,10 @@ impl MockAdaptPlanner {
     pub fn with_plan(plan: AdaptPlan) -> Self {
         Self { result: Some(plan) }
     }
+
+    pub fn without_plan() -> Self {
+        Self { result: None }
+    }
 }
 
 #[cfg(test)]
@@ -157,5 +161,91 @@ mod tests {
         let json = serde_json::to_string(&plan).unwrap();
         let rt: AdaptPlan = serde_json::from_str(&json).unwrap();
         assert_eq!(rt.milestones[0].issues[1].blocked_by_titles.len(), 1);
+    }
+
+    #[test]
+    fn empty_plan_serializes_to_empty_milestones() {
+        let plan = AdaptPlan {
+            milestones: vec![],
+            maestro_toml_patch: None,
+        };
+        let json = serde_json::to_string(&plan).unwrap();
+        let rt: AdaptPlan = serde_json::from_str(&json).unwrap();
+        assert!(rt.milestones.is_empty());
+        assert!(rt.maestro_toml_patch.is_none());
+    }
+
+    #[test]
+    fn plan_with_multiple_milestones_preserves_order() {
+        let plan = AdaptPlan {
+            milestones: vec![
+                PlannedMilestone {
+                    title: "M0: Foundation".into(),
+                    description: "First".into(),
+                    issues: vec![],
+                },
+                PlannedMilestone {
+                    title: "M1: Core".into(),
+                    description: "Second".into(),
+                    issues: vec![PlannedIssue {
+                        title: "feat: core".into(),
+                        body: "Core feature".into(),
+                        labels: vec![],
+                        blocked_by_titles: vec!["M0 issue".into()],
+                    }],
+                },
+            ],
+            maestro_toml_patch: None,
+        };
+        let json = serde_json::to_string(&plan).unwrap();
+        let rt: AdaptPlan = serde_json::from_str(&json).unwrap();
+        assert_eq!(rt.milestones.len(), 2);
+        assert_eq!(rt.milestones[0].title, "M0: Foundation");
+        assert_eq!(rt.milestones[1].title, "M1: Core");
+        assert_eq!(rt.milestones[1].issues[0].blocked_by_titles.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn mock_planner_without_plan_returns_error() {
+        let planner = MockAdaptPlanner::without_plan();
+        let profile = ProjectProfile {
+            name: "test".into(),
+            root: PathBuf::from("/tmp"),
+            language: ProjectLanguage::Rust,
+            manifests: vec![],
+            config_files: vec![],
+            entry_points: vec![],
+            source_stats: SourceStats {
+                total_files: 0,
+                total_lines: 0,
+                by_extension: vec![],
+            },
+            test_infra: TestInfraInfo {
+                has_tests: false,
+                framework: None,
+                test_directories: vec![],
+                test_file_count: 0,
+            },
+            ci: CiInfo {
+                provider: None,
+                config_files: vec![],
+            },
+            git: GitInfo {
+                is_git_repo: false,
+                default_branch: None,
+                remote_url: None,
+                commit_count: 0,
+                recent_contributors: vec![],
+            },
+            dependencies: DependencySummary::default(),
+            directory_tree: String::new(),
+            has_maestro_config: false,
+        };
+        let report = AdaptReport {
+            summary: "test".into(),
+            modules: vec![],
+            tech_debt_items: vec![],
+        };
+        assert!(planner.plan(&profile, &report).await.is_err());
     }
 }

--- a/src/integration_tests/adapt_pipeline.rs
+++ b/src/integration_tests/adapt_pipeline.rs
@@ -1,0 +1,164 @@
+//! Integration tests for the adapt pipeline (scanner → analyzer → planner → materializer).
+//!
+//! Uses mock implementations for analyzer and planner to test the pipeline
+//! stages in isolation without calling Claude.
+
+use crate::adapt::analyzer::{MockProjectAnalyzer, ProjectAnalyzer};
+use crate::adapt::planner::{AdaptPlanner, MockAdaptPlanner};
+use crate::adapt::types::*;
+use std::path::PathBuf;
+
+fn sample_profile() -> ProjectProfile {
+    ProjectProfile {
+        name: "test-project".into(),
+        root: PathBuf::from("/tmp/test"),
+        language: ProjectLanguage::Rust,
+        manifests: vec![PathBuf::from("Cargo.toml")],
+        config_files: vec![],
+        entry_points: vec![PathBuf::from("src/main.rs")],
+        source_stats: SourceStats {
+            total_files: 10,
+            total_lines: 500,
+            by_extension: vec![],
+        },
+        test_infra: TestInfraInfo {
+            has_tests: true,
+            framework: Some("cargo test".into()),
+            test_directories: vec![],
+            test_file_count: 3,
+        },
+        ci: CiInfo {
+            provider: Some("github_actions".into()),
+            config_files: vec![],
+        },
+        git: GitInfo {
+            is_git_repo: true,
+            default_branch: Some("main".into()),
+            remote_url: Some("https://github.com/owner/repo".into()),
+            commit_count: 42,
+            recent_contributors: vec!["alice".into()],
+        },
+        dependencies: DependencySummary {
+            direct_count: 5,
+            dev_count: 2,
+            notable: vec!["tokio".into(), "serde".into()],
+        },
+        directory_tree: "src/\n  main.rs".into(),
+        has_maestro_config: false,
+    }
+}
+
+fn sample_report() -> AdaptReport {
+    AdaptReport {
+        summary: "A Rust CLI with async runtime".into(),
+        modules: vec![
+            ModuleDescription {
+                path: "src/main.rs".into(),
+                purpose: "Entry point".into(),
+                complexity: "low".into(),
+            },
+            ModuleDescription {
+                path: "src/config.rs".into(),
+                purpose: "Configuration".into(),
+                complexity: "medium".into(),
+            },
+        ],
+        tech_debt_items: vec![TechDebtItem {
+            title: "Missing unit tests".into(),
+            description: "No tests for config parsing".into(),
+            location: "src/config.rs".into(),
+            suggested_fix: "Add unit tests".into(),
+            category: TechDebtCategory::MissingTests,
+            severity: TechDebtSeverity::Medium,
+        }],
+    }
+}
+
+fn sample_plan() -> AdaptPlan {
+    AdaptPlan {
+        milestones: vec![
+            PlannedMilestone {
+                title: "M0: Foundation".into(),
+                description: "Initial setup and scaffolding".into(),
+                issues: vec![PlannedIssue {
+                    title: "feat: project scaffolding".into(),
+                    body: "## Overview\n\nSet up the project.".into(),
+                    labels: vec!["enhancement".into()],
+                    blocked_by_titles: vec![],
+                }],
+            },
+            PlannedMilestone {
+                title: "M1: Testing".into(),
+                description: "Add test coverage".into(),
+                issues: vec![PlannedIssue {
+                    title: "test: add config tests".into(),
+                    body: "## Overview\n\nAdd config tests.".into(),
+                    labels: vec!["testing".into()],
+                    blocked_by_titles: vec!["feat: project scaffolding".into()],
+                }],
+            },
+        ],
+        maestro_toml_patch: Some("[project]\nrepo = \"owner/repo\"".into()),
+    }
+}
+
+/// End-to-end: mock analyzer produces report → mock planner produces plan from that report.
+#[tokio::test]
+async fn pipeline_analyze_then_plan_with_mocks() {
+    let profile = sample_profile();
+
+    // Phase 2: Analyze
+    let analyzer = MockProjectAnalyzer::with_report(sample_report());
+    let report = analyzer.analyze(&profile).await.unwrap();
+    assert_eq!(report.modules.len(), 2);
+    assert_eq!(report.tech_debt_items.len(), 1);
+
+    // Phase 3: Plan
+    let planner = MockAdaptPlanner::with_plan(sample_plan());
+    let plan = planner.plan(&profile, &report).await.unwrap();
+    assert_eq!(plan.milestones.len(), 2);
+    assert_eq!(plan.milestones[0].issues.len(), 1);
+    assert_eq!(plan.milestones[1].issues[0].blocked_by_titles.len(), 1);
+    assert!(plan.maestro_toml_patch.is_some());
+}
+
+/// Pipeline handles empty analysis gracefully.
+#[tokio::test]
+async fn pipeline_empty_analysis_produces_valid_plan() {
+    let profile = sample_profile();
+
+    let analyzer = MockProjectAnalyzer::with_report(AdaptReport {
+        summary: "Empty project".into(),
+        modules: vec![],
+        tech_debt_items: vec![],
+    });
+    let report = analyzer.analyze(&profile).await.unwrap();
+    assert!(report.modules.is_empty());
+
+    let planner = MockAdaptPlanner::with_plan(AdaptPlan {
+        milestones: vec![],
+        maestro_toml_patch: None,
+    });
+    let plan = planner.plan(&profile, &report).await.unwrap();
+    assert!(plan.milestones.is_empty());
+    assert!(plan.maestro_toml_patch.is_none());
+}
+
+/// Analyzer failure propagates correctly.
+#[tokio::test]
+async fn pipeline_analyzer_failure_propagates() {
+    let profile = sample_profile();
+    let analyzer = MockProjectAnalyzer::without_report();
+    let err = analyzer.analyze(&profile).await;
+    assert!(err.is_err());
+}
+
+/// Planner failure propagates correctly.
+#[tokio::test]
+async fn pipeline_planner_failure_propagates() {
+    let profile = sample_profile();
+    let report = sample_report();
+    let planner = MockAdaptPlanner::without_plan();
+    let err = planner.plan(&profile, &report).await;
+    assert!(err.is_err());
+}

--- a/src/integration_tests/mod.rs
+++ b/src/integration_tests/mod.rs
@@ -4,6 +4,8 @@
 //! All external dependencies are replaced with in-process mocks.
 
 #[cfg(test)]
+mod adapt_pipeline;
+#[cfg(test)]
 mod completion_pipeline;
 #[cfg(test)]
 mod concurrent_sessions;
@@ -15,8 +17,6 @@ mod stream_parsing;
 mod upgrade;
 #[cfg(test)]
 mod worktree_lifecycle;
-#[cfg(test)]
-mod adapt_pipeline;
 
 /// Shared test helpers used across integration test modules.
 #[cfg(test)]

--- a/src/integration_tests/mod.rs
+++ b/src/integration_tests/mod.rs
@@ -15,6 +15,8 @@ mod stream_parsing;
 mod upgrade;
 #[cfg(test)]
 mod worktree_lifecycle;
+#[cfg(test)]
+mod adapt_pipeline;
 
 /// Shared test helpers used across integration test modules.
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Add planner tests: empty plan, multi-milestone ordering, mock error propagation
- Add analyzer tests: multi-module report with tech debt, mock error propagation
- Add `without_report()`/`without_plan()` constructors to mock types
- Create `src/integration_tests/adapt_pipeline.rs` with 4 end-to-end pipeline tests
- Total tests: 2487 (up from 2478)

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] All 2487 tests pass
- [x] 98 adapt-related tests pass
- [x] 4 new integration tests pass

Closes #358