### PR TITLE
feat: add scaffold phase to adapt pipeline

### DIFF
--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-15 00:00 (UTC)
+> Last updated: 2026-04-17 00:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -79,14 +79,15 @@ maestro/
 │   ├── flags/                             # Feature flag registry and runtime store  [Issue #141, #146]
 │   │   ├── mod.rs                         # Flag enum (6 variants); FlagSource enum (Default, Config, Cli); serde serialization; default_enabled(), description(), name(), all() helpers
 │   │   └── store.rs                       # FeatureFlags store; source tracking per flag; HashMap-based resolution: CLI override > config file > compile-time defaults; source(), all_with_source() methods
-│   ├── adapt/                             # Adapt pipeline: onboard existing projects to maestro workflow  [Issue #87-95]
-│   │   ├── mod.rs                         # Module exports; cmd_adapt() CLI entry point; adapt pipeline orchestration
-│   │   ├── types.rs                       # AdaptPlan, AdaptReport, TechDebtItem, AdaptConfig type definitions
+│   ├── adapt/                             # Adapt pipeline: onboard existing projects to maestro workflow  [Issue #87-95, #371]
+│   │   ├── mod.rs                         # Module exports; cmd_adapt() CLI entry point; adapt pipeline orchestration including scaffold phase  [Issue #371]
+│   │   ├── types.rs                       # AdaptPlan, AdaptReport, TechDebtItem, AdaptConfig, ScaffoldFileStatus, ScaffoldedFile, ScaffoldResult type definitions  [Issue #371]
 │   │   ├── scanner.rs                     # Project scanner Phase 1: detect language, framework, existing issues, CI config
 │   │   ├── analyzer.rs                    # Claude-backed analyzer Phase 2: builds structured adapt plan from scan results
 │   │   ├── planner.rs                     # Adaptation planner Phase 3: maps analyzer output to actionable plan steps
 │   │   ├── materializer.rs               # Plan materializer Phase 4: creates GitHub issues and milestones; GhMaterializer struct; ensure_labels() auto-creates missing labels before issue creation; STANDARD_LABEL_COLORS constant defines canonical hex colors for all maestro labels  [Issue #93, #348]
-│   │   └── prompts.rs                     # Claude prompt builders for analyzer and planner phases
+│   │   ├── scaffolder.rs                  # Scaffold phase: ProjectScaffolder trait, ClaudeScaffolder impl, write_scaffold_files(); generates project files from adapt plan  [Issue #371]
+│   │   └── prompts.rs                     # Claude prompt builders for analyzer, planner, and scaffold phases  [Issue #371]
 │   ├── updater/                           # Self-upgrade subsystem  [Issue #118]
 │   │   ├── mod.rs                         # UpgradeState state machine (Idle, Checking, UpdateAvailable, Downloading, Installing, Done, Failed); ReleaseInfo type (tag_name, download_url, body)
 │   │   ├── checker.rs                     # UpdateChecker trait; GitHubReleaseChecker (hits GitHub Releases API); version parsing via semver comparison; asset names use Rust target triples (e.g. aarch64-apple-darwin); checksum file resolves to sha256sums.txt; check_for_update() async entry point  [Issue #118, #233]
@@ -144,16 +145,16 @@ maestro/
 │   │   ├── store.rs                       # JSON state persistence
 │   │   └── types.rs                       # State types; fork_lineage HashMap; record_fork, fork_chain, fork_depth methods; pending_prs: Vec<PendingPr> field on MaestroState — persisted to JSON state for PR retry recovery  [Issue #12, #159]
 │   ├── tui/
-│   │   ├── mod.rs                         # Event loop; keybindings; handle_screen_action() rewritten; command processing loop; launch_session_from_config(); FetchSuggestionData async handler spawns background GitHub fetch for ready/failed counts and milestone progress; spawns async version check on startup via check_for_update() — result delivered as VersionCheckResult data event; key handlers for upgrade flow (confirm/decline banner); CompletionSummary key-intercept branch: [f] collects NeedsReview sessions and calls spawn_gate_fix_session() for each then transitions to Overview, [i] opens issue browser, [r] opens prompt input, [l] switches to Overview (activity log view), [Enter]/[Esc] returns to dashboard via transition_to_dashboard(), [q] quits; ContinuousPause key-intercept overlay: [s] skip, [r] retry, [q] quit continuous loop; RefreshSuggestions branch sets loading_suggestions=true and queues FetchSuggestionData; exit path checks once_mode — exits immediately when true, otherwise shows CompletionSummary overlay; "All Issues" navigation always creates a fresh IssueBrowserScreen to prevent stale milestone filters leaking across navigation contexts; PromptInputScreen always created with injected history so Up/Down arrow recall works correctly; F-key bar actions wired (F1–F10, Alt-X); per-tick flash_counter decrement dispatched to session pool; pub mod theme; pub mod widgets  [Phase 3, Issue #31-33, #46-48, #35, #38, #83, #84, #85, #86, #104, #117, #118, #124, #202, #218, #232]
+│   │   ├── mod.rs                         # Event loop; keybindings; handle_screen_action() rewritten; command processing loop; launch_session_from_config(); FetchSuggestionData async handler spawns background GitHub fetch for ready/failed counts and milestone progress; spawns async version check on startup via check_for_update() — result delivered as VersionCheckResult data event; key handlers for upgrade flow (confirm/decline banner); CompletionSummary key-intercept branch: [f] collects NeedsReview sessions and calls spawn_gate_fix_session() for each then transitions to Overview, [i] opens issue browser, [r] opens prompt input, [l] switches to Overview (activity log view), [Enter]/[Esc] returns to dashboard via transition_to_dashboard(), [q] quits; ContinuousPause key-intercept overlay: [s] skip, [r] retry, [q] quit continuous loop; RefreshSuggestions branch sets loading_suggestions=true and queues FetchSuggestionData; exit path checks once_mode — exits immediately when true, otherwise shows CompletionSummary overlay; "All Issues" navigation always creates a fresh IssueBrowserScreen to prevent stale milestone filters leaking across navigation contexts; PromptInputScreen always created with injected history so Up/Down arrow recall works correctly; F-key bar actions wired (F1–F10, Alt-X); per-tick flash_counter decrement dispatched to session pool; pub mod theme; pub mod widgets; RunAdaptScaffold command dispatch  [Phase 3, Issue #31-33, #46-48, #35, #38, #83, #84, #85, #86, #104, #117, #118, #124, #202, #218, #232, #371]
 │   │   ├── app/                           # App state module (split across multiple files)
 │   │   │   ├── mod.rs                     # App struct; nav_stack: NavigationStack field (replaces confirm_exit_return_mode); navigate_to(), navigate_back(), navigate_back_or_dashboard(), navigate_to_root() navigation methods; gh_auth_ok: bool; theme: Theme; pending_prs: Vec<PendingPr>; process_pending_pr_retries(); trigger_manual_pr_retry()  [Issue #12, #31-33, #35, #38, #40, #41, #43, #46-48, #52, #83, #84, #85, #86, #102, #104, #118, #123, #158, #159, #342]
-│   │   │   ├── types.rs                   # TuiMode enum (+ CompletionSummary, ContinuousPause variants) with breadcrumb_label() method; NavigationStack struct (push/pop/peek/clear/breadcrumbs, cap 32); TuiCommand enum; TuiDataEvent enum; SuggestionDataPayload; CompletionSummaryData; CompletionSessionLine; GateFailureInfo  [Issue #342]
+│   │   │   ├── types.rs                   # TuiMode enum (+ CompletionSummary, ContinuousPause variants) with breadcrumb_label() method; NavigationStack struct (push/pop/peek/clear/breadcrumbs, cap 32); TuiCommand enum (+ RunAdaptScaffold); TuiDataEvent enum (+ AdaptScaffoldResult); SuggestionDataPayload; CompletionSummaryData; CompletionSessionLine; GateFailureInfo  [Issue #342, #371]
 │   │   │   ├── budget.rs                  # Budget enforcement helpers within App
 │   │   │   ├── ci_polling.rs              # poll_ci_status() CI auto-fix loop using CiCheck trait; decide_ci_action(); spawn_ci_fix_session()  [Issue #41, #123]
 │   │   │   ├── completion_pipeline.rs     # check_completions() config-driven gate evaluation with per-gate logging  [Issue #40, #104]
 │   │   │   ├── completion_summary.rs      # build_completion_summary(); transition_to_dashboard() calls navigate_to_root() to clear nav stack  [Issue #342]
 │   │   │   ├── context_overflow.rs        # Context overflow detection and fork triggering
