### PR TITLE
chore: enforce snapshot test review in CI via cargo-insta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --verbose
+      # Snapshot enforcement: fails if any insta snapshot has an unreviewed diff.
+      # Run `cargo insta review` locally to approve snapshot changes before pushing.
+      - name: Check snapshots
+        env:
+          INSTA_UPDATE: "no"
+        run: cargo test --verbose 2>&1 | (! grep -q "pending snapshots")
 
   clippy:
     name: Clippy


### PR DESCRIPTION
## Summary

- Add snapshot enforcement step to `.github/workflows/ci.yml`
- Runs tests with `INSTA_UPDATE=no` and fails if any pending snapshot diffs exist
- Forces contributors to run `cargo insta review` locally before pushing

## Test plan

- [x] No pending snapshots in current main
- [x] CI step uses env variable (no command injection risk)
- [ ] CI pipeline passes with the new step

Closes #360