### PR TITLE
feat(hooks): implement-gates.sh pre-check hook + bats suite (Chunk 3)

### DIFF
--- a/.claude/hooks/implement-gates.sh
+++ b/.claude/hooks/implement-gates.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Pre-check hook for /implement.
+# Argument: $1 = issue number.
+
+set -euo pipefail
+
+issue_number="${1:-}"
+
+if [ -z "$issue_number" ]; then
+  echo "implement-gates: issue number required as first argument" >&2
+  exit 1
+fi
+
+# Gate 1: must be inside a git repo.
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "implement-gates: not inside a git repository" >&2
+  exit 1
+fi

--- a/.claude/hooks/implement-gates.sh
+++ b/.claude/hooks/implement-gates.sh
@@ -50,3 +50,22 @@ if [ "$issue_state" = "CLOSED" ]; then
   echo "implement-gates: Issue #${issue_number} is CLOSED. Re-open or pick a different issue." >&2
   exit 1
 fi
+
+# Gate 6: working tree must be clean, or user must confirm stash.
+if [ -n "$(git status --porcelain)" ]; then
+  echo "implement-gates: Working tree has uncommitted changes"
+  git status --short
+  echo ""
+  echo "(S)tash and continue, (A)bort"
+  read -r choice
+  case "$choice" in
+    S|s)
+      git stash push -m "auto-stash before /implement #${issue_number}"
+      echo "implement-gates: stashed as 'auto-stash before /implement #${issue_number}'"
+      ;;
+    *)
+      echo "implement-gates: aborting on dirty tree"
+      exit 6
+      ;;
+  esac
+fi

--- a/.claude/hooks/implement-gates.sh
+++ b/.claude/hooks/implement-gates.sh
@@ -28,3 +28,18 @@ if ! gh auth status >/dev/null 2>&1; then
   echo "implement-gates: gh not authenticated. Run: gh auth login" >&2
   exit 1
 fi
+
+# Gate 4: fetch and cache the issue JSON.
+GATE_LOG_DIR="/tmp/maestro-${issue_number}-$(date +%s)"
+mkdir -p "$GATE_LOG_DIR"
+echo "gate log dir: $GATE_LOG_DIR"
+
+if ! gh issue view "$issue_number" \
+  --json title,body,labels,assignees,milestone,state,comments \
+  > "$GATE_LOG_DIR/issue.json" 2>"$GATE_LOG_DIR/gh-error.log"; then
+  echo "implement-gates: failed to fetch issue #${issue_number}" >&2
+  cat "$GATE_LOG_DIR/gh-error.log" >&2
+  exit 1
+fi
+
+export GATE_LOG_DIR

--- a/.claude/hooks/implement-gates.sh
+++ b/.claude/hooks/implement-gates.sh
@@ -22,3 +22,9 @@ if ! command -v gh >/dev/null 2>&1; then
   echo "implement-gates: gh CLI not installed. Install: brew install gh" >&2
   exit 1
 fi
+
+# Gate 3: gh must be authenticated.
+if ! gh auth status >/dev/null 2>&1; then
+  echo "implement-gates: gh not authenticated. Run: gh auth login" >&2
+  exit 1
+fi

--- a/.claude/hooks/implement-gates.sh
+++ b/.claude/hooks/implement-gates.sh
@@ -77,3 +77,15 @@ if ! cargo test --quiet > "$GATE_LOG_DIR/baseline.log" 2>&1; then
   echo "implement-gates: See $GATE_LOG_DIR/baseline.log" >&2
   exit 2
 fi
+
+# Gate 8 (optional): preflight bridge.
+if [ -x .claude/hooks/preflight.sh ]; then
+  set +e
+  bash .claude/hooks/preflight.sh
+  preflight_exit=$?
+  set -e
+  if [ $preflight_exit -ne 0 ]; then
+    echo "implement-gates: Pre-flight CI checks failed. Fix before starting a new branch." >&2
+    exit $preflight_exit
+  fi
+fi

--- a/.claude/hooks/implement-gates.sh
+++ b/.claude/hooks/implement-gates.sh
@@ -69,3 +69,11 @@ if [ -n "$(git status --porcelain)" ]; then
       ;;
   esac
 fi