-│   │   │   ├── data_handler.rs            # handle_data_event(); data_tx/data_rx channel; SuggestionData, VersionCheckResult, UpgradeResult handlers
+│   │   │   ├── data_handler.rs            # handle_data_event(); data_tx/data_rx channel; SuggestionData, VersionCheckResult, UpgradeResult, AdaptScaffoldResult handlers  [Issue #371]
 │   │   │   ├── event_handler.rs           # Top-level event dispatch and tick handling
 │   │   │   ├── helpers.rs                 # Shared App helper utilities
 │   │   │   ├── issue_completion.rs        # on_issue_session_completed(); skips PR creation for CI-fix sessions
@@ -199,7 +200,7 @@ maestro/
 │   │   │   ├── milestone.rs               # 4 snapshot tests for MilestoneScreen (with milestones, empty, loading, detail pane); snapshots updated to reflect color hierarchy and selection visibility changes  [Issue #299]
 │   │   │   ├── cost_dashboard.rs          # 5 snapshot tests for CostDashboard (no budget, under threshold, over 90%, empty, sorted)
 │   │   │   └── snapshots/                 # Committed insta snapshot files (.snap files)
-│   │   ├── screen_dispatch.rs             # ScreenDispatch: routes key events and render calls to the active screen; constructor receives FeatureFlags for settings screen injection; always injects prompt history when constructing PromptInputScreen; ScreenAction::Push delegates to navigate_to(), ScreenAction::Pop delegates to navigate_back()  [Issue #146, #232, #342]
+│   │   ├── screen_dispatch.rs             # ScreenDispatch: routes key events and render calls to the active screen; constructor receives FeatureFlags for settings screen injection; always injects prompt history when constructing PromptInputScreen; ScreenAction::Push delegates to navigate_to(), ScreenAction::Pop delegates to navigate_back(); Scaffolding case in StartAdaptPipeline dispatch  [Issue #146, #232, #342, #371]
 │   │   └── screens/                       # Interactive screen components  [Issue #31-33]
 │   │       ├── mod.rs                     # Screen types: ScreenAction enum (+ RefreshSuggestions variant), SessionConfig; re-exports HomeScreen, IssueBrowserScreen, MilestoneScreen  [Issue #31-33, #86]
 │   │       ├── hollow_retry.rs            # HollowRetryScreen: minimal retry prompt overlay shown when a session stalls and user confirmation is required
@@ -208,10 +209,10 @@ maestro/
 │   │       ├── prompt_input.rs            # PromptInputScreen: free-text prompt entry; Enter submits, Shift+Enter/Alt+Enter inserts newline via insert_newline() (not input()), Ctrl+V pastes from clipboard (image or text), Esc cancels; Up/Down arrows navigate prompt history (injected at construction); image attachment list with [a]/[d]; keybinds bar always visible; uses wrap::soft_wrap_lines() for word-wrapped rendering  [Issue #101, #232, #263]
 │   │       ├── queue_confirmation.rs      # QueueConfirmationScreen: confirmation overlay before bulk-queuing selected issues from the issue browser
 │   │       ├── wrap.rs                    # Soft-wrap utilities: soft_wrap_lines() splits a multi-line string into display lines that fit within a given column width using unicode-width for correct grapheme measurement  [Issue #263]
-│   │       ├── adapt/                     # Adapt wizard screen components  [Issue #88]
-│   │       │   ├── mod.rs                 # AdaptScreen struct with Screen trait impl; wizard entry point
-│   │       │   ├── types.rs               # AdaptStep, AdaptWizardConfig, AdaptResults, AdaptError
-│   │       │   └── draw.rs                # ratatui rendering for adapt wizard steps and layout
+│   │       ├── adapt/                     # Adapt wizard screen components  [Issue #88, #371]
+│   │       │   ├── mod.rs                 # AdaptScreen struct with Screen trait impl; wizard entry point; complete_scaffold(), set_scaffold_result()  [Issue #371]
+│   │       │   ├── types.rs               # AdaptStep (+ Scaffolding variant), AdaptWizardConfig, AdaptResults (+ scaffold field), AdaptError  [Issue #371]
+│   │       │   └── draw.rs                # ratatui rendering for adapt wizard steps and layout; scaffold phase rendering  [Issue #371]
 │   │       ├── home/                      # Home screen components
 │   │       │   ├── mod.rs                 # HomeScreen: idle dashboard, logo, quick-actions menu, suggestions panel, recent activity panel; SuggestionKind enum, Suggestion struct, HomeSection enum; build_suggestions() derives contextual hints from GitHub data; loading_suggestions bool field; R key emits RefreshSuggestions; Tab-based focus navigation  [Issue #31, #49, #34, #35, #86]
 │   │       │   ├── draw.rs                # ratatui rendering for home screen layout and panels; draw_suggestions() renders Suggestions panel with "Loading..." placeholder
