### PR TITLE
refactor: split src/util.rs into focused sub-modules

### DIFF
--- a/src/util/formatting.rs
+++ b/src/util/formatting.rs
@@ -1,0 +1,23 @@
+//! String formatting and truncation helpers.
+
+/// Find the largest byte offset <= max_bytes that is a valid char boundary.
+pub fn truncate_at_char_boundary(s: &str, max_bytes: usize) -> usize {
+    if s.len() <= max_bytes {
+        return s.len();
+    }
+    let mut end = max_bytes;
+    while !s.is_char_boundary(end) && end > 0 {
+        end -= 1;
+    }
+    end
+}
+
+/// Truncate a string at a char boundary and append "..." if it was truncated.
+pub fn truncate_with_ellipsis(s: &str, max_bytes: usize) -> String {
+    let end = truncate_at_char_boundary(s, max_bytes);
+    if end < s.len() {
+        format!("{}...", &s[..end])
+    } else {
+        s.to_string()
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,8 @@
+//! Shared utility helpers, grouped by domain.
+
+pub mod formatting;
+pub mod validation;
+
+// Re-export all public items so existing `use crate::util::*` call sites continue to work.
+pub use formatting::*;
+pub use validation::*;

--- a/src/util/validation.rs
+++ b/src/util/validation.rs
@@ -1,30 +1,8 @@
+//! Input validation for user-supplied strings (branch names, slugs, env vars, CLI args).
+
 use anyhow::{Result, bail};
 use regex::Regex;
 use std::sync::LazyLock;
-
-/// Find the largest byte offset <= max_bytes that is a valid char boundary.
-pub fn truncate_at_char_boundary(s: &str, max_bytes: usize) -> usize {
-    if s.len() <= max_bytes {
-        return s.len();
-    }
-    let mut end = max_bytes;
-    while !s.is_char_boundary(end) && end > 0 {
-        end -= 1;
-    }
-    end
-}
-
-/// Truncate a string at a char boundary and append "..." if it was truncated.
-pub fn truncate_with_ellipsis(s: &str, max_bytes: usize) -> String {
-    let end = truncate_at_char_boundary(s, max_bytes);
-    if end < s.len() {
-        format!("{}...", &s[..end])
-    } else {
-        s.to_string()
-    }
-}
-
-// --- Input validation ---
 
 static ENV_VAR_NAME_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[A-Z][A-Z0-9_]*$").unwrap());


### PR DESCRIPTION
## Summary

- Split `src/util.rs` into `src/util/formatting.rs` and `src/util/validation.rs`
- `formatting.rs`: string truncation helpers
- `validation.rs`: input validation (branch names, slugs, env vars, gh args)
- Re-exports in `mod.rs` preserve all existing call sites

## Test plan

- [x] All 2495 tests pass
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] No import changes needed at call sites

Closes #362