+
+# Gate 7: baseline cargo test must be green.
+if ! cargo test --quiet > "$GATE_LOG_DIR/baseline.log" 2>&1; then
+  echo "implement-gates: BASELINE NOT GREEN — existing tests are failing before /implement ran." >&2
+  echo "implement-gates: The RED gate would pass for the wrong reason. Fix baseline first." >&2
+  echo "implement-gates: See $GATE_LOG_DIR/baseline.log" >&2
+  exit 2
+fi

--- a/.claude/hooks/implement-gates.sh
+++ b/.claude/hooks/implement-gates.sh
@@ -16,3 +16,9 @@ if ! git rev-parse --git-dir >/dev/null 2>&1; then
   echo "implement-gates: not inside a git repository" >&2
   exit 1
 fi
+
+# Gate 2: gh CLI must be installed.
+if ! command -v gh >/dev/null 2>&1; then
+  echo "implement-gates: gh CLI not installed. Install: brew install gh" >&2
+  exit 1
+fi

--- a/.claude/hooks/implement-gates.sh
+++ b/.claude/hooks/implement-gates.sh
@@ -43,3 +43,10 @@ if ! gh issue view "$issue_number" \
 fi
 
 export GATE_LOG_DIR
+
+# Gate 5: issue must not be CLOSED.
+issue_state=$(python3 -c "import json; print(json.load(open('$GATE_LOG_DIR/issue.json'))['state'])")
+if [ "$issue_state" = "CLOSED" ]; then
+  echo "implement-gates: Issue #${issue_number} is CLOSED. Re-open or pick a different issue." >&2
+  exit 1
+fi

--- a/tests/hooks/fixtures/fake-cargo.sh
+++ b/tests/hooks/fixtures/fake-cargo.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Test fixture: PATH-shim for `cargo`.
+#
+# Environment variables:
+#   FAKE_CARGO_TEST_EXIT — exit code for `cargo test` (default: 0)
+#   FAKE_CARGO_TEST_OUT  — stdout to print (default: "test result: ok")
+#
+# Supports only: cargo test (with any args).
+
+cmd="${1:-}"
+
+if [ "$cmd" = "test" ]; then
+  echo "${FAKE_CARGO_TEST_OUT:-test result: ok. 5 passed; 0 failed; 0 ignored}"
+  exit "${FAKE_CARGO_TEST_EXIT:-0}"
+fi
+
+echo "fake-cargo: unsupported subcommand '$cmd'" >&2
+exit 2

--- a/tests/hooks/fixtures/fake-gh.sh
+++ b/tests/hooks/fixtures/fake-gh.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Test fixture: PATH-shim for `gh` CLI.
+#
+# Environment variables consumed:
+#   FAKE_GH_AUTH_STATUS   — "authed" (default) or "unauthed"
+#   FAKE_GH_ISSUE_STATE   — "OPEN" (default) or "CLOSED"
+#   FAKE_GH_ISSUE_BODY    — body to return (default: minimal issue)
+#   FAKE_GH_RETURN_CODE   — exit code for the subcommand (default: 0)
+#
+# Supports: gh auth status, gh issue view
+
+set -euo pipefail
+
+cmd="${1:-}"
+sub="${2:-}"
+
+if [ "$cmd" = "auth" ] && [ "$sub" = "status" ]; then
+  if [ "${FAKE_GH_AUTH_STATUS:-authed}" = "authed" ]; then
+    echo "github.com"
+    echo "  ✓ Logged in to github.com as test-user"
+    exit 0
+  else
+    echo "You are not logged into any GitHub hosts." >&2
+    exit 1
+  fi
+fi
+
+if [ "$cmd" = "issue" ] && [ "$sub" = "view" ]; then
+  cat <<EOF
+{
+  "title": "test issue",
+  "body": "${FAKE_GH_ISSUE_BODY:-## Overview\nTest\n## Expected Behavior\nTest\n## Acceptance Criteria\n- [ ] Test\n## Files to Modify\n- src/lib.rs\n## Test Hints\n- None\n## Blocked By\n- None\n## Definition of Done\n- [ ] Tests pass}",
+  "labels": [{"name": "type:feature"}],
+  "assignees": [],
+  "milestone": null,
+  "state": "${FAKE_GH_ISSUE_STATE:-OPEN}",
+  "comments": []
+}
+EOF
+  exit "${FAKE_GH_RETURN_CODE:-0}"
+fi
+
+echo "fake-gh: unsupported subcommand '$cmd $sub'" >&2
+exit 2

