### PR TITLE
feat(tui): interactive follow-up after adapt — selectable next actions

### DIFF
--- a/src/adapt/mod.rs
+++ b/src/adapt/mod.rs
@@ -7,6 +7,7 @@ pub mod prd;
 mod prompts;
 pub mod scaffolder;
 pub mod scanner;
+pub mod suggestions;
 pub mod types;
 
 /// Configuration for the `maestro adapt` command.

--- a/src/adapt/suggestions.rs
+++ b/src/adapt/suggestions.rs
@@ -1,0 +1,252 @@
+//! Parses numbered "next iteration path" suggestions out of free-form
+//! adapt session output so the TUI can present them as selectable actions.
+//!
+//! The expected format is a header (e.g. `## Suggested next iteration paths`)
+//! followed by a numbered list:
+//! ```text
+//! ## Suggested next iteration paths
+//!
+//! 1. Burn down M0 — start with high-severity tests
+//! 2. Fill the empty feature docs — sos.mdx, respiracao.mdx
+//! 3. Observability gap — no Sentry/error reporting
+//! ```
+//!
+//! The parser is tolerant:
+//! - Any of a few well-known headers qualifies as "start of list"
+//! - Numbered items may use `1.` or `1)` separators
+//! - Whitespace and blank lines inside an item are preserved but collapsed
+
+/// Headers that indicate the start of a suggestion list.
+const HEADER_MARKERS: &[&str] = &[
+    "suggested next iteration paths",
+    "suggested next steps",
+    "next iteration paths",
+    "next steps",
+    "recommended next actions",
+    "what to do next",
+];
+
+/// Parse numbered suggestions from adapt session output.
+///
+/// Returns the trimmed body of each numbered item under the first matching
+/// header found. Returns an empty vec when no suggestions section is present.
+pub fn parse_suggestions(text: &str) -> Vec<String> {
+    let lower = text.to_lowercase();
+    let header_start = HEADER_MARKERS.iter().find_map(|m| lower.find(m));
+    let Some(start) = header_start else {
+        return parse_numbered_items(text);
+    };
+
+    // Skip past the header line.
+    let after_header = match text[start..].find('\n') {
+        Some(nl) => &text[start + nl + 1..],
+        None => return Vec::new(),
+    };
+
+    parse_numbered_items(after_header)
+}
+
+/// Extract numbered list items ("1. foo", "1) foo") from the start of `text`,
+/// stopping at the first non-item, non-blank line.
+fn parse_numbered_items(text: &str) -> Vec<String> {
+    let mut items: Vec<String> = Vec::new();
+    let mut current: Option<String> = None;
+
+    for line in text.lines() {
+        let trimmed = line.trim();
+
+        if trimmed.is_empty() {
+            // Blank line — if we have a current item being built, finish it.
+            // If we're between items or before any, keep scanning.
+            if let Some(item) = current.take() {
+                items.push(item);
+            }
+            continue;
+        }
+
+        if let Some(body) = strip_number_prefix(trimmed) {
+            if let Some(prev) = current.take() {
+                items.push(prev);
+            }
+            current = Some(body.to_string());
+        } else if let Some(cur) = current.as_mut() {
+            // Continuation of the previous numbered item (wrap).
+            cur.push(' ');
+            cur.push_str(trimmed);
+        } else {
+            // We haven't started the list yet — ignore preamble lines.
+            continue;
+        }
+    }
+
+    if let Some(item) = current {
+        items.push(item);
+    }
+
+    // Trim trailing whitespace from each item body.
+    items.into_iter().map(|s| s.trim().to_string()).collect()
+}
+
+fn strip_number_prefix(s: &str) -> Option<&str> {
+    let mut chars = s.char_indices();
+    let mut digit_end: Option<usize> = None;
+    for (i, c) in chars.by_ref() {
+        if c.is_ascii_digit() {
+            digit_end = Some(i + c.len_utf8());
+        } else {
+            break;
+        }
+    }
+    let end = digit_end?;
+    let rest = &s[end..];
+    // Need a ". " or ") " after the digits.
+    if let Some(body) = rest.strip_prefix(". ") {
+        Some(body.trim())
+    } else if let Some(body) = rest.strip_prefix(") ") {
+        Some(body.trim())
+    } else {
+        None
+    }
+}
+
+/// Build the prompt for the follow-up session after the user selected a
+/// direction from the adapt output.
+pub fn build_follow_up_prompt(direction: &str) -> String {
+    format!(
+        "Based on the previous adapt analysis, execute this direction:\n\n\
+         {}\n\n\
+         Plan the work into GitHub issues (or milestones when appropriate) \
+         and either implement the first step immediately or queue the issues \
+         for the /implement flow.",
+        direction.trim()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_example_from_issue_391() {
+        let text = "\
+Some preamble text that should be ignored.
+
+## Suggested next iteration paths
+
+1. Burn down M0 — start with high-severity tests (#37/#38/#39).
+2. Fill the empty feature docs — sos.mdx, respiracao.mdx.
+3. Observability gap — no Sentry/error reporting.
+
+Tell me which direction to go and I'll plan it.
+";
+        let out = parse_suggestions(text);
+        assert_eq!(out.len(), 3);
+        assert!(out[0].starts_with("Burn down M0"));
+        assert!(out[1].starts_with("Fill the empty feature docs"));
+        assert!(out[2].starts_with("Observability gap"));
+    }
+
+    #[test]
+    fn parses_next_steps_header_variant() {
+        let text = "## Next steps\n\n1. First action\n2. Second action\n";
+        let out = parse_suggestions(text);
+        assert_eq!(out.len(), 2);
+    }
+
+    #[test]
+    fn parses_parens_style_numbering() {
+        let text = "## Next steps\n\n1) First action\n2) Second action\n";
+        let out = parse_suggestions(text);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0], "First action");
+    }
+
+    #[test]
+    fn collapses_wrapped_items_into_single_string() {
+        let text = "\
+## Suggested next steps
+
+1. Burn down M0 by
+   tackling the tests
+   one milestone at a time
+2. Something else
+";
+        let out = parse_suggestions(text);
+        assert_eq!(out.len(), 2);
+        assert!(out[0].contains("Burn down M0"));
+        assert!(out[0].contains("tackling the tests"));
+        assert!(out[0].contains("one milestone"));
+    }
+
+    #[test]
+    fn returns_empty_when_no_suggestions_section() {
+        let text = "Just some prose without any numbered list of directions.";
+        let out = parse_suggestions(text);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn parses_standalone_numbered_list_without_header() {
+        // No well-known header, but the text IS just a numbered list —
+        // treat it as suggestions.
+        let text = "1. Do the thing\n2. Do the other thing\n";
+        let out = parse_suggestions(text);
+        assert_eq!(out.len(), 2);
+    }
+
+    #[test]
+    fn empty_input_returns_empty() {
+        assert!(parse_suggestions("").is_empty());
+    }
+
+    #[test]
+    fn header_without_items_returns_empty() {
+        let text = "## Suggested next iteration paths\n\nNothing to suggest.\n";
+        let out = parse_suggestions(text);
+        assert!(out.is_empty(), "prose after header is not a numbered item");
+    }
+
+    #[test]
+    fn parses_case_insensitive_header() {
+        let text = "## SUGGESTED NEXT ITERATION PATHS\n\n1. Action one\n";
+        let out = parse_suggestions(text);
+        assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn build_follow_up_prompt_includes_direction() {
+        let prompt = build_follow_up_prompt("Burn down M0");
+        assert!(prompt.contains("Burn down M0"));
+        assert!(prompt.contains("adapt analysis"));
+        assert!(prompt.contains("GitHub issues"));
+    }
+
+    #[test]
+    fn build_follow_up_prompt_trims_direction() {
+        let prompt = build_follow_up_prompt("   Burn down M0   \n");
+        assert!(prompt.contains("Burn down M0\n"));
+        assert!(!prompt.contains("   Burn down"));
+    }
+
+    #[test]
+    fn parses_multi_line_wrapping_survives_blank_lines_between_items() {
+        let text = "\
+## Suggested next steps
+
+1. First
+
+2. Second
+";
+        let out = parse_suggestions(text);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0], "First");
+        assert_eq!(out[1], "Second");
+    }
+
+    #[test]
+    fn items_with_special_chars_preserved() {
+        let text = "## Next steps\n\n1. Fix #42 — edge case in parser.rs\n";
+        let out = parse_suggestions(text);
+        assert_eq!(out[0], "Fix #42 — edge case in parser.rs");
+    }
+}

