### PR TITLE
chore(v0.14): simplify post-milestone code — reuse, quality, efficiency

### DIFF
--- a/src/adapt/prd_fetcher.rs
+++ b/src/adapt/prd_fetcher.rs
@@ -36,10 +36,11 @@ pub fn fetch_existing(
 
 fn fetch_local(project_root: &Path) -> anyhow::Result<Option<FetchedPrd>> {
     let path = project_root.join("docs/PRD.md");
-    if !path.exists() {
-        return Ok(None);
-    }
-    let content = std::fs::read_to_string(&path)?;
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e.into()),
+    };
     if content.trim().is_empty() {
         return Ok(None);
     }
@@ -49,15 +50,10 @@ fn fetch_local(project_root: &Path) -> anyhow::Result<Option<FetchedPrd>> {
     }))
 }
 
-/// Try to find an existing PRD among GitHub issues in the current repo.
-///
-/// Priority order:
-/// 1. Pinned issue (via `gh api repos/.../pinned_issues`)
-/// 2. Issue labeled `prd`
-///
-/// The `gh` CLI already handles repo detection via `git remote`.
+/// Try to find an existing PRD among GitHub issues in the current repo by
+/// looking for an open issue labeled `prd`. Delegates repo detection to the
+/// `gh` CLI (via `git remote`).
 fn fetch_github(_project_root: &Path) -> anyhow::Result<Option<FetchedPrd>> {
-    // 1) Labeled issue
     let labeled = std::process::Command::new("gh")
         .args([
             "issue",

--- a/src/session/intent.rs
+++ b/src/session/intent.rs
@@ -157,8 +157,8 @@ pub fn classify_intent(prompt: &str) -> SessionIntent {
         return SessionIntent::Work;
     }
 
-    // 1) Modal / hypothetical questions — highest precedence so "how would you fix this?"
-    //    wins over the "fix" work-verb signal.
+    // Modal questions take precedence so "how would you fix this?" is not
+    // classified by the "fix" work-verb rule below.
     if MODAL_QUESTION_MARKERS
         .iter()
         .any(|m| normalized.contains(m))
@@ -166,7 +166,6 @@ pub fn classify_intent(prompt: &str) -> SessionIntent {
         return SessionIntent::Consultation;
     }
 
-    // 2) Explanatory / enumeration verbs at start or after a polite prefix.
     let after_polite = strip_polite_prefix(&normalized);
     if CONSULTATION_VERBS
         .iter()
@@ -175,13 +174,10 @@ pub fn classify_intent(prompt: &str) -> SessionIntent {
         return SessionIntent::Consultation;
     }
 
-    // 3) Polite imperative + work verb → Work. "can you fix this?" is a work
-    //    request despite ending in '?'.
     if after_polite != normalized && starts_with_work_verb(after_polite) {
         return SessionIntent::Work;
     }
 
-    // 4) Hard work signals — issue references, file paths, shell commands.
     if contains_issue_reference(&normalized)
         || contains_file_path(&normalized)
         || contains_shell_command(&normalized)
@@ -189,22 +185,18 @@ pub fn classify_intent(prompt: &str) -> SessionIntent {
         return SessionIntent::Work;
     }
 
-    // 5) Starts with a work verb → Work.
     if starts_with_work_verb(&normalized) {
         return SessionIntent::Work;
     }
 
-    // 6) Starts with a question word → Consultation.
     if starts_with_question_word(&normalized) {
         return SessionIntent::Consultation;
     }
 
-    // 7) Ends with '?' without any work signal → Consultation.
     if normalized.ends_with('?') {
         return SessionIntent::Consultation;
     }
 
-    // Conservative default: treat as work so we preserve legacy retry behavior.
     SessionIntent::Work
 }
 
@@ -217,18 +209,20 @@ fn strip_polite_prefix(normalized: &str) -> &str {
     normalized
 }
 
+fn starts_with_token(s: &str, token: &str) -> bool {
+    match s.strip_prefix(token) {
+        Some("") => true,
+        Some(rest) => rest.starts_with(' '),
+        None => false,
+    }
+}
+
 fn starts_with_work_verb(s: &str) -> bool {
-    WORK_VERBS.iter().any(|v| {
-        // Match either "verb " (followed by space) or "verb" as the whole string
-        // (edge case: single-word prompt like "fix").
-        s.starts_with(&format!("{} ", v)) || s == *v
-    })
+    WORK_VERBS.iter().any(|v| starts_with_token(s, v))
 }
 
 fn starts_with_question_word(s: &str) -> bool {
-    QUESTION_WORDS
-        .iter()
-        .any(|q| s.starts_with(&format!("{} ", q)))
+    QUESTION_WORDS.iter().any(|q| starts_with_token(s, q))
 }
 
 fn contains_issue_reference(s: &str) -> bool {

--- a/src/session/manager.rs
+++ b/src/session/manager.rs
@@ -437,6 +437,8 @@ mod tests {
             tq_compressed_tokens: None,
             transition_history: vec![],
             intent: crate::session::intent::SessionIntent::default(),
+            consultation_skip_logged: false,
+            adapt_follow_up_considered: false,
         };
         ManagedSession::new(session)
     }

--- a/src/session/retry.rs
+++ b/src/session/retry.rs
@@ -47,8 +47,6 @@ impl RetryPolicy {
 
     /// Check if a session is eligible for retry based on its status and retry count.
     pub fn should_retry(&self, session: &Session) -> bool {
-        // Intent check: a consultation prompt that got a text response is
-        // considered done, even if its mechanical signals look hollow.
         if Self::is_consultation_satisfied(session) {
             return false;
         }

--- a/src/session/types.rs
+++ b/src/session/types.rs
@@ -279,6 +279,15 @@ pub struct Session {
     /// Classified intent of the prompt (Work vs. Consultation). Derived at spawn time.
     #[serde(default)]
     pub intent: super::intent::SessionIntent,
+    /// Set once after the "consultation satisfied — retry skipped" log line
+    /// has been emitted, so the completion pipeline doesn't re-log each tick.
+    #[serde(skip)]
+    pub consultation_skip_logged: bool,
+    /// Set once the adapt follow-up overlay has been shown or checked for this
+    /// session, so the completion pipeline doesn't re-parse `last_message`
+    /// and re-surface the overlay after the user dismisses it.
+    #[serde(skip)]
+    pub adapt_follow_up_considered: bool,
 }
 
 /// Lightweight gate result stored on a session for post-completion display.
@@ -355,6 +364,8 @@ impl Session {
             tq_compressed_tokens: None,
             transition_history: Vec::new(),
             intent,
+            consultation_skip_logged: false,
+            adapt_follow_up_considered: false,
         }
     }
 

--- a/src/tui/app/completion_pipeline.rs
+++ b/src/tui/app/completion_pipeline.rs
@@ -226,8 +226,6 @@ impl App {
             Vec::new()
         };
 
-        // Intent-aware skip: consultation prompts that answered successfully are
-        // "done" even if they look hollow. Log once and don't show hollow retry UI.
         let consultation_skip_ids: Vec<uuid::Uuid> = self
             .pool
             .all_sessions()
@@ -239,25 +237,19 @@ impl App {
             .collect();
 
         for id in &consultation_skip_ids {
-            if let Some(managed) = self.pool.get_active_mut(*id) {
-                let skip_marker = "CONSULTATION_RETRY_SKIPPED";
-                let already_logged = managed
+            if let Some(managed) = self.pool.get_active_mut(*id)
+                && !managed.session.consultation_skip_logged
+            {
+                let label = session_label(&managed.session);
+                managed
                     .session
-                    .activity_log
-                    .iter()
-                    .any(|e| e.message.contains(skip_marker));
-                if !already_logged {
-                    let label = session_label(&managed.session);
-                    managed.session.log_activity(format!(
-                        "{}: consultation prompt answered successfully",
-                        skip_marker
-                    ));
-                    self.activity_log.push_simple(
-                        label,
-                        "Skipping retry: consultation prompt answered successfully".to_string(),
-                        LogLevel::Info,
-                    );
-                }
+                    .log_activity("consultation prompt answered successfully".to_string());
+                managed.session.consultation_skip_logged = true;
+                self.activity_log.push_simple(
+                    label,
+                    "Skipping retry: consultation prompt answered successfully".to_string(),
+                    LogLevel::Info,
+                );
             }
         }
 
@@ -308,22 +300,35 @@ impl App {
             self.add_session(session).await?;
         }
 
-        // Show adapt follow-up overlay when a just-completed session's final
-        // message contains parsed next-iteration paths.
-        if self.adapt_follow_up_screen.is_none()
-            && let Some(candidate) = self.pool.all_sessions().iter().find(|s| {
-                matches!(s.status, SessionStatus::Completed | SessionStatus::Retrying)
-                    && !s.last_message.trim().is_empty()
-                    && crate::adapt::suggestions::parse_suggestions(&s.last_message).len() >= 2
-            })
-        {
-            let suggestions = crate::adapt::suggestions::parse_suggestions(&candidate.last_message);
-            let label = session_label(candidate);
-            self.adapt_follow_up_screen = Some(crate::tui::screens::AdaptFollowUpScreen::new(
-                label,
-                suggestions,
-            ));
-            self.tui_mode = TuiMode::AdaptFollowUp;
+        if self.adapt_follow_up_screen.is_none() {
+            // Pick the first just-completed session we haven't yet evaluated;
+            // mark the candidate "considered" so the overlay sticks when
+            // dismissed and `parse_suggestions` doesn't run twice per tick.
+            let candidate_id = self
+                .pool
+                .all_sessions()
+                .iter()
+                .find(|s| {
+                    matches!(s.status, SessionStatus::Completed | SessionStatus::Retrying)
+                        && !s.adapt_follow_up_considered
+                        && !s.last_message.trim().is_empty()
+                })
+                .map(|s| s.id);
+
+            if let Some(id) = candidate_id
+                && let Some(managed) = self.pool.get_active_mut(id)
+            {
+                managed.session.adapt_follow_up_considered = true;
+                let suggestions =
+                    crate::adapt::suggestions::parse_suggestions(&managed.session.last_message);
+                if suggestions.len() >= 2 {
+                    let label = session_label(&managed.session);
+                    self.adapt_follow_up_screen = Some(
+                        crate::tui::screens::AdaptFollowUpScreen::new(label, suggestions),
+                    );
+                    self.tui_mode = TuiMode::AdaptFollowUp;
+                }
+            }
         }
 
         // Show hollow retry prompt for sessions that exceeded auto-retry limits.

--- a/src/tui/marquee.rs
+++ b/src/tui/marquee.rs
@@ -130,11 +130,6 @@ pub fn needs_scroll(text_len: usize, viewport_width: usize) -> bool {
     text_len > viewport_width
 }
 
-/// Total character count across a slice of styled spans.
-pub fn spans_char_count(spans: &[ratatui::text::Span<'_>]) -> usize {
-    spans.iter().map(|s| s.content.chars().count()).sum()
-}
-
 /// Return styled spans representing a horizontal window over `spans` starting
 /// at character-position `offset` and spanning `viewport_width` characters.
 ///
@@ -612,16 +607,6 @@ mod tests {
 
     fn style_green() -> Style {
         Style::default().fg(Color::Green)
-    }
-
-    #[test]
-    fn spans_char_count_sums_across_spans() {
-        let spans = vec![
-            Span::styled("Hello", style_red()),
-            Span::raw(", "),
-            Span::styled("world", style_green()),
-        ];
-        assert_eq!(spans_char_count(&spans), 12);
     }
 
     #[test]

--- a/src/tui/screens/adapt/types.rs
+++ b/src/tui/screens/adapt/types.rs
@@ -72,24 +72,6 @@ impl AdaptWizardConfig {
             prd_source: self.prd_source,
         }
     }
-
-    /// Cycle the PRD source to the next value (for j/Space key handling).
-    #[allow(
-        dead_code,
-        reason = "Public API reserved for wizard PRD Source field keybindings."
-    )]
-    pub fn cycle_prd_source(&mut self) {
-        self.prd_source = self.prd_source.next();
-    }
-
-    /// Cycle the PRD source to the previous value (for k key handling).
-    #[allow(
-        dead_code,
-        reason = "Public API reserved for wizard PRD Source field keybindings."
-    )]
-    pub fn cycle_prd_source_back(&mut self) {
-        self.prd_source = self.prd_source.previous();
-    }
 }
 
 /// Accumulated results from pipeline phases.

--- a/src/tui/screens/home/mod.rs
+++ b/src/tui/screens/home/mod.rs
@@ -248,20 +248,30 @@ impl Screen for HomeScreen {
 }
 
 impl HomeScreen {
-    /// Reset the stats-bar marquee if the identity fields changed since last render.
+    /// Reset the stats-bar marquee when the repo/branch/user/milestone identity
+    /// changes, so freshly-loaded content starts from the beginning instead of
+    /// mid-scroll. Compares borrowed fields first and only clones on change.
     pub(super) fn sync_stats_bar_marquee(
         &mut self,
         data: &crate::tui::widgets::stats_bar::StatsBarData,
     ) {
-        let identity = StatsBarIdentity {
-            repo: data.repo.clone(),
-            branch: data.branch.clone(),
-            username: data.username.clone(),
-            milestone_title: data.milestone_title.clone(),
+        let changed = match &self.stats_bar_identity {
+            Some(prev) => {
+                prev.repo != data.repo
+                    || prev.branch != data.branch
+                    || prev.username != data.username
+                    || prev.milestone_title != data.milestone_title
+            }
+            None => true,
         };
-        if self.stats_bar_identity.as_ref() != Some(&identity) {
+        if changed {
             self.stats_bar_marquee.reset();
-            self.stats_bar_identity = Some(identity);
+            self.stats_bar_identity = Some(StatsBarIdentity {
+                repo: data.repo.clone(),
+                branch: data.branch.clone(),
+                username: data.username.clone(),
+                milestone_title: data.milestone_title.clone(),
+            });
         }
     }
 }

--- a/src/tui/widgets/stats_bar.rs
+++ b/src/tui/widgets/stats_bar.rs
@@ -7,7 +7,7 @@ use ratatui::{
 };
 
 use crate::tui::icons::{self, IconId};
-use crate::tui::marquee::{MarqueeConfig, MarqueeState, spans_char_count, visible_spans};
+use crate::tui::marquee::{MarqueeConfig, MarqueeState, visible_spans};
 use crate::tui::theme::Theme;
 
 /// Data for the compact stats bar widget.
@@ -54,27 +54,20 @@ impl<'a> StatsBar<'a> {
             return;
         }
 
-        let spans = self.build_spans();
-        let total_width = spans_char_count(&spans);
+        let line = self.build_line();
+        let total_width = line.width();
         let viewport_width = inner.width as usize;
 
         if total_width <= viewport_width {
-            // Fits — render exactly like before and pin the marquee to the start.
             marquee.reset();
-            Paragraph::new(Line::from(spans)).render(inner, buf);
+            Paragraph::new(line).render(inner, buf);
             return;
         }
 
-        // Overflow path: advance marquee and render the visible window.
         let overflow = total_width.saturating_sub(viewport_width);
         marquee.advance(overflow, &MarqueeConfig::default());
-        let windowed = visible_spans(&spans, marquee.offset, viewport_width);
+        let windowed = visible_spans(&line.spans, marquee.offset, viewport_width);
         Paragraph::new(Line::from(windowed)).render(inner, buf);
-    }
-
-    fn build_spans(&self) -> Vec<Span<'_>> {
-        let line = self.build_line();
-        line.spans
     }
 
     fn build_line(&self) -> Line<'_> {


### PR DESCRIPTION
## Summary

No-behavior-change cleanup across the five PRs merged into v0.14.0 (#411 / #412 / #413 / #414 / #415). 2750 tests still pass; clippy + fmt clean.

## Reuse

- Drop hand-rolled \`spans_char_count\` — use ratatui's \`Line::width()\` / \`Span::width()\` (also correct for wide unicode).

## Quality

- Replace the stringly-typed \`CONSULTATION_RETRY_SKIPPED\` activity-log marker with a \`Session.consultation_skip_logged\` field — the per-tick \`activity_log.iter().any(contains)\` scan is gone.
- Add \`Session.adapt_follow_up_considered\` so \`parse_suggestions\` runs at most once per session and dismissing the overlay is sticky.
- Inline \`StatsBar::build_spans\` into its single caller.
- Drop dead \`cycle_prd_source\` / \`cycle_prd_source_back\` wrappers.
- Remove step-number / name-restating / orphaned comments.

## Efficiency

- \`classify_intent\`: \`format!("{} ", verb)\` → zero-alloc \`starts_with_token\` helper (saves ~60 \`String\` allocations per \`Session::new\`).
- \`HomeScreen::sync_stats_bar_marquee\`: compare identity fields by reference first; only clone the 4 \`String\`s on actual change (was cloning every frame).
- \`completion_pipeline\`: mark each candidate \"considered\" after the adapt-follow-up check, so \`parse_suggestions\` runs at most once per session across ticks.
- \`fetch_local\`: drop TOCTOU \`path.exists()\` pre-check; read + treat \`NotFound\` as \`Ok(None)\`.

## Skipped

- Making \`prd_fetcher\` async via \`tokio::process\` — \`cmd_prd\` is a one-shot CLI command that already does plenty of blocking work; not worth the plumbing churn here. Follow-up issue if we ever invoke the fetcher from the TUI event loop.
- Routing \`fetch_github\` through the existing \`GhCliClient\` — the PRD flow wants a label-list call that doesn't exist on the trait yet. Small follow-up.
- Extracting a shared \`SelectListOverlay\` from \`HollowRetryScreen\` + \`AdaptFollowUpScreen\` — real duplication but a bigger refactor than this cleanup.

## Test plan

- [x] \`cargo test\` — 2750 pass
- [x] \`cargo clippy --lib --bin maestro -- -D warnings\` clean
- [x] \`cargo fmt\` applied