--- a/tests/hooks/fixtures/init-test-repo.sh
+++ b/tests/hooks/fixtures/init-test-repo.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Test fixture: create a scratch git repo in a temp dir.
+# Prints the temp dir path to stdout.
+
+set -euo pipefail
+
+tmp=$(mktemp -d -t maestro-gate-test-XXXXXX)
+cd "$tmp"
+git init -q
+git config user.email "test@example.com"
+git config user.name "Test User"
+# Seed with an initial commit so `git status` behaves like a real repo.
+touch README.md
+git add README.md
+git commit -q -m "init"
+echo "$tmp"

--- a/tests/hooks/implement-gates.bats
+++ b/tests/hooks/implement-gates.bats
@@ -47,3 +47,11 @@ teardown() {
   [[ "$output" == *"gh CLI not installed"* ]]
   [[ "$output" == *"brew install gh"* ]]
 }
+
+@test "exits 1 when gh is not authenticated" {
+  export FAKE_GH_AUTH_STATUS=unauthed
+  run bash "$HOOK" 123
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"gh not authenticated"* ]]
+  [[ "$output" == *"gh auth login"* ]]
+}

--- a/tests/hooks/implement-gates.bats
+++ b/tests/hooks/implement-gates.bats
@@ -55,3 +55,11 @@ teardown() {
   [[ "$output" == *"gh not authenticated"* ]]
   [[ "$output" == *"gh auth login"* ]]
 }
+
+@test "caches issue JSON to GATE_LOG_DIR/issue.json" {
+  run bash "$HOOK" 123
+  [[ "$output" == *"/tmp/maestro-123-"* ]]
+  log_dir=$(echo "$output" | grep -oE '/tmp/maestro-123-[0-9]+' | head -1)
+  [ -f "$log_dir/issue.json" ]
+  python3 -c "import json; json.load(open('$log_dir/issue.json'))"
+}

--- a/tests/hooks/implement-gates.bats
+++ b/tests/hooks/implement-gates.bats
@@ -77,3 +77,28 @@ teardown() {
   [ "$status" -eq 6 ]
   [[ "$output" == *"Working tree has uncommitted changes"* ]]
 }
+
+@test "exits 2 when baseline cargo test fails" {
+  export FAKE_CARGO_TEST_EXIT=1
+  export FAKE_CARGO_TEST_OUT="test result: FAILED. 3 passed; 2 failed; 0 ignored"
+  run bash "$HOOK" 123
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"BASELINE NOT GREEN"* ]]
+}
+
+@test "continues past baseline when cargo test is green" {
+  export FAKE_CARGO_TEST_EXIT=0
+  run bash "$HOOK" 123
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"gate log dir"* ]]
+}
+
+@test "dirty tree with (S)tash stashes and continues past baseline" {
+  echo "dirty" > new-file.txt
+  git add new-file.txt
+  export FAKE_CARGO_TEST_EXIT=0
+  run bash -c "echo 'S' | bash '$HOOK' 123"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"stashed as 'auto-stash before /implement #123'"* ]]
+  [ -n "$(git stash list | grep 'auto-stash before /implement #123')" ]
+}

--- a/tests/hooks/implement-gates.bats
+++ b/tests/hooks/implement-gates.bats
@@ -102,3 +102,42 @@ teardown() {
   [[ "$output" == *"stashed as 'auto-stash before /implement #123'"* ]]
   [ -n "$(git stash list | grep 'auto-stash before /implement #123')" ]
 }