--- a/src/tui/app/completion_pipeline.rs
+++ b/src/tui/app/completion_pipeline.rs
@@ -308,6 +308,24 @@ impl App {
             self.add_session(session).await?;
         }
 
+        // Show adapt follow-up overlay when a just-completed session's final
+        // message contains parsed next-iteration paths.
+        if self.adapt_follow_up_screen.is_none()
+            && let Some(candidate) = self.pool.all_sessions().iter().find(|s| {
+                matches!(s.status, SessionStatus::Completed | SessionStatus::Retrying)
+                    && !s.last_message.trim().is_empty()
+                    && crate::adapt::suggestions::parse_suggestions(&s.last_message).len() >= 2
+            })
+        {
+            let suggestions = crate::adapt::suggestions::parse_suggestions(&candidate.last_message);
+            let label = session_label(candidate);
+            self.adapt_follow_up_screen = Some(crate::tui::screens::AdaptFollowUpScreen::new(
+                label,
+                suggestions,
+            ));
+            self.tui_mode = TuiMode::AdaptFollowUp;
+        }
+
         // Show hollow retry prompt for sessions that exceeded auto-retry limits.
         // Consultation-satisfied sessions are excluded — they're already "done".
         if self.hollow_retry_screen.is_none()

--- a/src/tui/app/mod.rs
+++ b/src/tui/app/mod.rs
@@ -102,6 +102,7 @@ pub struct App {
     pub queue_executor: Option<crate::work::executor::QueueExecutor>,
     pub queue_launch_configs: Option<Vec<crate::tui::screens::SessionConfig>>,
     pub hollow_retry_screen: Option<crate::tui::screens::HollowRetryScreen>,
+    pub adapt_follow_up_screen: Option<crate::tui::screens::AdaptFollowUpScreen>,
     pub sanitize_screen: Option<crate::sanitize::screen::SanitizeScreen>,
     pub settings_screen: Option<crate::tui::screens::SettingsScreen>,
     pub prompt_history: crate::state::prompt_history::PromptHistoryStore,
@@ -190,6 +191,7 @@ impl App {
             queue_executor: None,
             queue_launch_configs: None,
             hollow_retry_screen: None,
+            adapt_follow_up_screen: None,
             sanitize_screen: None,
             settings_screen: None,
             prompt_history: crate::state::prompt_history::PromptHistoryStore::new(

--- a/src/tui/app/types.rs
+++ b/src/tui/app/types.rs
@@ -38,6 +38,9 @@ pub enum TuiMode {
     ConfirmExit,
     SessionSummary,
     TurboquantDashboard,
+    /// Overlay shown after an adapt-flavored session completes, presenting the
+    /// parsed next-iteration paths for one-key selection.
+    AdaptFollowUp,
 }
 
 impl TuiMode {
@@ -70,6 +73,7 @@ impl TuiMode {
             Self::ConfirmExit => "Confirm Exit",
             Self::SessionSummary => "Sessions",
             Self::TurboquantDashboard => "TQ Dashboard",
+            Self::AdaptFollowUp => "Next Steps",
         }
     }
 }

--- a/src/tui/navigation/mode_hints.rs
+++ b/src/tui/navigation/mode_hints.rs
@@ -519,6 +519,22 @@ pub fn mode_keymap(
                 },
             ],
         ),
