### PR TITLE
feat: configurable milestone naming convention in adapt settings

### DIFF
--- a/src/adapt/planner.rs
+++ b/src/adapt/planner.rs
@@ -31,7 +31,7 @@ impl AdaptPlanner for ClaudePlanner {
     ) -> anyhow::Result<AdaptPlan> {
         let profile_json = serde_json::to_string_pretty(profile)?;
         let report_json = serde_json::to_string_pretty(report)?;
-        let prompt = build_planning_prompt(&profile_json, &report_json);
+        let prompt = build_planning_prompt(&profile_json, &report_json, None);
         let raw = run_claude_print(&self.model, &prompt, &profile.root).await?;
         parse_json_response(&raw)
     }

--- a/src/adapt/prompts.rs
+++ b/src/adapt/prompts.rs
@@ -51,7 +51,15 @@ Return ONLY the JSON object, no markdown fences, no commentary."#,
     )
 }
 
-pub fn build_planning_prompt(profile_json: &str, report_json: &str) -> String {
+pub fn build_planning_prompt(
+    profile_json: &str,
+    report_json: &str,
+    milestone_naming_hint: Option<&str>,
+) -> String {
+    let naming_section = match milestone_naming_hint {
+        Some(hint) => format!("\n6. **Milestone naming**: {}\n", hint),
+        None => String::new(),
+    };
     format!(
         r#"You are creating a project adaptation plan to onboard a project to the maestro workflow.
 
@@ -97,7 +105,7 @@ Create a structured plan with milestones and DOR-compliant issues. Return a JSON
 3. **Labels**: Use `enhancement`, `testing`, `documentation`, `tech-debt` as appropriate
 4. **maestro_toml_patch**: Suggest initial configuration based on the project analysis
 5. Prefix titles with `feat:`, `test:`, `chore:`, `fix:`, or `docs:` as appropriate
-
+{naming_section}
 Return ONLY the JSON object, no markdown fences, no commentary."#,
     )
 }
@@ -200,11 +208,27 @@ mod tests {
 
     #[test]
     fn build_planning_prompt_contains_both_inputs() {
-        let prompt = build_planning_prompt(r#"{"name":"test"}"#, r#"{"summary":"good"}"#);
+        let prompt = build_planning_prompt(r#"{"name":"test"}"#, r#"{"summary":"good"}"#, None);
         assert!(prompt.contains(r#"{"name":"test"}"#));
         assert!(prompt.contains(r#"{"summary":"good"}"#));
         assert!(prompt.contains("milestones"));
         assert!(prompt.contains("maestro_toml_patch"));
+    }
+
+    #[test]
+    fn build_planning_prompt_includes_naming_hint_when_provided() {
+        let prompt = build_planning_prompt(
+            r#"{"name":"test"}"#,
+            r#"{"summary":"good"}"#,
+            Some("Use semver format: vX.Y.Z"),
+        );
+        assert!(prompt.contains("Use semver format: vX.Y.Z"));
+    }
+
+    #[test]
+    fn build_planning_prompt_omits_naming_section_when_none() {
+        let prompt = build_planning_prompt(r#"{"name":"test"}"#, r#"{"summary":"good"}"#, None);
+        assert!(!prompt.contains("Milestone naming"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,12 +35,39 @@ pub struct Config {
     pub flags: FlagsConfig,
     #[serde(default)]
     pub turboquant: TurboQuantConfig,
+    #[serde(default)]
+    pub adapt: AdaptSettings,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct FlagsConfig {
     #[serde(flatten)]
     pub entries: HashMap<String, bool>,
+}
+
+/// Milestone naming convention for the adapt pipeline.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MilestoneNaming {
+    /// Infer naming from existing milestones (e.g. semver `vX.X.X`).
+    Standard,
+    /// Let Claude decide scope and naming (default: `MN: Description`).
+    #[default]
+    Ai,
+    /// User-provided template pattern.
+    Custom,
+}
+
+/// Configuration for the `maestro adapt` command.
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AdaptSettings {
+    /// How milestones should be named in the generated plan.
+    #[serde(default)]
+    pub milestone_naming: MilestoneNaming,
+    /// Custom template for milestone names (only used when `milestone_naming = "custom"`).
+    /// Supports `{n}` (index) and `{title}` (description) placeholders.
+    #[serde(default)]
+    pub milestone_template: Option<String>,
 }
 
 pub use crate::turboquant::types::{ApplyTarget, QuantStrategy};
@@ -1447,5 +1474,80 @@ text_primary = "cyan"
         assert!(cfg.turboquant.enabled);
         assert_eq!(cfg.turboquant.bit_width, 3);
         assert_eq!(cfg.turboquant.strategy, QuantStrategy::PolarQuant);
+    }
+
+    // -- AdaptSettings --
+
+    #[test]
+    fn adapt_settings_default_is_ai_naming() {
+        let settings = AdaptSettings::default();
+        assert_eq!(settings.milestone_naming, MilestoneNaming::Ai);
+        assert!(settings.milestone_template.is_none());
+    }
+
+    #[test]
+    fn adapt_settings_parses_standard_naming() {
+        let toml_str = r#"
+[project]
+repo = "owner/repo"
+[sessions]
+max_concurrent = 1
+default_model = "opus"
+default_mode = "orchestrator"
+[budget]
+max_cost_per_session = 1.0
+max_cost_total = 10.0
+[github]
+[notifications]
+[adapt]
+milestone_naming = "standard"
+"#;
+        let cfg: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.adapt.milestone_naming, MilestoneNaming::Standard);
+    }
+
+    #[test]
+    fn adapt_settings_parses_custom_naming_with_template() {
+        let toml_str = r#"
+[project]
+repo = "owner/repo"
+[sessions]
+max_concurrent = 1
+default_model = "opus"
+default_mode = "orchestrator"
+[budget]
+max_cost_per_session = 1.0
+max_cost_total = 10.0
+[github]
+[notifications]
+[adapt]
+milestone_naming = "custom"
+milestone_template = "v{n}.0.0 — {title}"
+"#;
+        let cfg: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.adapt.milestone_naming, MilestoneNaming::Custom);
+        assert_eq!(
+            cfg.adapt.milestone_template.as_deref(),
+            Some("v{n}.0.0 — {title}")
+        );
+    }
+
+    #[test]
+    fn adapt_settings_defaults_when_section_missing() {
+        let toml_str = r#"
+[project]
+repo = "owner/repo"
+[sessions]
+max_concurrent = 1
+default_model = "opus"
+default_mode = "orchestrator"
+[budget]
+max_cost_per_session = 1.0
+max_cost_total = 10.0
+[github]
+[notifications]
+"#;
+        let cfg: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.adapt.milestone_naming, MilestoneNaming::Ai);
     }
 }


### PR DESCRIPTION
## Summary

- Add `[adapt]` config section with `milestone_naming` field (`standard`/`ai`/`custom`)
- Add `milestone_template` option for custom naming patterns
- Update planner prompt to accept naming convention hints
- Add 6 tests for config parsing and prompt injection
- Total tests: 2510

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] All 2510 tests pass
- [x] Config parsing works for all 3 variants
- [x] Missing `[adapt]` section defaults to `ai`

Closes #368