### PR TITLE
feat: detect existing milestone-naming pattern in adapt

### DIFF
--- a/src/adapt/milestone_pattern.rs
+++ b/src/adapt/milestone_pattern.rs
@@ -1,0 +1,300 @@
+//! Detect the dominant milestone-naming pattern on a GitHub repo so the
+//! `adapt` planner emits titles that match existing conventions instead of
+//! diverging into an `M0/M1/M2` scheme the user doesn't use.
+//!
+//! Pure logic, no I/O. Fed a list of milestone titles, returns the best
+//! guess at the pattern plus a natural-language hint suitable for
+//! inclusion in the Claude planning prompt.
+
+use regex::Regex;
+use std::sync::OnceLock;
+
+/// Detected milestone-naming pattern.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MilestonePattern {
+    /// Semantic version — `v1.2.3`, `v0.14.0`, etc.
+    Semver,
+    /// Short-form `M0`, `M1:`, `Mn — Title`, etc. (what adapt emitted previously).
+    MStyle,
+    /// Quarterly or sprint-style cadence (e.g. `Q2-2026`, `Sprint 42`).
+    Cadence,
+    /// None of the recognized patterns dominated.
+    Unknown,
+}
+
+/// Threshold (fraction, 0.0–1.0) above which a pattern is considered dominant.
+const DOMINANCE_THRESHOLD: f64 = 0.6;
+
+fn semver_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"^v\d+\.\d+\.\d+$").unwrap())
+}
+
+fn mstyle_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"^M\d+(\b|:|\s|$)").unwrap())
+}
+
+fn cadence_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"(?i)^(q[1-4][-\s]\d{4}|sprint[-\s]\d+)").unwrap())
+}
+
+fn classify(title: &str) -> Option<MilestonePattern> {
+    let t = title.trim();
+    if semver_re().is_match(t) {
+        return Some(MilestonePattern::Semver);
+    }
+    if mstyle_re().is_match(t) {
+        return Some(MilestonePattern::MStyle);
+    }
+    if cadence_re().is_match(t) {
+        return Some(MilestonePattern::Cadence);
+    }
+    None
+}
+
+/// Inspect milestone titles and return the dominant pattern, or `Unknown`
+/// if no pattern exceeds [`DOMINANCE_THRESHOLD`] or `titles` is empty.
+pub fn detect_pattern(titles: &[&str]) -> MilestonePattern {
+    if titles.is_empty() {
+        return MilestonePattern::Unknown;
+    }
+
+    let mut semver = 0usize;
+    let mut mstyle = 0usize;
+    let mut cadence = 0usize;
+    let mut classified = 0usize;
+
+    for title in titles {
+        match classify(title) {
+            Some(MilestonePattern::Semver) => {
+                semver += 1;
+                classified += 1;
+            }
+            Some(MilestonePattern::MStyle) => {
+                mstyle += 1;
+                classified += 1;
+            }
+            Some(MilestonePattern::Cadence) => {
+                cadence += 1;
+                classified += 1;
+            }
+            _ => {}
+        }
+    }
+
+    if classified == 0 {
+        return MilestonePattern::Unknown;
+    }
+
+    let total = titles.len() as f64;
+    let top = [
+        (semver, MilestonePattern::Semver),
+        (mstyle, MilestonePattern::MStyle),
+        (cadence, MilestonePattern::Cadence),
+    ]
+    .into_iter()
+    .max_by_key(|(n, _)| *n)
+    .unwrap();
+
+    if (top.0 as f64) / total >= DOMINANCE_THRESHOLD {
+        top.1
+    } else {
+        MilestonePattern::Unknown
+    }
+}
+
+/// Extract the highest semver title (by lexicographic compare on the
+/// `(major, minor, patch)` tuple) and return a natural-language "next slot"
+/// suggestion for use in the planner prompt.
+pub fn next_semver_slot(titles: &[&str]) -> Option<String> {
+    let re = semver_re();
+    let mut versions: Vec<(u32, u32, u32)> = titles
+        .iter()
+        .filter_map(|t| {
+            let t = t.trim();
+            if !re.is_match(t) {
+                return None;
+            }
+            let rest = &t[1..];
+            let parts: Vec<&str> = rest.split('.').collect();
+            if parts.len() != 3 {
+                return None;
+            }
+            Some((
+                parts[0].parse().ok()?,
+                parts[1].parse().ok()?,
+                parts[2].parse().ok()?,
+            ))
+        })
+        .collect();
+
+    if versions.is_empty() {
+        return None;
+    }
+    versions.sort();
+    let (major, minor, _) = *versions.last().unwrap();
+    Some(format!("v{}.{}.0", major, minor + 1))
+}
+
+/// Build the natural-language hint passed to the Claude planner.
+/// Returns `None` when no useful hint can be derived (falls back to default behavior).
+pub fn build_planner_hint(titles: &[&str]) -> Option<String> {
+    let pattern = detect_pattern(titles);
+    match pattern {
+        MilestonePattern::Semver => {
+            let example = next_semver_slot(titles).unwrap_or_else(|| "v0.1.0".to_string());
+            Some(format!(
+                "The project uses semantic versioning for milestone titles (e.g. `v0.14.0`, `v1.0.0`). \
+                 Every new milestone title MUST match the regex `^v\\d+\\.\\d+\\.\\d+$`. \
+                 Suggested next slot: `{}`. Do NOT emit titles like `M0:`, `Phase 1`, or `Foundation`. \
+                 Put the descriptive name in the milestone description, not the title.",
+                example
+            ))
+        }
+        MilestonePattern::MStyle => Some(
+            "The project uses short-form milestone titles prefixed with `M<number>:` (e.g. `M0: Foundation`). \
+             Match this convention for new milestones."
+                .to_string(),
+        ),
+        MilestonePattern::Cadence => Some(
+            "The project uses a cadence-based milestone naming (e.g. `Q2-2026`, `Sprint 42`). \
+             Match this convention; infer the next slot from the highest existing."
+                .to_string(),
+        ),
+        MilestonePattern::Unknown => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_titles_returns_unknown() {
+        assert_eq!(detect_pattern(&[]), MilestonePattern::Unknown);
+    }
+
+    #[test]
+    fn detects_semver_when_all_titles_are_semver() {
+        let titles = vec!["v0.1.0", "v0.2.0", "v0.14.0", "v1.0.0"];
+        assert_eq!(detect_pattern(&titles), MilestonePattern::Semver);
+    }
+
+    #[test]
+    fn detects_semver_when_mostly_semver_above_threshold() {
+        // 5/6 = 83% semver, above the 60% threshold
+        let titles = vec!["v0.1.0", "v0.2.0", "v0.3.0", "v0.4.0", "v0.5.0", "M0: odd"];
+        assert_eq!(detect_pattern(&titles), MilestonePattern::Semver);
+    }
+
+    #[test]
+    fn detects_mstyle_when_all_titles_are_m_style() {
+        let titles = vec!["M0: Foundation", "M1: Core", "M2 — Testing", "M3: Polish"];
+        assert_eq!(detect_pattern(&titles), MilestonePattern::MStyle);
+    }
+
+    #[test]
+    fn detects_cadence_for_quarter_style() {
+        let titles = vec!["Q1-2026", "Q2 2026", "Q3-2026"];
+        assert_eq!(detect_pattern(&titles), MilestonePattern::Cadence);
+    }
+
+    #[test]
+    fn detects_cadence_for_sprint_style() {
+        let titles = vec!["Sprint 40", "Sprint 41", "sprint-42"];
+        assert_eq!(detect_pattern(&titles), MilestonePattern::Cadence);
+    }
+
+    #[test]
+    fn returns_unknown_when_no_titles_classify() {
+        let titles = vec!["Release A", "Release B"];
+        assert_eq!(detect_pattern(&titles), MilestonePattern::Unknown);
+    }
+
+    #[test]
+    fn returns_unknown_when_no_pattern_dominates() {
+        // 50/50 split — below the 60% threshold
+        let titles = vec!["v0.1.0", "v0.2.0", "M0: foo", "M1: bar"];
+        assert_eq!(detect_pattern(&titles), MilestonePattern::Unknown);
+    }
+
+    #[test]
+    fn detects_semver_with_v_prefix_only_not_raw_numbers() {
+        // Raw "1.0.0" (no v prefix) should NOT match
+        let titles = vec!["1.0.0", "2.0.0", "3.0.0"];
+        assert_eq!(detect_pattern(&titles), MilestonePattern::Unknown);
+    }
+
+    #[test]
+    fn detects_semver_ignores_suffixes() {
+        // "v0.14.0-rc1" isn't strict semver per our regex; should not classify
+        let titles = vec!["v0.14.0-rc1", "v0.15.0-beta", "v0.1.0"];
+        // Only 1/3 classifies — below threshold
+        assert_eq!(detect_pattern(&titles), MilestonePattern::Unknown);
+    }
+
+    // -- next_semver_slot --
+
+    #[test]
+    fn next_semver_slot_picks_max_version() {
+        let titles = vec!["v0.1.0", "v0.14.0", "v0.5.0"];
+        assert_eq!(next_semver_slot(&titles), Some("v0.15.0".to_string()));
+    }
+
+    #[test]
+    fn next_semver_slot_ignores_non_semver_titles() {
+        let titles = vec!["v0.14.0", "M0: foo", "not a version"];
+        assert_eq!(next_semver_slot(&titles), Some("v0.15.0".to_string()));
+    }
+
+    #[test]
+    fn next_semver_slot_returns_none_when_no_semver_present() {
+        let titles = vec!["M0: foo"];
+        assert_eq!(next_semver_slot(&titles), None);
+    }
+
+    #[test]
+    fn next_semver_slot_considers_major_bump() {
+        let titles = vec!["v0.21.0", "v1.0.0"];
+        assert_eq!(next_semver_slot(&titles), Some("v1.1.0".to_string()));
+    }
+
+    // -- build_planner_hint --
+
+    #[test]
+    fn hint_for_semver_project_mentions_regex_and_next_slot() {
+        let titles = vec!["v0.1.0", "v0.13.0", "v0.14.0"];
+        let hint = build_planner_hint(&titles).expect("semver project should produce a hint");
+        assert!(hint.contains("semantic versioning"));
+        assert!(hint.contains(r"^v\d+\.\d+\.\d+$"));
+        assert!(hint.contains("v0.15.0"));
+        assert!(hint.to_lowercase().contains("do not emit titles like"));
+    }
+
+    #[test]
+    fn hint_for_mstyle_project_mentions_m_prefix() {
+        let titles = vec!["M0: Foo", "M1: Bar", "M2: Baz"];
+        let hint = build_planner_hint(&titles).expect("m-style project should produce a hint");
+        assert!(hint.contains("M<number>"));
+    }
+
+    #[test]
+    fn hint_returns_none_for_empty_titles() {
+        assert_eq!(build_planner_hint(&[]), None);
+    }
+
+    #[test]
+    fn hint_returns_none_for_unknown_pattern() {
+        let titles = vec!["Release A", "Release B"];
+        assert_eq!(build_planner_hint(&titles), None);
+    }
+
+    #[test]
+    fn hint_for_semver_with_only_one_milestone_works() {
+        let titles = vec!["v0.1.0"];
+        let hint = build_planner_hint(&titles).expect("single semver title still works");
+        assert!(hint.contains("v0.2.0"));
+    }
+}

--- a/src/adapt/mod.rs
+++ b/src/adapt/mod.rs
@@ -1,6 +1,7 @@
 pub mod analyzer;
 pub mod knowledge;
 pub mod materializer;
+pub mod milestone_pattern;
 pub mod planner;
 pub mod prd;
 mod prompts;
@@ -180,11 +181,27 @@ pub async fn cmd_adapt(config: AdaptConfig) -> anyhow::Result<()> {
         Err(e) => eprintln!("  Failed to write knowledge.md: {}", e),
     }
 
+    // Phase 2.7: Detect the repo's existing milestone-naming pattern so the
+    // planner's output matches conventions already in use. Falls back to the
+    // configured `MilestoneNaming` when the repo has no detectable pattern.
+    let milestone_hint = detect_milestone_hint(&profile.root, project_cfg.as_ref()).await;
+    if let Some(ref hint) = milestone_hint {
+        let preview: String = hint.chars().take(120).collect();
+        eprintln!("Phase 2.7: Milestone pattern → {}…", preview);
+    } else {
+        eprintln!("Phase 2.7: No milestone pattern detected (will defer to planner).");
+    }
+
     // Phase 3: Plan
     eprintln!("Phase 3: Planning milestones and issues...");
     let planner = ClaudePlanner::new(model.clone());
     let plan = planner
-        .plan(&profile, &report, prd_content.as_deref())
+        .plan(
+            &profile,
+            &report,
+            prd_content.as_deref(),
+            milestone_hint.as_deref(),
+        )
         .await?;
     eprintln!(
         "  {} milestones, {} issues",
@@ -233,6 +250,50 @@ pub async fn cmd_adapt(config: AdaptConfig) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+/// Build the milestone-naming hint for the Claude planner.
+///
+/// Precedence:
+/// 1. `MilestoneNaming::Custom` with a template → use it verbatim (user opt-in).
+/// 2. `MilestoneNaming::Standard` or `Ai` → try to detect an existing pattern
+///    from the repo's milestones. Return `Some(hint)` if detected, `None` if
+///    the repo has no milestones or no dominant pattern (let Claude decide).
+///
+/// Failures talking to GitHub are non-fatal — returns `None` and adapt proceeds
+/// with the planner's default behavior.
+pub async fn detect_milestone_hint(
+    _project_root: &std::path::Path,
+    project_cfg: Option<&crate::config::Config>,
+) -> Option<String> {
+    use crate::config::MilestoneNaming;
+
+    if let Some(cfg) = project_cfg
+        && cfg.adapt.milestone_naming == MilestoneNaming::Custom
+        && let Some(template) = cfg.adapt.milestone_template.as_deref()
+    {
+        return Some(format!(
+            "Use this exact milestone title template (user-provided): `{}`. \
+             `{{n}}` is the zero-based milestone index; `{{title}}` is a short description.",
+            template
+        ));
+    }
+
+    let github = crate::provider::github::client::GhCliClient::new();
+    let mut titles: Vec<String> = Vec::new();
+    for state in ["open", "closed"] {
+        match crate::provider::github::client::GitHubClient::list_milestones(&github, state).await {
+            Ok(ms) => titles.extend(ms.into_iter().map(|m| m.title)),
+            Err(e) => {
+                tracing::warn!("Failed to list {state} milestones for pattern detection: {e}");
+            }
+        }
+    }
+    if titles.is_empty() {
+        return None;
+    }
+    let refs: Vec<&str> = titles.iter().map(|s| s.as_str()).collect();
+    milestone_pattern::build_planner_hint(&refs)
 }
 
 fn build_adapter_from_config(

--- a/src/adapt/planner.rs
+++ b/src/adapt/planner.rs
@@ -10,6 +10,7 @@ pub trait AdaptPlanner: Send + Sync {
         profile: &ProjectProfile,
         report: &AdaptReport,
         prd_content: Option<&str>,
+        milestone_naming_hint: Option<&str>,
     ) -> anyhow::Result<AdaptPlan>;
 }
 
@@ -30,10 +31,16 @@ impl AdaptPlanner for ClaudePlanner {
         profile: &ProjectProfile,
         report: &AdaptReport,
         prd_content: Option<&str>,
+        milestone_naming_hint: Option<&str>,
     ) -> anyhow::Result<AdaptPlan> {
         let profile_json = serde_json::to_string_pretty(profile)?;
         let report_json = serde_json::to_string_pretty(report)?;
-        let prompt = build_planning_prompt(&profile_json, &report_json, None, prd_content);
+        let prompt = build_planning_prompt(
+            &profile_json,
+            &report_json,
+            milestone_naming_hint,
+            prd_content,
+        );
         let raw = run_claude_print(&self.model, &prompt, &profile.root).await?;
         parse_json_response(&raw)
     }
@@ -63,6 +70,7 @@ impl AdaptPlanner for MockAdaptPlanner {
         _profile: &ProjectProfile,
         _report: &AdaptReport,
         _prd_content: Option<&str>,
+        _milestone_naming_hint: Option<&str>,
     ) -> anyhow::Result<AdaptPlan> {
         self.result
             .clone()
@@ -151,7 +159,7 @@ mod tests {
             tech_debt_items: vec![],
         };
 
-        let result = planner.plan(&profile, &report, None).await.unwrap();
+        let result = planner.plan(&profile, &report, None, None).await.unwrap();
         assert_eq!(result.milestones.len(), 1);
         assert_eq!(result.milestones[0].issues.len(), 2);
         assert_eq!(
@@ -254,6 +262,6 @@ mod tests {
             modules: vec![],
             tech_debt_items: vec![],
         };
-        assert!(planner.plan(&profile, &report, None).await.is_err());
+        assert!(planner.plan(&profile, &report, None, None).await.is_err());
     }
 }

--- a/src/adapt/prompts.rs
+++ b/src/adapt/prompts.rs
@@ -140,7 +140,7 @@ Create a structured plan with milestones and DOR-compliant issues. Return a JSON
 {{
   "milestones": [
     {{
-      "title": "M0: Foundation",
+      "title": "<short milestone title>",
       "description": "Description of the milestone goals",
       "issues": [
         {{

--- a/src/integration_tests/adapt_pipeline.rs
+++ b/src/integration_tests/adapt_pipeline.rs
@@ -117,7 +117,7 @@ async fn pipeline_analyze_then_plan_with_mocks() {
 
     // Phase 3: Plan
     let planner = MockAdaptPlanner::with_plan(sample_plan());
-    let plan = planner.plan(&profile, &report, None).await.unwrap();
+    let plan = planner.plan(&profile, &report, None, None).await.unwrap();
     assert_eq!(plan.milestones.len(), 2);
     assert_eq!(plan.milestones[0].issues.len(), 1);
     assert_eq!(plan.milestones[1].issues[0].blocked_by_titles.len(), 1);
@@ -142,7 +142,7 @@ async fn pipeline_empty_analysis_produces_valid_plan() {
         maestro_toml_patch: None,
         workflow_guide: None,
     });
-    let plan = planner.plan(&profile, &report, None).await.unwrap();
+    let plan = planner.plan(&profile, &report, None, None).await.unwrap();
     assert!(plan.milestones.is_empty());
     assert!(plan.maestro_toml_patch.is_none());
 }
@@ -162,6 +162,6 @@ async fn pipeline_planner_failure_propagates() {
     let profile = sample_profile();
     let report = sample_report();
     let planner = MockAdaptPlanner::without_plan();
-    let err = planner.plan(&profile, &report, None).await;
+    let err = planner.plan(&profile, &report, None, None).await;
     assert!(err.is_err());
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -357,9 +357,21 @@ async fn event_loop(
                     let model = config.model.unwrap_or_else(|| "sonnet".to_string());
                     tokio::spawn(async move {
                         use crate::adapt::planner::{AdaptPlanner, ClaudePlanner};
+                        let project_cfg =
+                            crate::config::Config::find_and_load_in(&config.path).ok();
+                        let milestone_hint = crate::adapt::detect_milestone_hint(
+                            &profile.root,
+                            project_cfg.as_ref(),
+                        )
+                        .await;
                         let planner = ClaudePlanner::new(model);
                         let result = planner
-                            .plan(&profile, &report, prd_content.as_deref())
+                            .plan(
+                                &profile,
+                                &report,
+                                prd_content.as_deref(),
+                                milestone_hint.as_deref(),
+                            )
                             .await;
                         let _ = tx.send(app::TuiDataEvent::AdaptPlanResult(result));
                     });


### PR DESCRIPTION
## Summary

`maestro adapt` previously emitted `M0: Foundation` / `M1: Code Organization` style milestone titles even on projects using strict `vX.Y.Z` semver, because the planner's `milestone_naming_hint` parameter was hardcoded to `None` and the prompt's JSON example biased Claude toward the `M0:` shape.

This PR adds a guardrail: before the planner runs, adapt fetches existing milestones, detects the dominant pattern, and passes a natural-language rule into the planner prompt.

- New `adapt::milestone_pattern` module with pure-logic `detect_pattern`, `next_semver_slot`, and `build_planner_hint`. Handles semver, `Mn:`/`Mn —`, and quarterly/sprint cadence, with a 60% dominance threshold.
- New adapt Phase 2.7 `detect_milestone_hint` — non-fatal on network failure, honors `MilestoneNaming::Custom` as an explicit override.
- Wired into both the CLI (`cmd_adapt`) and the TUI (`RunAdaptPlan`) planner paths. Removed the `M0: Foundation` example bias from the prompt schema.

## Test plan

- [x] `cargo test` — 2,650 passing (+19 new tests in `milestone_pattern::tests`)
- [x] `cargo clippy --bin maestro -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manual: run `maestro adapt` on this repo and verify Phase 2.7 logs the semver pattern + suggests the next free slot (should be `v0.22.0` after the four newly-renamed milestones)
- [ ] Manual: run `maestro adapt` on a repo with no milestones and verify the phase logs "No milestone pattern detected" without failing