### PR TITLE
docs: workflow guide detection for adapt output

### DIFF
--- a/src/adapt/analyzer.rs
+++ b/src/adapt/analyzer.rs
@@ -99,6 +99,7 @@ mod tests {
             },
             directory_tree: "src/\n  main.rs".into(),
             has_maestro_config: false,
+            has_workflow_docs: false,
         }
     }
 

--- a/src/adapt/materializer.rs
+++ b/src/adapt/materializer.rs
@@ -315,6 +315,7 @@ mod tests {
                 ],
             }],
             maestro_toml_patch: None,
+            workflow_guide: None,
         }
     }
 
@@ -525,6 +526,7 @@ mod tests {
                 }],
             }],
             maestro_toml_patch: None,
+            workflow_guide: None,
         }
     }
 

--- a/src/adapt/planner.rs
+++ b/src/adapt/planner.rs
@@ -94,6 +94,7 @@ mod tests {
                 ],
             }],
             maestro_toml_patch: Some("[project]\nrepo = \"owner/repo\"".into()),
+            workflow_guide: None,
         }
     }
 
@@ -138,6 +139,7 @@ mod tests {
             },
             directory_tree: String::new(),
             has_maestro_config: false,
+            has_workflow_docs: false,
         };
 
         let report = AdaptReport {
@@ -168,6 +170,7 @@ mod tests {
         let plan = AdaptPlan {
             milestones: vec![],
             maestro_toml_patch: None,
+            workflow_guide: None,
         };
         let json = serde_json::to_string(&plan).unwrap();
         let rt: AdaptPlan = serde_json::from_str(&json).unwrap();
@@ -196,6 +199,7 @@ mod tests {
                 },
             ],
             maestro_toml_patch: None,
+            workflow_guide: None,
         };
         let json = serde_json::to_string(&plan).unwrap();
         let rt: AdaptPlan = serde_json::from_str(&json).unwrap();
@@ -240,6 +244,7 @@ mod tests {
             dependencies: DependencySummary::default(),
             directory_tree: String::new(),
             has_maestro_config: false,
+            has_workflow_docs: false,
         };
         let report = AdaptReport {
             summary: "test".into(),

--- a/src/adapt/scanner.rs
+++ b/src/adapt/scanner.rs
@@ -78,6 +78,9 @@ fn scan_project(root: &Path) -> anyhow::Result<ProjectProfile> {
     let directory_tree = build_directory_tree(root, 3);
     let has_maestro_config =
         root.join("maestro.toml").exists() || root.join(".claude/CLAUDE.md").exists();
+    let has_workflow_docs = root.join("docs/WORKFLOW.md").exists()
+        || root.join("CONTRIBUTING.md").exists()
+        || root.join(".github/CONTRIBUTING.md").exists();
 
     Ok(ProjectProfile {
         name,
@@ -93,6 +96,7 @@ fn scan_project(root: &Path) -> anyhow::Result<ProjectProfile> {
         dependencies,
         directory_tree,
         has_maestro_config,
+        has_workflow_docs,
     })
 }
 
@@ -782,6 +786,34 @@ tempfile = "3"
         assert_eq!(profile.language, ProjectLanguage::Rust);
         assert_eq!(profile.source_stats.total_files, 1);
         assert!(profile.manifests.contains(&PathBuf::from("Cargo.toml")));
+        assert!(!profile.has_workflow_docs);
+    }
+
+    #[tokio::test]
+    async fn scanner_detects_contributing_md() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("Cargo.toml"), "[package]\nname = \"test\"").unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+        std::fs::write(dir.path().join("CONTRIBUTING.md"), "# Contributing\n").unwrap();
+
+        let scanner = LocalProjectScanner::new();
+        let profile = scanner.scan(dir.path()).await.unwrap();
+        assert!(profile.has_workflow_docs);
+    }
+
+    #[tokio::test]
+    async fn scanner_detects_docs_workflow_md() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("Cargo.toml"), "[package]\nname = \"test\"").unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+        std::fs::create_dir_all(dir.path().join("docs")).unwrap();
+        std::fs::write(dir.path().join("docs/WORKFLOW.md"), "# Workflow\n").unwrap();
+
+        let scanner = LocalProjectScanner::new();
+        let profile = scanner.scan(dir.path()).await.unwrap();
+        assert!(profile.has_workflow_docs);
     }
 
     #[test]