+
+@test "calls preflight.sh when present and propagates exit code on failure" {
+  mkdir -p .claude/hooks
+  cat > .claude/hooks/preflight.sh <<'PFEOF'
+#!/usr/bin/env bash
+echo "preflight: simulated ci fail"
+exit 7
+PFEOF
+  chmod +x .claude/hooks/preflight.sh
+  git add .claude/hooks/preflight.sh
+  git commit -m "test: add failing preflight.sh"
+  export FAKE_CARGO_TEST_EXIT=0
+  run bash "$HOOK" 123
+  [ "$status" -eq 7 ]
+  [[ "$output" == *"Pre-flight CI checks failed"* ]]
+}
+
+@test "calls preflight.sh when present and passes on exit 0" {
+  mkdir -p .claude/hooks
+  cat > .claude/hooks/preflight.sh <<'PFEOF'
+#!/usr/bin/env bash
+echo "preflight: all clear"
+exit 0
+PFEOF
+  chmod +x .claude/hooks/preflight.sh
+  git add .claude/hooks/preflight.sh
+  git commit -m "test: add passing preflight.sh"
+  export FAKE_CARGO_TEST_EXIT=0
+  run bash "$HOOK" 123
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"preflight: all clear"* ]]
+}
+
+@test "silently skips when preflight.sh is absent" {
+  export FAKE_CARGO_TEST_EXIT=0
+  run bash "$HOOK" 123
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"preflight"* ]]
+}

--- a/tests/hooks/implement-gates.bats
+++ b/tests/hooks/implement-gates.bats
@@ -31,3 +31,10 @@ teardown() {
 }
 
 # --- tests defined below, one per task ---
+
+@test "exits 1 when not in a git repo" {
+  cd "$(mktemp -d -t non-repo-XXXXXX)"
+  run bash "$HOOK" 123
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"not inside a git repository"* ]]
+}

--- a/tests/hooks/implement-gates.bats
+++ b/tests/hooks/implement-gates.bats
@@ -38,3 +38,12 @@ teardown() {
   [ "$status" -eq 1 ]
   [[ "$output" == *"not inside a git repository"* ]]
 }
+
+@test "exits 1 when gh CLI is not installed" {
+  # Use a clean PATH without the shim dir.
+  export PATH="/bin:/usr/bin"
+  run bash "$HOOK" 123
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"gh CLI not installed"* ]]
+  [[ "$output" == *"brew install gh"* ]]
+}

--- a/tests/hooks/implement-gates.bats
+++ b/tests/hooks/implement-gates.bats
@@ -70,3 +70,10 @@ teardown() {
   [ "$status" -eq 1 ]
   [[ "$output" == *"Issue #123 is CLOSED"* ]]
 }
+
+@test "exits 6 on dirty tree when user chooses (A)bort" {
+  echo "dirty" > new-file.txt
+  run bash -c "echo 'A' | bash '$HOOK' 123"
+  [ "$status" -eq 6 ]
+  [[ "$output" == *"Working tree has uncommitted changes"* ]]
+}

--- a/tests/hooks/implement-gates.bats
+++ b/tests/hooks/implement-gates.bats
@@ -63,3 +63,10 @@ teardown() {
   [ -f "$log_dir/issue.json" ]
   python3 -c "import json; json.load(open('$log_dir/issue.json'))"
 }
+
+@test "exits 1 when issue is CLOSED" {
+  export FAKE_GH_ISSUE_STATE=CLOSED
+  run bash "$HOOK" 123
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Issue #123 is CLOSED"* ]]
+}

--- a/tests/hooks/implement-gates.bats
+++ b/tests/hooks/implement-gates.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+#
+# Tests for .claude/hooks/implement-gates.sh
+#
+# Each test:
+#   1. Creates a scratch git repo (via init-test-repo.sh).
+#   2. Sets up PATH with fake-gh.sh and fake-cargo.sh in front.
+#   3. Invokes the hook with environment overrides as needed.
+#   4. Asserts exit code and relevant stdout/stderr.
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  HOOK="$REPO_ROOT/.claude/hooks/implement-gates.sh"
+  FIXTURES="$REPO_ROOT/tests/hooks/fixtures"
+
+  # Make the fakes visible as `gh` and `cargo` on PATH.
+  SHIM_DIR="$(mktemp -d)"
+  ln -s "$FIXTURES/fake-gh.sh" "$SHIM_DIR/gh"
+  ln -s "$FIXTURES/fake-cargo.sh" "$SHIM_DIR/cargo"
+  PATH="$SHIM_DIR:$PATH"
+  export PATH
+
+  # Scratch git repo.
+  TEST_REPO="$("$FIXTURES/init-test-repo.sh")"
+  cd "$TEST_REPO"
+}
+
+teardown() {
+  cd /
+  rm -rf "$TEST_REPO" "$SHIM_DIR"
+}
+
+# --- tests defined below, one per task ---


