### PR TITLE
chore: release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,30 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-04-21
+
 ### Added
 
+- Fork-handoff compression — `compress_handoff()` on `TurboQuantAdapter` produces a `CompressedHandoff` struct; integrated into `ForkPolicy` to keep continuation prompts within a configurable token budget (#343)
+- System-prompt compaction — `compact_system_prompt()` on `TurboQuantAdapter`; integrated into `SessionPool::try_promote` to trim oversized system prompts before session launch (#344)
+- State compression — `compact_session_history()` on `TurboQuantAdapter` returns a `StateCompactionReport`; `MaestroState::compact()` and `StateStore::save_compacted()` persist trimmed state (#345)
+- Knowledge compression in `maestro adapt` — new `src/adapt/knowledge.rs` module (Phase 2.6); produces a token-budgeted `KnowledgeBase` and writes `.maestro/knowledge.md`; auto-loaded by `SessionPool::try_promote` as a system-prompt component (#347)
 - TurboQuant savings projections dashboard — `src/tui/turboquant_dashboard.rs`; shows "Estimated Savings (projection)" when no fork-handoff compression data exists, "Actual Savings" once real handoff metrics are present; per-session `ACTUAL` / `proj.` kind markers; aggregate token and USD totals (#346)
 - `SavingsProjection`, `SavingsKind`, `SessionSavings` public types and `project_savings()`, `session_savings()`, `implied_rate_per_token()` free functions in `src/turboquant/adapter.rs` (#346)
 - `tq_handoff_original_tokens` and `tq_handoff_compressed_tokens` fields on `Session` (with `#[serde(default)]` for backward compat) — populated by `context_overflow.rs` after fork-handoff compression so the dashboard can surface real savings (#346)
 - 3 new snapshot tests for `TurboQuantDashboard` (projections-only, mixed actual+projections, empty sessions) in `src/tui/snapshot_tests/turboquant_dashboard.rs` (#346)
+- `TextRanker` trait and impl in `src/turboquant/adapter.rs` — shared text scoring primitive used by all compression paths
+- `TokenBudget` helper in `src/turboquant/budget.rs` — greedy ranked-segment selection under a token limit; `BudgetSelection` struct (indices, tokens_used, truncated_first)
+- Three new `TurboQuantConfig` fields: `fork_handoff_budget`, `system_prompt_budget`, `knowledge_budget` (token-limit knobs for each compression feature)
+- Shared `Arc<TurboQuantAdapter>` on `App` — single adapter instance reused across all compression features
+- Session intent classification (`work` vs `consultation`) used to drive retry decisions (#273)
+- Skip hollow retry for consultation/Q&A prompts — no retry loop for questions (#274)
 - `[sessions.hollow_retry]` config section with three policies: `always`, `intent-aware` (default), and `never`; replaces the flat `sessions.hollow_max_retries` field (#275)
 - `HollowRetryPolicy` enum and `HollowRetryConfig` struct in `src/config.rs`; `merge_legacy_hollow()` pure function for backward-compatible TOML parsing (#275)
 - Per-intent retry limits: `work_max_retries` (default 2) and `consultation_max_retries` (default 0) under `[sessions.hollow_retry]` (#275)
 - Settings UI hollow-retry section in the Sessions tab: `[policy]` dropdown, `[work_max_retries]` stepper, `[consultation_max_retries]` stepper (#275)
+- Interactive follow-up after `maestro adapt` — selectable next actions menu (#391)
+- PRD source selection in adapt — local file, GitHub issue, or Azure DevOps work item (#390)
 
 ### Changed
 
@@ -29,18 +43,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 > **Backward compatibility**: existing `sessions.hollow_max_retries = N` in `maestro.toml` still parses and maps to `work_max_retries = N` with policy `intent-aware`.
 
-## [0.14.0] - 2026-04-17
+### Fixed
 
-### Added
-
-- Fork-handoff compression — `compress_handoff()` on `TurboQuantAdapter` produces a `CompressedHandoff` struct; integrated into `ForkPolicy` to keep continuation prompts within a configurable token budget (#343)
-- System-prompt compaction — `compact_system_prompt()` on `TurboQuantAdapter`; integrated into `SessionPool::try_promote` to trim oversized system prompts before session launch (#344)
-- State compression — `compact_session_history()` on `TurboQuantAdapter` returns a `StateCompactionReport`; `MaestroState::compact()` and `StateStore::save_compacted()` persist trimmed state (#345)
-- Knowledge compression in `maestro adapt` — new `src/adapt/knowledge.rs` module (Phase 2.6); produces a token-budgeted `KnowledgeBase` and writes `.maestro/knowledge.md`; auto-loaded by `SessionPool::try_promote` as a system-prompt component (#347)
-- `TextRanker` trait and impl in `src/turboquant/adapter.rs` — shared text scoring primitive used by all compression paths
-- `TokenBudget` helper in `src/turboquant/budget.rs` — greedy ranked-segment selection under a token limit; `BudgetSelection` struct (indices, tokens_used, truncated_first)
-- Three new `TurboQuantConfig` fields: `fork_handoff_budget`, `system_prompt_budget`, `knowledge_budget` (token-limit knobs for each compression feature)
-- Shared `Arc<TurboQuantAdapter>` on `App` — single adapter instance reused across all compression features
+- Marquee-scroll the stats bar when the repo/branch line overflows the viewport width (#410)
 
 ### Security
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maestro"
-version = "0.13.1"
+version = "0.14.0"
 edition = "2024"
 rust-version = "1.89"
 description = "Multi-session Claude Code orchestrator with Matrix-style TUI"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__dashboard__home_screen_baseline.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__dashboard__home_screen_baseline.snap
@@ -1,16 +1,15 @@
 ---
 source: src/tui/snapshot_tests/dashboard.rs
-assertion_line: 27
 expression: terminal.backend()
 ---
 "────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────"
 "  owner/repo   main   @carlos  │  Loading...                                                                         "
 "────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────"
-"╔══════════════════════════════════════════════[ What's New in v0.13.1 ]═══════════════════════════════════════════════╗"
-"║  [Added] Configurable milestone naming convention in adapt settings (#368)                                           ║"
-"║  [Added] PRD generator — standalone command + adapt integration (#370)                                               ║"
-"║  [Added] Adapt AI scaffolding phase — generate .claude/ commands, skills, and subagents for target project (#371)    ║"
-"║  [Changed] Add runtime state files to `.gitignore` (#352)                                                            ║"
+"╔══════════════════════════════════════════════[ What's New in v0.14.0 ]═══════════════════════════════════════════════╗"
+"║  [Added] Fork-handoff compression — `compress_handoff()` on `TurboQuantAdapter` produces a `CompressedHandoff` str...║"
+"║  [Added] System-prompt compaction — `compact_system_prompt()` on `TurboQuantAdapter`; integrated into `SessionPool...║"
+"║  [Added] State compression — `compact_session_history()` on `TurboQuantAdapter` returns a `StateCompactionReport`;...║"
+"║  [Added] Knowledge compression in `maestro adapt` — new `src/adapt/knowledge.rs` module (Phase 2.6); produces a to...║"
 "╚══════════════════════════════════════════ Press [n] for full release notes ══════════════════════════════════════════╝"
 "╔════════[ Quick Actions ]═════════╗╔════════════[ Suggestions ]═════════════╗╔══════════[ Recent Activity ]═══════════╗"
 "║  [i]  Browse Issues              ║║  No suggestions — everything looks good║║  No recent sessions                    ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__dashboard__home_screen_selected_action.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__dashboard__home_screen_selected_action.snap
@@ -1,16 +1,15 @@
 ---
 source: src/tui/snapshot_tests/dashboard.rs
-assertion_line: 78
 expression: terminal.backend()
 ---
 "────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────"
 "  owner/repo   main   @carlos  │  Loading...                                                                         "
 "────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────"
-"╔══════════════════════════════════════════════[ What's New in v0.13.1 ]═══════════════════════════════════════════════╗"
-"║  [Added] Configurable milestone naming convention in adapt settings (#368)                                           ║"
-"║  [Added] PRD generator — standalone command + adapt integration (#370)                                               ║"
-"║  [Added] Adapt AI scaffolding phase — generate .claude/ commands, skills, and subagents for target project (#371)    ║"
-"║  [Changed] Add runtime state files to `.gitignore` (#352)                                                            ║"
+"╔══════════════════════════════════════════════[ What's New in v0.14.0 ]═══════════════════════════════════════════════╗"
+"║  [Added] Fork-handoff compression — `compress_handoff()` on `TurboQuantAdapter` produces a `CompressedHandoff` str...║"
+"║  [Added] System-prompt compaction — `compact_system_prompt()` on `TurboQuantAdapter`; integrated into `SessionPool...║"
+"║  [Added] State compression — `compact_session_history()` on `TurboQuantAdapter` returns a `StateCompactionReport`;...║"
+"║  [Added] Knowledge compression in `maestro adapt` — new `src/adapt/knowledge.rs` module (Phase 2.6); produces a to...║"
 "╚══════════════════════════════════════════ Press [n] for full release notes ══════════════════════════════════════════╝"
 "╔════════[ Quick Actions ]═════════╗╔════════════[ Suggestions ]═════════════╗╔══════════[ Recent Activity ]═══════════╗"
 "║  [i]  Browse Issues              ║║  No suggestions — everything looks good║║  No recent sessions                    ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__dashboard__home_screen_with_suggestions.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__dashboard__home_screen_with_suggestions.snap
@@ -1,16 +1,15 @@
 ---
 source: src/tui/snapshot_tests/dashboard.rs
-assertion_line: 62
 expression: terminal.backend()
 ---
 "────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────"
 "  owner/repo   main   @carlos  │  Loading...                                                                         "
 "────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────"
-"╔══════════════════════════════════════════════[ What's New in v0.13.1 ]═══════════════════════════════════════════════╗"
-"║  [Added] Configurable milestone naming convention in adapt settings (#368)                                           ║"
-"║  [Added] PRD generator — standalone command + adapt integration (#370)                                               ║"
-"║  [Added] Adapt AI scaffolding phase — generate .claude/ commands, skills, and subagents for target project (#371)    ║"
-"║  [Changed] Add runtime state files to `.gitignore` (#352)                                                            ║"
+"╔══════════════════════════════════════════════[ What's New in v0.14.0 ]═══════════════════════════════════════════════╗"
+"║  [Added] Fork-handoff compression — `compress_handoff()` on `TurboQuantAdapter` produces a `CompressedHandoff` str...║"
+"║  [Added] System-prompt compaction — `compact_system_prompt()` on `TurboQuantAdapter`; integrated into `SessionPool...║"
+"║  [Added] State compression — `compact_session_history()` on `TurboQuantAdapter` returns a `StateCompactionReport`;...║"
+"║  [Added] Knowledge compression in `maestro adapt` — new `src/adapt/knowledge.rs` module (Phase 2.6); produces a to...║"
 "╚══════════════════════════════════════════ Press [n] for full release notes ══════════════════════════════════════════╝"
 "╔════════[ Quick Actions ]═════════╗╔════════════[ Suggestions ]═════════════╗╔══════════[ Recent Activity ]═══════════╗"
 "║  [i]  Browse Issues              ║║  󰝦 3 issues labeled maestro:ready — pre║║  No recent sessions                    ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__dashboard__home_screen_with_warnings.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__dashboard__home_screen_with_warnings.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tui/snapshot_tests/dashboard.rs
-assertion_line: 46
 expression: terminal.backend()
 ---
 "────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────"
@@ -9,11 +8,11 @@ expression: terminal.backend()
 "╔═════════════════════════════════════════════════════[ Warnings ]═════════════════════════════════════════════════════╗"
 "║  ! Budget 90% consumed                                                                                               ║"
 "╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝"
-"╔══════════════════════════════════════════════[ What's New in v0.13.1 ]═══════════════════════════════════════════════╗"
-"║  [Added] Configurable milestone naming convention in adapt settings (#368)                                           ║"
-"║  [Added] PRD generator — standalone command + adapt integration (#370)                                               ║"
-"║  [Added] Adapt AI scaffolding phase — generate .claude/ commands, skills, and subagents for target project (#371)    ║"
-"║  [Changed] Add runtime state files to `.gitignore` (#352)                                                            ║"
+"╔══════════════════════════════════════════════[ What's New in v0.14.0 ]═══════════════════════════════════════════════╗"
+"║  [Added] Fork-handoff compression — `compress_handoff()` on `TurboQuantAdapter` produces a `CompressedHandoff` str...║"
+"║  [Added] System-prompt compaction — `compact_system_prompt()` on `TurboQuantAdapter`; integrated into `SessionPool...║"
+"║  [Added] State compression — `compact_session_history()` on `TurboQuantAdapter` returns a `StateCompactionReport`;...║"
+"║  [Added] Knowledge compression in `maestro adapt` — new `src/adapt/knowledge.rs` module (Phase 2.6); produces a to...║"
 "╚══════════════════════════════════════════ Press [n] for full release notes ══════════════════════════════════════════╝"
 "╔════════[ Quick Actions ]═════════╗╔════════════[ Suggestions ]═════════════╗╔══════════[ Recent Activity ]═══════════╗"
 "║  [i]  Browse Issues              ║║  No suggestions — everything looks good║║  No recent sessions                    ║"


### PR DESCRIPTION
## Summary

Release cut for **v0.14.0 — TurboQuant Realistic Integration**.

- Bumps `Cargo.toml` from `0.13.1` → `0.14.0`
- Merges staged `[Unreleased]` content into a consolidated `[0.14.0] - 2026-04-21` section
- Adds changelog entries for the milestone issues that landed after the initial 0.14.0 draft (#273, #274, #390, #391, #410)

Tag `v0.14.0` is already pushed and the release workflow is building binaries. Milestone #24 will be closed after this PR merges.

## Closed milestone: v0.14.0

21 issues — #343, #344, #345, #346, #347, #273, #274, #275, #390, #391, #410 plus merge/tracking items.

## Test plan

- [x] `cargo test` — 2802 passed
- [x] `cargo clippy -- -D warnings -A dead_code` — clean
- [x] `cargo fmt -- --check` — clean
- [ ] Release workflow produces binaries for all targets