--- a/src/adapt/types.rs
+++ b/src/adapt/types.rs
@@ -16,6 +16,9 @@ pub struct ProjectProfile {
     pub dependencies: DependencySummary,
     pub directory_tree: String,
     pub has_maestro_config: bool,
+    /// Whether existing workflow documentation (WORKFLOW.md, CONTRIBUTING.md) was detected.
+    #[serde(default)]
+    pub has_workflow_docs: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -122,6 +125,9 @@ pub enum TechDebtSeverity {
 pub struct AdaptPlan {
     pub milestones: Vec<PlannedMilestone>,
     pub maestro_toml_patch: Option<String>,
+    /// Generated workflow guide content (markdown). `None` if existing docs were detected.
+    #[serde(default)]
+    pub workflow_guide: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -271,6 +277,7 @@ mod tests {
             },
             directory_tree: "src/\n  main.rs".into(),
             has_maestro_config: false,
+            has_workflow_docs: false,
         };
 
         let json = serde_json::to_string(&profile).unwrap();
@@ -325,6 +332,7 @@ mod tests {
                 }],
             }],
             maestro_toml_patch: Some("[project]\nrepo = \"owner/repo\"".into()),
+            workflow_guide: None,
         };
 
         let json = serde_json::to_string(&plan).unwrap();

--- a/src/integration_tests/adapt_pipeline.rs
+++ b/src/integration_tests/adapt_pipeline.rs
@@ -45,6 +45,7 @@ fn sample_profile() -> ProjectProfile {
         },
         directory_tree: "src/\n  main.rs".into(),
         has_maestro_config: false,
+        has_workflow_docs: false,
     }
 }
 
@@ -99,6 +100,7 @@ fn sample_plan() -> AdaptPlan {
             },
         ],
         maestro_toml_patch: Some("[project]\nrepo = \"owner/repo\"".into()),
+        workflow_guide: None,
     }
 }
 
@@ -138,6 +140,7 @@ async fn pipeline_empty_analysis_produces_valid_plan() {
     let planner = MockAdaptPlanner::with_plan(AdaptPlan {
         milestones: vec![],
         maestro_toml_patch: None,
+        workflow_guide: None,
     });
     let plan = planner.plan(&profile, &report).await.unwrap();
     assert!(plan.milestones.is_empty());

--- a/src/tui/app/tests.rs
+++ b/src/tui/app/tests.rs
@@ -1408,6 +1408,7 @@ mod adapt_chaining {
             dependencies: DependencySummary::default(),
             directory_tree: String::new(),
             has_maestro_config: false,
+            has_workflow_docs: false,
         }
     }
 
@@ -1423,6 +1424,7 @@ mod adapt_chaining {
         AdaptPlan {
             milestones: vec![],
             maestro_toml_patch: None,
+            workflow_guide: None,
         }
     }
 

--- a/src/tui/screens/adapt/mod.rs
+++ b/src/tui/screens/adapt/mod.rs
@@ -376,6 +376,7 @@ mod tests {
             dependencies: DependencySummary::default(),
             directory_tree: String::new(),
             has_maestro_config: false,
+            has_workflow_docs: false,
         }
     }
 
@@ -391,6 +392,7 @@ mod tests {
         AdaptPlan {
             milestones: vec![],
             maestro_toml_patch: None,
+            workflow_guide: None,
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `has_workflow_docs` to `ProjectProfile` — scanner checks for WORKFLOW.md, CONTRIBUTING.md, .github/CONTRIBUTING.md
- Add `workflow_guide: Option<String>` to `AdaptPlan` for generated guide content
- Add 2 scanner tests: detect CONTRIBUTING.md, detect docs/WORKFLOW.md
- Total tests: 2512

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] All 2512 tests pass
- [x] Scanner correctly detects workflow docs presence

Closes #369