### PR TITLE
refactor: simplify v0.13.1 code after review

### DIFF
--- a/src/provider/azure_devops/mod.rs
+++ b/src/provider/azure_devops/mod.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)] // Reason: Azure DevOps provider — planned multi-provider feature
 use super::types::Issue;
 use crate::provider::github::client::GitHubClient;
 use crate::provider::github::types::GhMilestone;

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)] // Reason: multi-provider support (Azure DevOps) — planned feature
+#[allow(dead_code)] // Reason: multi-provider support — planned feature
 pub mod azure_devops;
 pub mod github;
 pub mod types;
@@ -12,6 +12,7 @@ use types::ProviderKind;
 use self::github::client::GhCliClient;
 
 /// Create the appropriate provider client from config.
+#[allow(dead_code)] // to be wired when provider selection is exposed via CLI/config
 pub fn create_provider(config: &ProviderConfig) -> Result<Box<dyn GitHubClient>> {
     match config.kind {
         ProviderKind::Github => Ok(Box::new(GhCliClient::new())),
@@ -29,6 +30,7 @@ pub fn create_provider(config: &ProviderConfig) -> Result<Box<dyn GitHubClient>>
 }
 
 /// Detect provider from a git remote URL string.
+#[allow(dead_code)] // to be wired when provider auto-detection is exposed
 pub fn detect_provider_from_remote(url: &str) -> ProviderKind {
     if url.contains("dev.azure.com") || url.contains("visualstudio.com") {
         ProviderKind::AzureDevops

--- a/src/tui/app/ci_polling.rs
+++ b/src/tui/app/ci_polling.rs
@@ -27,26 +27,26 @@ impl Default for CiPoller {
 
 impl CiPoller {
     /// Returns true if a poll should happen (interval elapsed and checks pending).
-    #[allow(dead_code)] // used in tests; poll_ci_status inlines this check currently
     pub fn should_poll(&self, interval: Duration) -> bool {
         self.last_ci_poll.elapsed() >= interval && !self.pending_pr_checks.is_empty()
     }
 
     /// Record that a poll just happened.
-    #[allow(dead_code)] // used in tests; poll_ci_status sets last_ci_poll directly currently
     pub fn mark_polled(&mut self) {
         self.last_ci_poll = Instant::now();
     }
 
     /// Add a new pending PR check.
-    #[allow(dead_code)] // used in tests; callers currently push directly
     pub fn add_check(&mut self, check: PendingPrCheck) {
         self.pending_pr_checks.push(check);
     }
 
     /// Remove completed checks by index (must be sorted ascending).
-    #[allow(dead_code)] // used in tests; callers currently inline the logic
     pub fn remove_completed(&mut self, indices: &[usize]) {
+        debug_assert!(
+            indices.windows(2).all(|w| w[0] <= w[1]),
+            "remove_completed requires sorted ascending indices"
+        );
         for &i in indices {
             let pr_number = self.pending_pr_checks[i].pr_number;
             self.ci_check_details.remove(&pr_number);
@@ -128,18 +128,16 @@ impl App {
             .map(|c| Duration::from_secs(c.gates.ci_poll_interval_secs))
             .unwrap_or(Duration::from_secs(30));
 
+        if !self.ci_poller.should_poll(ci_poll_interval) {
+            return;
+        }
+        self.ci_poller.mark_polled();
+
         let ci_max_wait = self
             .config
             .as_ref()
             .map(|c| Duration::from_secs(c.gates.ci_max_wait_secs))
             .unwrap_or(Duration::from_secs(1800));
-
-        if self.ci_poller.last_ci_poll.elapsed() < ci_poll_interval
-            || self.ci_poller.pending_pr_checks.is_empty()
-        {
-            return;
-        }
-        self.ci_poller.last_ci_poll = Instant::now();
 
         let auto_fix_enabled = self.flags.is_enabled(crate::flags::Flag::CiAutoFix);
         let max_retries = self
@@ -360,14 +358,8 @@ impl App {
             self.ci_poller.ci_check_details.insert(pr_number, details);
         }
 
-        // Remove completed checks in reverse order to preserve indices
+        // Remove completed checks
         completed_indices.sort_unstable();
-        for &i in &completed_indices {
-            let pr_number = self.ci_poller.pending_pr_checks[i].pr_number;
-            self.ci_poller.ci_check_details.remove(&pr_number);
-        }
-        for i in completed_indices.into_iter().rev() {
-            self.ci_poller.pending_pr_checks.remove(i);
-        }
+        self.ci_poller.remove_completed(&completed_indices);
     }
 }

--- a/src/tui/app/issue_completion.rs
+++ b/src/tui/app/issue_completion.rs
@@ -207,7 +207,7 @@ impl App {
                         );
                         // Track PR for CI polling
                         if let Some(ref branch_name) = worktree_branch {
-                            self.ci_poller.pending_pr_checks.push(PendingPrCheck {
+                            self.ci_poller.add_check(PendingPrCheck {
                                 pr_number: pr_num,
                                 issue_number,
                                 branch: branch_name.clone(),

--- a/src/tui/app/mod.rs
+++ b/src/tui/app/mod.rs
@@ -98,7 +98,6 @@ pub struct App {
     pub pending_prs: Vec<crate::provider::github::types::PendingPr>,
     pub flags: crate::flags::store::FeatureFlags,
     pub queue_confirmation_screen: Option<crate::tui::screens::QueueConfirmationScreen>,
-    // ci_check_details moved into ci_poller
     pub queue_executor: Option<crate::work::executor::QueueExecutor>,
     pub queue_launch_configs: Option<Vec<crate::tui::screens::SessionConfig>>,
     pub hollow_retry_screen: Option<crate::tui::screens::HollowRetryScreen>,
@@ -186,7 +185,6 @@ impl App {
             pending_prs: Vec::new(),
             flags: crate::flags::store::FeatureFlags::default(),
             queue_confirmation_screen: None,
-            // ci_check_details is in ci_poller
             queue_executor: None,
             queue_launch_configs: None,
             hollow_retry_screen: None,

--- a/src/tui/app/pr_retry.rs
+++ b/src/tui/app/pr_retry.rs
@@ -67,7 +67,7 @@ impl App {
                             format!("PR #{} created (retry {})", pr_num, attempt),
                             LogLevel::Info,
                         );
-                        self.ci_poller.pending_pr_checks.push(PendingPrCheck {
+                        self.ci_poller.add_check(PendingPrCheck {
                             pr_number: pr_num,
                             issue_number,
                             branch: branch.clone(),

--- a/src/tui/app/tests.rs
+++ b/src/tui/app/tests.rs
@@ -299,7 +299,7 @@ fn build_completion_summary_sets_pr_link_when_pending_check_matches() {
     );
     session.status = crate::session::types::SessionStatus::Completed;
     app.pool.enqueue(session);
-    app.ci_poller.pending_pr_checks.push(PendingPrCheck {
+    app.ci_poller.add_check(PendingPrCheck {
         pr_number: 42,
         issue_number: 10,
         branch: "feat/issue-10".into(),
@@ -328,7 +328,7 @@ fn build_completion_summary_pr_link_empty_when_no_matching_check() {
         Some(99),
     );
     app.pool.enqueue(session);
-    app.ci_poller.pending_pr_checks.push(PendingPrCheck {
+    app.ci_poller.add_check(PendingPrCheck {
         pr_number: 5,
         issue_number: 5,
         branch: "feat/issue-5".into(),
@@ -357,7 +357,7 @@ fn build_completion_summary_pr_link_empty_when_no_issue_number() {
         None,
     );
     app.pool.enqueue(session);
-    app.ci_poller.pending_pr_checks.push(PendingPrCheck {
+    app.ci_poller.add_check(PendingPrCheck {
         pr_number: 1,
         issue_number: 1,
         branch: "feat/issue-1".into(),
@@ -1083,7 +1083,7 @@ fn poll_ci_status_skips_fix_when_ci_auto_fix_flag_disabled() {
         vec!["ci_auto_fix".to_string()],
     );
     let mut app = make_app_with_flags(flags);
-    app.ci_poller.pending_pr_checks.push(PendingPrCheck {
+    app.ci_poller.add_check(PendingPrCheck {
         pr_number: 99,
         issue_number: 42,
         branch: "feat/test".to_string(),


### PR DESCRIPTION
## Summary

Post-implementation review cleanup from 3 parallel review agents (reuse, quality, efficiency).

**Fixed:**
- Wire `CiPoller` methods into production code — `should_poll()`, `mark_polled()`, `remove_completed()`, `add_check()` now used instead of inlined duplicates
- Remove all `#[allow(dead_code)]` from CiPoller methods
- Add `debug_assert!` for sorted indices in `remove_completed()`
- Reorder `poll_ci_status` to check `should_poll()` before extracting `ci_max_wait` config
- Scope `#[allow(dead_code)]` in `provider/mod.rs` to specific functions instead of blanket module suppression
- Remove duplicate `#![allow(dead_code)]` from `azure_devops/mod.rs`
- Remove migration breadcrumb comments from App struct

**Skipped (low priority / not actionable):**
- Test fixture duplication (test-only, 3 files)
- `ModuleDescription::complexity` stringly-typed (pre-existing, Claude API contract)
- `ci_check_details.len()` redundant in render (O(1), negligible)

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] All 2512 tests pass