### PR TITLE
feat(session): configurable hollow retry policy + TUI drift fixes (#275)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- `[sessions.hollow_retry]` config section with three policies: `always`, `intent-aware` (default), and `never`; replaces the flat `sessions.hollow_max_retries` field (#275)
+- `HollowRetryPolicy` enum and `HollowRetryConfig` struct in `src/config.rs`; `merge_legacy_hollow()` pure function for backward-compatible TOML parsing (#275)
+- Per-intent retry limits: `work_max_retries` (default 2) and `consultation_max_retries` (default 0) under `[sessions.hollow_retry]` (#275)
+- Settings UI hollow-retry section in the Sessions tab: `[policy]` dropdown, `[work_max_retries]` stepper, `[consultation_max_retries]` stepper (#275)
+
+### Changed
+
+- Hollow retry dispatch is now intent-aware by default: work sessions retry up to 2 times, consultation sessions never retry (#275)
+- `RetryPolicy` in `src/session/retry.rs` owns a `hollow: HollowRetryConfig` field (was flat `hollow_max_retries: u32`); `effective_max()` dispatches by policy and session intent (#275)
+- `HollowRetryScreen` in `src/tui/app/completion_pipeline.rs` receives the per-intent `effective_max` rather than the raw work limit (#275)
+
+> **Backward compatibility**: existing `sessions.hollow_max_retries = N` in `maestro.toml` still parses and maps to `work_max_retries = N` with policy `always`.
+
 ## [0.14.0] - 2026-04-17
 
 ### Added

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-17 12:00 (UTC)
+> Last updated: 2026-04-21 00:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -67,7 +67,7 @@ maestro/
 │   ├── icons.rs                           # Shared icon registry: IconId enum (38 variants across Navigation, Status, UI Chrome, Indicators categories, plus NeedsReview variant added in #308), IconPair struct (nerd: &'static str, ascii: &'static str), icon_pair() const fn compiles to a zero-allocation jump table, get(IconId) returns the correct variant based on global mode, get_for_mode(id, nerd_font) pure testable variant; extracted from tui/icons.rs  [Issue #308]
 │   ├── main.rs                            # CLI entry point (clap); Run, Queue, Add, Status, Cost, Init, Doctor; --skip-doctor flag on Run subcommand bypasses preflight; cmd_run() runs validate_preflight() before session launch and uses PromptBuilder::build_issue_prompt() for issue sessions; setup_app_from_config() shared helper wires budget, model router, notifications, plugins, and permission_mode/allowed_tools from config; propagates once_mode from parsed CLI flag into App; forces max_concurrent=1 when --continuous is set; cmd_dashboard() performs orphan worktree cleanup, log cleanup, fetches username from doctor report, delegates App construction to setup_app_from_config(), and queues FetchSuggestionData on startup; declares #[cfg(test)] mod integration_tests; declares mod updater; declares mod flags; propagates startup gh auth check result into App.gh_auth_ok; declares #[cfg(feature = "experimental-sanitizer")] mod sanitizer; constructs FeatureFlags from --enable-flag / --disable-flag CLI args merged with [flags] config  [Issue #15, #29, #49, #34, #36, #35, #52, #83, #85, #118, #141, #142, #143, #158]
 │   ├── cli.rs                             # CLI definition extracted from main.rs; Cli struct and Commands enum (clap derive); --once flag on Run subcommand (exits after all sessions complete, for CI/scripting); --continuous / -C flag on Run subcommand (auto-advance through issues, pause on failure); --enable-flag / --disable-flag repeatable args on Run subcommand for runtime feature flag overrides; generate_completions() and cmd_completions() for shell tab-completion output; cmd_mangen() for roff man page generation; Completions and Mangen subcommands  [Issue #18, #83, #85, #143]
-│   ├── config.rs                          # maestro.toml parsing; ModelsConfig, GatesConfig, ReviewConfig; ContextOverflowConfig; ProviderConfig (kind, organization, az_project); guardrail_prompt in SessionsConfig; CompletionGatesConfig and CompletionGateEntry; CiAutoFixConfig (enabled, max_retries, poll_interval_secs) under GatesConfig.ci_auto_fix; TuiConfig struct with optional theme field; Config gains tui field; FlagsConfig (flattened HashMap<String, bool>) loaded from [flags] table; Config gains flags field  [Issue #29, #40, #41, #43, #38, #143]
+│   ├── config.rs                          # maestro.toml parsing; ModelsConfig, GatesConfig, ReviewConfig; ContextOverflowConfig; ProviderConfig (kind, organization, az_project); guardrail_prompt in SessionsConfig; CompletionGatesConfig and CompletionGateEntry; CiAutoFixConfig (enabled, max_retries, poll_interval_secs) under GatesConfig.ci_auto_fix; TuiConfig struct with optional theme field; Config gains tui field; FlagsConfig (flattened HashMap<String, bool>) loaded from [flags] table; Config gains flags field; HollowRetryPolicy enum (Always/IntentAware/Never), HollowRetryConfig struct (policy, work_max_retries, consultation_max_retries), merge_legacy_hollow() for backward-compat TOML parsing, SessionsConfigRaw shadow struct for custom Deserialize  [Issue #29, #40, #41, #43, #38, #143, #275]
 │   ├── continuous.rs                      # ContinuousModeState and ContinuousFailure structs; state machine for --continuous / -C flag: auto-advances to next ready issue, pauses loop on failure waiting for user decision (skip / retry / quit)  [Issue #85]
 │   ├── budget.rs                          # BudgetEnforcer: per-session and global budget checks  [Phase 3]
 │   ├── doctor.rs                          # Preflight checks: CheckSeverity, CheckResult, DoctorReport, run_all_checks(), print_report(); validate_preflight() (public, fails fast on required check failures); build_claude_cli_result() (pub(crate), pure/testable); check_claude_cli() elevated to Required severity; build_gh_auth_result() (pure, testable); check_az_identity(); 10 check functions  [Issue #49, #34, #52]
@@ -133,7 +133,7 @@ maestro/
 │   │   ├── types.rs                       # Session state machine; fork fields (parent_session_id, child_session_ids, fork_depth); ContextUpdate StreamEvent; GatesRunning and NeedsReview status variants; CiFix variant; CiFixContext struct (pr_number, issue_number, branch, attempt); ci_fix_context field on Session; StreamEvent::Thinking { text } variant; command_preview: Option<String> field on StreamEvent::ToolUse; GateResultEntry struct (gate, passed, message); gate_results: Vec<GateResultEntry> field on Session; NeedsPr variant — non-terminal status indicating PR creation failed and is queued for retry; flash_counter: u8 field on Session — decremented each render tick to drive border-flash effect on state transition  [Phase 3, Issue #40, #41, #102, #104, #159, #202]
 │   │   ├── worktree.rs                    # Git worktree isolation: WorktreeManager trait, GitWorktreeManager, MockWorktreeManager  [Phase 1]
 │   │   ├── health.rs                      # HealthMonitor: stall detection, HealthCheck trait  [Phase 3]
-│   │   ├── retry.rs                       # RetryPolicy: configurable max retries and cooldown  [Phase 3]
+│   │   ├── retry.rs                       # RetryPolicy: configurable max retries and cooldown; hollow field owns HollowRetryConfig (replaces flat hollow_max_retries); effective_max() dispatches by policy + session intent; 18 unit tests  [Phase 3, Issue #275]
 │   │   ├── cleanup.rs                     # CleanupManager: orphaned worktree detection and removal  [Phase 3]
 │   │   ├── image.rs                       # Image attachment helpers: VALID_IMAGE_EXTENSIONS constant, path validation, base64 encoding for multimodal session prompts
 │   │   ├── logger.rs                      # SessionLogger: logs ContextUpdate events; logs Thinking events with "THINKING:" prefix; per-session timestamped file logging  [Phase 3, Issue #102]
@@ -226,7 +226,7 @@ maestro/
 │   │       │   ├── mod.rs                 # ReleaseNotesScreen struct with Screen trait impl
 │   │       │   └── draw.rs                # ratatui rendering for release notes display
 │   │       └── settings/                  # Settings screen components  [Issue #124, #146]
-│   │           ├── mod.rs                 # SettingsScreen: interactive settings screen with tabbed TUI widget system; Flags tab displays all feature flags with name, on/off state, source (Default/Config/Cli), and description in read-only mode; focused fields rendered with green accent
+│   │           ├── mod.rs                 # SettingsScreen: interactive settings screen with tabbed TUI widget system; Flags tab displays all feature flags with name, on/off state, source (Default/Config/Cli), and description in read-only mode; focused fields rendered with green accent; Sessions tab gains hollow-retry widgets: [policy] dropdown (always/intent-aware/never), [work_max_retries] stepper, [consultation_max_retries] stepper  [Issue #275]
 │   │           └── validation.rs          # Settings field validation helpers
 │   │   └── widgets/                       # Reusable TUI widget components  [Issue #124]
 │   │       ├── mod.rs                     # Module re-exports for all widgets
@@ -285,7 +285,7 @@ maestro/
 ├── SECURITY.md                            # Security policy: supported versions, vulnerability reporting, and disclosure process
 ├── directory-tree.md                      # This file — SINGLE SOURCE OF TRUTH for structure
 ├── maestro-state.json                     # Runtime state persistence file
-└── maestro.toml                           # Runtime configuration; [sessions.context_overflow] section; guardrail_prompt option (commented); [sessions.completion_gates] with fmt, clippy, test defaults  [Issue #12, #40, #43]
+└── maestro.toml                           # Runtime configuration; [sessions.context_overflow] section; guardrail_prompt option (commented); [sessions.completion_gates] with fmt, clippy, test defaults; [sessions.hollow_retry] section (policy, work_max_retries, consultation_max_retries)  [Issue #12, #40, #43, #275]
 ```
 
 ## Quick Reference
@@ -354,7 +354,7 @@ maestro/
 | `src/review/dispatch.rs` | Single reviewer execution and config |
 | `src/session/` | Claude CLI process and session lifecycle management |
 | `src/session/health.rs` | Stall detection and HealthCheck trait (Phase 3) |
-| `src/session/retry.rs` | Configurable retry policy (Phase 3) |
+| `src/session/retry.rs` | Configurable retry policy; `hollow: HollowRetryConfig` field; `effective_max()` dispatches by policy + session intent (Phase 3, Issue #275) |
 | `src/session/pool.rs` | Concurrent session pool with queue and auto-promote; guardrail_prompt merged into system prompt; `find_by_issue_mut()` (Issue #40, #43) |
 | `src/session/worktree.rs` | Git worktree isolation per session |
 | `src/session/cleanup.rs` | Orphaned worktree detection and removal (Phase 3) |

--- a/src/config.rs
+++ b/src/config.rs
@@ -204,48 +204,160 @@ pub struct ProjectConfig {
     pub base_branch: String,
 }
 
+/// Policy variant for retrying hollow-completion sessions (#275).
+///
+/// The label is serialized as kebab-case in TOML
+/// (e.g. `policy = "intent-aware"`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum HollowRetryPolicy {
+    /// Always retry hollow completions up to `work_max_retries`
+    /// (consultation intent is ignored — one knob governs everything).
+    Always,
+    /// Route by `SessionIntent`: work sessions use `work_max_retries`,
+    /// consultation sessions use `consultation_max_retries`. Default.
+    #[default]
+    IntentAware,
+    /// Never retry a hollow completion, regardless of intent.
+    Never,
+}
+
+/// Hollow-completion retry configuration. See `[sessions.hollow_retry]`
+/// in `maestro.toml`. Default: `IntentAware` with `work = 2`, `consultation = 0`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HollowRetryConfig {
+    #[serde(default)]
+    pub policy: HollowRetryPolicy,
+    #[serde(default = "default_work_max_retries")]
+    pub work_max_retries: u32,
+    #[serde(default = "default_consultation_max_retries")]
+    pub consultation_max_retries: u32,
+}
+
+impl Default for HollowRetryConfig {
+    fn default() -> Self {
+        Self {
+            policy: HollowRetryPolicy::default(),
+            work_max_retries: default_work_max_retries(),
+            consultation_max_retries: default_consultation_max_retries(),
+        }
+    }
+}
+
+/// Merge a legacy flat `sessions.hollow_max_retries = N` value into the
+/// new `[sessions.hollow_retry]` section. When both are present, the new
+/// section wins and a one-shot deprecation warning is logged.
+fn merge_legacy_hollow(
+    new_section: Option<HollowRetryConfig>,
+    legacy_flat: Option<u32>,
+) -> HollowRetryConfig {
+    match (new_section, legacy_flat) {
+        (Some(new), Some(_)) => {
+            tracing::warn!(
+                "both `sessions.hollow_max_retries` (legacy) and `[sessions.hollow_retry]` \
+                 are set in maestro.toml; the new section takes precedence. \
+                 Remove `hollow_max_retries` to silence this warning."
+            );
+            new
+        }
+        (Some(new), None) => new,
+        (None, Some(n)) => HollowRetryConfig {
+            policy: HollowRetryPolicy::IntentAware,
+            work_max_retries: n,
+            consultation_max_retries: 0,
+        },
+        (None, None) => HollowRetryConfig::default(),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(from = "SessionsConfigRaw")]
 pub struct SessionsConfig {
-    #[serde(default = "default_max_concurrent")]
     pub max_concurrent: usize,
-    #[serde(default = "default_stall_timeout")]
     pub stall_timeout_secs: u64,
-    #[serde(default = "default_model")]
     pub default_model: String,
-    #[serde(default = "default_mode")]
     pub default_mode: String,
     /// Permission mode for Claude CLI sessions.
     /// Options: "default", "acceptEdits", "bypassPermissions", "dontAsk", "plan", "auto"
-    #[serde(default = "default_permission_mode")]
     pub permission_mode: String,
     /// Allowed tools whitelist (comma-separated). Empty = all tools allowed.
-    #[serde(default)]
     pub allowed_tools: Vec<String>,
     /// Maximum number of retries for failed/stalled sessions.
-    #[serde(default = "default_max_retries")]
     pub max_retries: u32,
     /// Cooldown in seconds between retries.
-    #[serde(default = "default_retry_cooldown")]
     pub retry_cooldown_secs: u64,
-    /// Maximum number of automatic retries for hollow completions (default: 1).
-    #[serde(default = "default_hollow_max_retries")]
-    pub hollow_max_retries: u32,
+    /// Hollow-completion retry policy (#275).
+    pub hollow_retry: HollowRetryConfig,
     /// Maximum number of prompt history entries to retain. Default: 100.
-    #[serde(default = "default_max_prompt_history")]
     pub max_prompt_history: usize,
     /// Context overflow detection and auto-fork configuration.
-    #[serde(default)]
     pub context_overflow: ContextOverflowConfig,
     /// Conflict detection policy configuration.
-    #[serde(default)]
     pub conflict: ConflictConfig,
     /// Custom guardrail prompt injected into every session's system prompt.
     /// If unset, a default is auto-detected based on project language.
-    #[serde(default)]
     pub guardrail_prompt: Option<String>,
     /// Completion gates that run after session finishes, before PR creation.
-    #[serde(default)]
     pub completion_gates: CompletionGatesConfig,
+}
+
+/// Shadow struct used only for deserialization. Mirrors `SessionsConfig`
+/// but accepts both the legacy flat `hollow_max_retries` field and the new
+/// `hollow_retry` section. The custom `Deserialize` impl for
+/// `SessionsConfig` reconciles them via `merge_legacy_hollow`.
+#[derive(Deserialize)]
+struct SessionsConfigRaw {
+    #[serde(default = "default_max_concurrent")]
+    max_concurrent: usize,
+    #[serde(default = "default_stall_timeout")]
+    stall_timeout_secs: u64,
+    #[serde(default = "default_model")]
+    default_model: String,
+    #[serde(default = "default_mode")]
+    default_mode: String,
+    #[serde(default = "default_permission_mode")]
+    permission_mode: String,
+    #[serde(default)]
+    allowed_tools: Vec<String>,
+    #[serde(default = "default_max_retries")]
+    max_retries: u32,
+    #[serde(default = "default_retry_cooldown")]
+    retry_cooldown_secs: u64,
+    #[serde(default)]
+    hollow_max_retries: Option<u32>,
+    #[serde(default)]
+    hollow_retry: Option<HollowRetryConfig>,
+    #[serde(default = "default_max_prompt_history")]
+    max_prompt_history: usize,
+    #[serde(default)]
+    context_overflow: ContextOverflowConfig,
+    #[serde(default)]
+    conflict: ConflictConfig,
+    #[serde(default)]
+    guardrail_prompt: Option<String>,
+    #[serde(default)]
+    completion_gates: CompletionGatesConfig,
+}
+
+impl From<SessionsConfigRaw> for SessionsConfig {
+    fn from(raw: SessionsConfigRaw) -> Self {
+        Self {
+            max_concurrent: raw.max_concurrent,
+            stall_timeout_secs: raw.stall_timeout_secs,
+            default_model: raw.default_model,
+            default_mode: raw.default_mode,
+            permission_mode: raw.permission_mode,
+            allowed_tools: raw.allowed_tools,
+            max_retries: raw.max_retries,
+            retry_cooldown_secs: raw.retry_cooldown_secs,
+            hollow_retry: merge_legacy_hollow(raw.hollow_retry, raw.hollow_max_retries),
+            max_prompt_history: raw.max_prompt_history,
+            context_overflow: raw.context_overflow,
+            conflict: raw.conflict,
+            guardrail_prompt: raw.guardrail_prompt,
+            completion_gates: raw.completion_gates,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -676,8 +788,11 @@ fn default_max_retries() -> u32 {
 fn default_retry_cooldown() -> u64 {
     60
 }
-fn default_hollow_max_retries() -> u32 {
-    1
+fn default_work_max_retries() -> u32 {
+    2
+}
+fn default_consultation_max_retries() -> u32 {
+    0
 }
 pub(crate) fn default_max_prompt_history() -> usize {
     100
@@ -1085,19 +1200,164 @@ review_council = false
         assert_eq!(cfg.flags.entries.get("review_council"), Some(&false));
     }
 
-    // --- Issue #171: hollow_max_retries config ---
+    // --- Issue #275: configurable hollow retry policy ---
+    // Group A: merge_legacy_hollow pure function.
 
     #[test]
-    fn hollow_max_retries_defaults_to_one() {
-        let cfg: SessionsConfig = toml::from_str("").expect("parse failed");
-        assert_eq!(cfg.hollow_max_retries, 1);
+    fn merge_both_none_returns_default() {
+        let result = merge_legacy_hollow(None, None);
+        assert_eq!(result, HollowRetryConfig::default());
     }
 
     #[test]
-    fn hollow_max_retries_deserializes_from_toml() {
-        let toml_str = r#"hollow_max_retries = 3"#;
+    fn merge_legacy_only_maps_to_work_max_retries() {
+        let result = merge_legacy_hollow(None, Some(3));
+        assert_eq!(result.policy, HollowRetryPolicy::IntentAware);
+        assert_eq!(result.work_max_retries, 3);
+        assert_eq!(result.consultation_max_retries, 0);
+    }
+
+    #[test]
+    fn merge_new_section_only_passes_through() {
+        let cfg = HollowRetryConfig {
+            policy: HollowRetryPolicy::Always,
+            work_max_retries: 7,
+            consultation_max_retries: 1,
+        };
+        let result = merge_legacy_hollow(Some(cfg.clone()), None);
+        assert_eq!(result, cfg);
+    }
+
+    #[test]
+    fn merge_both_new_wins() {
+        let cfg = HollowRetryConfig {
+            policy: HollowRetryPolicy::Always,
+            work_max_retries: 7,
+            consultation_max_retries: 1,
+        };
+        let result = merge_legacy_hollow(Some(cfg.clone()), Some(99));
+        assert_eq!(result, cfg);
+        assert_ne!(result.work_max_retries, 99);
+    }
+
+    #[test]
+    fn merge_legacy_zero_is_respected() {
+        let result = merge_legacy_hollow(None, Some(0));
+        assert_eq!(result.work_max_retries, 0);
+        assert_eq!(result.consultation_max_retries, 0);
+    }
+
+    // Group B: HollowRetryPolicy enum.
+
+    #[test]
+    fn hollow_retry_policy_defaults_to_intent_aware() {
+        assert_eq!(HollowRetryPolicy::default(), HollowRetryPolicy::IntentAware);
+    }
+
+    #[test]
+    fn hollow_retry_policy_serializes_as_kebab_case() {
+        assert_eq!(
+            serde_json::to_string(&HollowRetryPolicy::IntentAware).unwrap(),
+            r#""intent-aware""#
+        );
+        assert_eq!(
+            serde_json::to_string(&HollowRetryPolicy::Always).unwrap(),
+            r#""always""#
+        );
+        assert_eq!(
+            serde_json::to_string(&HollowRetryPolicy::Never).unwrap(),
+            r#""never""#
+        );
+    }
+
+    #[test]
+    fn hollow_retry_policy_deserializes_from_kebab_case() {
+        let p: HollowRetryPolicy = serde_json::from_str(r#""intent-aware""#).unwrap();
+        assert_eq!(p, HollowRetryPolicy::IntentAware);
+        let p: HollowRetryPolicy = serde_json::from_str(r#""never""#).unwrap();
+        assert_eq!(p, HollowRetryPolicy::Never);
+        let p: HollowRetryPolicy = serde_json::from_str(r#""always""#).unwrap();
+        assert_eq!(p, HollowRetryPolicy::Always);
+    }
+
+    // Group C: HollowRetryConfig defaults + serde.
+
+    #[test]
+    fn hollow_retry_config_default_is_intent_aware_with_expected_limits() {
+        let cfg = HollowRetryConfig::default();
+        assert_eq!(cfg.policy, HollowRetryPolicy::IntentAware);
+        assert_eq!(cfg.work_max_retries, 2);
+        assert_eq!(cfg.consultation_max_retries, 0);
+    }
+
+    #[test]
+    fn hollow_retry_config_round_trips_via_serde() {
+        let cfg = HollowRetryConfig {
+            policy: HollowRetryPolicy::Never,
+            work_max_retries: 5,
+            consultation_max_retries: 1,
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        let rt: HollowRetryConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(rt, cfg);
+    }
+
+    // Group D: SessionsConfig TOML parsing.
+
+    #[test]
+    fn sessions_config_parses_new_hollow_retry_section() {
+        let toml_str = r#"
+[hollow_retry]
+policy = "never"
+work_max_retries = 4
+consultation_max_retries = 1
+"#;
         let cfg: SessionsConfig = toml::from_str(toml_str).expect("parse failed");
-        assert_eq!(cfg.hollow_max_retries, 3);
+        assert_eq!(cfg.hollow_retry.policy, HollowRetryPolicy::Never);
+        assert_eq!(cfg.hollow_retry.work_max_retries, 4);
+        assert_eq!(cfg.hollow_retry.consultation_max_retries, 1);
+    }
+
+    #[test]
+    fn sessions_config_parses_legacy_hollow_max_retries() {
+        let toml_str = "hollow_max_retries = 3";
+        let cfg: SessionsConfig = toml::from_str(toml_str).expect("parse failed");
+        assert_eq!(cfg.hollow_retry.work_max_retries, 3);
+        assert_eq!(cfg.hollow_retry.policy, HollowRetryPolicy::IntentAware);
+        assert_eq!(cfg.hollow_retry.consultation_max_retries, 0);
+    }
+
+    #[test]
+    fn sessions_config_new_section_wins_over_legacy() {
+        let toml_str = r#"
+hollow_max_retries = 99
+[hollow_retry]
+work_max_retries = 5
+"#;
+        let cfg: SessionsConfig = toml::from_str(toml_str).expect("parse failed");
+        assert_eq!(cfg.hollow_retry.work_max_retries, 5);
+    }
+
+    #[test]
+    fn sessions_config_empty_sessions_uses_default_hollow_retry() {
+        let cfg: SessionsConfig = toml::from_str("").expect("parse failed");
+        assert_eq!(cfg.hollow_retry, HollowRetryConfig::default());
+    }
+
+    #[test]
+    fn sessions_config_round_trips() {
+        let original: SessionsConfig = toml::from_str(
+            r#"
+[hollow_retry]
+policy = "never"
+work_max_retries = 4
+consultation_max_retries = 2
+"#,
+        )
+        .expect("parse failed");
+        let serialized = toml::to_string_pretty(&original).expect("serialize failed");
+        let rt: SessionsConfig = toml::from_str(&serialized).expect("reparse failed");
+        assert_eq!(rt.hollow_retry, original.hollow_retry);
     }
 
     #[test]
@@ -1114,7 +1374,7 @@ review_council = false
     }
 
     #[test]
-    fn full_config_hollow_max_retries_defaults_when_absent() {
+    fn full_config_hollow_retry_defaults_when_absent() {
         use std::io::Write;
         let mut f = tempfile::NamedTempFile::new().unwrap();
         write!(
@@ -1133,7 +1393,7 @@ alert_threshold_pct = 80
         )
         .unwrap();
         let cfg = Config::load(f.path()).expect("load failed");
-        assert_eq!(cfg.sessions.hollow_max_retries, 1);
+        assert_eq!(cfg.sessions.hollow_retry, HollowRetryConfig::default());
     }
 
     // --- Issue #121: LayoutConfig tests ---

--- a/src/session/retry.rs
+++ b/src/session/retry.rs
@@ -2,20 +2,21 @@ use chrono::Utc;
 
 use super::intent::SessionIntent;
 use super::types::{Session, SessionStatus};
+use crate::config::{HollowRetryConfig, HollowRetryPolicy};
 
 /// Retry policy configuration.
 pub struct RetryPolicy {
     pub max_retries: u32,
     pub cooldown_secs: u64,
-    pub hollow_max_retries: u32,
+    pub hollow: HollowRetryConfig,
 }
 
 impl RetryPolicy {
-    pub fn new(max_retries: u32, cooldown_secs: u64, hollow_max_retries: u32) -> Self {
+    pub fn new(max_retries: u32, cooldown_secs: u64, hollow: HollowRetryConfig) -> Self {
         Self {
             max_retries,
             cooldown_secs,
-            hollow_max_retries,
+            hollow,
         }
     }
 
@@ -23,16 +24,26 @@ impl RetryPolicy {
         Self::new(
             cfg.max_retries,
             cfg.retry_cooldown_secs,
-            cfg.hollow_max_retries,
+            cfg.hollow_retry.clone(),
         )
     }
 
-    /// The effective max retries for a session, accounting for hollow completions.
+    /// Retry budget for `session`. Non-hollow sessions always get
+    /// `self.max_retries`; hollow sessions route through the configured
+    /// `HollowRetryPolicy`. The `Always` arm deliberately uses
+    /// `work_max_retries` for both intents — its contract is "one knob
+    /// governs every hollow session".
     pub fn effective_max(&self, session: &Session) -> u32 {
-        if session.is_hollow_completion {
-            self.hollow_max_retries
-        } else {
-            self.max_retries
+        if !session.is_hollow_completion {
+            return self.max_retries;
+        }
+        match self.hollow.policy {
+            HollowRetryPolicy::Never => 0,
+            HollowRetryPolicy::Always => self.hollow.work_max_retries,
+            HollowRetryPolicy::IntentAware => match session.intent {
+                SessionIntent::Work => self.hollow.work_max_retries,
+                SessionIntent::Consultation => self.hollow.consultation_max_retries,
+            },
         }
     }
 
@@ -153,6 +164,38 @@ impl RetryPolicy {
 mod tests {
     use super::*;
 
+    /// Build a `HollowRetryConfig` matching the pre-#275 flat
+    /// `hollow_max_retries = N` semantics: `IntentAware` policy,
+    /// `work_max_retries = N`, `consultation_max_retries = 0`. Used by
+    /// legacy tests to preserve their original assertions.
+    fn legacy_hollow(work_max_retries: u32) -> HollowRetryConfig {
+        HollowRetryConfig {
+            policy: HollowRetryPolicy::IntentAware,
+            work_max_retries,
+            consultation_max_retries: 0,
+        }
+    }
+
+    fn policy_with(policy: HollowRetryPolicy, work: u32, consultation: u32) -> RetryPolicy {
+        RetryPolicy::new(
+            5,
+            0,
+            HollowRetryConfig {
+                policy,
+                work_max_retries: work,
+                consultation_max_retries: consultation,
+            },
+        )
+    }
+
+    fn hollow_session_with_intent(intent: SessionIntent) -> Session {
+        let mut s = Session::new("prompt".into(), "opus".into(), "orchestrator".into(), None);
+        s.status = SessionStatus::Completed;
+        s.is_hollow_completion = true;
+        s.intent = intent;
+        s
+    }
+
     fn make_session(status: SessionStatus, retry_count: u32) -> Session {
         let mut s = Session::new(
             "test prompt".into(),
@@ -167,49 +210,49 @@ mod tests {
 
     #[test]
     fn should_retry_true_for_stalled_under_max() {
-        let policy = RetryPolicy::new(2, 0, 1);
+        let policy = RetryPolicy::new(2, 0, legacy_hollow(1));
         let session = make_session(SessionStatus::Stalled, 0);
         assert!(policy.should_retry(&session));
     }
 
     #[test]
     fn should_retry_true_for_errored_under_max() {
-        let policy = RetryPolicy::new(2, 0, 1);
+        let policy = RetryPolicy::new(2, 0, legacy_hollow(1));
         let session = make_session(SessionStatus::Errored, 0);
         assert!(policy.should_retry(&session));
     }
 
     #[test]
     fn should_retry_false_when_max_reached() {
-        let policy = RetryPolicy::new(2, 0, 1);
+        let policy = RetryPolicy::new(2, 0, legacy_hollow(1));
         let session = make_session(SessionStatus::Stalled, 2);
         assert!(!policy.should_retry(&session));
     }
 
     #[test]
     fn should_retry_false_for_completed() {
-        let policy = RetryPolicy::new(2, 0, 1);
+        let policy = RetryPolicy::new(2, 0, legacy_hollow(1));
         let session = make_session(SessionStatus::Completed, 0);
         assert!(!policy.should_retry(&session));
     }
 
     #[test]
     fn should_retry_false_for_running() {
-        let policy = RetryPolicy::new(2, 0, 1);
+        let policy = RetryPolicy::new(2, 0, legacy_hollow(1));
         let session = make_session(SessionStatus::Running, 0);
         assert!(!policy.should_retry(&session));
     }
 
     #[test]
     fn should_retry_false_for_killed() {
-        let policy = RetryPolicy::new(2, 0, 1);
+        let policy = RetryPolicy::new(2, 0, legacy_hollow(1));
         let session = make_session(SessionStatus::Killed, 0);
         assert!(!policy.should_retry(&session));
     }
 
     #[test]
     fn should_retry_respects_cooldown() {
-        let policy = RetryPolicy::new(2, 9999, 1);
+        let policy = RetryPolicy::new(2, 9999, legacy_hollow(1));
         let mut session = make_session(SessionStatus::Stalled, 0);
         session.last_retry_at = Some(Utc::now());
         assert!(!policy.should_retry(&session));
@@ -217,7 +260,7 @@ mod tests {
 
     #[test]
     fn should_retry_allows_after_cooldown() {
-        let policy = RetryPolicy::new(2, 0, 1);
+        let policy = RetryPolicy::new(2, 0, legacy_hollow(1));
         let mut session = make_session(SessionStatus::Stalled, 0);
         session.last_retry_at = Some(Utc::now() - chrono::Duration::seconds(100));
         assert!(policy.should_retry(&session));
@@ -225,7 +268,7 @@ mod tests {
 
     #[test]
     fn prepare_retry_increments_count() {
-        let policy = RetryPolicy::new(2, 0, 1);
+        let policy = RetryPolicy::new(2, 0, legacy_hollow(1));
         let original = make_session(SessionStatus::Stalled, 0);
         let retry = policy.prepare_retry(&original, None, None);
         assert_eq!(retry.retry_count, 1);
@@ -233,7 +276,7 @@ mod tests {
 
     #[test]
     fn prepare_retry_sets_last_retry_at() {
-        let policy = RetryPolicy::new(2, 0, 1);
+        let policy = RetryPolicy::new(2, 0, legacy_hollow(1));
         let original = make_session(SessionStatus::Stalled, 0);
         let retry = policy.prepare_retry(&original, None, None);
         assert!(retry.last_retry_at.is_some());
@@ -241,7 +284,7 @@ mod tests {
 
     #[test]
     fn prepare_retry_preserves_issue_number() {
-        let policy = RetryPolicy::new(2, 0, 1);
+        let policy = RetryPolicy::new(2, 0, legacy_hollow(1));
         let original = make_session(SessionStatus::Errored, 0);
         let retry = policy.prepare_retry(&original, None, None);
         assert_eq!(retry.issue_number, Some(1));
@@ -249,7 +292,7 @@ mod tests {
 
     #[test]
     fn prepare_retry_appends_context_to_prompt() {
-        let policy = RetryPolicy::new(2, 0, 1);
+        let policy = RetryPolicy::new(2, 0, legacy_hollow(1));
         let original = make_session(SessionStatus::Stalled, 0);
         let retry = policy.prepare_retry(&original, None, None);
         assert!(retry.prompt.contains("RETRY CONTEXT"));
@@ -259,7 +302,7 @@ mod tests {
 
     #[test]
     fn prepare_retry_resets_status_to_queued() {
-        let policy = RetryPolicy::new(2, 0, 1);
+        let policy = RetryPolicy::new(2, 0, legacy_hollow(1));
         let original = make_session(SessionStatus::Errored, 1);
         let retry = policy.prepare_retry(&original, None, None);
         assert_eq!(retry.status, SessionStatus::Queued);
@@ -267,7 +310,7 @@ mod tests {
 
     #[test]
     fn prepare_retry_preserves_model_and_mode() {
-        let policy = RetryPolicy::new(2, 0, 1);
+        let policy = RetryPolicy::new(2, 0, legacy_hollow(1));
         let original = make_session(SessionStatus::Stalled, 0);
         let retry = policy.prepare_retry(&original, None, None);
         assert_eq!(retry.model, "opus");
@@ -277,7 +320,7 @@ mod tests {
     #[test]
     fn prepare_retry_includes_progress_context() {
         use crate::state::progress::{SessionPhase, SessionProgress};
-        let policy = RetryPolicy::new(2, 0, 1);
+        let policy = RetryPolicy::new(2, 0, legacy_hollow(1));
         let original = make_session(SessionStatus::Errored, 0);
         let mut progress = SessionProgress::new();
         progress.phase = SessionPhase::Implementing;
@@ -296,7 +339,7 @@ mod tests {
 
     #[test]
     fn prepare_retry_without_progress_omits_details() {
-        let policy = RetryPolicy::new(2, 0, 1);
+        let policy = RetryPolicy::new(2, 0, legacy_hollow(1));
         let original = make_session(SessionStatus::Stalled, 0);
         let retry = policy.prepare_retry(&original, None, None);
         assert!(!retry.prompt.contains("Phase:"));
@@ -305,7 +348,7 @@ mod tests {
 
     #[test]
     fn zero_max_retries_never_retries() {
-        let policy = RetryPolicy::new(0, 0, 1);
+        let policy = RetryPolicy::new(0, 0, legacy_hollow(1));
         let session = make_session(SessionStatus::Stalled, 0);
         assert!(!policy.should_retry(&session));
     }
@@ -314,7 +357,7 @@ mod tests {
 
     #[test]
     fn should_retry_true_for_hollow_completion_under_max() {
-        let policy = RetryPolicy::new(2, 0, 1);
+        let policy = RetryPolicy::new(2, 0, legacy_hollow(1));
         let mut session = make_session(SessionStatus::Completed, 0);
         session.is_hollow_completion = true;
         assert!(policy.should_retry(&session));
@@ -322,7 +365,7 @@ mod tests {
 
     #[test]
     fn should_retry_false_for_hollow_completion_at_max() {
-        let policy = RetryPolicy::new(2, 0, 1);
+        let policy = RetryPolicy::new(2, 0, legacy_hollow(1));
         let mut session = make_session(SessionStatus::Completed, 1);
         session.is_hollow_completion = true;
         assert!(!policy.should_retry(&session));
@@ -330,7 +373,7 @@ mod tests {
 
     #[test]
     fn should_retry_false_for_hollow_when_hollow_max_is_zero() {
-        let policy = RetryPolicy::new(2, 0, 0);
+        let policy = RetryPolicy::new(2, 0, legacy_hollow(0));
         let mut session = make_session(SessionStatus::Completed, 0);
         session.is_hollow_completion = true;
         assert!(!policy.should_retry(&session));
@@ -338,7 +381,7 @@ mod tests {
 
     #[test]
     fn should_retry_hollow_respects_cooldown() {
-        let policy = RetryPolicy::new(2, 9999, 1);
+        let policy = RetryPolicy::new(2, 9999, legacy_hollow(1));
         let mut session = make_session(SessionStatus::Completed, 0);
         session.is_hollow_completion = true;
         session.last_retry_at = Some(Utc::now());
@@ -347,7 +390,7 @@ mod tests {
 
     #[test]
     fn prepare_retry_hollow_includes_hollow_context() {
-        let policy = RetryPolicy::new(2, 0, 2);
+        let policy = RetryPolicy::new(2, 0, legacy_hollow(2));
         let mut original = make_session(SessionStatus::Completed, 0);
         original.is_hollow_completion = true;
         let retry = policy.prepare_retry(&original, None, None);
@@ -384,7 +427,7 @@ mod tests {
 
     #[test]
     fn should_retry_false_for_hollow_consultation_with_response() {
-        let policy = RetryPolicy::new(2, 0, 2);
+        let policy = RetryPolicy::new(2, 0, legacy_hollow(2));
         let session = make_hollow_consultation("I'm doing well, thanks!");
         assert!(
             !policy.should_retry(&session),
@@ -394,7 +437,7 @@ mod tests {
 
     #[test]
     fn should_retry_true_for_hollow_work_session() {
-        let policy = RetryPolicy::new(2, 0, 2);
+        let policy = RetryPolicy::new(2, 0, legacy_hollow(2));
         let session = make_hollow_work();
         assert!(
             policy.should_retry(&session),
@@ -405,18 +448,23 @@ mod tests {
     #[test]
     fn should_retry_true_for_hollow_consultation_with_empty_response() {
         // If the consultation produced no response, something went wrong —
-        // we still want to retry it.
-        let policy = RetryPolicy::new(2, 0, 2);
+        // we still want to retry it, PROVIDED the configured policy allows
+        // consultation retries. Under the new #275 defaults
+        // (consultation_max_retries=0), this case doesn't retry — that's
+        // covered in a separate #275 group test. Here we exercise the
+        // long-standing "empty response means not-yet-satisfied" invariant
+        // using a policy with a non-zero consultation limit.
+        let policy = policy_with(HollowRetryPolicy::IntentAware, 2, 2);
         let session = make_hollow_consultation("");
         assert!(
             policy.should_retry(&session),
-            "empty consultation response should still be retried"
+            "empty consultation response should still be retried when consultation_max > 0"
         );
     }
 
     #[test]
     fn should_retry_true_for_hollow_consultation_whitespace_only_response() {
-        let policy = RetryPolicy::new(2, 0, 2);
+        let policy = policy_with(HollowRetryPolicy::IntentAware, 2, 2);
         let session = make_hollow_consultation("   \n\t  ");
         assert!(
             policy.should_retry(&session),
@@ -451,10 +499,133 @@ mod tests {
 
     #[test]
     fn prepare_retry_hollow_shows_correct_max() {
-        let policy = RetryPolicy::new(5, 0, 2);
+        let policy = RetryPolicy::new(5, 0, legacy_hollow(2));
         let mut original = make_session(SessionStatus::Completed, 0);
         original.is_hollow_completion = true;
         let retry = policy.prepare_retry(&original, None, None);
         assert!(retry.prompt.contains("attempt 1 of 2"));
+    }
+
+    // --- Issue #275: configurable hollow retry policy ---
+    // Group E: effective_max matrix across {policy} × {intent} × {is_hollow}.
+
+    #[test]
+    fn effective_max_non_hollow_returns_max_retries() {
+        let policy = policy_with(HollowRetryPolicy::IntentAware, 2, 0);
+        let session = make_session(SessionStatus::Errored, 0);
+        assert!(!session.is_hollow_completion);
+        assert_eq!(policy.effective_max(&session), 5);
+    }
+
+    #[test]
+    fn effective_max_never_policy_returns_zero_for_work_hollow() {
+        let policy = policy_with(HollowRetryPolicy::Never, 3, 0);
+        let session = hollow_session_with_intent(SessionIntent::Work);
+        assert_eq!(policy.effective_max(&session), 0);
+    }
+
+    #[test]
+    fn effective_max_never_policy_returns_zero_for_consultation_hollow() {
+        let policy = policy_with(HollowRetryPolicy::Never, 3, 0);
+        let session = hollow_session_with_intent(SessionIntent::Consultation);
+        assert_eq!(policy.effective_max(&session), 0);
+    }
+
+    #[test]
+    fn effective_max_always_policy_returns_work_for_work_hollow() {
+        let policy = policy_with(HollowRetryPolicy::Always, 4, 1);
+        let session = hollow_session_with_intent(SessionIntent::Work);
+        assert_eq!(policy.effective_max(&session), 4);
+    }
+
+    #[test]
+    fn effective_max_always_policy_returns_work_for_consultation_hollow() {
+        // Always policy documents "one knob governs every hollow session":
+        // consultation sessions use work_max_retries, not consultation_max_retries.
+        let policy = policy_with(HollowRetryPolicy::Always, 4, 1);
+        let session = hollow_session_with_intent(SessionIntent::Consultation);
+        assert_eq!(policy.effective_max(&session), 4);
+    }
+
+    #[test]
+    fn effective_max_intent_aware_work_returns_work_limit() {
+        let policy = policy_with(HollowRetryPolicy::IntentAware, 3, 0);
+        let session = hollow_session_with_intent(SessionIntent::Work);
+        assert_eq!(policy.effective_max(&session), 3);
+    }
+
+    #[test]
+    fn effective_max_intent_aware_consultation_returns_consultation_limit() {
+        let policy = policy_with(HollowRetryPolicy::IntentAware, 3, 1);
+        let session = hollow_session_with_intent(SessionIntent::Consultation);
+        assert_eq!(policy.effective_max(&session), 1);
+    }
+
+    // Group F: should_retry regression with new config shape.
+
+    #[test]
+    fn should_retry_false_for_consultation_when_consultation_max_is_zero() {
+        // Empty last_message so is_consultation_satisfied is false — the
+        // retry-count-vs-max check must carry the weight.
+        let policy = policy_with(HollowRetryPolicy::IntentAware, 2, 0);
+        let mut session = hollow_session_with_intent(SessionIntent::Consultation);
+        session.last_message = String::new();
+        assert!(!policy.should_retry(&session));
+    }
+
+    #[test]
+    fn should_retry_true_for_work_hollow_under_work_max() {
+        let policy = policy_with(HollowRetryPolicy::IntentAware, 2, 0);
+        let mut session = hollow_session_with_intent(SessionIntent::Work);
+        session.retry_count = 0;
+        assert!(policy.should_retry(&session));
+    }
+
+    #[test]
+    fn should_retry_false_for_work_hollow_at_work_max() {
+        let policy = policy_with(HollowRetryPolicy::IntentAware, 2, 0);
+        let mut session = hollow_session_with_intent(SessionIntent::Work);
+        session.retry_count = 2;
+        assert!(!policy.should_retry(&session));
+    }
+
+    #[test]
+    fn should_retry_false_for_never_policy_any_intent() {
+        let policy = policy_with(HollowRetryPolicy::Never, 3, 1);
+        let session = hollow_session_with_intent(SessionIntent::Work);
+        assert!(!policy.should_retry(&session));
+        let session = hollow_session_with_intent(SessionIntent::Consultation);
+        assert!(!policy.should_retry(&session));
+    }
+
+    // Group G: from_config integration.
+
+    #[test]
+    fn from_config_reads_hollow_retry_struct() {
+        let toml_str = r#"
+[hollow_retry]
+policy = "never"
+work_max_retries = 9
+consultation_max_retries = 3
+"#;
+        let cfg: crate::config::SessionsConfig = toml::from_str(toml_str).expect("parse failed");
+        let policy = RetryPolicy::from_config(&cfg);
+        let session = hollow_session_with_intent(SessionIntent::Work);
+        assert_eq!(policy.effective_max(&session), 0);
+    }
+
+    // Group I: completion_pipeline contract — effective_max is the
+    // canonical source of the HollowRetryScreen's max, replacing the
+    // removed `p.hollow_max_retries` direct access.
+
+    #[test]
+    fn hollow_retry_screen_max_reflects_effective_max_not_work_limit() {
+        let policy = policy_with(HollowRetryPolicy::IntentAware, 3, 0);
+        let mut session = hollow_session_with_intent(SessionIntent::Consultation);
+        session.last_message = String::new();
+        session.retry_count = 0;
+        // A consultation hollow session with consultation_max=0 must report
+        // effective_max=0, NOT the work_max_retries of 3.
+        assert_eq!(policy.effective_max(&session), 0);
     }
 }

--- a/src/tui/app/completion_pipeline.rs
+++ b/src/tui/app/completion_pipeline.rs
@@ -340,7 +340,7 @@ impl App {
             let label = session_label(hollow_session);
             let max = retry_policy
                 .as_ref()
-                .map(|p| p.hollow_max_retries)
+                .map(|p| p.effective_max(hollow_session))
                 .unwrap_or(0);
             self.hollow_retry_screen = Some(crate::tui::screens::HollowRetryScreen::new(
                 hollow_session.id,

--- a/src/tui/app/completion_summary.rs
+++ b/src/tui/app/completion_summary.rs
@@ -89,6 +89,17 @@ impl App {
         }
     }
 
+    /// Populate the session-summary overlay state and navigate to it.
+    /// Used by both the F2 F-key handler and the `S`-key overview
+    /// shortcut — keep the two entry points in sync by funnelling
+    /// through this helper.
+    pub fn open_session_summary(&mut self) {
+        let summary = self.build_completion_summary();
+        self.completion_summary = Some(summary);
+        self.session_summary_state = Some(crate::tui::app::types::SessionSummaryState::default());
+        self.navigate_to(crate::tui::app::TuiMode::SessionSummary);
+    }
+
     /// Transition from CompletionSummary to Dashboard mode.
     pub fn transition_to_dashboard(&mut self) {
         let all = self.pool.all_sessions();

--- a/src/tui/app/mod.rs
+++ b/src/tui/app/mod.rs
@@ -306,8 +306,34 @@ impl App {
     }
 
     /// Navigate to a new mode, pushing the current mode onto the back-stack.
+    /// Navigate to `target`, maintaining a back-stack invariant that
+    /// disallows duplicates at the top and collapses cycles.
+    ///
+    /// Rules:
+    /// - Same-mode nav is a no-op (repeatedly pressing F5 while on
+    ///   TokenDashboard must not grow the breadcrumb trail).
+    /// - If `target` already appears in the stack, truncate to that
+    ///   position instead of pushing (A → B → A collapses to just [A]
+    ///   rather than [A, B, A], so `Esc` takes the user back one real
+    ///   step, not one keypress).
     pub fn navigate_to(&mut self, target: TuiMode) {
-        self.nav_stack.push(self.tui_mode);
+        if self.tui_mode == target {
+            return;
+        }
+        // Post-fix the stack cannot contain duplicates (same-mode pushes
+        // are blocked above, and cycles are collapsed on entry), so the
+        // first match IS the only match. `position` communicates that
+        // invariant more directly than `rposition`.
+        if let Some(idx) = self
+            .nav_stack
+            .breadcrumbs()
+            .iter()
+            .position(|m| *m == target)
+        {
+            self.nav_stack.truncate_to(idx);
+        } else {
+            self.nav_stack.push(self.tui_mode);
+        }
         self.tui_mode = target;
     }
 

--- a/src/tui/app/types.rs
+++ b/src/tui/app/types.rs
@@ -124,6 +124,14 @@ impl NavigationStack {
         self.stack.clear();
     }
 
+    /// Truncate the stack so that only the first `len` entries remain.
+    /// Used by `navigate_to` to collapse A → B → A cycles: when the
+    /// user navigates back to an ancestor, everything after that
+    /// ancestor is discarded instead of piling onto the stack.
+    pub fn truncate_to(&mut self, len: usize) {
+        self.stack.truncate(len);
+    }
+
     pub fn breadcrumbs(&self) -> &[TuiMode] {
         &self.stack
     }

--- a/src/tui/input_handler.rs
+++ b/src/tui/input_handler.rs
@@ -509,63 +509,68 @@ fn handle_global_shortcuts(app: &mut App, key: &KeyEvent) -> bool {
         return true;
     }
 
-    // F-key aliases
+    // F-key dispatch — looks up the current mode's F-key table (built by
+    // `mode_keymap` and cached on `app.cached_mode_km` by the renderer
+    // each frame) and executes the paired action. Label and dispatch
+    // come from the SAME `FKeyRelevance` entry, so they cannot drift.
     if let KeyCode::F(n) = key.code {
-        match n {
-            2 => {
-                let summary = app.build_completion_summary();
-                app.completion_summary = Some(summary);
-                app.session_summary_state =
-                    Some(crate::tui::app::types::SessionSummaryState::default());
-                app.navigate_to(app::TuiMode::SessionSummary);
-                return true;
-            }
-            3 => {
-                let selected = app.panel_view.selected_index();
-                if let Some(id) = app.pool.session_id_at_index(selected) {
-                    app.navigate_to(app::TuiMode::Fullscreen(id));
-                }
-                return true;
-            }
-            4 => {
-                app.navigate_to(app::TuiMode::CostDashboard);
-                return true;
-            }
-            5 => {
-                app.navigate_to(app::TuiMode::TokenDashboard);
-                return true;
-            }
-            6 => {
-                app.tui_mode = match app.tui_mode {
-                    app::TuiMode::Overview => app::TuiMode::DependencyGraph,
-                    app::TuiMode::DependencyGraph => app::TuiMode::CostDashboard,
-                    app::TuiMode::CostDashboard => app::TuiMode::TokenDashboard,
-                    app::TuiMode::TokenDashboard => app::TuiMode::TurboquantDashboard,
-                    app::TuiMode::TurboquantDashboard => app::TuiMode::Overview,
-                    _ => app::TuiMode::Overview,
-                };
-                return true;
-            }
-            #[cfg(unix)]
-            9 => {
-                app.pause_all();
-                return true;
-            }
-            10 => {
-                let selected = app.panel_view.selected_index();
-                if let Some(id) = app.pool.session_id_at_index(selected)
-                    && let Some(session) = app.pool.get_session(id)
-                    && !session.status.is_terminal()
-                {
-                    app.navigate_to(app::TuiMode::ConfirmKill(id));
-                }
-                return true;
-            }
-            _ => {}
+        let key_label = format!("F{}", n);
+        let action = app
+            .cached_mode_km
+            .as_ref()
+            .and_then(|km| km.fkeys.iter().find(|r| r.key == key_label))
+            .filter(|r| r.active)
+            .map(|r| r.action);
+        if let Some(action) = action {
+            dispatch_fkey_action(app, action);
+            return true;
+        }
+        // Key exists in the table but inactive (or the key isn't bound
+        // in this mode). Either way, consume to prevent fall-through to
+        // the screen dispatch path treating the F-key as a text input.
+        if app
+            .cached_mode_km
+            .as_ref()
+            .is_some_and(|km| km.fkeys.iter().any(|r| r.key == key_label))
+        {
+            return true;
         }
     }
 
     false
+}
+
+fn dispatch_fkey_action(app: &mut App, action: crate::tui::navigation::keymap::FKeyAction) {
+    use crate::tui::navigation::keymap::FKeyAction;
+    match action {
+        FKeyAction::ToggleHelp => {
+            app.help_state = Some(crate::tui::help::HelpOverlayState::new());
+        }
+        FKeyAction::OpenSummary => app.open_session_summary(),
+        FKeyAction::OpenFullscreenSelected => {
+            let selected = app.panel_view.selected_index();
+            if let Some(id) = app.pool.session_id_at_index(selected) {
+                app.navigate_to(app::TuiMode::Fullscreen(id));
+            }
+        }
+        FKeyAction::OpenCostDashboard => app.navigate_to(app::TuiMode::CostDashboard),
+        FKeyAction::OpenTokenDashboard => app.navigate_to(app::TuiMode::TokenDashboard),
+        FKeyAction::OpenDependencyGraph => app.navigate_to(app::TuiMode::DependencyGraph),
+        FKeyAction::PauseAll => {
+            #[cfg(unix)]
+            app.pause_all();
+        }
+        FKeyAction::KillSelected => {
+            let selected = app.panel_view.selected_index();
+            if let Some(id) = app.pool.session_id_at_index(selected)
+                && let Some(session) = app.pool.get_session(id)
+                && !session.status.is_terminal()
+            {
+                app.navigate_to(app::TuiMode::ConfirmKill(id));
+            }
+        }
+        FKeyAction::Exit => app.running = false,
+    }
 }
 
 /// Returns true if the current TUI mode accepts text input (q should type, not quit).
@@ -578,12 +583,15 @@ fn is_text_input_mode(app: &App) -> bool {
 
 /// Handle the confirm-exit dialog (y/n/Enter/Esc).
 fn handle_confirm_exit(app: &mut App, key: &KeyEvent) -> KeyAction {
+    // Enter is deliberately NOT an affirmative here. The dialog is often
+    // opened by a menu-Enter (e.g. Quick Action "Quit"), and reflex-pressing
+    // Enter again would silently destroy the session. Require explicit `y`.
     match key.code {
-        KeyCode::Char('y') | KeyCode::Enter => {
+        KeyCode::Char('y') | KeyCode::Char('Y') => {
             app.running = false;
             KeyAction::Quit
         }
-        KeyCode::Char('n') | KeyCode::Esc => {
+        KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc | KeyCode::Enter => {
             if let Some(prev) = app.nav_stack.pop() {
                 app.tui_mode = prev;
             } else {
@@ -591,7 +599,7 @@ fn handle_confirm_exit(app: &mut App, key: &KeyEvent) -> KeyAction {
             }
             KeyAction::Consumed
         }
-        _ => KeyAction::Consumed, // swallow all other keys
+        _ => KeyAction::Consumed, // unrelated keys: stay in the dialog
     }
 }
 
@@ -631,13 +639,7 @@ fn handle_overview_keys(app: &mut App, key: &KeyEvent) {
         (KeyCode::Char('t'), _) => {
             app.navigate_to(app::TuiMode::TokenDashboard);
         }
-        (KeyCode::Char('S'), _) => {
-            let summary = app.build_completion_summary();
-            app.completion_summary = Some(summary);
-            app.session_summary_state =
-                Some(crate::tui::app::types::SessionSummaryState::default());
-            app.navigate_to(app::TuiMode::SessionSummary);
-        }
+        (KeyCode::Char('S'), _) => app.open_session_summary(),
         (KeyCode::Tab, _) => {
             app.tui_mode = match app.tui_mode {
                 app::TuiMode::Overview => app::TuiMode::DependencyGraph,
@@ -820,7 +822,7 @@ mod tests {
         assert!(!is_text_input_mode(&app));
     }
 
-    // ── Group 3: handle_confirm_exit — y/Enter confirm ────────────────
+    // ── Group 3: handle_confirm_exit — only `y` confirms ──────────────
 
     #[test]
     fn y_in_confirm_exit_sets_running_false() {
@@ -832,12 +834,31 @@ mod tests {
     }
 
     #[test]
-    fn enter_in_confirm_exit_sets_running_false() {
+    fn uppercase_y_in_confirm_exit_sets_running_false() {
         let mut app = make_app();
         app.tui_mode = TuiMode::ConfirmExit;
         app.running = true;
-        handle_confirm_exit(&mut app, &key_code(KeyCode::Enter));
+        handle_confirm_exit(&mut app, &key('Y'));
         assert!(!app.running);
+    }
+
+    /// Regression guard: the dialog is often opened by a menu-Enter
+    /// (Quick Action "Quit"). If Enter were an affirmative here, a
+    /// reflexive second Enter would silently exit the app before the
+    /// user could see the dialog. Enter must cancel instead.
+    #[test]
+    fn enter_in_confirm_exit_cancels_instead_of_confirming() {
+        let mut app = make_app();
+        app.nav_stack.push(TuiMode::Dashboard);
+        app.tui_mode = TuiMode::ConfirmExit;
+        app.running = true;
+        handle_confirm_exit(&mut app, &key_code(KeyCode::Enter));
+        assert!(app.running, "Enter must NOT quit");
+        assert_eq!(
+            app.tui_mode,
+            TuiMode::Dashboard,
+            "Enter must restore the previous mode"
+        );
     }
 
     #[test]
@@ -846,7 +867,6 @@ mod tests {
         app.tui_mode = TuiMode::ConfirmExit;
         app.nav_stack.push(TuiMode::Overview);
         handle_confirm_exit(&mut app, &key('y'));
-        // After quitting, running is false — stack state doesn't matter
         assert!(!app.running);
     }
 
@@ -997,5 +1017,95 @@ mod tests {
         app.navigate_to_root();
         assert_eq!(app.tui_mode, TuiMode::Dashboard);
         assert!(app.nav_stack.is_empty());
+    }
+
+    // F-key label/dispatch contract: every F-key advertised in the bottom
+    // bar must dispatch to its label's target. Previously the label lived
+    // in `mode_hints.rs` and the dispatch lived in `handle_global_shortcuts`
+    // — two independent tables that drifted (F6 "Deps" label but dispatched
+    // to Overview from Dashboard mode). After the unification, both live on
+    // `FKeyRelevance`, so these tests are sanity checks that the action
+    // enum maps to the expected `TuiMode`.
+
+    fn fkey_action_target_mode(
+        action: crate::tui::navigation::keymap::FKeyAction,
+    ) -> Option<TuiMode> {
+        use crate::tui::navigation::keymap::FKeyAction;
+        match action {
+            FKeyAction::OpenCostDashboard => Some(TuiMode::CostDashboard),
+            FKeyAction::OpenTokenDashboard => Some(TuiMode::TokenDashboard),
+            FKeyAction::OpenDependencyGraph => Some(TuiMode::DependencyGraph),
+            FKeyAction::OpenSummary => Some(TuiMode::SessionSummary),
+            _ => None,
+        }
+    }
+
+    // navigate_to must be idempotent and cycle-collapsing. Pressing F5
+    // repeatedly while already on TokenDashboard used to grow the
+    // breadcrumb trail by one entry per keystroke; navigating A → B → A
+    // used to produce [A, B] on the stack instead of just [A].
+
+    #[test]
+    fn navigate_to_same_mode_is_a_noop() {
+        let mut app = make_app();
+        app.tui_mode = TuiMode::TokenDashboard;
+        app.navigate_to(TuiMode::TokenDashboard);
+        app.navigate_to(TuiMode::TokenDashboard);
+        app.navigate_to(TuiMode::TokenDashboard);
+        assert_eq!(app.tui_mode, TuiMode::TokenDashboard);
+        assert_eq!(app.nav_stack.depth(), 0);
+    }
+
+    #[test]
+    fn navigate_to_truncates_to_existing_ancestor_instead_of_pushing() {
+        let mut app = make_app();
+        app.tui_mode = TuiMode::Dashboard;
+        app.navigate_to(TuiMode::TokenDashboard);
+        app.navigate_to(TuiMode::Dashboard);
+        assert_eq!(app.tui_mode, TuiMode::Dashboard);
+        // Stack should be empty — we returned to the root, not pushed
+        // TokenDashboard onto it.
+        assert_eq!(app.nav_stack.depth(), 0);
+    }
+
+    #[test]
+    fn navigate_to_through_several_modes_does_not_grow_on_same_press() {
+        let mut app = make_app();
+        app.tui_mode = TuiMode::Dashboard;
+        app.navigate_to(TuiMode::DependencyGraph);
+        app.navigate_to(TuiMode::DependencyGraph); // idempotent
+        app.navigate_to(TuiMode::TokenDashboard);
+        app.navigate_to(TuiMode::TokenDashboard); // idempotent
+        app.navigate_to(TuiMode::TokenDashboard); // idempotent
+        assert_eq!(app.tui_mode, TuiMode::TokenDashboard);
+        assert_eq!(
+            app.nav_stack.breadcrumbs(),
+            &[TuiMode::Dashboard, TuiMode::DependencyGraph]
+        );
+    }
+
+    #[test]
+    fn fkey_dashboard_mode_advertises_f4_f5_f6_and_each_dispatches() {
+        use crate::tui::navigation::keymap::mode_keymap;
+        let km = mode_keymap(TuiMode::Dashboard, None, &[]);
+        let mut checked = 0;
+        for fkey in &km.fkeys {
+            let Some(expected) = fkey_action_target_mode(fkey.action) else {
+                continue;
+            };
+            let mut app = make_app();
+            app.tui_mode = TuiMode::Dashboard;
+            dispatch_fkey_action(&mut app, fkey.action);
+            assert_eq!(
+                app.tui_mode, expected,
+                "F-bar entry `{}` labeled `{}` advertised in TuiMode::Dashboard \
+                 but dispatching its action did not land in {:?} (landed in {:?}). \
+                 See `build_fkeys` in mode_hints.rs and `dispatch_fkey_action` in \
+                 input_handler.rs.",
+                fkey.key, fkey.label, expected, app.tui_mode
+            );
+            checked += 1;
+        }
+        assert!(checked >= 3, "expected F4/F5/F6 to be verified, got {}", checked);
     }
 }

--- a/src/tui/input_handler.rs
+++ b/src/tui/input_handler.rs
@@ -1106,6 +1106,10 @@ mod tests {
             );
             checked += 1;
         }
-        assert!(checked >= 3, "expected F4/F5/F6 to be verified, got {}", checked);
+        assert!(
+            checked >= 3,
+            "expected F4/F5/F6 to be verified, got {}",
+            checked
+        );
     }
 }

--- a/src/tui/navigation/keymap.rs
+++ b/src/tui/navigation/keymap.rs
@@ -128,12 +128,47 @@ pub fn global_keybindings() -> &'static [KeyBindingGroup] {
     &GLOBALS
 }
 
+/// Action dispatched when an F-key is pressed. Paired with a label in
+/// `FKeyRelevance` so the F-bar and the handler cannot drift — a label
+/// like "Deps" and an action like `OpenDependencyGraph` live in the
+/// same declaration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FKeyAction {
+    ToggleHelp,
+    OpenSummary,
+    OpenFullscreenSelected,
+    OpenCostDashboard,
+    OpenTokenDashboard,
+    OpenDependencyGraph,
+    PauseAll,
+    KillSelected,
+    Exit,
+}
+
 #[derive(Debug, Clone)]
 pub struct FKeyRelevance {
     pub key: &'static str,
     pub label: &'static str,
     pub visible: bool,
     pub active: bool,
+    pub action: FKeyAction,
+}
+
+impl FKeyRelevance {
+    pub const fn new(key: &'static str, label: &'static str, action: FKeyAction) -> Self {
+        Self {
+            key,
+            label,
+            visible: true,
+            active: true,
+            action,
+        }
+    }
+
+    pub const fn with_active(mut self, active: bool) -> Self {
+        self.active = active;
+        self
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/tui/navigation/mode_hints.rs
+++ b/src/tui/navigation/mode_hints.rs
@@ -1,7 +1,9 @@
 use crate::session::types::SessionStatus;
 use crate::tui::app::TuiMode;
 
-use super::keymap::{FKeyRelevance, InlineHint, KeyBindingGroup, ModeKeyMap, global_keybindings};
+use super::keymap::{
+    FKeyAction, FKeyRelevance, InlineHint, KeyBindingGroup, ModeKeyMap, global_keybindings,
+};
 
 /// Build the `ModeKeyMap` for a given `TuiMode`.
 ///
@@ -118,6 +120,11 @@ pub fn mode_keymap(
                     key: "a",
                     action: "Adapt",
                     priority: 4,
+                },
+                InlineHint {
+                    key: "Q",
+                    action: "TurboQuant",
+                    priority: 5,
                 },
             ],
         ),
@@ -565,108 +572,31 @@ fn build_fkeys(
     is_running: bool,
     is_terminal: bool,
 ) -> Vec<FKeyRelevance> {
+    // Each FKey entry declares key + label + action together. Adding a
+    // new F-key means one `FKeyRelevance::new(...)` here — the dispatch
+    // path in `input_handler::dispatch_fkey_action` reads `action` from
+    // the same struct, so the bar label and handler cannot drift.
+    use FKeyAction::*;
+    let help = FKeyRelevance::new("F1", "Help", ToggleHelp);
+    let costs = FKeyRelevance::new("F4", "Costs", OpenCostDashboard);
+    let tokens = FKeyRelevance::new("F5", "Tokens", OpenTokenDashboard);
+    let deps = FKeyRelevance::new("F6", "Deps", OpenDependencyGraph);
+    let exit = FKeyRelevance::new("^X", "Exit", Exit);
+
     match vis {
         FKeyVis::SessionAware => vec![
-            FKeyRelevance {
-                key: "F1",
-                label: "Help",
-                visible: true,
-                active: true,
-            },
-            FKeyRelevance {
-                key: "F2",
-                label: "Summary",
-                visible: true,
-                active: true,
-            },
-            FKeyRelevance {
-                key: "F3",
-                label: "Full",
-                visible: true,
-                active: has_session,
-            },
-            FKeyRelevance {
-                key: "F4",
-                label: "Costs",
-                visible: true,
-                active: true,
-            },
-            FKeyRelevance {
-                key: "F5",
-                label: "Tokens",
-                visible: true,
-                active: true,
-            },
-            FKeyRelevance {
-                key: "F6",
-                label: "Deps",
-                visible: true,
-                active: true,
-            },
-            FKeyRelevance {
-                key: "F9",
-                label: "Pause",
-                visible: true,
-                active: is_running,
-            },
-            FKeyRelevance {
-                key: "F10",
-                label: "Kill",
-                visible: true,
-                active: has_session && !is_terminal,
-            },
-            FKeyRelevance {
-                key: "^X",
-                label: "Exit",
-                visible: true,
-                active: true,
-            },
+            help.clone(),
+            FKeyRelevance::new("F2", "Summary", OpenSummary),
+            FKeyRelevance::new("F3", "Full", OpenFullscreenSelected).with_active(has_session),
+            costs.clone(),
+            tokens.clone(),
+            deps.clone(),
+            FKeyRelevance::new("F9", "Pause", PauseAll).with_active(is_running),
+            FKeyRelevance::new("F10", "Kill", KillSelected)
+                .with_active(has_session && !is_terminal),
+            exit.clone(),
         ],
-        FKeyVis::DashboardLike => vec![
-            FKeyRelevance {
-                key: "F1",
-                label: "Help",
-                visible: true,
-                active: true,
-            },
-            FKeyRelevance {
-                key: "F4",
-                label: "Costs",
-                visible: true,
-                active: true,
-            },
-            FKeyRelevance {
-                key: "F5",
-                label: "Tokens",
-                visible: true,
-                active: true,
-            },
-            FKeyRelevance {
-                key: "F6",
-                label: "Deps",
-                visible: true,
-                active: true,
-            },
-            FKeyRelevance {
-                key: "^X",
-                label: "Exit",
-                visible: true,
-                active: true,
-            },
-        ],
-        FKeyVis::Minimal => vec![
-            FKeyRelevance {
-                key: "F1",
-                label: "Help",
-                visible: true,
-                active: true,
-            },
-            FKeyRelevance {
-                key: "^X",
-                label: "Exit",
-                visible: true,
-                active: true,
-            },
-        ],
+        FKeyVis::DashboardLike => vec![help, costs, tokens, deps, exit],
+        FKeyVis::Minimal => vec![help, exit],
     }
 }

--- a/src/tui/screens/home/draw.rs
+++ b/src/tui/screens/home/draw.rs
@@ -1,7 +1,6 @@
 use super::types::{Suggestion, SuggestionKind};
 use super::{HomeScreen, QUICK_ACTIONS};
 use crate::changelog::{self, ChangeCategory, ChangeItem};
-use crate::tui::app::TuiMode;
 use crate::tui::icons::{self, IconId};
 use crate::tui::screens::ScreenAction;
 use crate::tui::theme::Theme;
@@ -111,20 +110,10 @@ impl HomeScreen {
     }
 
     pub(super) fn execute_selected_action(&self) -> ScreenAction {
-        match self.selected_action {
-            0 => ScreenAction::Push(TuiMode::IssueBrowser),
-            1 => ScreenAction::Push(TuiMode::MilestoneView),
-            2 => ScreenAction::Push(TuiMode::PromptInput),
-            3 => ScreenAction::Push(TuiMode::AdaptWizard),
-            4 => ScreenAction::Push(TuiMode::PrReview),
-            5 => ScreenAction::Push(TuiMode::Overview),
-            6 => ScreenAction::Push(TuiMode::CostDashboard),
-            7 => ScreenAction::Push(TuiMode::TokenDashboard),
-            8 => ScreenAction::Push(TuiMode::Settings),
-            9 => ScreenAction::CheckForUpdate,
-            10 => ScreenAction::Quit,
-            _ => ScreenAction::None,
-        }
+        super::QUICK_ACTIONS
+            .get(self.selected_action)
+            .map(|(_, _, action)| (*action).into())
+            .unwrap_or(ScreenAction::None)
     }
 
     fn draw_warnings(&self, f: &mut Frame, area: Rect, theme: &Theme) {
@@ -205,7 +194,7 @@ impl HomeScreen {
             .add_modifier(Modifier::BOLD);
 
         let mut lines = Vec::new();
-        for (idx, (label, key)) in QUICK_ACTIONS.iter().enumerate() {
+        for (idx, (label, key, _)) in QUICK_ACTIONS.iter().enumerate() {
             let is_selected = is_focused && idx == self.selected_action;
             let style = if is_selected {
                 selected_style

--- a/src/tui/screens/home/mod.rs
+++ b/src/tui/screens/home/mod.rs
@@ -14,18 +14,53 @@ use crate::tui::theme::Theme;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind};
 use ratatui::{Frame, layout::Rect};
 
-const QUICK_ACTIONS: &[(&str, char)] = &[
-    ("Browse Issues", 'i'),
-    ("Browse Milestones", 'm'),
-    ("Run Prompt", 'r'),
-    ("Adapt Project", 'a'),
-    ("Review PRs", 'p'),
-    ("Status", 's'),
-    ("Cost Report", 'c'),
-    ("Token Report", 't'),
-    ("Settings", 'S'),
-    ("Update Maestro", 'u'),
-    ("Quit", 'q'),
+/// Dispatch tag for a Quick Action, paired with label + key in
+/// `QUICK_ACTIONS` so the three fields cannot drift. Quit routes to
+/// `ConfirmExit` to match the global `q` handler — see the regression
+/// test `enter_in_confirm_exit_cancels_instead_of_confirming`.
+#[derive(Clone, Copy)]
+enum QuickActionDispatch {
+    Push(TuiMode),
+    CheckForUpdate,
+}
+
+impl From<QuickActionDispatch> for ScreenAction {
+    fn from(dispatch: QuickActionDispatch) -> Self {
+        match dispatch {
+            QuickActionDispatch::Push(mode) => ScreenAction::Push(mode),
+            QuickActionDispatch::CheckForUpdate => ScreenAction::CheckForUpdate,
+        }
+    }
+}
+
+const fn find_action_index_by_key(target: char) -> usize {
+    let mut i = 0;
+    while i < QUICK_ACTIONS.len() {
+        if QUICK_ACTIONS[i].1 == target {
+            return i;
+        }
+        i += 1;
+    }
+    panic!("QUICK_ACTIONS missing expected key");
+}
+
+const QUICK_ACTIONS: &[(&str, char, QuickActionDispatch)] = &[
+    ("Browse Issues", 'i', QuickActionDispatch::Push(TuiMode::IssueBrowser)),
+    ("Browse Milestones", 'm', QuickActionDispatch::Push(TuiMode::MilestoneView)),
+    ("Run Prompt", 'r', QuickActionDispatch::Push(TuiMode::PromptInput)),
+    ("Adapt Project", 'a', QuickActionDispatch::Push(TuiMode::AdaptWizard)),
+    ("Review PRs", 'p', QuickActionDispatch::Push(TuiMode::PrReview)),
+    ("Status", 's', QuickActionDispatch::Push(TuiMode::Overview)),
+    ("Cost Report", 'c', QuickActionDispatch::Push(TuiMode::CostDashboard)),
+    ("Token Report", 't', QuickActionDispatch::Push(TuiMode::TokenDashboard)),
+    (
+        "TurboQuant Savings",
+        'Q',
+        QuickActionDispatch::Push(TuiMode::TurboquantDashboard),
+    ),
+    ("Settings", 'S', QuickActionDispatch::Push(TuiMode::Settings)),
+    ("Update Maestro", 'u', QuickActionDispatch::CheckForUpdate),
+    ("Quit", 'q', QuickActionDispatch::Push(TuiMode::ConfirmExit)),
 ];
 
 pub struct HomeScreen {
@@ -59,7 +94,10 @@ pub(super) struct StatsBarIdentity {
 impl HomeScreen {
     pub const NUM_ACTIONS: usize = QUICK_ACTIONS.len();
     #[allow(dead_code)] // Reason: quit action index for keyboard shortcut
-    pub const QUIT_ACTION_INDEX: usize = 10;
+    /// Index of the `Quit` entry in `QUICK_ACTIONS`. Derived from the
+    /// table at compile time so this cannot drift when the menu is
+    /// reordered.
+    pub const QUIT_ACTION_INDEX: usize = find_action_index_by_key('q');
     pub const QUICK_ACTIONS_PANE: FocusId = FocusId("home:quick_actions");
     pub const SUGGESTIONS_PANE: FocusId = FocusId("home:suggestions");
 
@@ -182,20 +220,17 @@ impl Screen for HomeScreen {
                 return ScreenAction::None;
             }
 
+            // Menu-letter shortcuts come from QUICK_ACTIONS so Enter and
+            // letter-press share one source of truth.
+            if let KeyCode::Char(c) = code
+                && let Some((_, _, action)) = QUICK_ACTIONS.iter().find(|(_, k, _)| k == c)
+            {
+                return (*action).into();
+            }
             match code {
-                KeyCode::Char('i') => return ScreenAction::Push(TuiMode::IssueBrowser),
-                KeyCode::Char('m') => return ScreenAction::Push(TuiMode::MilestoneView),
-                KeyCode::Char('r') => return ScreenAction::Push(TuiMode::PromptInput),
-                KeyCode::Char('a') => return ScreenAction::Push(TuiMode::AdaptWizard),
+                // Hidden keyboard shortcuts (not shown in Quick Actions).
                 KeyCode::Char('n') => return ScreenAction::Push(TuiMode::ReleaseNotes),
-                KeyCode::Char('p') => return ScreenAction::Push(TuiMode::PrReview),
                 KeyCode::Char('R') => return ScreenAction::RefreshSuggestions,
-                KeyCode::Char('s') => return ScreenAction::Push(TuiMode::Overview),
-                KeyCode::Char('c') => return ScreenAction::Push(TuiMode::CostDashboard),
-                KeyCode::Char('t') => return ScreenAction::Push(TuiMode::TokenDashboard),
-                KeyCode::Char('S') => return ScreenAction::Push(TuiMode::Settings),
-                KeyCode::Char('u') => return ScreenAction::CheckForUpdate,
-                KeyCode::Char('q') => return ScreenAction::Quit,
                 KeyCode::Tab => {
                     self.focus_ring.next();
                 }
@@ -369,10 +404,14 @@ mod tests {
     }
 
     #[test]
-    fn home_key_q_returns_quit() {
+    fn home_key_q_routes_through_confirm_exit() {
+        // The letter `q` on the HomeScreen is intercepted globally before
+        // reaching this handler in production, but when dispatched through
+        // the screen (Enter path or tests) it must route to ConfirmExit,
+        // not the direct-quit action — both paths must be equivalent.
         let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
         let action = screen.handle_input(&key_event(KeyCode::Char('q')), InputMode::Normal);
-        assert_eq!(action, ScreenAction::Quit);
+        assert_eq!(action, ScreenAction::Push(TuiMode::ConfirmExit));
     }
 
     #[test]
@@ -391,13 +430,54 @@ mod tests {
     }
 
     #[test]
-    fn home_enter_on_quit_action_returns_quit() {
+    fn home_enter_on_quit_action_routes_through_confirm_exit() {
+        // Enter on the Quit row must go through the confirm-exit dialog
+        // so menu-Enter matches the letter-`q` flow (which is intercepted
+        // globally in `input_handler::handle_key` and navigates to
+        // ConfirmExit). Direct `ScreenAction::Quit` would bypass the
+        // dialog and exit immediately — user-hostile.
         let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
         for _ in 0..HomeScreen::QUIT_ACTION_INDEX {
             screen.handle_input(&key_event(KeyCode::Down), InputMode::Normal);
         }
         let action = screen.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
-        assert_eq!(action, ScreenAction::Quit);
+        assert_eq!(action, ScreenAction::Push(TuiMode::ConfirmExit));
+    }
+
+    /// Every Quick Action's Enter-press AND letter-press must dispatch
+    /// to exactly the action declared in `QUICK_ACTIONS`. Guards against
+    /// two classes of drift:
+    /// - index-based `execute_selected_action` shifting silently when a
+    ///   row is inserted (the original bug);
+    /// - a bulk reassignment where every row gets the same target (the
+    ///   previous cross-path-only form of this test would have passed).
+    #[test]
+    fn home_enter_matches_letter_key_for_every_quick_action() {
+        for (idx, &(label, key, action)) in QUICK_ACTIONS.iter().enumerate() {
+            let expected: ScreenAction = action.into();
+
+            let mut by_enter = HomeScreen::new(make_project_info(), vec![], vec![]);
+            for _ in 0..idx {
+                by_enter.handle_input(&key_event(KeyCode::Down), InputMode::Normal);
+            }
+            let enter_action =
+                by_enter.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
+
+            let mut by_letter = HomeScreen::new(make_project_info(), vec![], vec![]);
+            let letter_action =
+                by_letter.handle_input(&key_event(KeyCode::Char(key)), InputMode::Normal);
+
+            assert_eq!(
+                enter_action, expected,
+                "Quick Action [{}] {}: Enter must dispatch the action declared in QUICK_ACTIONS",
+                key, label
+            );
+            assert_eq!(
+                letter_action, expected,
+                "Quick Action [{}] {}: letter-key must dispatch the action declared in QUICK_ACTIONS",
+                key, label
+            );
+        }
     }
 
     #[test]
@@ -767,11 +847,11 @@ mod tests {
     }
 
     #[test]
-    fn home_char_q_returns_quit_when_focused_on_suggestions() {
+    fn home_char_q_routes_through_confirm_exit_when_focused_on_suggestions() {
         let mut screen = HomeScreen::new(make_project_info(), vec![], vec![]);
         focus_suggestions(&mut screen);
         let action = screen.handle_input(&key_event(KeyCode::Char('q')), InputMode::Normal);
-        assert_eq!(action, ScreenAction::Quit);
+        assert_eq!(action, ScreenAction::Push(TuiMode::ConfirmExit));
     }
 
     // -- Edge cases --

--- a/src/tui/screens/home/mod.rs
+++ b/src/tui/screens/home/mod.rs
@@ -45,20 +45,52 @@ const fn find_action_index_by_key(target: char) -> usize {
 }
 
 const QUICK_ACTIONS: &[(&str, char, QuickActionDispatch)] = &[
-    ("Browse Issues", 'i', QuickActionDispatch::Push(TuiMode::IssueBrowser)),
-    ("Browse Milestones", 'm', QuickActionDispatch::Push(TuiMode::MilestoneView)),
-    ("Run Prompt", 'r', QuickActionDispatch::Push(TuiMode::PromptInput)),
-    ("Adapt Project", 'a', QuickActionDispatch::Push(TuiMode::AdaptWizard)),
-    ("Review PRs", 'p', QuickActionDispatch::Push(TuiMode::PrReview)),
+    (
+        "Browse Issues",
+        'i',
+        QuickActionDispatch::Push(TuiMode::IssueBrowser),
+    ),
+    (
+        "Browse Milestones",
+        'm',
+        QuickActionDispatch::Push(TuiMode::MilestoneView),
+    ),
+    (
+        "Run Prompt",
+        'r',
+        QuickActionDispatch::Push(TuiMode::PromptInput),
+    ),
+    (
+        "Adapt Project",
+        'a',
+        QuickActionDispatch::Push(TuiMode::AdaptWizard),
+    ),
+    (
+        "Review PRs",
+        'p',
+        QuickActionDispatch::Push(TuiMode::PrReview),
+    ),
     ("Status", 's', QuickActionDispatch::Push(TuiMode::Overview)),
-    ("Cost Report", 'c', QuickActionDispatch::Push(TuiMode::CostDashboard)),
-    ("Token Report", 't', QuickActionDispatch::Push(TuiMode::TokenDashboard)),
+    (
+        "Cost Report",
+        'c',
+        QuickActionDispatch::Push(TuiMode::CostDashboard),
+    ),
+    (
+        "Token Report",
+        't',
+        QuickActionDispatch::Push(TuiMode::TokenDashboard),
+    ),
     (
         "TurboQuant Savings",
         'Q',
         QuickActionDispatch::Push(TuiMode::TurboquantDashboard),
     ),
-    ("Settings", 'S', QuickActionDispatch::Push(TuiMode::Settings)),
+    (
+        "Settings",
+        'S',
+        QuickActionDispatch::Push(TuiMode::Settings),
+    ),
     ("Update Maestro", 'u', QuickActionDispatch::CheckForUpdate),
     ("Quit", 'q', QuickActionDispatch::Push(TuiMode::ConfirmExit)),
 ];
@@ -460,8 +492,7 @@ mod tests {
             for _ in 0..idx {
                 by_enter.handle_input(&key_event(KeyCode::Down), InputMode::Normal);
             }
-            let enter_action =
-                by_enter.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
+            let enter_action = by_enter.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
 
             let mut by_letter = HomeScreen::new(make_project_info(), vec![], vec![]);
             let letter_action =

--- a/src/tui/screens/settings/mod.rs
+++ b/src/tui/screens/settings/mod.rs
@@ -101,6 +101,16 @@ pub struct SettingsScreen {
     validation_results: HashMap<FieldKey, ValidationFeedback>,
 }
 
+/// Find a widget in a tab's field slice by its label. Returns the first
+/// match. Used by `sync_widgets_to_config` so reordering widgets in
+/// `build_*_fields` cannot silently drop a sync.
+fn widget_by_label<'a>(fields: &'a [SettingsField], label: &str) -> Option<&'a WidgetKind> {
+    fields
+        .iter()
+        .find(|f| f.widget.label() == label)
+        .map(|f| &f.widget)
+}
+
 impl SettingsScreen {
     pub fn new(config: Config, flags: FeatureFlags) -> Self {
         let fields_per_tab = Self::build_fields(&config);
@@ -267,6 +277,28 @@ impl SettingsScreen {
                 NumberStepper::new("retry_cooldown_secs", s.retry_cooldown_secs as i64, 0, 600)
                     .with_step(10),
             )),
+            // Hollow retry policy (#275) — dropdown + per-intent steppers.
+            Self::field(WidgetKind::Dropdown(Dropdown::new(
+                "hollow_retry.policy",
+                vec!["always".into(), "intent-aware".into(), "never".into()],
+                match s.hollow_retry.policy {
+                    crate::config::HollowRetryPolicy::Always => 0,
+                    crate::config::HollowRetryPolicy::IntentAware => 1,
+                    crate::config::HollowRetryPolicy::Never => 2,
+                },
+            ))),
+            Self::field(WidgetKind::NumberStepper(NumberStepper::new(
+                "hollow_retry.work_max_retries",
+                s.hollow_retry.work_max_retries as i64,
+                0,
+                10,
+            ))),
+            Self::field(WidgetKind::NumberStepper(NumberStepper::new(
+                "hollow_retry.consultation_max_retries",
+                s.hollow_retry.consultation_max_retries as i64,
+                0,
+                10,
+            ))),
             // Context Overflow sub-section
             Self::field(WidgetKind::NumberStepper(
                 NumberStepper::new(
@@ -612,46 +644,72 @@ impl SettingsScreen {
             }
         }
 
-        // Sessions (tab 1)
+        // Sessions (tab 1) — looked up by label so widget reordering
+        // cannot silently drop a sync. New widgets only need to appear in
+        // `build_sessions_fields`; no index bookkeeping here.
         if let Some(fields) = self.fields_per_tab.get(1) {
             let s = &mut self.config.sessions;
-            if let Some(WidgetKind::NumberStepper(w)) = fields.first().map(|f| &f.widget) {
+            if let Some(WidgetKind::NumberStepper(w)) = widget_by_label(fields, "max_concurrent") {
                 s.max_concurrent = w.value as usize;
             }
-            if let Some(WidgetKind::NumberStepper(w)) = fields.get(1).map(|f| &f.widget) {
+            if let Some(WidgetKind::NumberStepper(w)) =
+                widget_by_label(fields, "stall_timeout_secs")
+            {
                 s.stall_timeout_secs = w.value as u64;
             }
-            if let Some(WidgetKind::TextInput(w)) = fields.get(2).map(|f| &f.widget) {
+            if let Some(WidgetKind::TextInput(w)) = widget_by_label(fields, "default_model") {
                 s.default_model = w.value.clone();
             }
-            if let Some(WidgetKind::TextInput(w)) = fields.get(3).map(|f| &f.widget) {
+            if let Some(WidgetKind::TextInput(w)) = widget_by_label(fields, "default_mode") {
                 s.default_mode = w.value.clone();
             }
-            if let Some(WidgetKind::Dropdown(w)) = fields.get(4).map(|f| &f.widget) {
+            if let Some(WidgetKind::Dropdown(w)) = widget_by_label(fields, "permission_mode") {
                 s.permission_mode = w.selected_value().to_string();
             }
-            if let Some(WidgetKind::NumberStepper(w)) = fields.get(5).map(|f| &f.widget) {
+            if let Some(WidgetKind::NumberStepper(w)) = widget_by_label(fields, "max_retries") {
                 s.max_retries = w.value as u32;
             }
-            if let Some(WidgetKind::NumberStepper(w)) = fields.get(6).map(|f| &f.widget) {
+            if let Some(WidgetKind::NumberStepper(w)) =
+                widget_by_label(fields, "retry_cooldown_secs")
+            {
                 s.retry_cooldown_secs = w.value as u64;
             }
-            if let Some(WidgetKind::NumberStepper(w)) = fields.get(7).map(|f| &f.widget) {
+            if let Some(WidgetKind::Dropdown(w)) = widget_by_label(fields, "hollow_retry.policy") {
+                s.hollow_retry.policy = match w.selected {
+                    0 => crate::config::HollowRetryPolicy::Always,
+                    1 => crate::config::HollowRetryPolicy::IntentAware,
+                    _ => crate::config::HollowRetryPolicy::Never,
+                };
+            }
+            if let Some(WidgetKind::NumberStepper(w)) =
+                widget_by_label(fields, "hollow_retry.work_max_retries")
+            {
+                s.hollow_retry.work_max_retries = w.value as u32;
+            }
+            if let Some(WidgetKind::NumberStepper(w)) =
+                widget_by_label(fields, "hollow_retry.consultation_max_retries")
+            {
+                s.hollow_retry.consultation_max_retries = w.value as u32;
+            }
+            if let Some(WidgetKind::NumberStepper(w)) =
+                widget_by_label(fields, "overflow_threshold_pct")
+            {
                 s.context_overflow.overflow_threshold_pct = w.value as u8;
             }
-            if let Some(WidgetKind::Toggle(w)) = fields.get(8).map(|f| &f.widget) {
+            if let Some(WidgetKind::Toggle(w)) = widget_by_label(fields, "auto_fork") {
                 s.context_overflow.auto_fork = w.value;
             }
-            if let Some(WidgetKind::NumberStepper(w)) = fields.get(9).map(|f| &f.widget) {
+            if let Some(WidgetKind::NumberStepper(w)) = widget_by_label(fields, "commit_prompt_pct")
+            {
                 s.context_overflow.commit_prompt_pct = w.value as u8;
             }
-            if let Some(WidgetKind::NumberStepper(w)) = fields.get(10).map(|f| &f.widget) {
+            if let Some(WidgetKind::NumberStepper(w)) = widget_by_label(fields, "max_fork_depth") {
                 s.context_overflow.max_fork_depth = w.value as u8;
             }
-            if let Some(WidgetKind::Toggle(w)) = fields.get(11).map(|f| &f.widget) {
+            if let Some(WidgetKind::Toggle(w)) = widget_by_label(fields, "conflict_enabled") {
                 s.conflict.enabled = w.value;
             }
-            if let Some(WidgetKind::Dropdown(w)) = fields.get(12).map(|f| &f.widget) {
+            if let Some(WidgetKind::Dropdown(w)) = widget_by_label(fields, "conflict_policy") {
                 s.conflict.policy = match w.selected {
                     0 => crate::config::ConflictPolicy::Warn,
                     1 => crate::config::ConflictPolicy::Pause,
@@ -1933,5 +1991,90 @@ alert_threshold_pct = 80
         let fb = screen.feedback_for(5, 3);
         assert!(fb.is_some());
         assert!(fb.unwrap().is_error());
+    }
+
+    // --- Issue #275: hollow retry policy widgets in Sessions tab ---
+
+    #[test]
+    fn sessions_tab_contains_hollow_retry_widgets() {
+        let screen = SettingsScreen::new(make_config(), make_flags());
+        let fields = &screen.fields_per_tab[1];
+        // Fields 7, 8, 9 are the three new widgets (after max_concurrent,
+        // stall_timeout_secs, default_model, default_mode, permission_mode,
+        // max_retries, retry_cooldown_secs).
+        match &fields[7].widget {
+            WidgetKind::Dropdown(d) => assert_eq!(d.label, "hollow_retry.policy"),
+            _ => panic!("expected Dropdown at field 7 (hollow_retry.policy)"),
+        }
+        match &fields[8].widget {
+            WidgetKind::NumberStepper(s) => {
+                assert_eq!(s.label, "hollow_retry.work_max_retries")
+            }
+            _ => panic!("expected NumberStepper at field 8 (work_max_retries)"),
+        }
+        match &fields[9].widget {
+            WidgetKind::NumberStepper(s) => {
+                assert_eq!(s.label, "hollow_retry.consultation_max_retries")
+            }
+            _ => panic!("expected NumberStepper at field 9 (consultation_max_retries)"),
+        }
+    }
+
+    #[test]
+    fn sessions_tab_hollow_retry_policy_defaults_to_intent_aware() {
+        let screen = SettingsScreen::new(make_config(), make_flags());
+        let fields = &screen.fields_per_tab[1];
+        let WidgetKind::Dropdown(d) = &fields[7].widget else {
+            panic!("field 7 must be Dropdown");
+        };
+        // Options order: [always, intent-aware, never] → default index 1.
+        assert_eq!(d.selected, 1);
+        assert_eq!(d.selected_value(), "intent-aware");
+    }
+
+    #[test]
+    fn sessions_tab_hollow_retry_sync_writes_policy_to_config() {
+        let mut screen = SettingsScreen::new(make_config(), make_flags());
+        // Directly mutate the dropdown to "never" (index 2).
+        if let Some(WidgetKind::Dropdown(d)) = screen
+            .fields_per_tab
+            .get_mut(1)
+            .and_then(|fs| fs.get_mut(7))
+            .map(|f| &mut f.widget)
+        {
+            d.selected = 2;
+        }
+        screen.sync_widgets_to_config();
+        assert_eq!(
+            screen.config.sessions.hollow_retry.policy,
+            crate::config::HollowRetryPolicy::Never
+        );
+    }
+
+    #[test]
+    fn sessions_tab_hollow_retry_sync_writes_steppers_to_config() {
+        let mut screen = SettingsScreen::new(make_config(), make_flags());
+        if let Some(WidgetKind::NumberStepper(s)) = screen
+            .fields_per_tab
+            .get_mut(1)
+            .and_then(|fs| fs.get_mut(8))
+            .map(|f| &mut f.widget)
+        {
+            s.value = 5;
+        }
+        if let Some(WidgetKind::NumberStepper(s)) = screen
+            .fields_per_tab
+            .get_mut(1)
+            .and_then(|fs| fs.get_mut(9))
+            .map(|f| &mut f.widget)
+        {
+            s.value = 3;
+        }
+        screen.sync_widgets_to_config();
+        assert_eq!(screen.config.sessions.hollow_retry.work_max_retries, 5);
+        assert_eq!(
+            screen.config.sessions.hollow_retry.consultation_max_retries,
+            3
+        );
     }
 }

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__dashboard__home_screen_baseline.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__dashboard__home_screen_baseline.snap
@@ -1,5 +1,6 @@
 ---
 source: src/tui/snapshot_tests/dashboard.rs
+assertion_line: 27
 expression: terminal.backend()
 ---
 "────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────"
@@ -20,10 +21,10 @@ expression: terminal.backend()
 "║  [s]  Status                     ║║                                        ║║                                        ║"
 "║  [c]  Cost Report                ║║                                        ║║                                        ║"
 "║  [t]  Token Report               ║║                                        ║║                                        ║"
+"║  [Q]  TurboQuant Savings         ║║                                        ║║                                        ║"
 "║  [S]  Settings                   ║║                                        ║║                                        ║"
 "║  [u]  Update Maestro             ║║                                        ║║                                        ║"
 "║  [q]  Quit                       ║║                                        ║║                                        ║"
-"║                                  ║║                                        ║║                                        ║"
 "║                                  ║║                                        ║║                                        ║"
 "║                                  ║║                                        ║║                                        ║"
 "║                                  ║║                                        ║║                                        ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__dashboard__home_screen_selected_action.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__dashboard__home_screen_selected_action.snap
@@ -1,5 +1,6 @@
 ---
 source: src/tui/snapshot_tests/dashboard.rs
+assertion_line: 78
 expression: terminal.backend()
 ---
 "────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────"
@@ -20,10 +21,10 @@ expression: terminal.backend()
 "║  [s]  Status                     ║║                                        ║║                                        ║"
 "║  [c]  Cost Report                ║║                                        ║║                                        ║"
 "║  [t]  Token Report               ║║                                        ║║                                        ║"
+"║  [Q]  TurboQuant Savings         ║║                                        ║║                                        ║"
 "║  [S]  Settings                   ║║                                        ║║                                        ║"
 "║  [u]  Update Maestro             ║║                                        ║║                                        ║"
 "║  [q]  Quit                       ║║                                        ║║                                        ║"
-"║                                  ║║                                        ║║                                        ║"
 "║                                  ║║                                        ║║                                        ║"
 "║                                  ║║                                        ║║                                        ║"
 "║                                  ║║                                        ║║                                        ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__dashboard__home_screen_with_suggestions.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__dashboard__home_screen_with_suggestions.snap
@@ -1,5 +1,6 @@
 ---
 source: src/tui/snapshot_tests/dashboard.rs
+assertion_line: 62
 expression: terminal.backend()
 ---
 "────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────"
@@ -20,10 +21,10 @@ expression: terminal.backend()
 "║  [s]  Status                     ║║                                        ║║                                        ║"
 "║  [c]  Cost Report                ║║                                        ║║                                        ║"
 "║  [t]  Token Report               ║║                                        ║║                                        ║"
+"║  [Q]  TurboQuant Savings         ║║                                        ║║                                        ║"
 "║  [S]  Settings                   ║║                                        ║║                                        ║"
 "║  [u]  Update Maestro             ║║                                        ║║                                        ║"
 "║  [q]  Quit                       ║║                                        ║║                                        ║"
-"║                                  ║║                                        ║║                                        ║"
 "║                                  ║║                                        ║║                                        ║"
 "║                                  ║║                                        ║║                                        ║"
 "║                                  ║║                                        ║║                                        ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__dashboard__home_screen_with_warnings.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__dashboard__home_screen_with_warnings.snap
@@ -1,5 +1,6 @@
 ---
 source: src/tui/snapshot_tests/dashboard.rs
+assertion_line: 46
 expression: terminal.backend()
 ---
 "────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────"
@@ -23,10 +24,10 @@ expression: terminal.backend()
 "║  [s]  Status                     ║║                                        ║║                                        ║"
 "║  [c]  Cost Report                ║║                                        ║║                                        ║"
 "║  [t]  Token Report               ║║                                        ║║                                        ║"
+"║  [Q]  TurboQuant Savings         ║║                                        ║║                                        ║"
 "║  [S]  Settings                   ║║                                        ║║                                        ║"
 "║  [u]  Update Maestro             ║║                                        ║║                                        ║"
 "║  [q]  Quit                       ║║                                        ║║                                        ║"
-"║                                  ║║                                        ║║                                        ║"
 "║                                  ║║                                        ║║                                        ║"
 "║                                  ║║                                        ║║                                        ║"
 "║                                  ║║                                        ║║                                        ║"

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -910,12 +910,12 @@ fn draw_confirm_exit_overlay(
         Line::from(""),
         Line::from(vec![
             Span::styled("  [y]", Style::default().fg(theme.accent_success)),
-            Span::raw("es / "),
-            Span::styled("[Enter]", Style::default().fg(theme.accent_success)),
-            Span::raw("  "),
+            Span::raw("es  "),
             Span::styled("[n]", Style::default().fg(theme.accent_error)),
             Span::raw("o / "),
             Span::styled("[Esc]", Style::default().fg(theme.accent_error)),
+            Span::raw(" / "),
+            Span::styled("[Enter]", Style::default().fg(theme.accent_error)),
         ]),
     ];
 


### PR DESCRIPTION
## Summary

Implements the configurable hollow-retry policy from #275 **and** fixes a class of TUI keybinding drift bugs discovered while testing it. Both sets of changes share the same structural theme: one concept, one declaration, no drift.

### #275 — hollow retry policy

- New `[sessions.hollow_retry]` config section with `policy` = `always` / `intent-aware` / `never`, plus `work_max_retries` and `consultation_max_retries`.
- Default: `intent-aware` with work=2, consultation=0 — work prompts retry, consultation Q&A never does.
- **Backward compatible**: legacy flat `sessions.hollow_max_retries = N` still parses (via a custom `Deserialize` + `merge_legacy_hollow` pure fn) and maps to `work_max_retries`; a one-shot `tracing::warn!` fires if both are set.
- Settings screen gains a policy dropdown + per-intent steppers.
- `RetryPolicy::effective_max` dispatches by policy × intent × is_hollow.
- `completion_pipeline.rs` switched from the raw flat field to `effective_max(session)` — the HollowRetryScreen now shows the correct per-intent limit.

### Drift-class TUI bug fixes

Every bug below traced to the same root cause: a keybinding's label and dispatch declared in separate hand-maintained tables with no compile-time link.

| Fix | Before | After |
|---|---|---|
| **F-keys** | `FKeyRelevance` label + `match n` dispatch in two files. F6 labeled "Deps" but from Dashboard dispatched to Overview. | `FKeyRelevance` carries `action: FKeyAction`; dispatch reads from the same struct. Adding a key is one `FKeyRelevance::new(...)`. |
| **Quick Actions** | `QUICK_ACTIONS` (label+key) and `execute_selected_action` (index→action) were separate. Inserting a row shifted Enter-dispatch for everything below. Enter on `[Q] TurboQuant` opened Settings. | `QUICK_ACTIONS` carries `QuickActionDispatch`; `execute_selected_action` is a table lookup; keyboard handler is a `find` on the same table; `QUIT_ACTION_INDEX` is compile-time-derived. |
| **`navigate_to`** | Pushed current mode unconditionally. Breadcrumbs accumulated `Tokens > Tokens > Tokens` on repeated F5; A → B → A left stack as `[A, B]` so Esc returned to B. | Same-mode nav is a no-op; if target is in stack, truncate to it. Breadcrumbs stay clean; Esc returns to the real previous screen. |
| **Confirm-exit Enter** | Enter confirmed "yes". Opening the dialog by Enter-on-menu and reflexively pressing Enter again silently killed the app. | Only `y` / `Y` confirms. Enter / n / Esc all cancel. Standard destructive-action default. |
| **TurboQuant dashboard discoverability** | Existed but only reachable via `Shift+Q` (unadvertised). | `[Q] TurboQuant Savings` entry in Quick Actions + `[Q] TurboQuant` hint in Dashboard status bar. |

### Tests

- 2787 passing (was 2766 pre-change).
- New drift-guard tests: every advertised hint dispatches to its label's target; Enter and letter-key dispatch the same `ScreenAction` for every Quick Action; F-bar F4/F5/F6 each reach the mode their label advertises; `navigate_to` idempotency + cycle collapse; confirm-exit Enter-cancels-regression.
- 31 new tests for the #275 config surface (policy × intent matrix, serde round-trip, backward-compat merge, settings widget sync).

Closes #275

## Test plan

- [ ] `cargo test --bin maestro` — 2787 passing, none failing.
- [ ] Resize terminal, press F-keys: F4 → Costs, F5 → Tokens, F6 → Deps.
- [ ] Press F5 five times while on Tokens — breadcrumb stays clean (not `Tokens > Tokens > Tokens > …`).
- [ ] On Dashboard, select `[q] Quit`, press Enter — confirm dialog opens and Enter cancels (only `y` exits).
- [ ] On Dashboard, press `Q` — TurboQuant Savings dashboard opens.
- [ ] Legacy config with top-level `hollow_max_retries = 3` still loads; `RetryPolicy` routes work prompts through 3 retries, consultations through 0.
- [ ] New config `[sessions.hollow_retry] policy = "never"` parses and blocks all hollow retries.
- [ ] Settings screen Sessions tab shows the three new widgets; changing them persists to config.