### PR TITLE
feat: PRD generator — standalone command + adapt integration (#370)

### DIFF
--- a/src/adapt/mod.rs
+++ b/src/adapt/mod.rs
@@ -1,6 +1,7 @@
 pub mod analyzer;
 pub mod materializer;
 pub mod planner;
+pub mod prd;
 mod prompts;
 pub mod scanner;
 pub mod types;
@@ -25,6 +26,56 @@ impl Default for AdaptConfig {
             model: None,
         }
     }
+}
+
+/// Configuration for the `maestro prd` standalone command.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PrdConfig {
+    pub path: std::path::PathBuf,
+    pub model: Option<String>,
+    pub force: bool,
+}
+
+pub async fn cmd_prd(config: PrdConfig) -> anyhow::Result<()> {
+    use prd::{ClaudePrdGenerator, PrdGenerator};
+    use scanner::{LocalProjectScanner, ProjectScanner};
+    use analyzer::{ClaudeAnalyzer, ProjectAnalyzer};
+
+    let model = config.model.as_deref().unwrap_or("sonnet").to_string();
+
+    // Phase 1: Scan
+    eprintln!("Scanning project...");
+    let scanner = LocalProjectScanner::new();
+    let profile = scanner.scan(&config.path).await?;
+
+    // Phase 2: Analyze
+    eprintln!("Analyzing project...");
+    let analyzer = ClaudeAnalyzer::new(model.clone());
+    let report = analyzer.analyze(&profile).await?;
+
+    // Phase 3: Generate PRD
+    eprintln!("Generating PRD...");
+    let generator = ClaudePrdGenerator::new(model);
+    let prd_content = generator.generate(&profile, &report).await?;
+
+    // Check for existing PRD
+    let output_path = config.path.join("docs/PRD.md");
+    if output_path.exists() && !config.force {
+        eprintln!(
+            "PRD already exists at {}. Use --force to overwrite.",
+            output_path.display()
+        );
+        return Ok(());
+    }
+
+    // Write PRD
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&output_path, &prd_content)?;
+    eprintln!("PRD written to {}", output_path.display());
+
+    Ok(())
 }
 
 pub async fn cmd_adapt(config: AdaptConfig) -> anyhow::Result<()> {
@@ -78,10 +129,34 @@ pub async fn cmd_adapt(config: AdaptConfig) -> anyhow::Result<()> {
         return Ok(());
     }
 
+    // Phase 2.5: Consolidate (PRD generation)
+    eprintln!("Phase 2.5: Generating PRD...");
+    use prd::PrdGenerator;
+    let prd_generator = prd::ClaudePrdGenerator::new(model.clone());
+    let prd_content = match prd_generator.generate(&profile, &report).await {
+        Ok(content) => {
+            let prd_path = config.path.join("docs/PRD.md");
+            if !prd_path.exists() {
+                if let Some(parent) = prd_path.parent() {
+                    let _ = std::fs::create_dir_all(parent);
+                }
+                let _ = std::fs::write(&prd_path, &content);
+                eprintln!("  PRD saved to {}", prd_path.display());
+            } else {
+                eprintln!("  PRD already exists, skipping write");
+            }
+            Some(content)
+        }
+        Err(e) => {
+            eprintln!("  PRD generation failed: {}. Continuing without PRD.", e);
+            None
+        }
+    };
+
     // Phase 3: Plan
     eprintln!("Phase 3: Planning milestones and issues...");
     let planner = ClaudePlanner::new(model);
-    let plan = planner.plan(&profile, &report).await?;
+    let plan = planner.plan(&profile, &report, prd_content.as_deref()).await?;
     eprintln!(
         "  {} milestones, {} issues",
         plan.milestones.len(),

--- a/src/adapt/mod.rs
+++ b/src/adapt/mod.rs
@@ -41,24 +41,6 @@ pub async fn cmd_prd(config: PrdConfig) -> anyhow::Result<()> {
     use scanner::{LocalProjectScanner, ProjectScanner};
     use analyzer::{ClaudeAnalyzer, ProjectAnalyzer};
 
-    let model = config.model.as_deref().unwrap_or("sonnet").to_string();
-
-    // Phase 1: Scan
-    eprintln!("Scanning project...");
-    let scanner = LocalProjectScanner::new();
-    let profile = scanner.scan(&config.path).await?;
-
-    // Phase 2: Analyze
-    eprintln!("Analyzing project...");
-    let analyzer = ClaudeAnalyzer::new(model.clone());
-    let report = analyzer.analyze(&profile).await?;
-
-    // Phase 3: Generate PRD
-    eprintln!("Generating PRD...");
-    let generator = ClaudePrdGenerator::new(model);
-    let prd_content = generator.generate(&profile, &report).await?;
-
-    // Check for existing PRD
     let output_path = config.path.join("docs/PRD.md");
     if output_path.exists() && !config.force {
         eprintln!(
@@ -68,7 +50,20 @@ pub async fn cmd_prd(config: PrdConfig) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    // Write PRD
+    let model = config.model.as_deref().unwrap_or("sonnet").to_string();
+
+    eprintln!("Scanning project...");
+    let scanner = LocalProjectScanner::new();
+    let profile = scanner.scan(&config.path).await?;
+
+    eprintln!("Analyzing project...");
+    let analyzer = ClaudeAnalyzer::new(model.clone());
+    let report = analyzer.analyze(&profile).await?;
+
+    eprintln!("Generating PRD...");
+    let generator = ClaudePrdGenerator::new(model);
+    let prd_content = generator.generate(&profile, &report).await?;
+
     if let Some(parent) = output_path.parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -137,11 +132,15 @@ pub async fn cmd_adapt(config: AdaptConfig) -> anyhow::Result<()> {
         Ok(content) => {
             let prd_path = config.path.join("docs/PRD.md");
             if !prd_path.exists() {
-                if let Some(parent) = prd_path.parent() {
-                    let _ = std::fs::create_dir_all(parent);
+                if let Some(parent) = prd_path.parent()
+                    && let Err(e) = std::fs::create_dir_all(parent)
+                {
+                    eprintln!("  Failed to create docs/: {}", e);
                 }
-                let _ = std::fs::write(&prd_path, &content);
-                eprintln!("  PRD saved to {}", prd_path.display());
+                match std::fs::write(&prd_path, &content) {
+                    Ok(()) => eprintln!("  PRD saved to {}", prd_path.display()),
+                    Err(e) => eprintln!("  Failed to write PRD: {}", e),
+                }
             } else {
                 eprintln!("  PRD already exists, skipping write");
             }

--- a/src/adapt/mod.rs
+++ b/src/adapt/mod.rs
@@ -37,9 +37,9 @@ pub struct PrdConfig {
 }
 
 pub async fn cmd_prd(config: PrdConfig) -> anyhow::Result<()> {
+    use analyzer::{ClaudeAnalyzer, ProjectAnalyzer};
     use prd::{ClaudePrdGenerator, PrdGenerator};
     use scanner::{LocalProjectScanner, ProjectScanner};
-    use analyzer::{ClaudeAnalyzer, ProjectAnalyzer};
 
     let output_path = config.path.join("docs/PRD.md");
     if output_path.exists() && !config.force {
@@ -155,7 +155,9 @@ pub async fn cmd_adapt(config: AdaptConfig) -> anyhow::Result<()> {
     // Phase 3: Plan
     eprintln!("Phase 3: Planning milestones and issues...");
     let planner = ClaudePlanner::new(model);
-    let plan = planner.plan(&profile, &report, prd_content.as_deref()).await?;
+    let plan = planner
+        .plan(&profile, &report, prd_content.as_deref())
+        .await?;
     eprintln!(
         "  {} milestones, {} issues",
         plan.milestones.len(),

--- a/src/adapt/planner.rs
+++ b/src/adapt/planner.rs
@@ -9,6 +9,7 @@ pub trait AdaptPlanner: Send + Sync {
         &self,
         profile: &ProjectProfile,
         report: &AdaptReport,
+        prd_content: Option<&str>,
     ) -> anyhow::Result<AdaptPlan>;
 }
 
@@ -28,10 +29,11 @@ impl AdaptPlanner for ClaudePlanner {
         &self,
         profile: &ProjectProfile,
         report: &AdaptReport,
+        prd_content: Option<&str>,
     ) -> anyhow::Result<AdaptPlan> {
         let profile_json = serde_json::to_string_pretty(profile)?;
         let report_json = serde_json::to_string_pretty(report)?;
-        let prompt = build_planning_prompt(&profile_json, &report_json, None);
+        let prompt = build_planning_prompt(&profile_json, &report_json, None, prd_content);
         let raw = run_claude_print(&self.model, &prompt, &profile.root).await?;
         parse_json_response(&raw)
     }
@@ -60,6 +62,7 @@ impl AdaptPlanner for MockAdaptPlanner {
         &self,
         _profile: &ProjectProfile,
         _report: &AdaptReport,
+        _prd_content: Option<&str>,
     ) -> anyhow::Result<AdaptPlan> {
         self.result
             .clone()
@@ -148,7 +151,7 @@ mod tests {
             tech_debt_items: vec![],
         };
 
-        let result = planner.plan(&profile, &report).await.unwrap();
+        let result = planner.plan(&profile, &report, None).await.unwrap();
         assert_eq!(result.milestones.len(), 1);
         assert_eq!(result.milestones[0].issues.len(), 2);
         assert_eq!(
@@ -251,6 +254,6 @@ mod tests {
             modules: vec![],
             tech_debt_items: vec![],
         };
-        assert!(planner.plan(&profile, &report).await.is_err());
+        assert!(planner.plan(&profile, &report, None).await.is_err());
     }
 }

--- a/src/adapt/prd.rs
+++ b/src/adapt/prd.rs
@@ -1,0 +1,150 @@
+use async_trait::async_trait;
+
+use super::types::{AdaptReport, ProjectProfile};
+
+#[async_trait]
+pub trait PrdGenerator: Send + Sync {
+    async fn generate(
+        &self,
+        profile: &ProjectProfile,
+        report: &AdaptReport,
+    ) -> anyhow::Result<String>;
+}
+
+pub struct ClaudePrdGenerator {
+    model: String,
+}
+
+impl ClaudePrdGenerator {
+    pub fn new(model: String) -> Self {
+        Self { model }
+    }
+}
+
+#[async_trait]
+impl PrdGenerator for ClaudePrdGenerator {
+    async fn generate(
+        &self,
+        profile: &ProjectProfile,
+        report: &AdaptReport,
+    ) -> anyhow::Result<String> {
+        let profile_json = serde_json::to_string_pretty(profile)?;
+        let report_json = serde_json::to_string_pretty(report)?;
+        let prompt = super::prompts::build_prd_prompt(&profile_json, &report_json);
+        super::prompts::run_claude_print(&self.model, &prompt, &profile.root).await
+    }
+}
+
+#[cfg(test)]
+pub struct MockPrdGenerator {
+    result: Option<String>,
+}
+
+#[cfg(test)]
+impl MockPrdGenerator {
+    pub fn with_content(content: String) -> Self {
+        Self {
+            result: Some(content),
+        }
+    }
+
+    pub fn without_content() -> Self {
+        Self { result: None }
+    }
+}
+
+#[cfg(test)]
+#[async_trait]
+impl PrdGenerator for MockPrdGenerator {
+    async fn generate(
+        &self,
+        _profile: &ProjectProfile,
+        _report: &AdaptReport,
+    ) -> anyhow::Result<String> {
+        self.result
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("mock prd generator: no content configured"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapt::types::*;
+    use std::path::PathBuf;
+
+    fn sample_profile() -> ProjectProfile {
+        ProjectProfile {
+            name: "test-project".into(),
+            root: PathBuf::from("/tmp"),
+            language: ProjectLanguage::Rust,
+            manifests: vec![],
+            config_files: vec![],
+            entry_points: vec![],
+            source_stats: SourceStats {
+                total_files: 10,
+                total_lines: 500,
+                by_extension: vec![],
+            },
+            test_infra: TestInfraInfo {
+                has_tests: true,
+                framework: Some("cargo test".into()),
+                test_directories: vec![],
+                test_file_count: 3,
+            },
+            ci: CiInfo {
+                provider: None,
+                config_files: vec![],
+            },
+            git: GitInfo {
+                is_git_repo: true,
+                default_branch: Some("main".into()),
+                remote_url: None,
+                commit_count: 42,
+                recent_contributors: vec![],
+            },
+            dependencies: DependencySummary::default(),
+            directory_tree: String::new(),
+            has_maestro_config: false,
+            has_workflow_docs: false,
+        }
+    }
+
+    fn sample_report() -> AdaptReport {
+        AdaptReport {
+            summary: "A Rust CLI tool".into(),
+            modules: vec![ModuleDescription {
+                path: "src/main.rs".into(),
+                purpose: "Entry point".into(),
+                complexity: "low".into(),
+            }],
+            tech_debt_items: vec![TechDebtItem {
+                title: "Missing tests".into(),
+                description: "No tests for auth module".into(),
+                location: "src/auth.rs".into(),
+                suggested_fix: "Add unit tests".into(),
+                category: TechDebtCategory::MissingTests,
+                severity: TechDebtSeverity::High,
+            }],
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_prd_generator_returns_configured_content() {
+        let generator = MockPrdGenerator::with_content("# PRD: Test".into());
+        let result = generator
+            .generate(&sample_profile(), &sample_report())
+            .await
+            .unwrap();
+        assert_eq!(result, "# PRD: Test");
+    }
+
+    #[tokio::test]
+    async fn mock_prd_generator_without_content_returns_error() {
+        let generator = MockPrdGenerator::without_content();
+        let result = generator
+            .generate(&sample_profile(), &sample_report())
+            .await;
+        assert!(result.is_err());
+    }
+}

--- a/src/adapt/prompts.rs
+++ b/src/adapt/prompts.rs
@@ -117,10 +117,7 @@ pub fn build_planning_prompt(
         None => String::new(),
     };
     let prd_section = match prd_content {
-        Some(prd) => format!(
-            "\n## Product Requirements Document\n\n{}\n",
-            prd
-        ),
+        Some(prd) => format!("\n## Product Requirements Document\n\n{}\n", prd),
         None => String::new(),
     };
     format!(
@@ -272,7 +269,8 @@ mod tests {
 
     #[test]
     fn build_planning_prompt_contains_both_inputs() {
-        let prompt = build_planning_prompt(r#"{"name":"test"}"#, r#"{"summary":"good"}"#, None, None);
+        let prompt =
+            build_planning_prompt(r#"{"name":"test"}"#, r#"{"summary":"good"}"#, None, None);
         assert!(prompt.contains(r#"{"name":"test"}"#));
         assert!(prompt.contains(r#"{"summary":"good"}"#));
         assert!(prompt.contains("milestones"));
@@ -292,7 +290,8 @@ mod tests {
 
     #[test]
     fn build_planning_prompt_omits_naming_section_when_none() {
-        let prompt = build_planning_prompt(r#"{"name":"test"}"#, r#"{"summary":"good"}"#, None, None);
+        let prompt =
+            build_planning_prompt(r#"{"name":"test"}"#, r#"{"summary":"good"}"#, None, None);
         assert!(!prompt.contains("Milestone naming"));
     }
 
@@ -386,7 +385,8 @@ That's all."#;
 
     #[test]
     fn build_planning_prompt_omits_prd_when_none() {
-        let prompt = build_planning_prompt(r#"{"name":"test"}"#, r#"{"summary":"good"}"#, None, None);
+        let prompt =
+            build_planning_prompt(r#"{"name":"test"}"#, r#"{"summary":"good"}"#, None, None);
         assert!(!prompt.contains("Product Requirements Document"));
     }
 

--- a/src/adapt/prompts.rs
+++ b/src/adapt/prompts.rs
@@ -51,13 +51,76 @@ Return ONLY the JSON object, no markdown fences, no commentary."#,
     )
 }
 
+pub fn build_prd_prompt(profile_json: &str, report_json: &str) -> String {
+    format!(
+        r#"You are generating a Product Requirements Document (PRD) for a software project.
+
+## Project Profile
+
+{profile_json}
+
+## Analysis Report
+
+{report_json}
+
+## Instructions
+
+Generate a comprehensive PRD in markdown format. The document must contain ALL of the following sections:
+
+# PRD: {{project name}}
+
+## 1. Project Identity
+- Name, description, primary language, tech stack summary
+
+## 2. Architecture Overview
+- Module map with responsibilities and boundaries
+- How modules relate to each other
+
+## 3. Component Inventory
+For each key component:
+- Purpose
+- Complexity (low/medium/high)
+- Dependencies on other components
+
+## 4. Data Flow
+- How data moves through the system
+- Key entry points and exit points
+
+## 5. Tech Stack
+- Languages and versions
+- Frameworks and libraries
+- Build tools
+- CI/CD pipeline
+- Test frameworks
+
+## 6. Current State
+- Test coverage status
+- Tech debt summary (reference the analysis report)
+- Security posture
+
+## 7. Non-Goals
+- What this project intentionally does NOT do
+- Explicit boundaries and out-of-scope items
+
+Return ONLY the markdown document, no code fences wrapping the entire output."#,
+    )
+}
+
 pub fn build_planning_prompt(
     profile_json: &str,
     report_json: &str,
     milestone_naming_hint: Option<&str>,
+    prd_content: Option<&str>,
 ) -> String {
     let naming_section = match milestone_naming_hint {
         Some(hint) => format!("\n6. **Milestone naming**: {}\n", hint),
+        None => String::new(),
+    };
+    let prd_section = match prd_content {
+        Some(prd) => format!(
+            "\n## Product Requirements Document\n\n{}\n",
+            prd
+        ),
         None => String::new(),
     };
     format!(
@@ -70,6 +133,7 @@ pub fn build_planning_prompt(
 ## Analysis Report
 
 {report_json}
+{prd_section}
 
 ## Instructions
 
@@ -208,7 +272,7 @@ mod tests {
 
     #[test]
     fn build_planning_prompt_contains_both_inputs() {
-        let prompt = build_planning_prompt(r#"{"name":"test"}"#, r#"{"summary":"good"}"#, None);
+        let prompt = build_planning_prompt(r#"{"name":"test"}"#, r#"{"summary":"good"}"#, None, None);
         assert!(prompt.contains(r#"{"name":"test"}"#));
         assert!(prompt.contains(r#"{"summary":"good"}"#));
         assert!(prompt.contains("milestones"));
@@ -221,13 +285,14 @@ mod tests {
             r#"{"name":"test"}"#,
             r#"{"summary":"good"}"#,
             Some("Use semver format: vX.Y.Z"),
+            None,
         );
         assert!(prompt.contains("Use semver format: vX.Y.Z"));
     }
 
     #[test]
     fn build_planning_prompt_omits_naming_section_when_none() {
-        let prompt = build_planning_prompt(r#"{"name":"test"}"#, r#"{"summary":"good"}"#, None);
+        let prompt = build_planning_prompt(r#"{"name":"test"}"#, r#"{"summary":"good"}"#, None, None);
         assert!(!prompt.contains("Milestone naming"));
     }
 
@@ -274,6 +339,43 @@ That's all."#;
         let raw = "This is not JSON at all";
         let result: anyhow::Result<AdaptReport> = parse_json_response(raw);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn build_prd_prompt_contains_profile_and_report() {
+        let prompt = build_prd_prompt(r#"{"name":"test"}"#, r#"{"summary":"good"}"#);
+        assert!(prompt.contains(r#"{"name":"test"}"#));
+        assert!(prompt.contains(r#"{"summary":"good"}"#));
+    }
+
+    #[test]
+    fn build_prd_prompt_contains_all_section_headings() {
+        let prompt = build_prd_prompt(r#"{}"#, r#"{}"#);
+        assert!(prompt.contains("Project Identity"));
+        assert!(prompt.contains("Architecture Overview"));
+        assert!(prompt.contains("Component Inventory"));
+        assert!(prompt.contains("Data Flow"));
+        assert!(prompt.contains("Tech Stack"));
+        assert!(prompt.contains("Current State"));
+        assert!(prompt.contains("Non-Goals"));
+    }
+
+    #[test]
+    fn build_planning_prompt_includes_prd_when_provided() {
+        let prompt = build_planning_prompt(
+            r#"{"name":"test"}"#,
+            r#"{"summary":"good"}"#,
+            None,
+            Some("# PRD: Test Project\n\nSome PRD content here"),
+        );
+        assert!(prompt.contains("Product Requirements Document"));
+        assert!(prompt.contains("# PRD: Test Project"));
+    }
+
+    #[test]
+    fn build_planning_prompt_omits_prd_when_none() {
+        let prompt = build_planning_prompt(r#"{"name":"test"}"#, r#"{"summary":"good"}"#, None, None);
+        assert!(!prompt.contains("Product Requirements Document"));
     }
 
     #[test]

--- a/src/adapt/prompts.rs
+++ b/src/adapt/prompts.rs
@@ -373,6 +373,18 @@ That's all."#;
     }
 
     #[test]
+    fn build_planning_prompt_prd_and_naming_hint_coexist() {
+        let prompt = build_planning_prompt(
+            r#"{"name":"test"}"#,
+            r#"{"summary":"good"}"#,
+            Some("Use semver format: vX.Y.Z"),
+            Some("## PRD content here"),
+        );
+        assert!(prompt.contains("Use semver format: vX.Y.Z"));
+        assert!(prompt.contains("## PRD content here"));
+    }
+
+    #[test]
     fn build_planning_prompt_omits_prd_when_none() {
         let prompt = build_planning_prompt(r#"{"name":"test"}"#, r#"{"summary":"good"}"#, None, None);
         assert!(!prompt.contains("Product Requirements Document"));

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -154,6 +154,20 @@ pub enum Commands {
         #[arg(short, long)]
         model: Option<String>,
     },
+    /// Generate a Product Requirements Document from project analysis
+    Prd {
+        /// Path to the project (defaults to current directory)
+        #[arg(short, long, default_value = ".")]
+        path: std::path::PathBuf,
+
+        /// AI model to use for analysis and generation
+        #[arg(short, long)]
+        model: Option<String>,
+
+        /// Overwrite existing PRD without confirmation
+        #[arg(long)]
+        force: bool,
+    },
     /// Analyze codebase for dead code and code smells
     Sanitize {
         /// Path to scan (defaults to current directory)
@@ -613,6 +627,56 @@ mod tests {
             assert!(disable_flags.is_empty());
         } else {
             panic!("Expected Commands::Run");
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Prd subcommand parsing
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn prd_subcommand_parses_with_no_flags() {
+        let cli = Cli::try_parse_from(["maestro", "prd"]).unwrap();
+        assert!(matches!(cli.command, Some(Commands::Prd { .. })));
+    }
+
+    #[test]
+    fn prd_path_defaults_to_current_dir() {
+        let cli = Cli::try_parse_from(["maestro", "prd"]).unwrap();
+        if let Some(Commands::Prd { path, .. }) = cli.command {
+            assert_eq!(path, PathBuf::from("."));
+        } else {
+            panic!("Expected Commands::Prd");
+        }
+    }
+
+    #[test]
+    fn prd_force_defaults_to_false() {
+        let cli = Cli::try_parse_from(["maestro", "prd"]).unwrap();
+        if let Some(Commands::Prd { force, .. }) = cli.command {
+            assert!(!force);
+        } else {
+            panic!("Expected Commands::Prd");
+        }
+    }
+
+    #[test]
+    fn prd_force_is_set_when_provided() {
+        let cli = Cli::try_parse_from(["maestro", "prd", "--force"]).unwrap();
+        if let Some(Commands::Prd { force, .. }) = cli.command {
+            assert!(force);
+        } else {
+            panic!("Expected Commands::Prd");
+        }
+    }
+
+    #[test]
+    fn prd_model_accepts_value() {
+        let cli = Cli::try_parse_from(["maestro", "prd", "--model", "opus"]).unwrap();
+        if let Some(Commands::Prd { model, .. }) = cli.command {
+            assert_eq!(model.as_deref(), Some("opus"));
+        } else {
+            panic!("Expected Commands::Prd");
         }
     }
 

--- a/src/integration_tests/adapt_pipeline.rs
+++ b/src/integration_tests/adapt_pipeline.rs
@@ -117,7 +117,7 @@ async fn pipeline_analyze_then_plan_with_mocks() {
 
     // Phase 3: Plan
     let planner = MockAdaptPlanner::with_plan(sample_plan());
-    let plan = planner.plan(&profile, &report).await.unwrap();
+    let plan = planner.plan(&profile, &report, None).await.unwrap();
     assert_eq!(plan.milestones.len(), 2);
     assert_eq!(plan.milestones[0].issues.len(), 1);
     assert_eq!(plan.milestones[1].issues[0].blocked_by_titles.len(), 1);
@@ -142,7 +142,7 @@ async fn pipeline_empty_analysis_produces_valid_plan() {
         maestro_toml_patch: None,
         workflow_guide: None,
     });
-    let plan = planner.plan(&profile, &report).await.unwrap();
+    let plan = planner.plan(&profile, &report, None).await.unwrap();
     assert!(plan.milestones.is_empty());
     assert!(plan.maestro_toml_patch.is_none());
 }
@@ -162,6 +162,6 @@ async fn pipeline_planner_failure_propagates() {
     let profile = sample_profile();
     let report = sample_report();
     let planner = MockAdaptPlanner::without_plan();
-    let err = planner.plan(&profile, &report).await;
+    let err = planner.plan(&profile, &report, None).await;
     assert!(err.is_err());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,17 +105,8 @@ async fn main() -> anyhow::Result<()> {
             })
             .await
         }
-        Some(Commands::Prd {
-            path,
-            model,
-            force,
-        }) => {
-            adapt::cmd_prd(adapt::PrdConfig {
-                path,
-                model,
-                force,
-            })
-            .await
+        Some(Commands::Prd { path, model, force }) => {
+            adapt::cmd_prd(adapt::PrdConfig { path, model, force }).await
         }
         Some(Commands::Sanitize {
             path,

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,6 +105,18 @@ async fn main() -> anyhow::Result<()> {
             })
             .await
         }
+        Some(Commands::Prd {
+            path,
+            model,
+            force,
+        }) => {
+            adapt::cmd_prd(adapt::PrdConfig {
+                path,
+                model,
+                force,
+            })
+            .await
+        }
         Some(Commands::Sanitize {
             path,
             output,

--- a/src/tui/app/data_handler.rs
+++ b/src/tui/app/data_handler.rs
@@ -181,6 +181,26 @@ impl App {
                     }
                 }
             }
+            TuiDataEvent::AdaptConsolidateResult(result) => {
+                if let Some(ref mut screen) = self.adapt_screen {
+                    if screen.is_cancelled() {
+                        return;
+                    }
+                    match result {
+                        Ok(prd_content) => {
+                            if let Some(cmd) = screen.complete_consolidate(prd_content) {
+                                self.pending_commands.push(cmd);
+                            }
+                        }
+                        Err(e) => {
+                            screen.set_error(
+                                crate::tui::screens::adapt::AdaptStep::Consolidating,
+                                format!("{}", e),
+                            );
+                        }
+                    }
+                }
+            }
             TuiDataEvent::AdaptPlanResult(result) => {
                 if let Some(ref mut screen) = self.adapt_screen {
                     if screen.is_cancelled() {

--- a/src/tui/app/tests.rs
+++ b/src/tui/app/tests.rs
@@ -1484,7 +1484,7 @@ mod adapt_chaining {
     }
 
     #[test]
-    fn analyze_ok_chains_to_plan() {
+    fn analyze_ok_chains_to_consolidate() {
         let mut app = app_with_adapt_screen();
         app.adapt_screen.as_mut().unwrap().step = AdaptStep::Analyzing;
         app.adapt_screen
@@ -1495,12 +1495,12 @@ mod adapt_chaining {
         app.handle_data_event(TuiDataEvent::AdaptAnalyzeResult(Ok(make_report())));
 
         let screen = app.adapt_screen.as_ref().unwrap();
-        assert_eq!(screen.step, AdaptStep::Planning);
+        assert_eq!(screen.step, AdaptStep::Consolidating);
         assert!(screen.results.report.is_some());
         assert_eq!(app.pending_commands.len(), 1);
         assert!(matches!(
             app.pending_commands[0],
-            TuiCommand::RunAdaptPlan(_, _, _)
+            TuiCommand::RunAdaptConsolidate(_, _, _)
         ));
     }
 
@@ -1645,11 +1645,22 @@ mod adapt_chaining {
         let cmd = app.pending_commands.pop().unwrap();
         assert!(matches!(cmd, TuiCommand::RunAdaptAnalyze(_, _)));
         app.handle_data_event(TuiDataEvent::AdaptAnalyzeResult(Ok(make_report())));
+        assert_eq!(
+            app.adapt_screen.as_ref().unwrap().step,
+            AdaptStep::Consolidating
+        );
+
+        // Phase 2.5: Consolidate (PRD)
+        let cmd = app.pending_commands.pop().unwrap();
+        assert!(matches!(cmd, TuiCommand::RunAdaptConsolidate(_, _, _)));
+        app.handle_data_event(TuiDataEvent::AdaptConsolidateResult(Ok(
+            "# PRD: Test".to_string(),
+        )));
         assert_eq!(app.adapt_screen.as_ref().unwrap().step, AdaptStep::Planning);
 
         // Phase 3: Plan
         let cmd = app.pending_commands.pop().unwrap();
-        assert!(matches!(cmd, TuiCommand::RunAdaptPlan(_, _, _)));
+        assert!(matches!(cmd, TuiCommand::RunAdaptPlan(_, _, _, _)));
         app.handle_data_event(TuiDataEvent::AdaptPlanResult(Ok(make_plan())));
         assert_eq!(
             app.adapt_screen.as_ref().unwrap().step,

--- a/src/tui/app/tests.rs
+++ b/src/tui/app/tests.rs
@@ -1654,7 +1654,7 @@ mod adapt_chaining {
         let cmd = app.pending_commands.pop().unwrap();
         assert!(matches!(cmd, TuiCommand::RunAdaptConsolidate(_, _, _)));
         app.handle_data_event(TuiDataEvent::AdaptConsolidateResult(Ok(
-            "# PRD: Test".to_string(),
+            "# PRD: Test".to_string()
         )));
         assert_eq!(app.adapt_screen.as_ref().unwrap().step, AdaptStep::Planning);
 

--- a/src/tui/app/types.rs
+++ b/src/tui/app/types.rs
@@ -156,7 +156,8 @@ pub enum TuiCommand {
     LaunchUnifiedSession(UnifiedSessionConfig),
     RunAdaptScan(AdaptConfig),
     RunAdaptAnalyze(AdaptConfig, ProjectProfile),
-    RunAdaptPlan(AdaptConfig, ProjectProfile, AdaptReport),
+    RunAdaptConsolidate(AdaptConfig, ProjectProfile, AdaptReport),
+    RunAdaptPlan(AdaptConfig, ProjectProfile, AdaptReport, Option<String>),
     RunAdaptMaterialize(AdaptPlan, AdaptReport),
     FetchOpenPrs,
     SubmitPrReview {
@@ -176,6 +177,7 @@ pub enum TuiDataEvent {
     UpgradeResult(Result<String, String>),
     AdaptScanResult(anyhow::Result<Box<ProjectProfile>>),
     AdaptAnalyzeResult(anyhow::Result<AdaptReport>),
+    AdaptConsolidateResult(anyhow::Result<String>),
     AdaptPlanResult(anyhow::Result<AdaptPlan>),
     AdaptMaterializeResult(anyhow::Result<MaterializeResult>),
     UnifiedIssues(anyhow::Result<Vec<GhIssue>>, Option<String>),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -328,13 +328,35 @@ async fn event_loop(
                         let _ = tx.send(app::TuiDataEvent::AdaptAnalyzeResult(result));
                     });
                 }
-                app::TuiCommand::RunAdaptPlan(config, profile, report) => {
+                app::TuiCommand::RunAdaptConsolidate(config, profile, report) => {
+                    let tx = app.data_tx.clone();
+                    let model = config.model.unwrap_or_else(|| "sonnet".to_string());
+                    tokio::spawn(async move {
+                        use crate::adapt::prd::{ClaudePrdGenerator, PrdGenerator};
+                        let generator = ClaudePrdGenerator::new(model);
+                        let result = generator.generate(&profile, &report).await;
+                        // Write PRD to docs/PRD.md if successful and file doesn't exist
+                        if let Ok(ref content) = result {
+                            let prd_path = profile.root.join("docs/PRD.md");
+                            if !prd_path.exists() {
+                                if let Some(parent) = prd_path.parent() {
+                                    let _ = std::fs::create_dir_all(parent);
+                                }
+                                let _ = std::fs::write(&prd_path, content);
+                            }
+                        }
+                        let _ = tx.send(app::TuiDataEvent::AdaptConsolidateResult(result));
+                    });
+                }
+                app::TuiCommand::RunAdaptPlan(config, profile, report, prd_content) => {
                     let tx = app.data_tx.clone();
                     let model = config.model.unwrap_or_else(|| "sonnet".to_string());
                     tokio::spawn(async move {
                         use crate::adapt::planner::{AdaptPlanner, ClaudePlanner};
                         let planner = ClaudePlanner::new(model);
-                        let result = planner.plan(&profile, &report).await;
+                        let result = planner
+                            .plan(&profile, &report, prd_content.as_deref())
+                            .await;
                         let _ = tx.send(app::TuiDataEvent::AdaptPlanResult(result));
                     });
                 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -335,14 +335,17 @@ async fn event_loop(
                         use crate::adapt::prd::{ClaudePrdGenerator, PrdGenerator};
                         let generator = ClaudePrdGenerator::new(model);
                         let result = generator.generate(&profile, &report).await;
-                        // Write PRD to docs/PRD.md if successful and file doesn't exist
                         if let Ok(ref content) = result {
                             let prd_path = profile.root.join("docs/PRD.md");
                             if !prd_path.exists() {
-                                if let Some(parent) = prd_path.parent() {
-                                    let _ = std::fs::create_dir_all(parent);
+                                if let Some(parent) = prd_path.parent()
+                                    && let Err(e) = std::fs::create_dir_all(parent)
+                                {
+                                    tracing::warn!("Failed to create docs/: {}", e);
                                 }
-                                let _ = std::fs::write(&prd_path, content);
+                                if let Err(e) = std::fs::write(&prd_path, content) {
+                                    tracing::warn!("Failed to write PRD: {}", e);
+                                }
                             }
                         }
                         let _ = tx.send(app::TuiDataEvent::AdaptConsolidateResult(result));

--- a/src/tui/screen_dispatch.rs
+++ b/src/tui/screen_dispatch.rs
@@ -281,13 +281,24 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
                                 .push(app::TuiCommand::RunAdaptAnalyze(config, profile));
                         }
                     }
+                    AdaptStep::Consolidating => {
+                        if let (Some(profile), Some(report)) = (
+                            screen.results.profile.clone(),
+                            screen.results.report.clone(),
+                        ) {
+                            app.pending_commands.push(
+                                app::TuiCommand::RunAdaptConsolidate(config, profile, report),
+                            );
+                        }
+                    }
                     AdaptStep::Planning => {
                         if let (Some(profile), Some(report)) = (
                             screen.results.profile.clone(),
                             screen.results.report.clone(),
                         ) {
+                            let prd = screen.results.prd_content.clone();
                             app.pending_commands
-                                .push(app::TuiCommand::RunAdaptPlan(config, profile, report));
+                                .push(app::TuiCommand::RunAdaptPlan(config, profile, report, prd));
                         }
                     }
                     AdaptStep::Materializing => {

--- a/src/tui/screen_dispatch.rs
+++ b/src/tui/screen_dispatch.rs
@@ -286,9 +286,10 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
                             screen.results.profile.clone(),
                             screen.results.report.clone(),
                         ) {
-                            app.pending_commands.push(
-                                app::TuiCommand::RunAdaptConsolidate(config, profile, report),
-                            );
+                            app.pending_commands
+                                .push(app::TuiCommand::RunAdaptConsolidate(
+                                    config, profile, report,
+                                ));
                         }
                     }
                     AdaptStep::Planning => {

--- a/src/tui/screens/adapt/draw.rs
+++ b/src/tui/screens/adapt/draw.rs
@@ -102,6 +102,7 @@ fn draw_progress(screen: &AdaptScreen, f: &mut Frame, area: Rect, theme: &Theme)
         phases.push((AdaptStep::Analyzing, "Analyzing with Claude"));
     }
     if !screen.config.scan_only && !screen.config.no_issues {
+        phases.push((AdaptStep::Consolidating, "Generating PRD"));
         phases.push((AdaptStep::Planning, "Generating plan"));
     }
     if !screen.config.scan_only && !screen.config.no_issues && !screen.config.dry_run {
@@ -117,7 +118,7 @@ fn draw_progress(screen: &AdaptScreen, f: &mut Frame, area: Rect, theme: &Theme)
     for (i, (_, label)) in phases.iter().enumerate() {
         let (marker, style) = if i < current_idx {
             // Completed
-            let info = phase_summary(screen, i);
+            let info = phase_summary(screen, phases[i].0);
             lines.push(Line::from(vec![
                 Span::styled(
                     format!("  {} ", icons::get(IconId::CheckCircle)),
@@ -301,16 +302,16 @@ fn bool_text(v: bool) -> String {
     }
 }
 
-fn phase_summary(screen: &AdaptScreen, phase_idx: usize) -> String {
-    match phase_idx {
-        0 => {
+fn phase_summary(screen: &AdaptScreen, step: AdaptStep) -> String {
+    match step {
+        AdaptStep::Scanning => {
             if let Some(ref p) = screen.results.profile {
                 format!(" — {:?}, {} files", p.language, p.source_stats.total_files)
             } else {
                 String::new()
             }
         }
-        1 => {
+        AdaptStep::Analyzing => {
             if let Some(ref r) = screen.results.report {
                 format!(
                     " — {} modules, {} debt items",
@@ -321,7 +322,14 @@ fn phase_summary(screen: &AdaptScreen, phase_idx: usize) -> String {
                 String::new()
             }
         }
-        2 => {
+        AdaptStep::Consolidating => {
+            if screen.results.prd_content.is_some() {
+                " — PRD generated".to_string()
+            } else {
+                String::new()
+            }
+        }
+        AdaptStep::Planning => {
             if let Some(ref p) = screen.results.plan {
                 let issues: usize = p.milestones.iter().map(|m| m.issues.len()).sum();
                 format!(" — {} milestones, {} issues", p.milestones.len(), issues)
@@ -329,7 +337,7 @@ fn phase_summary(screen: &AdaptScreen, phase_idx: usize) -> String {
                 String::new()
             }
         }
-        3 => {
+        AdaptStep::Materializing => {
             if let Some(ref m) = screen.results.materialize {
                 format!(
                     " — {} milestones, {} issues created",

--- a/src/tui/screens/adapt/mod.rs
+++ b/src/tui/screens/adapt/mod.rs
@@ -654,6 +654,71 @@ mod tests {
         assert_eq!(results.resume_step(), AdaptStep::Analyzing);
     }
 
+    // ── complete_analyze → Consolidating ────────────────────────────
+
+    #[test]
+    fn complete_analyze_transitions_to_consolidating() {
+        let mut screen = AdaptScreen::new();
+        screen.results.profile = Some(make_mock_profile());
+        let cmd = screen.complete_analyze(make_mock_report());
+        assert_eq!(screen.step, AdaptStep::Consolidating);
+        assert!(matches!(
+            cmd,
+            Some(crate::tui::app::TuiCommand::RunAdaptConsolidate(_, _, _))
+        ));
+    }
+
+    #[test]
+    fn complete_analyze_with_no_issues_skips_consolidating() {
+        let mut screen = AdaptScreen::new();
+        screen.config.no_issues = true;
+        screen.results.profile = Some(make_mock_profile());
+        let cmd = screen.complete_analyze(make_mock_report());
+        assert_eq!(screen.step, AdaptStep::Complete);
+        assert!(cmd.is_none());
+    }
+
+    // ── complete_consolidate ─────────────────────────────────────────
+
+    #[test]
+    fn complete_consolidate_transitions_to_planning() {
+        let mut screen = AdaptScreen::new();
+        screen.step = AdaptStep::Consolidating;
+        screen.results.profile = Some(make_mock_profile());
+        screen.results.report = Some(make_mock_report());
+        let cmd = screen.complete_consolidate("# PRD".into());
+        assert_eq!(screen.step, AdaptStep::Planning);
+        assert!(matches!(
+            cmd,
+            Some(crate::tui::app::TuiCommand::RunAdaptPlan(_, _, _, _))
+        ));
+    }
+
+    #[test]
+    fn complete_consolidate_stores_prd_content() {
+        let mut screen = AdaptScreen::new();
+        screen.step = AdaptStep::Consolidating;
+        screen.results.profile = Some(make_mock_profile());
+        screen.results.report = Some(make_mock_report());
+        screen.complete_consolidate("# Generated PRD".into());
+        assert_eq!(
+            screen.results.prd_content.as_deref(),
+            Some("# Generated PRD")
+        );
+    }
+
+    #[test]
+    fn complete_consolidate_without_profile_returns_none() {
+        let mut screen = AdaptScreen::new();
+        screen.step = AdaptStep::Consolidating;
+        screen.results.profile = None;
+        screen.results.report = Some(make_mock_report());
+        let cmd = screen.complete_consolidate("# PRD".into());
+        assert!(cmd.is_none());
+    }
+
+    // ── resume_step with Consolidating ────────────────────────────────
+
     #[test]
     fn resume_step_consolidating_when_report_cached() {
         let results = AdaptResults {

--- a/src/tui/screens/adapt/mod.rs
+++ b/src/tui/screens/adapt/mod.rs
@@ -106,10 +106,39 @@ impl AdaptScreen {
             AdaptResults::clear_cache();
             None
         } else {
+            self.step = AdaptStep::Consolidating;
+            let profile = self.results.profile.clone()?;
+            Some(crate::tui::app::TuiCommand::RunAdaptConsolidate(
+                config, profile, report,
+            ))
+        }
+    }
+
+    pub fn set_prd_result(&mut self, content: String) {
+        self.results.prd_content = Some(content);
+    }
+
+    /// Advance the wizard after a successful consolidate (PRD) phase.
+    pub fn complete_consolidate(
+        &mut self,
+        prd_content: String,
+    ) -> Option<crate::tui::app::TuiCommand> {
+        self.set_prd_result(prd_content.clone());
+        self.results.save_cache();
+        let config = self.build_adapt_config();
+        if config.no_issues {
+            self.step = AdaptStep::Complete;
+            AdaptResults::clear_cache();
+            None
+        } else {
             self.step = AdaptStep::Planning;
             let profile = self.results.profile.clone()?;
+            let report = self.results.report.clone()?;
             Some(crate::tui::app::TuiCommand::RunAdaptPlan(
-                config, profile, report,
+                config,
+                profile,
+                report,
+                Some(prd_content),
             ))
         }
     }
@@ -626,10 +655,21 @@ mod tests {
     }
 
     #[test]
-    fn resume_step_planning_when_report_cached() {
+    fn resume_step_consolidating_when_report_cached() {
         let results = AdaptResults {
             profile: Some(make_mock_profile()),
             report: Some(make_mock_report()),
+            ..Default::default()
+        };
+        assert_eq!(results.resume_step(), AdaptStep::Consolidating);
+    }
+
+    #[test]
+    fn resume_step_planning_when_prd_cached() {
+        let results = AdaptResults {
+            profile: Some(make_mock_profile()),
+            report: Some(make_mock_report()),
+            prd_content: Some("# PRD".into()),
             ..Default::default()
         };
         assert_eq!(results.resume_step(), AdaptStep::Planning);

--- a/src/tui/screens/adapt/types.rs
+++ b/src/tui/screens/adapt/types.rs
@@ -8,6 +8,7 @@ pub enum AdaptStep {
     Configure,
     Scanning,
     Analyzing,
+    Consolidating,
     Planning,
     Materializing,
     Complete,
@@ -18,7 +19,11 @@ impl AdaptStep {
     pub fn is_progress(&self) -> bool {
         matches!(
             self,
-            Self::Scanning | Self::Analyzing | Self::Planning | Self::Materializing
+            Self::Scanning
+                | Self::Analyzing
+                | Self::Consolidating
+                | Self::Planning
+                | Self::Materializing
         )
     }
 }
@@ -67,6 +72,8 @@ impl AdaptWizardConfig {
 pub struct AdaptResults {
     pub profile: Option<ProjectProfile>,
     pub report: Option<AdaptReport>,
+    #[serde(default)]
+    pub prd_content: Option<String>,
     pub plan: Option<AdaptPlan>,
     pub materialize: Option<MaterializeResult>,
 }
@@ -104,8 +111,10 @@ impl AdaptResults {
     pub fn resume_step(&self) -> AdaptStep {
         if self.plan.is_some() {
             AdaptStep::Materializing
-        } else if self.report.is_some() {
+        } else if self.prd_content.is_some() {
             AdaptStep::Planning
+        } else if self.report.is_some() {
+            AdaptStep::Consolidating
         } else if self.profile.is_some() {
             AdaptStep::Analyzing
         } else {
@@ -137,6 +146,7 @@ mod tests {
         assert!(!AdaptStep::Configure.is_progress());
         assert!(AdaptStep::Scanning.is_progress());
         assert!(AdaptStep::Analyzing.is_progress());
+        assert!(AdaptStep::Consolidating.is_progress());
         assert!(AdaptStep::Planning.is_progress());
         assert!(AdaptStep::Materializing.is_progress());
         assert!(!AdaptStep::Complete.is_progress());

--- a/src/tui/screens/adapt/types.rs
+++ b/src/tui/screens/adapt/types.rs
@@ -193,5 +193,30 @@ mod tests {
         assert!(results.materialize.is_none());
     }
 
+    #[test]
+    fn adapt_results_prd_content_defaults_to_none() {
+        let results = AdaptResults::default();
+        assert!(results.prd_content.is_none());
+    }
+
+    #[test]
+    fn adapt_results_prd_content_survives_json_round_trip() {
+        let results = AdaptResults {
+            prd_content: Some("# PRD".into()),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&results).unwrap();
+        let rt: AdaptResults = serde_json::from_str(&json).unwrap();
+        assert_eq!(rt.prd_content, Some("# PRD".into()));
+    }
+
+    #[test]
+    fn adapt_results_json_without_prd_field_deserializes_as_none() {
+        let raw = r#"{"profile":null,"report":null,"plan":null,"materialize":null}"#;
+        let result: Result<AdaptResults, _> = serde_json::from_str(raw);
+        assert!(result.is_ok());
+        assert!(result.unwrap().prd_content.is_none());
+    }
+
     // resume_step tests are in mod.rs tests (they need make_mock_profile helper)
 }


### PR DESCRIPTION
## Summary

- Add `maestro prd` CLI command for standalone PRD generation from project analysis
- Insert Consolidate (PRD) phase in adapt pipeline between Analyze and Plan
- PRD content feeds into planner prompt for higher-quality issue generation
- TUI shows the new phase with progress indicator and summary

## Test plan

- [x] Mock PRD generator tests (content return, error propagation)
- [x] Prompt construction tests (PRD prompt sections, planner PRD injection)
- [x] TUI state machine tests (Consolidating step, resume_step with PRD)
- [x] CLI parsing tests (prd subcommand, flags)
- [x] Full pipeline integration test with Consolidate phase
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (2524 tests, 0 failures)

Closes #370