### PR TITLE
refactor: extract session spawning service from src/tui/app/

### DIFF
--- a/src/tui/app/session_spawners.rs
+++ b/src/tui/app/session_spawners.rs
@@ -1,3 +1,5 @@
+//! Session spawning service — factory methods for creating specialized sessions.
+
 use super::App;
 use super::helpers::build_gate_fix_prompt;
 use super::types::{CompletionSessionLine, TuiCommand};
@@ -5,19 +7,69 @@ use crate::session::transition::TransitionReason;
 use crate::session::types::{Session, SessionStatus};
 use crate::tui::activity_log::LogLevel;
 
+/// Resolve default model and mode from config (or built-in defaults).
+pub(crate) fn default_model_and_mode(config: Option<&crate::config::Config>) -> (String, String) {
+    let model = config
+        .map(|c| c.sessions.default_model.clone())
+        .unwrap_or_else(|| "opus".to_string());
+    let mode = config
+        .map(|c| c.sessions.default_mode.clone())
+        .unwrap_or_else(|| "orchestrator".to_string());
+    (model, mode)
+}
+
+/// Create a CI fix session (does not enqueue — caller pushes to pending_session_launches).
+pub(crate) fn create_ci_fix_session(
+    model: &str,
+    mode: &str,
+    pr_number: u64,
+    issue_number: u64,
+    branch: &str,
+    attempt: u32,
+    failure_log: &str,
+) -> Session {
+    use crate::provider::github::ci::build_ci_fix_prompt;
+    use crate::session::types::CiFixContext;
+
+    let prompt = build_ci_fix_prompt(pr_number, issue_number, branch, attempt, failure_log);
+    let mut session = Session::new(
+        prompt,
+        model.to_string(),
+        mode.to_string(),
+        Some(issue_number),
+    );
+    let _ = session.transition_to(SessionStatus::CiFix, TransitionReason::CiFixStarted);
+    session.issue_title = Some(format!("CI Fix #{} for PR #{}", attempt, pr_number));
+    session.ci_fix_context = Some(CiFixContext {
+        pr_number,
+        issue_number,
+        branch: branch.to_string(),
+        attempt,
+    });
+    session
+}
+
+/// Create a gate fix session (does not enqueue — caller pushes to pending_session_launches).
+pub(crate) fn create_gate_fix_session(
+    model: &str,
+    mode: &str,
+    issue_number: u64,
+    gate_failure_details: &str,
+) -> Session {
+    let prompt = build_gate_fix_prompt(issue_number, gate_failure_details);
+    let mut session = Session::new(
+        prompt,
+        model.to_string(),
+        mode.to_string(),
+        Some(issue_number),
+    );
+    session.issue_title = Some(format!("Gate Fix for #{}", issue_number));
+    session
+}
+
 impl App {
     pub(super) fn default_model_and_mode(&self) -> (String, String) {
-        let model = self
-            .config
-            .as_ref()
-            .map(|c| c.sessions.default_model.clone())
-            .unwrap_or_else(|| "opus".to_string());
-        let mode = self
-            .config
-            .as_ref()
-            .map(|c| c.sessions.default_mode.clone())
-            .unwrap_or_else(|| "orchestrator".to_string());
-        (model, mode)
+        default_model_and_mode(self.config.as_ref())
     }
 
     pub(super) fn spawn_ci_fix_session(
@@ -28,23 +80,16 @@ impl App {
         attempt: u32,
         failure_log: &str,
     ) {
-        use crate::provider::github::ci::build_ci_fix_prompt;
-        use crate::session::types::CiFixContext;
-
         let (model, mode) = self.default_model_and_mode();
-
-        let prompt = build_ci_fix_prompt(pr_number, issue_number, &branch, attempt, failure_log);
-
-        let mut session = Session::new(prompt, model, mode, Some(issue_number));
-        let _ = session.transition_to(SessionStatus::CiFix, TransitionReason::CiFixStarted);
-        session.issue_title = Some(format!("CI Fix #{} for PR #{}", attempt, pr_number));
-        session.ci_fix_context = Some(CiFixContext {
+        let session = create_ci_fix_session(
+            &model,
+            &mode,
             pr_number,
             issue_number,
-            branch,
+            &branch,
             attempt,
-        });
-
+            failure_log,
+        );
         self.pending_session_launches.push(session);
     }
 
@@ -73,11 +118,7 @@ impl App {
             failed_line.model.clone()
         };
 
-        let prompt = build_gate_fix_prompt(issue_number, &gate_failure_details);
-
-        let mut session = Session::new(prompt, model, mode, Some(issue_number));
-        session.issue_title = Some(format!("Gate Fix for #{}", issue_number));
-
+        let session = create_gate_fix_session(&model, &mode, issue_number, &gate_failure_details);
         self.pending_session_launches.push(session);
 
         self.activity_log.push_simple(
@@ -146,5 +187,67 @@ impl App {
                 .push(TuiCommand::LaunchSession(config.clone()));
         }
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_model_and_mode_without_config_returns_defaults() {
+        let (model, mode) = default_model_and_mode(None);
+        assert_eq!(model, "opus");
+        assert_eq!(mode, "orchestrator");
+    }
+
+    #[test]
+    fn default_model_and_mode_with_config_uses_config_values() {
+        let toml_str = r#"
+[project]
+repo = "owner/repo"
+[sessions]
+default_model = "haiku"
+default_mode = "vibe"
+max_concurrent = 1
+[budget]
+max_cost_per_session = 1.0
+max_cost_total = 10.0
+[github]
+[notifications]
+"#;
+        let config: crate::config::Config = toml::from_str(toml_str).unwrap();
+        let (model, mode) = default_model_and_mode(Some(&config));
+        assert_eq!(model, "haiku");
+        assert_eq!(mode, "vibe");
+    }
+
+    #[test]
+    fn create_ci_fix_session_sets_correct_fields() {
+        let session = create_ci_fix_session(
+            "sonnet",
+            "orchestrator",
+            42,
+            10,
+            "feat/fix",
+            1,
+            "CI error log",
+        );
+        assert!(session.ci_fix_context.is_some());
+        let ctx = session.ci_fix_context.unwrap();
+        assert_eq!(ctx.pr_number, 42);
+        assert_eq!(ctx.issue_number, 10);
+        assert_eq!(ctx.branch, "feat/fix");
+        assert_eq!(ctx.attempt, 1);
+        assert!(session.issue_title.unwrap().contains("CI Fix"));
+        assert_eq!(session.status, SessionStatus::CiFix);
+    }
+
+    #[test]
+    fn create_gate_fix_session_sets_correct_fields() {
+        let session =
+            create_gate_fix_session("opus", "orchestrator", 99, "- [clippy]: lint failed");
+        assert_eq!(session.issue_number, Some(99));
+        assert!(session.issue_title.unwrap().contains("Gate Fix"));
     }
 }


### PR DESCRIPTION
## Summary

- Extract session creation into standalone factory functions (`create_ci_fix_session`, `create_gate_fix_session`, `default_model_and_mode`)
- App methods delegate to factories, keeping only enqueue and logging as App concerns
- Add 4 unit tests for factory functions (testable without full App instance)
- Total tests: 2504 (up from 2500)

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] All 2504 tests pass
- [x] No behavior change in TUI

Closes #364