### PR TITLE
docs: add module-level documentation to src/turboquant/

### DIFF
--- a/src/turboquant/adapter.rs
+++ b/src/turboquant/adapter.rs
@@ -1,3 +1,8 @@
+//! TurboQuant adapter for session context compression.
+//!
+//! Bridges the raw quantization pipeline with the session layer by converting
+//! text chunks into pseudo-embeddings, compressing them, and tracking metrics.
+
 use super::pipeline::turbo_quantize;
 use super::types::{QuantStrategy, TurboQuantized};
 

--- a/src/turboquant/mod.rs
+++ b/src/turboquant/mod.rs
@@ -1,3 +1,23 @@
+//! TurboQuant — vector quantization for context compression.
+//!
+//! Combines **PolarQuant** (recursive polar decomposition) with a
+//! **QJL** (Quantized Johnson-Lindenstrauss) residual sketch to compress
+//! high-dimensional embedding vectors into compact bit representations
+//! while preserving dot-product similarity.
+//!
+//! The pipeline is gated by the `TurboQuant` feature flag and invoked
+//! during session context overflow to compress token embeddings before
+//! re-injection.
+//!
+//! ## Pipeline stages
+//!
+//! 1. **PolarQuant** (`polar.rs`) — encodes the direction via recursive
+//!    polar angle quantization at `total_bits - 1` bits.
+//! 2. **QJL** (`qjl.rs`) — sketches the residual using a seeded random
+//!    projection at 1 bit per dimension.
+//! 3. **Combine** (`pipeline.rs`) — merges both representations and
+//!    provides dot-product estimation for similarity search.
+
 pub mod adapter;
 pub mod pipeline;
 pub mod polar;

--- a/src/turboquant/pipeline.rs
+++ b/src/turboquant/pipeline.rs
@@ -1,3 +1,8 @@
+//! TurboQuant pipeline entry point.
+//!
+//! Orchestrates the two-stage quantization (PolarQuant + QJL) and provides
+//! strategy-aware wrappers for quantization and dot-product estimation.
+
 use super::polar::{polar_dequantize, polar_quantize};
 use super::qjl::{qjl_compress, qjl_estimate_dot};
 use super::types::{QjlBitVector, QuantStrategy, QuantizedVector, TurboQuantized};

--- a/src/turboquant/polar.rs
+++ b/src/turboquant/polar.rs
@@ -1,3 +1,10 @@
+//! PolarQuant — recursive polar decomposition quantizer.
+//!
+//! Encodes a vector's direction by recursively splitting it into polar angle
+//! pairs, quantizing each angle into a fixed number of bits. The result is a
+//! compact code that preserves angular similarity (cosine distance) at the
+//! cost of magnitude information, which is stored separately as a scalar norm.
+
 use super::types::QuantizedVector;
 use std::f32::consts::PI;
 

--- a/src/turboquant/qjl.rs
+++ b/src/turboquant/qjl.rs
@@ -1,3 +1,10 @@
+//! Quantized Johnson-Lindenstrauss (QJL) projection.
+//!
+//! Compresses a residual vector into a 1-bit-per-dimension sketch using a
+//! seeded random Gaussian projection matrix. The seed makes the projection
+//! deterministic and reproducible, so the same seed can reconstruct the
+//! projection at dot-product estimation time.
+
 use super::types::QjlBitVector;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};


### PR DESCRIPTION
## Summary

- Add `//!` module-level doc comments to all 5 turboquant sub-modules
- Documents: TurboQuant purpose, QJL acronym expansion, PolarQuant algorithm, pipeline stages, adapter role
- No code changes, documentation only

## Test plan

- [x] `cargo doc --no-deps` produces no turboquant-related warnings
- [x] All 2495 tests pass

Closes #361