+        TuiMode::AdaptFollowUp => (
+            "Next iteration paths",
+            FKeyVis::Minimal,
+            &[
+                InlineHint {
+                    key: "Enter",
+                    action: "Execute",
+                    priority: 0,
+                },
+                InlineHint {
+                    key: "Esc",
+                    action: "Dismiss",
+                    priority: 1,
+                },
+            ],
+        ),
     };
 
     let fkeys = build_fkeys(fkey_vis, has_session, is_running, is_terminal);

--- a/src/tui/screen_dispatch.rs
+++ b/src/tui/screen_dispatch.rs
@@ -14,6 +14,7 @@ pub(super) fn dispatch_to_active_screen(app: &mut app::App, event: &Event) -> Op
         app::TuiMode::PromptInput => app.prompt_input_screen.as_mut()?,
         app::TuiMode::QueueConfirmation => app.queue_confirmation_screen.as_mut()?,
         app::TuiMode::HollowRetry => app.hollow_retry_screen.as_mut()?,
+        app::TuiMode::AdaptFollowUp => app.adapt_follow_up_screen.as_mut()?,
         app::TuiMode::Sanitize => app.sanitize_screen.as_mut()?,
         app::TuiMode::Settings => app.settings_screen.as_mut()?,
         app::TuiMode::AdaptWizard => app.adapt_screen.as_mut()?,
@@ -130,6 +131,9 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
                 app::TuiMode::HollowRetry => {
                     app.hollow_retry_screen = None;
                 }