@@ -307,14 +308,15 @@ maestro/
 | `src/git.rs` | GitOps trait and CLI-backed commit+push (Phase 3) |
 | `src/models.rs` | Label-based model routing (Phase 3) |
 | `src/prompts.rs` | Structured issue prompt builder with task-type detection; ProjectLanguage detection; guardrail resolution (Phase 3, Issue #43) |
-| `src/adapt/` | Adapt pipeline: onboard existing projects to maestro workflow (Issues #87-95) |
-| `src/adapt/mod.rs` | Module exports; `cmd_adapt()` CLI entry point; adapt pipeline orchestration |
-| `src/adapt/types.rs` | `AdaptPlan`, `AdaptReport`, `TechDebtItem`, `AdaptConfig` type definitions |
+| `src/adapt/` | Adapt pipeline: onboard existing projects to maestro workflow (Issues #87-95, #371) |
+| `src/adapt/mod.rs` | Module exports; `cmd_adapt()` CLI entry point; adapt pipeline orchestration including scaffold phase; `pub mod scaffolder` (Issue #371) |
+| `src/adapt/types.rs` | `AdaptPlan`, `AdaptReport`, `TechDebtItem`, `AdaptConfig`, `ScaffoldFileStatus`, `ScaffoldedFile`, `ScaffoldResult` type definitions (Issue #371) |
 | `src/adapt/scanner.rs` | Project scanner Phase 1: detect language, framework, existing issues, CI config |
 | `src/adapt/analyzer.rs` | Claude-backed analyzer Phase 2: structured adapt plan from scan results |
 | `src/adapt/planner.rs` | Adaptation planner Phase 3: maps analyzer output to actionable plan steps |
 | `src/adapt/materializer.rs` | Plan materializer Phase 4 — `GhMaterializer`: creates GitHub issues and milestones; `ensure_labels()` auto-creates missing labels before issue creation; `STANDARD_LABEL_COLORS` constant defines canonical hex colors for all maestro labels (Issues #93, #348) |
-| `src/adapt/prompts.rs` | Claude prompt builders for the analyzer and planner phases |
+| `src/adapt/scaffolder.rs` | Scaffold phase — `ProjectScaffolder` trait, `ClaudeScaffolder` impl, `write_scaffold_files()`; generates project config files from the adapt plan (Issue #371) |
+| `src/adapt/prompts.rs` | Claude prompt builders for the analyzer, planner, and scaffold phases; `build_scaffold_prompt()` added (Issue #371) |
 | `src/gates/` | Completion gates: TestsPass, FileExists, FileContains, PrCreated, Command (Phase 3, Issue #40) |
 | `src/updater/` | Self-upgrade subsystem: version check, binary installation, and restart (Issue #118) |
 | `src/updater/mod.rs` | `UpgradeState` state machine (`Idle` → `Checking` → `UpdateAvailable` → `Downloading` → `Installing` → `Done` / `Failed`); `ReleaseInfo` type |
@@ -353,9 +355,9 @@ maestro/
 | `src/state/file_claims.rs` | Per-session file claim registry |
 | `src/state/progress.rs` | Session phase tracking (Phase 3) |
 | `src/tui/` | Terminal UI (ratatui) |
-| `src/tui/mod.rs` | Event loop; `handle_screen_action()`; command processing; `launch_session_from_config()`; `FetchSuggestionData` async handler for GitHub ready/failed counts and milestone progress; spawns async version check on startup via `check_for_update()` — result delivered as `VersionCheckResult` data event; key handlers for upgrade confirmation banner (`[y]` confirm / `[n]` decline); `CompletionSummary` key-intercept branch with `[i]` issue browser, `[r]` new prompt, `[l]` activity log view, `[Enter]`/`[Esc]` dashboard; `ContinuousPause` key-intercept overlay: `[s]` skip, `[r]` retry, `[q]` quit continuous loop; exit path respects `once_mode`; `PromptInputScreen` always constructed with injected history for correct Up/Down recall; `pub mod theme` (Issues #31-33, #35, #38, #46-48, #83, #84, #85, #118, #232) |
+| `src/tui/mod.rs` | Event loop; `handle_screen_action()`; command processing; `launch_session_from_config()`; `FetchSuggestionData` async handler for GitHub ready/failed counts and milestone progress; spawns async version check on startup via `check_for_update()` — result delivered as `VersionCheckResult` data event; key handlers for upgrade confirmation banner (`[y]` confirm / `[n]` decline); `CompletionSummary` key-intercept branch with `[i]` issue browser, `[r]` new prompt, `[l]` activity log view, `[Enter]`/`[Esc]` dashboard; `ContinuousPause` key-intercept overlay: `[s]` skip, `[r]` retry, `[q]` quit continuous loop; exit path respects `once_mode`; `PromptInputScreen` always constructed with injected history for correct Up/Down recall; `pub mod theme`; `RunAdaptScaffold` command dispatch (Issues #31-33, #35, #38, #46-48, #83, #84, #85, #118, #232, #371) |
 | `src/tui/app/` | App state module split into focused sub-files; `App` struct with `nav_stack: NavigationStack` field (replaces `confirm_exit_return_mode`); `navigate_to()`, `navigate_back()`, `navigate_back_or_dashboard()`, `navigate_to_root()` navigation methods; `theme: Theme`; `gh_auth_ok: bool`; `upgrade_state: UpgradeState`; `pending_prs: Vec<PendingPr>` (Issues #12, #31-33, #35, #38, #40, #41, #43, #46-48, #52, #83, #84, #85, #118, #158, #342) |
-| `src/tui/app/types.rs` | `TuiMode` enum with `breadcrumb_label()` for human-readable mode names; `NavigationStack` struct — push/pop/peek/clear/breadcrumbs with a cap of 32 entries; `TuiCommand`, `TuiDataEvent`, `SuggestionDataPayload`, `CompletionSummaryData`, `CompletionSessionLine`, `GateFailureInfo` (Issue #342) |
+| `src/tui/app/types.rs` | `TuiMode` enum with `breadcrumb_label()` for human-readable mode names; `NavigationStack` struct — push/pop/peek/clear/breadcrumbs with a cap of 32 entries; `TuiCommand` (+ `RunAdaptScaffold`), `TuiDataEvent` (+ `AdaptScaffoldResult`), `SuggestionDataPayload`, `CompletionSummaryData`, `CompletionSessionLine`, `GateFailureInfo` (Issues #342, #371) |
 | `src/tui/app/completion_summary.rs` | `build_completion_summary()`; `transition_to_dashboard()` now calls `navigate_to_root()` to fully clear the nav stack on dashboard return (Issue #342) |
 | `src/tui/theme.rs` | `Theme` (resolved ratatui `Color` fields); `ThemeConfig` (`preset` + `overrides`); `ThemePreset` (`Dark`, `Light`); `ThemeOverrides` (per-field optional overrides); `SerializableColor` (named string / `#rrggbb` hex / 256-color index); `ColorCapability`; all 14 TUI rendering files consume theme fields instead of hardcoded `Color::` constants (Issue #38) |
 | `src/tui/activity_log.rs` | Scrollable log widget |
@@ -384,15 +386,15 @@ maestro/
 | `src/icon_mode.rs` | Shared icon mode detection: `AtomicBool` global, `init_from_config()`, `use_nerd_font()`; reads `tui.ascii_icons` config and `MAESTRO_ASCII_ICONS` env var (Issue #307) |
 | `src/icons.rs` | Shared icon registry: `IconId` enum (38 variants + `NeedsReview`), `IconPair` struct, `icon_pair()` const jump table, `get(IconId)`, `get_for_mode(id, nerd_font)` (Issue #308) |
 | `src/tui/icons.rs` | Thin re-export shim: re-exports all public items from `src/icon_mode.rs` and `src/icons.rs` so existing `tui::icons::` import paths remain valid (Issues #307, #308) |
-| `src/tui/screens/adapt/` | Adapt wizard screen: multi-step TUI wizard for onboarding a project into maestro (Issue #88) |
-| `src/tui/screens/adapt/mod.rs` | `AdaptScreen` struct implementing the `Screen` trait; wizard entry point and step coordination |
-| `src/tui/screens/adapt/types.rs` | `AdaptStep`, `AdaptWizardConfig`, `AdaptResults`, `AdaptError` type definitions |
-| `src/tui/screens/adapt/draw.rs` | ratatui rendering functions for adapt wizard steps and layout |
+| `src/tui/screens/adapt/` | Adapt wizard screen: multi-step TUI wizard for onboarding a project into maestro (Issues #88, #371) |
+| `src/tui/screens/adapt/mod.rs` | `AdaptScreen` struct implementing the `Screen` trait; wizard entry point and step coordination; `complete_scaffold()`, `set_scaffold_result()` methods (Issue #371) |
+| `src/tui/screens/adapt/types.rs` | `AdaptStep` (+ `Scaffolding` variant), `AdaptWizardConfig`, `AdaptResults` (+ `scaffold` field), `AdaptError` type definitions (Issue #371) |
+| `src/tui/screens/adapt/draw.rs` | ratatui rendering functions for adapt wizard steps and layout; scaffold phase rendering (Issue #371) |
 | `src/tui/screens/pr_review/` | PR review screen: multi-step TUI screen for reviewing and submitting pull request feedback |
 | `src/tui/screens/pr_review/mod.rs` | `PrReviewScreen` struct implementing the `Screen` trait |
 | `src/tui/screens/pr_review/types.rs` | `PrReviewStep` state machine, `ReviewForm` and related type definitions |
 | `src/tui/screens/pr_review/draw.rs` | ratatui rendering logic with markdown integration |
-| `src/tui/screen_dispatch.rs` | `ScreenDispatch`: routes key events and render calls to the active screen; constructor accepts `FeatureFlags` to supply the settings screen; always injects prompt history when constructing `PromptInputScreen`; `ScreenAction::Push` delegates to `navigate_to()`, `ScreenAction::Pop` delegates to `navigate_back()` (Issues #146, #232, #342) |
+| `src/tui/screen_dispatch.rs` | `ScreenDispatch`: routes key events and render calls to the active screen; constructor accepts `FeatureFlags` to supply the settings screen; always injects prompt history when constructing `PromptInputScreen`; `ScreenAction::Push` delegates to `navigate_to()`, `ScreenAction::Pop` delegates to `navigate_back()`; `Scaffolding` case wired in `StartAdaptPipeline` dispatch (Issues #146, #232, #342, #371) |
 | `src/tui/spinner.rs` | Braille spinner helpers: `spinner_frame()`, `format_thinking_elapsed()`, full spinner activity string builder |
 | `src/tui/snapshot_tests/` | TUI snapshot test suite; 33 tests across 7 views using `insta`; run with `cargo test tui::snapshot_tests`; update with `INSTA_UPDATE=always cargo test` or `cargo insta review` (Issue #16) |
 | `src/tui/snapshot_tests/overview.rs` | 6 snapshot tests for `PanelView`: empty, single running, multiple, selected, context overflow, forked |

--- a/src/adapt/mod.rs
+++ b/src/adapt/mod.rs
@@ -3,6 +3,7 @@ pub mod materializer;
 pub mod planner;
 pub mod prd;
 mod prompts;
+pub mod scaffolder;
 pub mod scanner;
 pub mod types;
 
@@ -154,7 +155,7 @@ pub async fn cmd_adapt(config: AdaptConfig) -> anyhow::Result<()> {
 
     // Phase 3: Plan
     eprintln!("Phase 3: Planning milestones and issues...");
-    let planner = ClaudePlanner::new(model);
+    let planner = ClaudePlanner::new(model.clone());
     let plan = planner
         .plan(&profile, &report, prd_content.as_deref())
         .await?;
@@ -172,6 +173,22 @@ pub async fn cmd_adapt(config: AdaptConfig) -> anyhow::Result<()> {
         println!("{}", json);
         return Ok(());
     }
+
+    // Phase 3.5: Scaffold
+    eprintln!("Phase 3.5: Scaffolding .claude/ directory...");
+    use scaffolder::{ClaudeScaffolder, ProjectScaffolder};
+    let scaffolder = ClaudeScaffolder::new(model);
+    match scaffolder.scaffold(&profile, &report, &plan).await {
+        Ok(result) => {
+            eprintln!(
+                "  {} files created, {} skipped",
+                result.created_count, result.skipped_count
+            );
+        }
+        Err(e) => {
+            eprintln!("  Scaffold failed: {}. Continuing without scaffolding.", e);
+        }
+    };
 
     // Phase 4: Materialize
     eprintln!("Phase 4: Creating GitHub artifacts...");

--- a/src/adapt/prompts.rs
+++ b/src/adapt/prompts.rs
@@ -171,6 +171,88 @@ Return ONLY the JSON object, no markdown fences, no commentary."#,
     )
 }
 
+pub fn build_scaffold_prompt(profile_json: &str, report_json: &str, plan_json: &str) -> String {
+    format!(
+        r#"You are generating a .claude/ directory scaffold for a software project to onboard it to the maestro AI-orchestrated workflow.
+
+## Project Profile
+
+{profile_json}
+
+## Analysis Report
+
+{report_json}
+
+## Adaptation Plan
+
+{plan_json}
+
+## Instructions
+
+Generate a JSON object containing all files to create in the `.claude/` directory. Each file has a relative path (from `.claude/`) and full content.
+
+The scaffold MUST include:
+
+### 1. CLAUDE.md (orchestrator configuration)
+- Tailored to the detected tech stack
+- Include: build commands, test commands, project structure, key files
+- Include: TDD workflow, subagent delegation rules
+- Stack-specific commands (e.g., `cargo test` for Rust, `npm test` for TypeScript, `pytest` for Python)
+
+### 2. Commands (.claude/commands/)
+- `implement.md` — fetch issue and implement with full workflow
+- `pushup.md` — commit, push, create PR, close issue
+- `release.md` — semantic version release workflow
+- `simplify.md` — refactoring and simplification workflow
+
+### 3. Subagents (.claude/agents/)
+- `subagent-architect.md` — architecture design and planning (consultive only)
+- `subagent-qa.md` — QA engineering, test design (consultive only)
+- `subagent-docs-analyst.md` — documentation management (CAN write .md files)
+- `subagent-security-analyst.md` — security review, OWASP (consultive only)
+
+### 4. Skills (.claude/skills/)
+- `project-patterns/SKILL.md` — project-specific patterns based on detected stack
+
+## Stack-Specific Customization
+
+Customize ALL content based on the detected language and stack:
+- **Rust**: cargo build/test/clippy/fmt, mod.rs structure, async_trait patterns
+- **TypeScript**: npm/yarn/pnpm, jest/vitest, ESLint, tsconfig
+- **Python**: pytest, mypy, ruff/black, pyproject.toml, venv
+- **Go**: go test, go vet, go fmt, go mod
+- **Java**: gradle/maven, JUnit, checkstyle
+- **Ruby**: rspec, rubocop, bundler
+
+## Output Schema
+
+```json
+{{{{
+  "files": [
+    {{{{
+      "path": "CLAUDE.md",
+      "content": "(full CLAUDE.md content here)"
+    }}}},
+    {{{{
+      "path": "commands/implement.md",
+      "content": "(full implement.md content here)"
+    }}}},
+    {{{{
+      "path": "agents/subagent-architect.md",
+      "content": "(full subagent-architect.md content here)"
+    }}}},
+    {{{{
+      "path": "skills/project-patterns/SKILL.md",
+      "content": "(full SKILL.md content here)"
+    }}}}
+  ]
+}}}}
+```
+
+Return ONLY the JSON object, no markdown fences, no commentary."#,
+    )
+}
+
 /// Run `claude --print` with the given prompt and return stdout.
 pub async fn run_claude_print(
     model: &str,
@@ -388,6 +470,27 @@ That's all."#;
         let prompt =
             build_planning_prompt(r#"{"name":"test"}"#, r#"{"summary":"good"}"#, None, None);
         assert!(!prompt.contains("Product Requirements Document"));
+    }
+
+    #[test]
+    fn build_scaffold_prompt_contains_profile_report_and_plan() {
+        let prompt = build_scaffold_prompt(
+            r#"{"name":"test"}"#,
+            r#"{"summary":"good"}"#,
+            r#"{"milestones":[]}"#,
+        );
+        assert!(prompt.contains(r#"{"name":"test"}"#));
+        assert!(prompt.contains(r#"{"summary":"good"}"#));
+        assert!(prompt.contains(r#"{"milestones":[]}"#));
+    }
+
+    #[test]
+    fn build_scaffold_prompt_contains_required_sections() {
+        let prompt = build_scaffold_prompt(r#"{}"#, r#"{}"#, r#"{}"#);
+        assert!(prompt.contains("CLAUDE.md"));
+        assert!(prompt.contains("commands/"));
+        assert!(prompt.contains("agents/"));
+        assert!(prompt.contains("skills/"));
     }
 
     #[test]

--- a/src/adapt/scaffolder.rs
+++ b/src/adapt/scaffolder.rs
@@ -1,0 +1,485 @@
+use async_trait::async_trait;
+use std::path::Path;
+
+use super::prompts;
+use super::types::{
+    AdaptPlan, AdaptReport, ProjectProfile, ScaffoldFileStatus, ScaffoldResult, ScaffoldedFile,
+};
+
+#[async_trait]
+pub trait ProjectScaffolder: Send + Sync {
+    async fn scaffold(
+        &self,
+        profile: &ProjectProfile,
+        report: &AdaptReport,
+        plan: &AdaptPlan,
+    ) -> anyhow::Result<ScaffoldResult>;
+}
+
+pub struct ClaudeScaffolder {
+    model: String,
+}
+
+impl ClaudeScaffolder {
+    pub fn new(model: String) -> Self {
+        Self { model }
+    }
+}
+
+/// The JSON structure Claude returns for scaffold content.
+#[derive(Debug, Clone, serde::Deserialize)]
+struct ScaffoldManifest {
+    files: Vec<ScaffoldFileEntry>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct ScaffoldFileEntry {
+    path: String,
+    content: String,
+}
+
+#[async_trait]
+impl ProjectScaffolder for ClaudeScaffolder {
+    async fn scaffold(
+        &self,
+        profile: &ProjectProfile,
+        report: &AdaptReport,
+        plan: &AdaptPlan,
+    ) -> anyhow::Result<ScaffoldResult> {
+        let profile_json = serde_json::to_string_pretty(profile)?;
+        let report_json = serde_json::to_string_pretty(report)?;
+        let plan_json = serde_json::to_string_pretty(plan)?;
+        let prompt = prompts::build_scaffold_prompt(&profile_json, &report_json, &plan_json);
+        let raw = prompts::run_claude_print(&self.model, &prompt, &profile.root).await?;
+        let manifest: ScaffoldManifest = prompts::parse_json_response(&raw)?;
+
+        let claude_dir = profile.root.join(".claude");
+        write_scaffold_files(&claude_dir, &manifest.files)
+    }
+}
+
+fn is_safe_relative_path(path: &str) -> bool {
+    !path.starts_with('/')
+        && !path.starts_with('\\')
+        && !path.contains("..")
+        && !path.contains('\0')
+}
+
+fn write_scaffold_files(
+    claude_dir: &Path,
+    entries: &[ScaffoldFileEntry],
+) -> anyhow::Result<ScaffoldResult> {
+    let mut files = Vec::with_capacity(entries.len());
+    let mut created_count = 0;
+    let mut skipped_count = 0;
+
+    for entry in entries {
+        let rel_display = format!(".claude/{}", entry.path);
+
+        if !is_safe_relative_path(&entry.path) {
+            files.push(ScaffoldedFile {
+                path: rel_display,
+                status: ScaffoldFileStatus::Failed,
+                reason: Some("path escapes .claude/ directory".into()),
+            });
+            continue;
+        }
+
+        let target = claude_dir.join(&entry.path);
+
+        if target.exists() {
+            files.push(ScaffoldedFile {
+                path: rel_display,
+                status: ScaffoldFileStatus::Skipped,
+                reason: Some("file already exists".into()),
+            });
+            skipped_count += 1;
+            continue;
+        }
+
+        if let Some(parent) = target.parent()
+            && let Err(e) = std::fs::create_dir_all(parent)
+        {
+            files.push(ScaffoldedFile {
+                path: rel_display,
+                status: ScaffoldFileStatus::Failed,
+                reason: Some(format!("mkdir failed: {}", e)),
+            });
+            continue;
+        }
+
+        match std::fs::write(&target, &entry.content) {
+            Ok(()) => {
+                files.push(ScaffoldedFile {
+                    path: rel_display,
+                    status: ScaffoldFileStatus::Created,
+                    reason: None,
+                });
+                created_count += 1;
+            }
+            Err(e) => {
+                files.push(ScaffoldedFile {
+                    path: rel_display,
+                    status: ScaffoldFileStatus::Failed,
+                    reason: Some(format!("write failed: {}", e)),
+                });
+            }
+        }
+    }
+
+    Ok(ScaffoldResult {
+        files,
+        created_count,
+        skipped_count,
+    })
+}
+
+#[cfg(test)]
+pub struct MockProjectScaffolder {
+    result: Option<ScaffoldResult>,
+}
+
+#[cfg(test)]
+impl MockProjectScaffolder {
+    pub fn with_result(result: ScaffoldResult) -> Self {
+        Self {
+            result: Some(result),
+        }
+    }
+
+    pub fn without_result() -> Self {
+        Self { result: None }
+    }
+}
+
+#[cfg(test)]
+#[async_trait]
+impl ProjectScaffolder for MockProjectScaffolder {
+    async fn scaffold(
+        &self,
+        _profile: &ProjectProfile,
+        _report: &AdaptReport,
+        _plan: &AdaptPlan,
+    ) -> anyhow::Result<ScaffoldResult> {
+        self.result
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("mock scaffolder: no result configured"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapt::types::*;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn sample_profile_rust() -> ProjectProfile {
+        ProjectProfile {
+            name: "test-project".into(),
+            root: PathBuf::from("/tmp"),
+            language: ProjectLanguage::Rust,
+            manifests: vec![],
+            config_files: vec![],
+            entry_points: vec![],
+            source_stats: SourceStats {
+                total_files: 10,
+                total_lines: 500,
+                by_extension: vec![],
+            },
+            test_infra: TestInfraInfo {
+                has_tests: true,
+                framework: Some("cargo test".into()),
+                test_directories: vec![],
+                test_file_count: 3,
+            },
+            ci: CiInfo {
+                provider: None,
+                config_files: vec![],
+            },
+            git: GitInfo {
+                is_git_repo: true,
+                default_branch: Some("main".into()),
+                remote_url: None,
+                commit_count: 42,
+                recent_contributors: vec![],
+            },
+            dependencies: DependencySummary::default(),
+            directory_tree: String::new(),
+            has_maestro_config: false,
+            has_workflow_docs: false,
+        }
+    }
+
+    fn sample_report() -> AdaptReport {
+        AdaptReport {
+            summary: "A test project".into(),
+            modules: vec![],
+            tech_debt_items: vec![],
+        }
+    }
+
+    fn sample_plan() -> AdaptPlan {
+        AdaptPlan {
+            milestones: vec![],
+            maestro_toml_patch: None,
+            workflow_guide: None,
+        }
+    }
+
+    fn entry(path: &str, content: &str) -> ScaffoldFileEntry {
+        ScaffoldFileEntry {
+            path: path.into(),
+            content: content.into(),
+        }
+    }
+
+    // ── Type serialization ────────────────────────────────────────────
+
+    #[test]
+    fn scaffold_file_status_serializes_as_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&ScaffoldFileStatus::Created).unwrap(),
+            r#""created""#
+        );
+        assert_eq!(
+            serde_json::to_string(&ScaffoldFileStatus::Skipped).unwrap(),
+            r#""skipped""#
+        );
+        assert_eq!(
+            serde_json::to_string(&ScaffoldFileStatus::Failed).unwrap(),
+            r#""failed""#
+        );
+    }
+
+    #[test]
+    fn scaffold_file_status_deserializes_from_snake_case() {
+        let status: ScaffoldFileStatus = serde_json::from_str(r#""skipped""#).unwrap();
+        assert_eq!(status, ScaffoldFileStatus::Skipped);
+    }
+
+    #[test]
+    fn scaffolded_file_round_trips_through_json() {
+        let file = ScaffoldedFile {
+            path: "CLAUDE.md".into(),
+            status: ScaffoldFileStatus::Created,
+            reason: None,
+        };
+        let json = serde_json::to_string(&file).unwrap();
+        let rt: ScaffoldedFile = serde_json::from_str(&json).unwrap();
+        assert_eq!(rt.path, "CLAUDE.md");
+        assert_eq!(rt.status, ScaffoldFileStatus::Created);
+        assert!(rt.reason.is_none());
+    }
+
+    #[test]
+    fn scaffolded_file_with_reason_round_trips() {
+        let file = ScaffoldedFile {
+            path: "CLAUDE.md".into(),
+            status: ScaffoldFileStatus::Skipped,
+            reason: Some("file already exists".into()),
+        };
+        let json = serde_json::to_string(&file).unwrap();
+        let rt: ScaffoldedFile = serde_json::from_str(&json).unwrap();
+        assert_eq!(rt.reason, Some("file already exists".into()));
+    }
+
+    #[test]
+    fn scaffold_result_round_trips_through_json() {
+        let result = ScaffoldResult {
+            files: vec![
+                ScaffoldedFile {
+                    path: "CLAUDE.md".into(),
+                    status: ScaffoldFileStatus::Created,
+                    reason: None,
+                },
+                ScaffoldedFile {
+                    path: "old.md".into(),
+                    status: ScaffoldFileStatus::Skipped,
+                    reason: Some("exists".into()),
+                },
+            ],
+            created_count: 1,
+            skipped_count: 1,
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        let rt: ScaffoldResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(rt.files.len(), 2);
+        assert_eq!(rt.created_count, 1);
+        assert_eq!(rt.skipped_count, 1);
+    }
+
+    #[test]
+    fn scaffold_result_empty_is_valid() {
+        let result = ScaffoldResult {
+            files: vec![],
+            created_count: 0,
+            skipped_count: 0,
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        let rt: ScaffoldResult = serde_json::from_str(&json).unwrap();
+        assert!(rt.files.is_empty());
+        assert_eq!(rt.created_count, 0);
+    }
+
+    // ── write_scaffold_files ──────────────────────────────────────────
+
+    #[test]
+    fn write_scaffold_files_creates_files_in_claude_dir() {
+        let dir = TempDir::new().unwrap();
+        let claude_dir = dir.path().join(".claude");
+        let entries = vec![entry("CLAUDE.md", "# Hello")];
+
+        let result = write_scaffold_files(&claude_dir, &entries).unwrap();
+        assert_eq!(result.created_count, 1);
+        assert_eq!(result.skipped_count, 0);
+        assert_eq!(result.files[0].status, ScaffoldFileStatus::Created);
+        assert_eq!(
+            std::fs::read_to_string(claude_dir.join("CLAUDE.md")).unwrap(),
+            "# Hello"
+        );
+    }
+
+    #[test]
+    fn write_scaffold_files_creates_nested_subdirectories() {
+        let dir = TempDir::new().unwrap();
+        let claude_dir = dir.path().join(".claude");
+        let entries = vec![entry("skills/rust/SKILL.md", "rust skill")];
+
+        write_scaffold_files(&claude_dir, &entries).unwrap();
+        assert!(claude_dir.join("skills/rust/SKILL.md").exists());
+    }
+
+    #[test]
+    fn write_scaffold_files_skips_existing_file() {
+        let dir = TempDir::new().unwrap();
+        let claude_dir = dir.path().join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        std::fs::write(claude_dir.join("CLAUDE.md"), "original").unwrap();
+
+        let entries = vec![entry("CLAUDE.md", "overwrite attempt")];
+        let result = write_scaffold_files(&claude_dir, &entries).unwrap();
+
+        assert_eq!(result.skipped_count, 1);
+        assert_eq!(result.created_count, 0);
+        assert_eq!(result.files[0].status, ScaffoldFileStatus::Skipped);
+        assert_eq!(
+            std::fs::read_to_string(claude_dir.join("CLAUDE.md")).unwrap(),
+            "original"
+        );
+    }
+
+    #[test]
+    fn write_scaffold_files_mixed_create_and_skip() {
+        let dir = TempDir::new().unwrap();
+        let claude_dir = dir.path().join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        std::fs::write(claude_dir.join("CLAUDE.md"), "existing").unwrap();
+
+        let entries = vec![entry("CLAUDE.md", "new"), entry("agents/qa.md", "qa agent")];
+        let result = write_scaffold_files(&claude_dir, &entries).unwrap();
+
+        assert_eq!(result.created_count, 1);
+        assert_eq!(result.skipped_count, 1);
+        assert_eq!(
+            std::fs::read_to_string(claude_dir.join("agents/qa.md")).unwrap(),
+            "qa agent"
+        );
+        assert_eq!(
+            std::fs::read_to_string(claude_dir.join("CLAUDE.md")).unwrap(),
+            "existing"
+        );
+    }
+
+    #[test]
+    fn write_scaffold_files_empty_entries_returns_zero_counts() {
+        let dir = TempDir::new().unwrap();
+        let claude_dir = dir.path().join(".claude");
+
+        let result = write_scaffold_files(&claude_dir, &[]).unwrap();
+        assert_eq!(result.created_count, 0);
+        assert_eq!(result.skipped_count, 0);
+        assert!(result.files.is_empty());
+    }
+
+    #[test]
+    fn write_scaffold_files_result_order_matches_input() {
+        let dir = TempDir::new().unwrap();
+        let claude_dir = dir.path().join(".claude");
+        let entries = vec![entry("a.md", "a"), entry("b.md", "b"), entry("c.md", "c")];
+
+        let result = write_scaffold_files(&claude_dir, &entries).unwrap();
+        assert_eq!(result.files[0].path, ".claude/a.md");
+        assert_eq!(result.files[1].path, ".claude/b.md");
+        assert_eq!(result.files[2].path, ".claude/c.md");
+    }
+
+    // ── Path traversal protection ───────────────────────────────────────
+
+    #[test]
+    fn write_scaffold_files_rejects_path_traversal() {
+        let dir = TempDir::new().unwrap();
+        let claude_dir = dir.path().join(".claude");
+        let entries = vec![entry("../../etc/evil", "pwned")];
+
+        let result = write_scaffold_files(&claude_dir, &entries).unwrap();
+        assert_eq!(result.files[0].status, ScaffoldFileStatus::Failed);
+        assert!(result.files[0]
+            .reason
+            .as_ref()
+            .unwrap()
+            .contains("escapes"));
+        assert!(!dir.path().join("etc/evil").exists());
+    }
+
+    #[test]
+    fn write_scaffold_files_rejects_absolute_path() {
+        let dir = TempDir::new().unwrap();
+        let claude_dir = dir.path().join(".claude");
+        let entries = vec![entry("/tmp/evil", "pwned")];
+
+        let result = write_scaffold_files(&claude_dir, &entries).unwrap();
+        assert_eq!(result.files[0].status, ScaffoldFileStatus::Failed);
+    }
+
+    #[test]
+    fn write_scaffold_files_rejects_null_bytes() {
+        let dir = TempDir::new().unwrap();
+        let claude_dir = dir.path().join(".claude");
+        let entries = vec![entry("evil\0.md", "pwned")];
+
+        let result = write_scaffold_files(&claude_dir, &entries).unwrap();
+        assert_eq!(result.files[0].status, ScaffoldFileStatus::Failed);
+    }
+
+    // ── MockProjectScaffolder ─────────────────────────────────────────
+
+    #[tokio::test]
+    async fn mock_scaffolder_returns_configured_result() {
+        let expected = ScaffoldResult {
+            files: vec![ScaffoldedFile {
+                path: "CLAUDE.md".into(),
+                status: ScaffoldFileStatus::Created,
+                reason: None,
+            }],
+            created_count: 1,
+            skipped_count: 0,
+        };
+        let mock = MockProjectScaffolder::with_result(expected);
+        let result = mock
+            .scaffold(&sample_profile_rust(), &sample_report(), &sample_plan())
+            .await
+            .unwrap();
+        assert_eq!(result.created_count, 1);
+        assert_eq!(result.files[0].status, ScaffoldFileStatus::Created);
+    }
+
+    #[tokio::test]
+    async fn mock_scaffolder_without_result_returns_error() {
+        let mock = MockProjectScaffolder::without_result();
+        let result = mock
+            .scaffold(&sample_profile_rust(), &sample_report(), &sample_plan())
+            .await;
+        assert!(result.is_err());
+    }
+}

--- a/src/adapt/scaffolder.rs
+++ b/src/adapt/scaffolder.rs
@@ -424,11 +424,7 @@ mod tests {
 
         let result = write_scaffold_files(&claude_dir, &entries).unwrap();
         assert_eq!(result.files[0].status, ScaffoldFileStatus::Failed);
-        assert!(result.files[0]
-            .reason
-            .as_ref()
-            .unwrap()
-            .contains("escapes"));
+        assert!(result.files[0].reason.as_ref().unwrap().contains("escapes"));
         assert!(!dir.path().join("etc/evil").exists());
     }
 

--- a/src/adapt/types.rs
+++ b/src/adapt/types.rs
@@ -166,6 +166,31 @@ pub struct CreatedIssue {
     pub milestone_number: Option<u64>,
 }
 
+/// Status of a single scaffolded file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScaffoldFileStatus {
+    Created,
+    Skipped,
+    Failed,
+}
+
+/// A single file generated (or skipped) by the scaffold phase.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScaffoldedFile {
+    pub path: String,
+    pub status: ScaffoldFileStatus,
+    pub reason: Option<String>,
+}
+
+/// Result of the scaffold phase.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScaffoldResult {
+    pub files: Vec<ScaffoldedFile>,
+    pub created_count: usize,
+    pub skipped_count: usize,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/tui/app/data_handler.rs
+++ b/src/tui/app/data_handler.rs
@@ -221,6 +221,26 @@ impl App {
                     }
                 }
             }
+            TuiDataEvent::AdaptScaffoldResult(result) => {
+                if let Some(ref mut screen) = self.adapt_screen {
+                    if screen.is_cancelled() {
+                        return;
+                    }
+                    match result {
+                        Ok(scaffold_result) => {
+                            if let Some(cmd) = screen.complete_scaffold(scaffold_result) {
+                                self.pending_commands.push(cmd);
+                            }
+                        }
+                        Err(e) => {
+                            screen.set_error(
+                                crate::tui::screens::adapt::AdaptStep::Scaffolding,
+                                format!("{}", e),
+                            );
+                        }
+                    }
+                }
+            }
             TuiDataEvent::PullRequests(Ok(prs)) => {
                 if let Some(ref mut screen) = self.pr_review_screen {
                     screen.set_prs(prs);

--- a/src/tui/app/tests.rs
+++ b/src/tui/app/tests.rs
@@ -1547,12 +1547,12 @@ mod adapt_chaining {
         app.handle_data_event(TuiDataEvent::AdaptPlanResult(Ok(make_plan())));
 
         let screen = app.adapt_screen.as_ref().unwrap();
-        assert_eq!(screen.step, AdaptStep::Materializing);
+        assert_eq!(screen.step, AdaptStep::Scaffolding);
         assert!(screen.results.plan.is_some());
         assert_eq!(app.pending_commands.len(), 1);
         assert!(matches!(
             app.pending_commands[0],
-            TuiCommand::RunAdaptMaterialize(_, _)
+            TuiCommand::RunAdaptScaffold(_, _, _, _)
         ));
     }
 
@@ -1662,6 +1662,20 @@ mod adapt_chaining {
         let cmd = app.pending_commands.pop().unwrap();
         assert!(matches!(cmd, TuiCommand::RunAdaptPlan(_, _, _, _)));
         app.handle_data_event(TuiDataEvent::AdaptPlanResult(Ok(make_plan())));
+        assert_eq!(
+            app.adapt_screen.as_ref().unwrap().step,
+            AdaptStep::Scaffolding
+        );
+
+        // Phase 3.5: Scaffold
+        let cmd = app.pending_commands.pop().unwrap();
+        assert!(matches!(cmd, TuiCommand::RunAdaptScaffold(_, _, _, _)));
+        use crate::adapt::types::ScaffoldResult;
+        app.handle_data_event(TuiDataEvent::AdaptScaffoldResult(Ok(ScaffoldResult {
+            files: vec![],
+            created_count: 0,
+            skipped_count: 0,
+        })));
         assert_eq!(
             app.adapt_screen.as_ref().unwrap().step,
             AdaptStep::Materializing

--- a/src/tui/app/types.rs
+++ b/src/tui/app/types.rs
@@ -1,5 +1,7 @@
 use crate::adapt::AdaptConfig;
-use crate::adapt::types::{AdaptPlan, AdaptReport, MaterializeResult, ProjectProfile};
+use crate::adapt::types::{
+    AdaptPlan, AdaptReport, MaterializeResult, ProjectProfile, ScaffoldResult,
+};
 use crate::plugins::hooks::{HookContext, HookPoint};
 use crate::provider::github::types::{GhIssue, GhMilestone};
 use crate::session::types::SessionStatus;
@@ -158,6 +160,7 @@ pub enum TuiCommand {
     RunAdaptAnalyze(AdaptConfig, ProjectProfile),
     RunAdaptConsolidate(AdaptConfig, ProjectProfile, AdaptReport),
     RunAdaptPlan(AdaptConfig, ProjectProfile, AdaptReport, Option<String>),
+    RunAdaptScaffold(AdaptConfig, ProjectProfile, AdaptReport, AdaptPlan),
     RunAdaptMaterialize(AdaptPlan, AdaptReport),
     FetchOpenPrs,
     SubmitPrReview {
@@ -179,6 +182,7 @@ pub enum TuiDataEvent {
     AdaptAnalyzeResult(anyhow::Result<AdaptReport>),
     AdaptConsolidateResult(anyhow::Result<String>),
     AdaptPlanResult(anyhow::Result<AdaptPlan>),
+    AdaptScaffoldResult(anyhow::Result<ScaffoldResult>),
     AdaptMaterializeResult(anyhow::Result<MaterializeResult>),
     UnifiedIssues(anyhow::Result<Vec<GhIssue>>, Option<String>),
     PullRequests(anyhow::Result<Vec<crate::provider::github::types::GhPullRequest>>),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -363,6 +363,16 @@ async fn event_loop(
                         let _ = tx.send(app::TuiDataEvent::AdaptPlanResult(result));
                     });
                 }
+                app::TuiCommand::RunAdaptScaffold(config, profile, report, plan) => {
+                    let tx = app.data_tx.clone();
+                    let model = config.model.unwrap_or_else(|| "sonnet".to_string());
+                    tokio::spawn(async move {
+                        use crate::adapt::scaffolder::{ClaudeScaffolder, ProjectScaffolder};
+                        let scaffolder = ClaudeScaffolder::new(model);
+                        let result = scaffolder.scaffold(&profile, &report, &plan).await;
+                        let _ = tx.send(app::TuiDataEvent::AdaptScaffoldResult(result));
+                    });
+                }
                 app::TuiCommand::RunAdaptMaterialize(plan, report) => {
                     let tx = app.data_tx.clone();
                     tokio::spawn(async move {

--- a/src/tui/screen_dispatch.rs
+++ b/src/tui/screen_dispatch.rs
@@ -302,6 +302,17 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
                                 .push(app::TuiCommand::RunAdaptPlan(config, profile, report, prd));
                         }
                     }
+                    AdaptStep::Scaffolding => {
+                        if let (Some(profile), Some(report), Some(plan)) = (
+                            screen.results.profile.clone(),
+                            screen.results.report.clone(),
+                            screen.results.plan.clone(),
+                        ) {
+                            app.pending_commands.push(app::TuiCommand::RunAdaptScaffold(
+                                config, profile, report, plan,
+                            ));
+                        }
+                    }
                     AdaptStep::Materializing => {
                         if let (Some(plan), Some(report)) =
                             (screen.results.plan.clone(), screen.results.report.clone())

--- a/src/tui/screens/adapt/draw.rs
+++ b/src/tui/screens/adapt/draw.rs
@@ -106,6 +106,7 @@ fn draw_progress(screen: &AdaptScreen, f: &mut Frame, area: Rect, theme: &Theme)
         phases.push((AdaptStep::Planning, "Generating plan"));
     }
     if !screen.config.scan_only && !screen.config.no_issues && !screen.config.dry_run {
+        phases.push((AdaptStep::Scaffolding, "Scaffolding .claude/"));
         phases.push((AdaptStep::Materializing, "Creating issues"));
     }
 
@@ -236,6 +237,20 @@ fn draw_complete(screen: &AdaptScreen, f: &mut Frame, area: Rect, theme: &Theme)
         ]));
     }
 
+    if let Some(ref scaffold) = screen.results.scaffold {
+        lines.push(Line::from(""));
+        lines.push(Line::from(vec![
+            Span::styled("Scaffolded: ", Style::default().fg(theme.text_secondary)),
+            Span::styled(
+                format!(
+                    "{} created, {} skipped",
+                    scaffold.created_count, scaffold.skipped_count
+                ),
+                Style::default().fg(theme.text_primary),
+            ),
+        ]));
+    }
+
     if let Some(ref mat) = screen.results.materialize {
         lines.push(Line::from(""));
         let label = if mat.dry_run { "Dry run" } else { "Created" };
@@ -333,6 +348,16 @@ fn phase_summary(screen: &AdaptScreen, step: AdaptStep) -> String {
             if let Some(ref p) = screen.results.plan {
                 let issues: usize = p.milestones.iter().map(|m| m.issues.len()).sum();
                 format!(" — {} milestones, {} issues", p.milestones.len(), issues)
+            } else {
+                String::new()
+            }
+        }
+        AdaptStep::Scaffolding => {
+            if let Some(ref s) = screen.results.scaffold {
+                format!(
+                    " — {} created, {} skipped",
+                    s.created_count, s.skipped_count
+                )
             } else {
                 String::new()
             }

--- a/src/tui/screens/adapt/mod.rs
+++ b/src/tui/screens/adapt/mod.rs
@@ -3,7 +3,9 @@ pub mod types;
 
 pub use types::*;
 
-use crate::adapt::types::{AdaptPlan, AdaptReport, MaterializeResult, ProjectProfile};
+use crate::adapt::types::{
+    AdaptPlan, AdaptReport, MaterializeResult, ProjectProfile, ScaffoldResult,
+};
 use crate::tui::navigation::InputMode;
 use crate::tui::navigation::keymap::{KeyBinding, KeyBindingGroup, KeymapProvider};
 use crate::tui::theme::Theme;
@@ -153,12 +155,32 @@ impl AdaptScreen {
             AdaptResults::clear_cache();
             None
         } else {
-            self.step = AdaptStep::Materializing;
+            self.step = AdaptStep::Scaffolding;
+            let profile = self.results.profile.clone()?;
             let report = self.results.report.clone()?;
-            Some(crate::tui::app::TuiCommand::RunAdaptMaterialize(
-                plan, report,
+            Some(crate::tui::app::TuiCommand::RunAdaptScaffold(
+                config, profile, report, plan,
             ))
         }
+    }
+
+    pub fn set_scaffold_result(&mut self, result: ScaffoldResult) {
+        self.results.scaffold = Some(result);
+    }
+
+    /// Advance the wizard after a successful scaffold phase.
+    pub fn complete_scaffold(
+        &mut self,
+        result: ScaffoldResult,
+    ) -> Option<crate::tui::app::TuiCommand> {
+        self.set_scaffold_result(result);
+        self.results.save_cache();
+        self.step = AdaptStep::Materializing;
+        let plan = self.results.plan.clone()?;
+        let report = self.results.report.clone()?;
+        Some(crate::tui::app::TuiCommand::RunAdaptMaterialize(
+            plan, report,
+        ))
     }
 
     /// Advance the wizard after a successful materialize phase.
@@ -741,13 +763,99 @@ mod tests {
     }
 
     #[test]
-    fn resume_step_materializing_when_plan_cached() {
+    fn resume_step_scaffolding_when_plan_cached() {
         let results = AdaptResults {
             profile: Some(make_mock_profile()),
             report: Some(make_mock_report()),
             plan: Some(make_mock_plan()),
             ..Default::default()
         };
+        assert_eq!(results.resume_step(), AdaptStep::Scaffolding);
+    }
+
+    #[test]
+    fn resume_step_materializing_when_scaffold_cached() {
+        use crate::adapt::types::{ScaffoldFileStatus, ScaffoldResult, ScaffoldedFile};
+        let results = AdaptResults {
+            profile: Some(make_mock_profile()),
+            report: Some(make_mock_report()),
+            plan: Some(make_mock_plan()),
+            scaffold: Some(ScaffoldResult {
+                files: vec![ScaffoldedFile {
+                    path: "CLAUDE.md".into(),
+                    status: ScaffoldFileStatus::Created,
+                    reason: None,
+                }],
+                created_count: 1,
+                skipped_count: 0,
+            }),
+            ..Default::default()
+        };
         assert_eq!(results.resume_step(), AdaptStep::Materializing);
+    }
+
+    // ── Scaffold setters and transitions ──────────────────────────────
+
+    #[test]
+    fn set_scaffold_result_stores_result() {
+        use crate::adapt::types::ScaffoldResult;
+        let mut screen = AdaptScreen::new();
+        let sr = ScaffoldResult {
+            files: vec![],
+            created_count: 0,
+            skipped_count: 0,
+        };
+        screen.set_scaffold_result(sr);
+        assert!(screen.results.scaffold.is_some());
+    }
+
+    #[test]
+    fn complete_plan_transitions_to_scaffolding() {
+        let mut screen = AdaptScreen::new();
+        screen.results.profile = Some(make_mock_profile());
+        screen.results.report = Some(make_mock_report());
+        let cmd = screen.complete_plan(make_mock_plan());
+        assert_eq!(screen.step, AdaptStep::Scaffolding);
+        assert!(matches!(
+            cmd,
+            Some(crate::tui::app::TuiCommand::RunAdaptScaffold(_, _, _, _))
+        ));
+    }
+
+    #[test]
+    fn complete_scaffold_transitions_to_materializing() {
+        use crate::adapt::types::ScaffoldResult;
+        let mut screen = AdaptScreen::new();
+        screen.step = AdaptStep::Scaffolding;
+        screen.results.profile = Some(make_mock_profile());
+        screen.results.report = Some(make_mock_report());
+        screen.results.plan = Some(make_mock_plan());
+        let sr = ScaffoldResult {
+            files: vec![],
+            created_count: 0,
+            skipped_count: 0,
+        };
+        let cmd = screen.complete_scaffold(sr);
+        assert_eq!(screen.step, AdaptStep::Materializing);
+        assert!(matches!(
+            cmd,
+            Some(crate::tui::app::TuiCommand::RunAdaptMaterialize(_, _))
+        ));
+    }
+
+    #[test]
+    fn complete_scaffold_stores_result() {
+        use crate::adapt::types::ScaffoldResult;
+        let mut screen = AdaptScreen::new();
+        screen.step = AdaptStep::Scaffolding;
+        screen.results.report = Some(make_mock_report());
+        screen.results.plan = Some(make_mock_plan());
+        let sr = ScaffoldResult {
+            files: vec![],
+            created_count: 0,
+            skipped_count: 0,
+        };
+        screen.complete_scaffold(sr);
+        assert!(screen.results.scaffold.is_some());
     }
 }

--- a/src/tui/screens/adapt/types.rs
+++ b/src/tui/screens/adapt/types.rs
@@ -1,5 +1,7 @@
 use crate::adapt::AdaptConfig;
-use crate::adapt::types::{AdaptPlan, AdaptReport, MaterializeResult, ProjectProfile};
+use crate::adapt::types::{
+    AdaptPlan, AdaptReport, MaterializeResult, ProjectProfile, ScaffoldResult,
+};
 use std::path::PathBuf;
 
 /// Wizard step state machine for the adapt pipeline.
@@ -10,6 +12,7 @@ pub enum AdaptStep {
     Analyzing,
     Consolidating,
     Planning,
+    Scaffolding,
     Materializing,
     Complete,
     Failed,
@@ -23,6 +26,7 @@ impl AdaptStep {
                 | Self::Analyzing
                 | Self::Consolidating
                 | Self::Planning
+                | Self::Scaffolding
                 | Self::Materializing
         )
     }
@@ -75,6 +79,8 @@ pub struct AdaptResults {
     #[serde(default)]
     pub prd_content: Option<String>,
     pub plan: Option<AdaptPlan>,
+    #[serde(default)]
+    pub scaffold: Option<ScaffoldResult>,
     pub materialize: Option<MaterializeResult>,
 }
 
@@ -109,8 +115,10 @@ impl AdaptResults {
 
     /// Determine which phase to resume from based on cached results.
     pub fn resume_step(&self) -> AdaptStep {
-        if self.plan.is_some() {
+        if self.scaffold.is_some() {
             AdaptStep::Materializing
+        } else if self.plan.is_some() {
+            AdaptStep::Scaffolding
         } else if self.prd_content.is_some() {
             AdaptStep::Planning
         } else if self.report.is_some() {
@@ -148,6 +156,7 @@ mod tests {
         assert!(AdaptStep::Analyzing.is_progress());
         assert!(AdaptStep::Consolidating.is_progress());
         assert!(AdaptStep::Planning.is_progress());
+        assert!(AdaptStep::Scaffolding.is_progress());
         assert!(AdaptStep::Materializing.is_progress());
         assert!(!AdaptStep::Complete.is_progress());
         assert!(!AdaptStep::Failed.is_progress());
@@ -216,6 +225,20 @@ mod tests {
         let result: Result<AdaptResults, _> = serde_json::from_str(raw);
         assert!(result.is_ok());
         assert!(result.unwrap().prd_content.is_none());
+    }
+
+    #[test]
+    fn adapt_results_scaffold_defaults_to_none() {
+        let results = AdaptResults::default();
+        assert!(results.scaffold.is_none());
+    }
+
+    #[test]
+    fn adapt_results_json_without_scaffold_field_deserializes_as_none() {
+        let raw = r#"{"profile":null,"report":null,"plan":null,"materialize":null}"#;
+        let result: Result<AdaptResults, _> = serde_json::from_str(raw);
+        assert!(result.is_ok());
+        assert!(result.unwrap().scaffold.is_none());
     }
 
     // resume_step tests are in mod.rs tests (they need make_mock_profile helper)


### PR DESCRIPTION
## Summary

- Add new **Scaffold** phase to the adapt pipeline between Plan and Materialize
- Generates a `.claude/` directory structure (CLAUDE.md, commands, subagents, skills) tailored to the detected tech stack
- Includes path traversal protection and never overwrites existing files

Closes #371

## Test plan
- [x] 17 unit tests for scaffolder (serialization, filesystem, security, mock)
- [x] 2 prompt tests for `build_scaffold_prompt`
- [x] 5 TUI screen tests (transitions, setters, resume)
- [x] 2 TUI types tests (defaults, backward-compat deserialization)
- [x] Updated existing adapt chaining tests for new phase
- [x] All 2754 tests passing, clean clippy