### PR TITLE
refactor: extract CI polling service from src/tui/app/

### DIFF
--- a/src/tui/app/ci_polling.rs
+++ b/src/tui/app/ci_polling.rs
@@ -1,7 +1,124 @@
 use super::App;
-use crate::provider::github::ci::{CiCheck, CiChecker, CiStatus};
+use crate::provider::github::ci::{CiCheck, CiChecker, CiStatus, PendingPrCheck};
 use crate::tui::activity_log::LogLevel;
+use std::collections::HashMap;
 use std::time::{Duration, Instant};
+
+/// CI polling state, grouped for testability.
+///
+/// Tracks pending PR checks, last poll time, and per-PR check run details.
+/// Owned by `App` and accessed via `app.ci_poller`.
+#[derive(Debug)]
+pub struct CiPoller {
+    pub pending_pr_checks: Vec<PendingPrCheck>,
+    pub last_ci_poll: Instant,
+    pub ci_check_details: HashMap<u64, Vec<crate::provider::github::ci::CheckRunDetail>>,
+}
+
+impl Default for CiPoller {
+    fn default() -> Self {
+        Self {
+            pending_pr_checks: Vec::new(),
+            last_ci_poll: Instant::now(),
+            ci_check_details: HashMap::new(),
+        }
+    }
+}
+
+impl CiPoller {
+    /// Returns true if a poll should happen (interval elapsed and checks pending).
+    #[allow(dead_code)] // used in tests; poll_ci_status inlines this check currently
+    pub fn should_poll(&self, interval: Duration) -> bool {
+        self.last_ci_poll.elapsed() >= interval && !self.pending_pr_checks.is_empty()
+    }
+
+    /// Record that a poll just happened.
+    #[allow(dead_code)] // used in tests; poll_ci_status sets last_ci_poll directly currently
+    pub fn mark_polled(&mut self) {
+        self.last_ci_poll = Instant::now();
+    }
+
+    /// Add a new pending PR check.
+    #[allow(dead_code)] // used in tests; callers currently push directly
+    pub fn add_check(&mut self, check: PendingPrCheck) {
+        self.pending_pr_checks.push(check);
+    }
+
+    /// Remove completed checks by index (must be sorted ascending).
+    #[allow(dead_code)] // used in tests; callers currently inline the logic
+    pub fn remove_completed(&mut self, indices: &[usize]) {
+        for &i in indices {
+            let pr_number = self.pending_pr_checks[i].pr_number;
+            self.ci_check_details.remove(&pr_number);
+        }
+        for &i in indices.iter().rev() {
+            self.pending_pr_checks.remove(i);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_check(pr: u64) -> PendingPrCheck {
+        PendingPrCheck {
+            pr_number: pr,
+            issue_number: pr,
+            branch: format!("feat/issue-{}", pr),
+            created_at: Instant::now(),
+            check_count: 0,
+            fix_attempt: 0,
+            awaiting_fix_ci: false,
+        }
+    }
+
+    #[test]
+    fn should_poll_returns_false_when_no_checks() {
+        let poller = CiPoller::default();
+        assert!(!poller.should_poll(Duration::from_secs(30)));
+    }
+
+    #[test]
+    fn should_poll_returns_false_when_interval_not_elapsed() {
+        let mut poller = CiPoller::default();
+        poller.add_check(make_check(1));
+        poller.mark_polled();
+        assert!(!poller.should_poll(Duration::from_secs(30)));
+    }
+
+    #[test]
+    fn should_poll_returns_true_when_interval_elapsed_and_checks_pending() {
+        let mut poller = CiPoller::default();
+        poller.add_check(make_check(1));
+        poller.last_ci_poll = Instant::now() - Duration::from_secs(60);
+        assert!(poller.should_poll(Duration::from_secs(30)));
+    }
+
+    #[test]
+    fn add_check_appends_to_pending() {
+        let mut poller = CiPoller::default();
+        poller.add_check(make_check(42));
+        assert_eq!(poller.pending_pr_checks.len(), 1);
+        assert_eq!(poller.pending_pr_checks[0].pr_number, 42);
+    }
+
+    #[test]
+    fn remove_completed_cleans_up_checks_and_details() {
+        let mut poller = CiPoller::default();
+        poller.add_check(make_check(1));
+        poller.add_check(make_check(2));
+        poller.add_check(make_check(3));
+        poller.ci_check_details.insert(1, vec![]);
+        poller.ci_check_details.insert(2, vec![]);
+
+        poller.remove_completed(&[0, 2]); // remove PR #1 and #3
+        assert_eq!(poller.pending_pr_checks.len(), 1);
+        assert_eq!(poller.pending_pr_checks[0].pr_number, 2);
+        assert!(!poller.ci_check_details.contains_key(&1));
+        assert!(poller.ci_check_details.contains_key(&2));
+    }
+}
 
 impl App {
     pub(super) fn poll_ci_status(&mut self) {
@@ -17,10 +134,12 @@ impl App {
             .map(|c| Duration::from_secs(c.gates.ci_max_wait_secs))
             .unwrap_or(Duration::from_secs(1800));
 
-        if self.last_ci_poll.elapsed() < ci_poll_interval || self.pending_pr_checks.is_empty() {
+        if self.ci_poller.last_ci_poll.elapsed() < ci_poll_interval
+            || self.ci_poller.pending_pr_checks.is_empty()
+        {
             return;
         }
-        self.last_ci_poll = Instant::now();
+        self.ci_poller.last_ci_poll = Instant::now();
 
         let auto_fix_enabled = self.flags.is_enabled(crate::flags::Flag::CiAutoFix);
         let max_retries = self
@@ -36,7 +155,7 @@ impl App {
         let mut detail_updates: Vec<(u64, Vec<crate::provider::github::ci::CheckRunDetail>)> =
             Vec::new();
 
-        for (i, check) in self.pending_pr_checks.iter_mut().enumerate() {
+        for (i, check) in self.ci_poller.pending_pr_checks.iter_mut().enumerate() {
             check.check_count += 1;
 
             // Timeout check
@@ -238,17 +357,17 @@ impl App {
 
         // Update CI check details for TUI display
         for (pr_number, details) in detail_updates {
-            self.ci_check_details.insert(pr_number, details);
+            self.ci_poller.ci_check_details.insert(pr_number, details);
         }
 
         // Remove completed checks in reverse order to preserve indices
         completed_indices.sort_unstable();
         for &i in &completed_indices {
-            let pr_number = self.pending_pr_checks[i].pr_number;
-            self.ci_check_details.remove(&pr_number);
+            let pr_number = self.ci_poller.pending_pr_checks[i].pr_number;
+            self.ci_poller.ci_check_details.remove(&pr_number);
         }
         for i in completed_indices.into_iter().rev() {
-            self.pending_pr_checks.remove(i);
+            self.ci_poller.pending_pr_checks.remove(i);
         }
     }
 }

--- a/src/tui/app/completion_summary.rs
+++ b/src/tui/app/completion_summary.rs
@@ -13,6 +13,7 @@ impl App {
         let mut total_cost = 0.0;
 
         let pr_map: HashMap<u64, u64> = self
+            .ci_poller
             .pending_pr_checks
             .iter()
             .map(|p| (p.issue_number, p.pr_number))

--- a/src/tui/app/issue_completion.rs
+++ b/src/tui/app/issue_completion.rs
@@ -207,7 +207,7 @@ impl App {
                         );
                         // Track PR for CI polling
                         if let Some(ref branch_name) = worktree_branch {
-                            self.pending_pr_checks.push(PendingPrCheck {
+                            self.ci_poller.pending_pr_checks.push(PendingPrCheck {
                                 pr_number: pr_num,
                                 issue_number,
                                 branch: branch_name.clone(),

--- a/src/tui/app/mod.rs
+++ b/src/tui/app/mod.rs
@@ -25,7 +25,6 @@ use crate::mascot::animator::SystemClock;
 use crate::models::ModelRouter;
 use crate::notifications::dispatcher::NotificationDispatcher;
 use crate::plugins::runner::PluginRunner;
-use crate::provider::github::ci::PendingPrCheck;
 use crate::provider::github::client::GitHubClient;
 use crate::session::context_monitor::{ContextMonitor, ProductionContextMonitor};
 use crate::session::fork::ForkPolicy;
@@ -43,6 +42,7 @@ use crate::tui::panels::PanelView;
 use crate::tui::theme::Theme;
 use crate::work::assigner::WorkAssigner;
 use chrono::Utc;
+pub use ci_polling::CiPoller;
 use std::time::Instant;
 use tokio::sync::mpsc;
 
@@ -70,8 +70,7 @@ pub struct App {
     /// Navigation back-stack for consistent [Esc] behavior.
     pub nav_stack: NavigationStack,
     pub session_logger: SessionLogger,
-    pub pending_pr_checks: Vec<PendingPrCheck>,
-    pub(crate) last_ci_poll: Instant,
+    pub ci_poller: CiPoller,
     pub(crate) last_work_tick: Instant,
     pub plugin_runner: Option<PluginRunner>,
     pub help_state: Option<crate::tui::help::HelpOverlayState>,
@@ -99,8 +98,7 @@ pub struct App {
     pub pending_prs: Vec<crate::provider::github::types::PendingPr>,
     pub flags: crate::flags::store::FeatureFlags,
     pub queue_confirmation_screen: Option<crate::tui::screens::QueueConfirmationScreen>,
-    pub ci_check_details:
-        std::collections::HashMap<u64, Vec<crate::provider::github::ci::CheckRunDetail>>,
+    // ci_check_details moved into ci_poller
     pub queue_executor: Option<crate::work::executor::QueueExecutor>,
     pub queue_launch_configs: Option<Vec<crate::tui::screens::SessionConfig>>,
     pub hollow_retry_screen: Option<crate::tui::screens::HollowRetryScreen>,
@@ -160,8 +158,7 @@ impl App {
             tui_mode: TuiMode::Overview,
             nav_stack: NavigationStack::default(),
             session_logger: SessionLogger::new(SessionLogger::default_dir()),
-            pending_pr_checks: Vec::new(),
-            last_ci_poll: Instant::now(),
+            ci_poller: CiPoller::default(),
             last_work_tick: Instant::now(),
             plugin_runner: None,
             help_state: None,
@@ -189,7 +186,7 @@ impl App {
             pending_prs: Vec::new(),
             flags: crate::flags::store::FeatureFlags::default(),
             queue_confirmation_screen: None,
-            ci_check_details: std::collections::HashMap::new(),
+            // ci_check_details is in ci_poller
             queue_executor: None,
             queue_launch_configs: None,
             hollow_retry_screen: None,

--- a/src/tui/app/pr_retry.rs
+++ b/src/tui/app/pr_retry.rs
@@ -67,7 +67,7 @@ impl App {
                             format!("PR #{} created (retry {})", pr_num, attempt),
                             LogLevel::Info,
                         );
-                        self.pending_pr_checks.push(PendingPrCheck {
+                        self.ci_poller.pending_pr_checks.push(PendingPrCheck {
                             pr_number: pr_num,
                             issue_number,
                             branch: branch.clone(),

--- a/src/tui/app/tests.rs
+++ b/src/tui/app/tests.rs
@@ -299,7 +299,7 @@ fn build_completion_summary_sets_pr_link_when_pending_check_matches() {
     );
     session.status = crate::session::types::SessionStatus::Completed;
     app.pool.enqueue(session);
-    app.pending_pr_checks.push(PendingPrCheck {
+    app.ci_poller.pending_pr_checks.push(PendingPrCheck {
         pr_number: 42,
         issue_number: 10,
         branch: "feat/issue-10".into(),
@@ -328,7 +328,7 @@ fn build_completion_summary_pr_link_empty_when_no_matching_check() {
         Some(99),
     );
     app.pool.enqueue(session);
-    app.pending_pr_checks.push(PendingPrCheck {
+    app.ci_poller.pending_pr_checks.push(PendingPrCheck {
         pr_number: 5,
         issue_number: 5,
         branch: "feat/issue-5".into(),
@@ -357,7 +357,7 @@ fn build_completion_summary_pr_link_empty_when_no_issue_number() {
         None,
     );
     app.pool.enqueue(session);
-    app.pending_pr_checks.push(PendingPrCheck {
+    app.ci_poller.pending_pr_checks.push(PendingPrCheck {
         pr_number: 1,
         issue_number: 1,
         branch: "feat/issue-1".into(),
@@ -1076,13 +1076,14 @@ fn check_context_overflow_skips_fork_when_auto_fork_flag_disabled() {
 
 #[test]
 fn poll_ci_status_skips_fix_when_ci_auto_fix_flag_disabled() {
+    use crate::provider::github::ci::PendingPrCheck;
     let flags = crate::flags::store::FeatureFlags::new(
         std::collections::HashMap::new(),
         vec![],
         vec!["ci_auto_fix".to_string()],
     );
     let mut app = make_app_with_flags(flags);
-    app.pending_pr_checks.push(PendingPrCheck {
+    app.ci_poller.pending_pr_checks.push(PendingPrCheck {
         pr_number: 99,
         issue_number: 42,
         branch: "feat/test".to_string(),
@@ -1093,7 +1094,7 @@ fn poll_ci_status_skips_fix_when_ci_auto_fix_flag_disabled() {
             .checked_sub(Duration::from_secs(120))
             .unwrap_or_else(Instant::now),
     });
-    app.last_ci_poll = Instant::now()
+    app.ci_poller.last_ci_poll = Instant::now()
         .checked_sub(Duration::from_secs(120))
         .unwrap_or_else(Instant::now);
     // poll_ci_status with Flag::CiAutoFix disabled — no fix sessions spawned.
@@ -1111,7 +1112,7 @@ fn poll_ci_status_skips_fix_when_ci_auto_fix_flag_disabled() {
 #[test]
 fn app_ci_check_details_field_defaults_to_empty() {
     let app = make_app();
-    assert!(app.ci_check_details.is_empty());
+    assert!(app.ci_poller.ci_check_details.is_empty());
 }
 
 #[test]
@@ -1124,9 +1125,9 @@ fn ci_check_details_can_be_populated_and_read() {
         started_at: None,
         elapsed_secs: Some(42),
     };
-    app.ci_check_details.insert(99, vec![detail]);
-    assert_eq!(app.ci_check_details.len(), 1);
-    assert_eq!(app.ci_check_details[&99][0].name, "build");
+    app.ci_poller.ci_check_details.insert(99, vec![detail]);
+    assert_eq!(app.ci_poller.ci_check_details.len(), 1);
+    assert_eq!(app.ci_poller.ci_check_details[&99][0].name, "build");
 }
 
 #[test]
@@ -1139,9 +1140,9 @@ fn ci_check_details_keyed_by_pr_number() {
         started_at: None,
         elapsed_secs: None,
     };
-    app.ci_check_details.insert(55, vec![detail]);
-    assert!(app.ci_check_details.contains_key(&55));
-    assert!(!app.ci_check_details.contains_key(&10));
+    app.ci_poller.ci_check_details.insert(55, vec![detail]);
+    assert!(app.ci_poller.ci_check_details.contains_key(&55));
+    assert!(!app.ci_poller.ci_check_details.contains_key(&10));
 }
 
 // --- Issue #67: QueueConfirmation screen state ---

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -388,9 +388,9 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     // Only render activity log area when visible
     if app.show_activity_log {
         // Conditionally split activity area for CI monitor
-        let has_ci_checks = app.gh_auth_ok && !app.ci_check_details.is_empty();
+        let has_ci_checks = app.gh_auth_ok && !app.ci_poller.ci_check_details.is_empty();
         if has_ci_checks {
-            let ci_pr_count = app.ci_check_details.len() as u16;
+            let ci_pr_count = app.ci_poller.ci_check_details.len() as u16;
             let ci_height = (ci_pr_count * 6).min(chunks[2].height / 2).max(4);
             let activity_chunks = Layout::default()
                 .direction(Direction::Vertical)
@@ -399,22 +399,24 @@ pub fn draw(f: &mut Frame, app: &mut App) {
 
             // Render CI monitor(s)
             let ci_area = activity_chunks[0];
-            if app.ci_check_details.len() == 1 {
-                let (&pr_number, details) = app.ci_check_details.iter().next().unwrap();
+            if app.ci_poller.ci_check_details.len() == 1 {
+                let (&pr_number, details) = app.ci_poller.ci_check_details.iter().next().unwrap();
                 let widget = crate::tui::widgets::CiMonitorWidget::new(details, &app.theme)
                     .pr_number(pr_number);
                 ratatui::widgets::Widget::render(widget, ci_area, f.buffer_mut());
             } else {
                 let constraints: Vec<Constraint> = app
+                    .ci_poller
                     .ci_check_details
                     .keys()
-                    .map(|_| Constraint::Ratio(1, app.ci_check_details.len() as u32))
+                    .map(|_| Constraint::Ratio(1, app.ci_poller.ci_check_details.len() as u32))
                     .collect();
                 let pr_chunks = Layout::default()
                     .direction(Direction::Horizontal)
                     .constraints(constraints)
                     .split(ci_area);
-                for (i, (&pr_number, details)) in app.ci_check_details.iter().enumerate() {
+                for (i, (&pr_number, details)) in app.ci_poller.ci_check_details.iter().enumerate()
+                {
                     let widget = crate::tui::widgets::CiMonitorWidget::new(details, &app.theme)
                         .pr_number(pr_number)
                         .max_visible_rows(3);


### PR DESCRIPTION
## Summary

- Create `CiPoller` struct grouping CI state: `pending_pr_checks`, `last_ci_poll`, `ci_check_details`
- Replace 3 separate App fields with single `ci_poller: CiPoller`
- Add testable methods: `should_poll`, `mark_polled`, `add_check`, `remove_completed`
- Add 5 unit tests for CiPoller
- Total tests: 2500 (up from 2495)

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] All 2500 tests pass
- [x] No behavior change in TUI

Closes #363