### PR DESCRIPTION
## Summary

Chunk 3 of the `/implement` harness enforcement rollout — the mechanical pre-check layer invoked as the very first step of the command.

- **`.claude/hooks/implement-gates.sh`**: bash hook with 8 sequential gates. Takes issue number as `$1`, runs every mechanical check the spec defines, caches issue JSON for downstream steps, and exits with spec-defined codes on failure.
- **`tests/hooks/implement-gates.bats`**: 12 bats tests, one per exit-code path. PATH-shim fixtures let the suite run deterministically without network, real `gh`, or real `cargo`.
- **`tests/hooks/fixtures/fake-gh.sh`, `fake-cargo.sh`, `init-test-repo.sh`**: stdlib-only shell shims for bats test setup.

## Gates (in order of invocation)

| # | Gate | Exit |
|---|------|------|
| 1 | Git repo check | 1 if not inside a git repo |
| 2 | `gh` CLI installed | 1 with `brew install gh` hint |
| 3 | `gh` authenticated | 1 with `gh auth login` hint |
| 4 | Fetch issue JSON → `$GATE_LOG_DIR/issue.json` | 1 on fetch failure |
| 5 | Issue not CLOSED | 1 with "re-open or pick a different issue" |
| 6 | Dirty tree → prompt (S)tash / (A)bort | 6 on abort |
| 7 | Baseline `cargo test` green | 2 on failure |
| 8 | `preflight.sh` bridge (optional) | propagates 7+ |

`$GATE_LOG_DIR` is `/tmp/maestro-<issue>-<timestamp>` and holds `issue.json`, `baseline.log`, and `gh-error.log`. Exported for downstream command consumption in Chunk 4.

## Critical design details honored from spec review

- **Preflight bridge uses `set +e` / `set -e` toggle** around `bash preflight.sh` (not bare invocation). Without this, `set -euo pipefail` at top would kill the outer script on non-zero before `preflight_exit=$?` captures the code. Tested with preflight-fail (exit 7), preflight-pass (exit 0), and preflight-absent paths.
- **Baseline gate uses `if !` pattern** for the same `set -e` safety — `cargo test` runs safely inside the conditional.
- **TDD cycles merged where needed**: Tasks 3.8 (dirty-tree abort) and 3.9 (baseline + stash-S) are separate commits; the stash-success test that depends on baseline-green landed in the same commit as baseline-green, avoiding a committed failing test.

## Commits

9 commits:

1. `52f7bc3` test(hooks): scaffold bats suite for implement-gates with PATH shims
2. `074bead` feat(hooks): implement-gates.sh — git-repo gate (exit 1)
3. `9686c0e` feat(hooks): gh-installed gate (exit 1)
4. `e2dc96f` feat(hooks): gh-authed gate (exit 1)
5. `466952d` feat(hooks): fetch and cache issue JSON in GATE_LOG_DIR
6. `67dca7a` feat(hooks): closed-issue gate (exit 1)
7. `0415d90` feat(hooks): dirty-tree gate with abort option (exit 6)
8. `388096e` feat(hooks): baseline-green gate + dirty-tree stash end-to-end
9. `b7f5646` feat(hooks): preflight.sh bridge with set -e-safe exit-code capture

## Test plan

- [x] `bats tests/hooks/implement-gates.bats` → 12 tests pass in ~1s
- [x] Each exit code (1, 2, 6, 7) has a dedicated test
- [x] Dirty tree (A)bort + (S)tash paths both tested end-to-end
- [x] Preflight bridge tested with present+failing, present+passing, absent
- [x] `shellcheck` not installed locally — skipped (would be added in a future CI lint pass)

## Scope

**Included:** hook + bats suite + fixtures.
**Excluded (future chunks):** `/implement` command rewrite (Chunk 4) — the hook is standalone but unused by the command until Chunk 4 wires it in. Acceptance checklist (Chunk 5).

## Next

After merge, Chunk 4 on a fresh branch: rewrite `.claude/commands/implement.md` to invoke this hook as Step 2, wire the gatekeeper (Chunk 2) as Step 4, and add RED/GREEN checkpoints + idempotency prompt + divergence handling.