+                app::TuiMode::AdaptFollowUp => {
+                    app.adapt_follow_up_screen = None;
+                }
                 app::TuiMode::Sanitize => {
                     app.sanitize_screen = None;
                 }
@@ -209,6 +213,7 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
         }
         ScreenAction::LaunchPromptSession(config) => {
             app.prompt_input_screen = None;
+            app.adapt_follow_up_screen = None;
             app.pending_commands
                 .push(app::TuiCommand::LaunchPromptSession(config));
             app.nav_stack.clear();

--- a/src/tui/screens/adapt_follow_up.rs
+++ b/src/tui/screens/adapt_follow_up.rs
@@ -1,0 +1,314 @@
+//! Overlay screen shown after an adapt session completes, presenting the
+//! parsed "next iteration paths" as a selectable list.
+//!
+//! Matches the pattern established by `HollowRetryScreen`: centered popup,
+//! j/k or number keys to select, Enter to confirm, Esc to dismiss.
+
+use super::{PromptSessionConfig, Screen, ScreenAction, draw_keybinds_bar};
+use crate::adapt::suggestions::build_follow_up_prompt;
+use crate::tui::navigation::InputMode;
+use crate::tui::navigation::keymap::{KeyBinding, KeyBindingGroup, KeymapProvider};
+use crate::tui::theme::Theme;
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind};
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Clear, Paragraph, Wrap},
+};
+
+/// Screen shown when an adapt session completes with parsed suggestions.
+pub struct AdaptFollowUpScreen {
+    pub session_label: String,
+    pub suggestions: Vec<String>,
+    pub selected: usize,
+}
+
+impl AdaptFollowUpScreen {
+    pub fn new(session_label: String, suggestions: Vec<String>) -> Self {
+        Self {
+            session_label,
+            suggestions,
+            selected: 0,
+        }
+    }
+
+    fn move_down(&mut self) {
+        if !self.suggestions.is_empty() && self.selected + 1 < self.suggestions.len() {
+            self.selected += 1;
+        }
+    }
+
+    fn move_up(&mut self) {
+        self.selected = self.selected.saturating_sub(1);
+    }
+
+    fn current_prompt(&self) -> Option<PromptSessionConfig> {
+        let direction = self.suggestions.get(self.selected)?;
+        Some(PromptSessionConfig {
+            prompt: build_follow_up_prompt(direction),
+            image_paths: Vec::new(),
+        })
+    }
+}
+
+impl KeymapProvider for AdaptFollowUpScreen {
+    fn keybindings(&self) -> Vec<KeyBindingGroup> {
+        vec![KeyBindingGroup {
+            title: "Adapt Follow-up",
+            bindings: vec![
+                KeyBinding {
+                    key: "j/k",
+                    description: "Move selection",
+                },
+                KeyBinding {
+                    key: "1-9",
+                    description: "Select by index",
+                },
+                KeyBinding {
+                    key: "Enter",
+                    description: "Execute direction",
+                },
+                KeyBinding {
+                    key: "Esc",
+                    description: "Dismiss",
+                },
+            ],
+        }]
+    }
+}
+
+impl Screen for AdaptFollowUpScreen {
+    fn handle_input(&mut self, event: &Event, _mode: InputMode) -> ScreenAction {
+        if let Event::Key(KeyEvent {
+            code,
+            kind: KeyEventKind::Press,
+            ..
+        }) = event
+        {
+            match code {
+                KeyCode::Char('j') | KeyCode::Down => {
+                    self.move_down();
+                }
+                KeyCode::Char('k') | KeyCode::Up => {
+                    self.move_up();
+                }
+                KeyCode::Char(c) if c.is_ascii_digit() && *c != '0' => {
+                    let idx = (*c as usize) - ('1' as usize);
+                    if idx < self.suggestions.len() {
+                        self.selected = idx;
+                        if let Some(cfg) = self.current_prompt() {
+                            return ScreenAction::LaunchPromptSession(cfg);
+                        }
+                    }
+                }
+                KeyCode::Enter => {
+                    if let Some(cfg) = self.current_prompt() {
+                        return ScreenAction::LaunchPromptSession(cfg);
+                    }
+                }
+                KeyCode::Esc | KeyCode::Char('q') => {
+                    return ScreenAction::Pop;
+                }
+                _ => {}
+            }
+        }
+        ScreenAction::None
+    }
+
+    fn draw(&mut self, f: &mut Frame, area: Rect, theme: &Theme) {
+        let items = self.suggestions.len() as u16;
+        let popup_width = 80.min(area.width.saturating_sub(4));
+        let popup_height = (7 + items).min(area.height.saturating_sub(4));
+        let x = area.x + (area.width.saturating_sub(popup_width)) / 2;
+        let y = area.y + (area.height.saturating_sub(popup_height)) / 2;
+        let popup_area = Rect::new(x, y, popup_width, popup_height);
+
+        f.render_widget(Clear, popup_area);
+
+        let block = theme
+            .styled_block("Next iteration paths", false)
+            .border_style(
+                Style::default()
+                    .fg(theme.accent_info)
+                    .add_modifier(Modifier::BOLD),
+            );
+
+        let inner = block.inner(popup_area);
+        f.render_widget(block, popup_area);
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(1),  // header
+                Constraint::Length(1),  // blank
+                Constraint::Min(items), // list
+                Constraint::Length(1),  // blank
+                Constraint::Length(1),  // keybinds
+            ])
+            .split(inner);
+
+        let header = Paragraph::new(Line::from(vec![
+            Span::styled("Session: ", Style::default().fg(theme.text_secondary)),
+            Span::styled(
+                &self.session_label,
+                Style::default()
+                    .fg(theme.text_primary)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]));
+        f.render_widget(header, chunks[0]);
+
+        let list_lines: Vec<Line> = self
+            .suggestions
+            .iter()
+            .enumerate()
+            .map(|(i, s)| {
+                let is_selected = i == self.selected;
+                let marker_style = if is_selected {
+                    Style::default()
+                        .fg(theme.branding_fg)
+                        .bg(theme.accent_info)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(theme.accent_info)
+                };
+                let text_style = if is_selected {
+                    Style::default()
+                        .fg(theme.branding_fg)
+                        .bg(theme.accent_info)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(theme.text_primary)
+                };
+                Line::from(vec![
+                    Span::styled(format!(" {}. ", i + 1), marker_style),
+                    Span::styled(s.clone(), text_style),
+                ])
+            })
+            .collect();
+
+        let list = Paragraph::new(list_lines).wrap(Wrap { trim: false });
+        f.render_widget(list, chunks[2]);
+
+        draw_keybinds_bar(
+            f,
+            chunks[4],
+            &[
+                ("j/k", "Move"),
+                ("1-9", "Pick"),
+                ("Enter", "Execute"),
+                ("Esc", "Dismiss"),
+            ],
+            theme,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::screens::test_helpers::key_event;
+
+    fn make_screen() -> AdaptFollowUpScreen {
+        AdaptFollowUpScreen::new(
+            "adapt".into(),
+            vec![
+                "Burn down M0".into(),
+                "Fill docs".into(),
+                "Observability".into(),
+            ],
+        )
+    }
+
+    #[test]
+    fn j_moves_selection_down() {
+        let mut s = make_screen();
+        s.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
+        assert_eq!(s.selected, 1);
+    }
+
+    #[test]
+    fn k_moves_selection_up() {
+        let mut s = make_screen();
+        s.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
+        s.handle_input(&key_event(KeyCode::Char('k')), InputMode::Normal);
+        assert_eq!(s.selected, 0);
+    }
+
+    #[test]
+    fn k_does_not_underflow() {
+        let mut s = make_screen();
+        s.handle_input(&key_event(KeyCode::Char('k')), InputMode::Normal);
+        assert_eq!(s.selected, 0);
+    }
+
+    #[test]
+    fn j_does_not_overflow() {
+        let mut s = make_screen();
+        for _ in 0..10 {
+            s.handle_input(&key_event(KeyCode::Char('j')), InputMode::Normal);
+        }
+        assert_eq!(s.selected, 2);
+    }
+
+    #[test]
+    fn enter_launches_prompt_session() {
+        let mut s = make_screen();
+        let action = s.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
+        match action {
+            ScreenAction::LaunchPromptSession(cfg) => {
+                assert!(cfg.prompt.contains("Burn down M0"));
+            }
+            other => panic!("expected LaunchPromptSession, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn digit_key_selects_and_launches() {
+        let mut s = make_screen();
+        let action = s.handle_input(&key_event(KeyCode::Char('2')), InputMode::Normal);
+        match action {
+            ScreenAction::LaunchPromptSession(cfg) => {
+                assert_eq!(s.selected, 1);
+                assert!(cfg.prompt.contains("Fill docs"));
+            }
+            other => panic!("expected LaunchPromptSession, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn esc_dismisses() {
+        let mut s = make_screen();
+        let action = s.handle_input(&key_event(KeyCode::Esc), InputMode::Normal);
+        assert_eq!(action, ScreenAction::Pop);
+    }
+
+    #[test]
+    fn q_dismisses() {
+        let mut s = make_screen();
+        let action = s.handle_input(&key_event(KeyCode::Char('q')), InputMode::Normal);
+        assert_eq!(action, ScreenAction::Pop);
+    }
+
+    #[test]
+    fn empty_suggestions_enter_returns_none() {
+        let mut s = AdaptFollowUpScreen::new("adapt".into(), vec![]);
+        let action = s.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
+        assert_eq!(action, ScreenAction::None);
+    }
+
+    #[test]
+    fn digit_beyond_list_is_noop() {
+        let mut s = make_screen();
+        let action = s.handle_input(&key_event(KeyCode::Char('9')), InputMode::Normal);
+        assert_eq!(action, ScreenAction::None);
+    }
+
+    #[test]
+    fn initial_selected_is_zero() {
+        let s = make_screen();
+        assert_eq!(s.selected, 0);
+    }
+}

--- a/src/tui/screens/mod.rs
+++ b/src/tui/screens/mod.rs
@@ -1,4 +1,5 @@
 pub mod adapt;
+pub mod adapt_follow_up;
 pub mod hollow_retry;
 pub mod home;
 #[allow(dead_code)]
@@ -11,6 +12,7 @@ pub mod release_notes;
 pub mod settings;
 pub mod wrap;
 
+pub use adapt_follow_up::AdaptFollowUpScreen;
 pub use hollow_retry::HollowRetryScreen;
 pub use home::HomeScreen;
 pub use issue_browser::IssueBrowserScreen;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -388,6 +388,20 @@ pub fn draw(f: &mut Frame, app: &mut App) {
                 f, &sessions, &app.flags, chunks[1], &theme,
             );
         }
+        TuiMode::AdaptFollowUp => {
+            let sessions = app.pool.all_sessions();
+            app.panel_view.draw_with_claims(
+                f,
+                &sessions,
+                Some(&app.pool.file_claims),
+                chunks[1],
+                &theme,
+                spinner_tick,
+            );
+            if let Some(ref mut screen) = app.adapt_follow_up_screen {
+                screen.draw(f, chunks[1], &app.theme);
+            }
+        }
     }
 
     // Only render activity log area when visible
@@ -503,6 +517,10 @@ fn active_screen(app: &App) -> Option<&dyn Screen> {
         TuiMode::Settings => app.settings_screen.as_ref().map(|s| s as &dyn Screen),
         TuiMode::PrReview => app.pr_review_screen.as_ref().map(|s| s as &dyn Screen),
         TuiMode::HollowRetry => app.hollow_retry_screen.as_ref().map(|s| s as &dyn Screen),
+        TuiMode::AdaptFollowUp => app
+            .adapt_follow_up_screen
+            .as_ref()
+            .map(|s| s as &dyn Screen),
         TuiMode::AdaptWizard => app.adapt_screen.as_ref().map(|s| s as &dyn Screen),
         TuiMode::ReleaseNotes => app.release_notes_screen.as_ref().map(|s| s as &dyn Screen),
         _ => None,


### PR DESCRIPTION
## Summary

- Parses "Suggested next iteration paths" / "Next steps" numbered lists out of any session's final message
- New \`AdaptFollowUpScreen\` overlay presents the items as a selectable list
- \`j\`/\`k\` (or \`↓\`/\`↑\`) navigate, \`Enter\` or a \`1-9\` digit executes, \`Esc\` dismisses
- Selection spawns a follow-up prompt session with a template that asks Claude to plan the direction into GitHub issues
- Completion pipeline pops the overlay once per matching session (≥2 parsed items)

## Test plan

- [x] \`cargo test\` — 2729 tests (13 parser tests + 11 overlay tests + existing suite)
- [x] Parser covers: spec example, \`## Next steps\` variant, \`1)\`-style numbering, wrapped items, empty / headerless / prose-only inputs, case-insensitive headers, unicode
- [x] Overlay covers: j/k/Up/Down, digit keys, Enter/Esc/q, empty list, overflow/underflow bounds
- [x] \`cargo clippy --lib --bin maestro -- -D warnings\` clean
- [x] \`cargo fmt\` applied

Closes #391