### PR TITLE
refactor(implement): rewrite command + wire harness into CLAUDE.md (Chunk 4)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -28,24 +28,29 @@
 
 **Orchestrator Mode workflow is ALWAYS (TDD ENFORCED):**
 1. Receive user request
-2. **Verify DOR (Definition of Ready) - MANDATORY:**
-   - Check the issue has all required DOR fields (see section 3)
-   - If missing required fields → comment on issue, apply `needs-info` label, **STOP**
-3. **Delegate to Architect for blueprint - MANDATORY:**
+2. **Pre-check hook (MANDATORY):**
+   - Run `bash .claude/hooks/implement-gates.sh <issue-number>`
+   - Abort on any non-zero exit (see exit-code table in `/implement`)
+3. **Delegate to Gatekeeper (MANDATORY):**
+   - `subagent-gatekeeper` → structured JSON report (DOR, blockers, contracts, task_type)
+   - Parse via `.claude/hooks/parse_gatekeeper_report.py`
+   - On DOR FAIL → orchestrator posts gatekeeper-drafted comment, applies `needs-info` label, **STOP**
+   - On blocker/contract FAIL → **STOP** with reasons from the report
+4. **Delegate to Architect for blueprint - MANDATORY:**
    - `subagent-architect` - For all architecture decisions
    - **NEVER skip architecture step - the architect MUST be called**
-4. **CONTRACT VALIDATION (if task involves API endpoints) - MANDATORY:**
+5. **CONTRACT VALIDATION (if task involves API endpoints) - MANDATORY:**
    - Run `/validate-contracts` to check existing models against `docs/api-contracts/` schemas
    - If no contract schema exists for the endpoint → **STOP and ask user to provide the JSON schema**
    - If contract exists but models mismatch → fix models BEFORE proceeding
-5. **Delegate to QA for test blueprint - MANDATORY (TDD):**
+6. **Delegate to QA for test blueprint - MANDATORY (TDD):**
    - `subagent-qa` - Provides test cases, mocks, and expected behaviors
    - **Tests are designed BEFORE implementation**
-6. **Write tests FIRST (RED)** — verify they fail
-7. **Implement minimum code (GREEN)** — make tests pass
-8. **Refactor** — clean up while tests stay green
-9. Delegate to Security for review of implemented code
-10. Call docs-analyst at the end
+7. **Write tests FIRST (RED)** — verify they fail (enforced by `/implement` Step 6e bash gate)
+8. **Implement minimum code (GREEN)** — make tests pass (enforced by `/implement` Step 6g bash gate)
+9. **Refactor** — clean up while tests stay green
+10. Delegate to Security for review of implemented code
+11. Call docs-analyst at the end
 
 **In 🎸 Vibe Coding Mode - You work DIRECTLY:**
 - Research, plan, and execute yourself
@@ -162,7 +167,11 @@ A conforming issue contains these sections (enforced by GitHub issue templates):
 
 **Orchestrator Mode TDD Flow:**
 ```
-VERIFY DOR (Definition of Ready) → STOP if missing required fields
+Pre-check hook (implement-gates.sh) → STOP on any gate failure
+    │
+    ▼
+subagent-gatekeeper → STOP if DOR/blockers/contracts FAIL
+                      (auto-comment + needs-info on DOR FAIL)
     │
     ▼
 subagent-architect → Blueprint (includes testable interfaces)
@@ -265,15 +274,16 @@ Immediately after language selection, ask:
 
 **Mandatory Subagent Sequence (IN THIS ORDER — TDD ENFORCED):**
 
-1. VERIFY DOR → Check issue has all required fields (MANDATORY)
-2. `subagent-architect` → Architecture Blueprint (MANDATORY)
-3. `/validate-contracts` → Contract validation (if API endpoints)
-4. `subagent-qa` → Test Blueprint (TDD RED)
-5. YOU WRITE TESTS (RED — verify they fail)
-6. YOU IMPLEMENT (GREEN — minimum code to pass)
-7. YOU REFACTOR (tests stay green)
-8. `subagent-security-analyst` → Security review
-9. `subagent-docs-analyst` → Documentation (MANDATORY)
+1. Pre-check hook → `bash .claude/hooks/implement-gates.sh <issue-number>` (MANDATORY)
+2. `subagent-gatekeeper` → DOR/blockers/contracts (MANDATORY)
+3. `subagent-architect` → Architecture Blueprint (MANDATORY)
+4. `/validate-contracts` → Contract validation (if API endpoints)
+5. `subagent-qa` → Test Blueprint (TDD RED)
+6. YOU WRITE TESTS (RED — verify they fail)
+7. YOU IMPLEMENT (GREEN — minimum code to pass)
+8. YOU REFACTOR (tests stay green)
+9. `subagent-security-analyst` → Security review
+10. `subagent-docs-analyst` → Documentation (MANDATORY)
 
 ### 📚 Training Mode
 

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -283,8 +283,8 @@ Implementation complete for Issue #$ISSUE_NUMBER: $TITLE
 Gates passed:
   - Pre-check hook (ok)
   - Gatekeeper (task_type: $TASK_TYPE)
-  - RED checkpoint (verified failing → passing)
-  - GREEN checkpoint (all tests pass)
+  - RED checkpoint (verified failing → passing)   # omit if task_type is docs/refactor
+  - GREEN checkpoint (all tests pass)              # omit if task_type is docs
 
 Logs: $GATE_LOG_DIR
 
@@ -297,8 +297,8 @@ Next: run /pushup to commit, push, create PR, and close the issue.
 
 | Code | Meaning |
 |------|---------|
-| 0 | Success |
-| 1 | Generic failure (gh missing, not authed, not in repo, closed issue, training mode rejected) |
+| 0 | Success — also returned when `--training` is passed (wrong-tool message, not a failure) |
+| 1 | Generic failure (gh missing, not authed, not in repo, closed issue) |
 | 2 | Baseline cargo test failing |
 | 3 | RED gate failed |
 | 4 | GREEN gate failed |

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -79,3 +79,44 @@ The hook has cached the issue JSON at `$GATE_LOG_DIR/issue.json`. Read it direct
 ```bash
 cat "$GATE_LOG_DIR/issue.json"
 ```
+
+### Step 4: Gatekeeper (GATE — MANDATORY)
+
+Invoke `subagent-gatekeeper` via the `Agent` tool. Pass the issue JSON (from `$GATE_LOG_DIR/issue.json`), selected mode, and repo name.
+
+The subagent's response will contain a fenced `json gatekeeper` code block. Pipe its full response through the parser:
+
+```bash
+echo "$SUBAGENT_RESPONSE" | python3 .claude/hooks/parse_gatekeeper_report.py > "$GATE_LOG_DIR/gatekeeper.json"
+```
+
+Then branch on the parsed report:
+
+```bash
+status=$(jq -r .status "$GATE_LOG_DIR/gatekeeper.json")
+task_type=$(jq -r .task_type "$GATE_LOG_DIR/gatekeeper.json")
+
+if [ "$status" = "FAIL" ]; then
+  dor_passed=$(jq -r .dor.passed "$GATE_LOG_DIR/gatekeeper.json")
+  if [ "$dor_passed" = "false" ]; then
+    # Auto-remediation for DOR failures.
+    comment_body=$(jq -r .remediation.comment_body "$GATE_LOG_DIR/gatekeeper.json")
+    gh issue comment "$ISSUE_NUMBER" --body "$comment_body"
+    for label in $(jq -r '.remediation.labels_to_add[]' "$GATE_LOG_DIR/gatekeeper.json"); do
+      gh issue edit "$ISSUE_NUMBER" --add-label "$label"
+    done
+  fi
+  # Print reasons for the operator.
+  echo "Gatekeeper FAIL:" >&2
+  jq -r '.reasons[]' "$GATE_LOG_DIR/gatekeeper.json" | while read -r r; do
+    echo "  - $r" >&2
+  done
+  exit 5
+fi
+
+# PASS — continue with the classified task_type.
+echo "Gatekeeper PASS (task_type: $task_type)"
+export TASK_TYPE="$task_type"
+```
+
+Exit code `5` is reserved for gatekeeper failure.

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -120,3 +120,78 @@ export TASK_TYPE="$task_type"
 ```
 
 Exit code `5` is reserved for gatekeeper failure.
+
+### Step 5: Branch selection with idempotency
+
+Check for an existing branch matching `feat/issue-${ISSUE_NUMBER}-*`:
+
+```bash
+existing=$(git branch --list "feat/issue-${ISSUE_NUMBER}-*" | head -1 | sed 's/^[ *]*//')
+```
+
+**If empty:** derive a slug from the issue title and create a new branch:
+
+```bash
+slug=$(jq -r .title "$GATE_LOG_DIR/issue.json" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | sed 's/^-//;s/-$//' | cut -c -40)
+git checkout -b "feat/issue-${ISSUE_NUMBER}-${slug}"
+```
+
+**If non-empty:** fire the idempotency prompt. Show recent commits:
+
+```
+Branch `<existing>` already exists.
+
+Recent commits on that branch:
+<git log main..HEAD --oneline -5>
+
+  (C)ontinue on this branch
+  (R)estart — delete branch and start over
+  (A)bort
+
+Choice [C/R/A]:
+```
+
+Handle each choice:
+
+**(C)ontinue:**
+- `git checkout <existing>`.
+- Re-invoke the gatekeeper (idempotent).
+- When delegating to architect/QA in Step 6, prepend the resumption context prompt from the spec (§Idempotency UX → Continue semantics):
+
+  > **Context for resumption:** This branch already has commits. Here is the history since `main`:
+  >
+  > ```
+  > $(git log --oneline main..HEAD)
+  > ```
+  >
+  > Before producing a full blueprint, inspect these commits (via Read / Grep on the branch). If the work described by the issue appears substantially done (architecture scaffolded, tests present, or implementation in place), return a **minimal response** acknowledging the existing state and listing only what remains. Do not duplicate work already in the branch. If the branch diverges from what you would design (e.g., different module layout, different abstractions), flag the divergence and recommend either reconciling or restarting — do not silently layer a conflicting plan on top.
+
+- **Divergence handling (spec §Idempotency UX → Divergence handling):** if the architect or QA subagent flags divergence, the orchestrator presents a secondary prompt:
+
+  ```
+  Architect detected divergence between the existing branch and the
+  issue's requirements:
+
+  <architect's divergence summary>
+
+    (R)econcile — continue and let subagents bridge the gap
+    (S)witch to Restart — delete and start over
+    (A)bort — inspect manually
+
+  Choice [R/S/A]:
+  ```
+
+  - **(R)econcile**: proceed with Step 6's subagent sequence, trusting the architect/QA to bridge the gap via follow-up edits.
+  - **(S)witch to Restart**: fall through to the Restart flow below (typed `RESTART` confirmation, branch deletion).
+  - **(A)bort**: exit cleanly, tell the user to inspect manually.
+
+**(R)estart:**
+- Require typed `RESTART` confirmation.
+- `git checkout main && git branch -D "$existing"`.
+- If the branch was pushed, prompt about remote deletion (default no).
+- Create fresh branch.
+
+**(A)bort:**
+- Exit cleanly. Tell the user to `git checkout <branch>` manually to inspect.
+
+If the user is already on the matching branch, skip the prompt and use Continue semantics.

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -195,3 +195,80 @@ Handle each choice:
 - Exit cleanly. Tell the user to `git checkout <branch>` manually to inspect.
 
 If the user is already on the matching branch, skip the prompt and use Continue semantics.
+
+### Step 6: Orchestrator-mode subagent sequence
+
+Vibe mode skips 6a and 6c. All gates use `bash` (not `sh`) — `${PIPESTATUS[0]}` requires it.
+
+#### 6a. `subagent-architect` → blueprint
+
+Orchestrator mode only. Invoke `subagent-architect` with the issue JSON and the architecture blueprint request. If Step 5 chose Continue, prepend the resumption context prompt.
+
+#### 6b. `/validate-contracts` (if architect blueprint touches API endpoints)
+
+Skip if no endpoints.
+
+#### 6c. `subagent-qa` → test blueprint
+
+Orchestrator mode only. Invoke `subagent-qa` with the architect's blueprint. If Step 5 chose Continue, prepend the resumption context prompt.
+
+#### 6d. Write tests from QA blueprint
+
+You (the orchestrator) write tests. No subagent.
+
+#### 6e. RED checkpoint (GATE)
+
+Skipped if `TASK_TYPE` is `docs` or `refactor`.
+
+```bash
+if [ "$TASK_TYPE" != "docs" ] && [ "$TASK_TYPE" != "refactor" ]; then
+  cargo test --quiet 2>&1 | tee "$GATE_LOG_DIR/red.log"
+  red_exit=${PIPESTATUS[0]}
+  if [ $red_exit -eq 0 ]; then
+    echo "RED GATE FAILED — cargo test passed, but implementation has not started." >&2
+    echo "Write a failing test for the new behavior before implementing." >&2
+    exit 3
+  fi
+fi
+```
+
+Exit code `3` reserved for RED failure.
+
+#### 6f. Implement
+
+You (the orchestrator) write the minimum code to make the failing test pass.
+
+#### 6g. GREEN checkpoint (GATE)
+
+Skipped only if `TASK_TYPE` is `docs`.
+
+```bash
+if [ "$TASK_TYPE" != "docs" ]; then
+  cargo test --quiet 2>&1 | tee "$GATE_LOG_DIR/green.log"
+  green_exit=${PIPESTATUS[0]}
+  if [ $green_exit -ne 0 ]; then
+    echo "GREEN GATE FAILED — tests still failing after implementation." >&2
+    echo "See $GATE_LOG_DIR/green.log" >&2
+    exit 4
+  fi
+fi
+```
+
+Exit code `4` reserved for GREEN failure.
+
+#### 6h. Refactor (if needed)
+
+Refactor while tests stay green. Re-run the GREEN checkpoint after:
+
+```bash
+cargo test --quiet 2>&1 | tee "$GATE_LOG_DIR/green-refactor.log"
+[ ${PIPESTATUS[0]} -eq 0 ] || { echo "Refactor broke tests"; exit 4; }
+```
+
+#### 6i. `subagent-security-analyst` → review
+
+Both modes. Invoke security analyst against the newly-written code.
+
+#### 6j. `subagent-docs-analyst` → docs + directory-tree.md
+
+Both modes. Mandatory at task end.

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -1,6 +1,6 @@
 # Implement Issue
 
-Fetch a GitHub issue and implement it following the full orchestrated workflow.
+Fetch a GitHub issue and implement it following the enforced TDD harness.
 
 **Usage:** `/implement #123` or `/implement 123 --english --orchestrator`
 
@@ -20,91 +20,37 @@ Fetch a GitHub issue and implement it following the full orchestrated workflow.
 | `--orchestrator` | `-o` | Use Subagents Orchestrator mode |
 | `--vibe-coding` | `-vc` | Use Vibe Coding mode |
 
+`--training` / `-t` is explicitly rejected — Training mode is for `.claude/` configuration, not implementation.
+
 ---
 
 ## Instructions
 
-### Step 0: Parse Arguments
+### Step 0: Parse arguments
 
 Extract from `$ARGUMENTS`:
-1. **Issue number**: The first number found (with or without `#` prefix)
-2. **Language flag** (if present)
-3. **Mode flag** (if present)
+1. **Issue number**: first `\d+` with optional `#` prefix. Export as `$ISSUE_NUMBER` for downstream steps.
+2. **Language flag** (if present).
+3. **Mode flag** (if present).
+
+```bash
+export ISSUE_NUMBER="<n>"  # substitute the parsed number
+```
+
+All subsequent gate commands in this file reference `$ISSUE_NUMBER`, not bare `<n>`.
+
+If `--training` or `-t` is detected, output:
+
+```
+Training mode is for configuring .claude/ agents, skills, and commands.
+/implement is for building features from GitHub issues.
+Drop --training, or use a free-form prompt for .claude/ configuration.
+```
+
+and exit 0 (not an error).
 
 If no issue number found, ask: "Which issue should I implement?"
 
-### Step 1: Language Selection
+### Step 1: Language and mode selection
 
-If a language flag was provided, use it. Otherwise, ask the user.
-
-### Step 2: Mode Selection
-
-If a mode flag was provided, use it. Otherwise, ask the user.
-
-### Step 3: Fetch Issue from GitHub
-
-```bash
-gh issue view <issue-number> --json title,body,labels,assignees,milestone,state,comments
-```
-
-### Step 4: Analyze Issue
-
-Present a brief summary:
-```
-Issue #<number>: <title>
-Labels: <labels>
-State: <state>
-
-Summary: <1-3 sentence summary>
-
-Proceeding with <selected mode>...
-```
-
-### Step 4.5: DOR Contract Check (if API endpoints involved)
-
-Scan the issue body for API endpoint references. If endpoints found:
-- Check `docs/api-contracts/` for existing schema
-- If no schema exists and issue body has one, save it
-- If no schema at all, **STOP** — DOR failure
-
-### Step 5: Create Feature Branch (if needed)
-
-If on `main`/`master`, create: `feat/issue-<number>-<short-description>`
-
-### Step 6: Execute Based on Selected Mode
-
-**Orchestrator Mode:**
-1. `subagent-architect` → Architecture Blueprint
-2. `/validate-contracts` → Contract Validation (if API)
-3. `subagent-qa` → Test Blueprint
-4. Write tests FIRST (RED)
-5. Implement (GREEN)
-6. Refactor
-7. `subagent-security-analyst` → Security review
-8. `subagent-docs-analyst` → Documentation
-
-**Vibe Coding Mode:**
-1. `/validate-contracts` (if API)
-2. Write tests FIRST (RED)
-3. Implement (GREEN)
-4. Refactor
-5. `subagent-docs-analyst` → Documentation
-
-### Step 7: Post-Implementation
-
-```
-Implementation complete for Issue #<number>: <title>
-
-Next steps:
-- Review changes: `git diff`
-- Run /pushup to commit, push, create PR, and close the issue
-```
-
----
-
-## Error Handling
-
-- If `gh` CLI not installed → suggest `brew install gh`
-- If not authenticated → suggest `gh auth login`
-- If issue closed → warn and ask to proceed
-- If dirty working tree → ask to stash or commit first
+If flags provided, honor them. Otherwise, ask the user.

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -272,3 +272,57 @@ Both modes. Invoke security analyst against the newly-written code.
 #### 6j. `subagent-docs-analyst` → docs + directory-tree.md
 
 Both modes. Mandatory at task end.
+
+### Step 7: Handoff
+
+Print a summary:
+
+```
+Implementation complete for Issue #$ISSUE_NUMBER: $TITLE
+
+Gates passed:
+  - Pre-check hook (ok)
+  - Gatekeeper (task_type: $TASK_TYPE)
+  - RED checkpoint (verified failing → passing)
+  - GREEN checkpoint (all tests pass)
+
+Logs: $GATE_LOG_DIR
+
+Next: run /pushup to commit, push, create PR, and close the issue.
+```
+
+---
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Generic failure (gh missing, not authed, not in repo, closed issue, training mode rejected) |
+| 2 | Baseline cargo test failing |
+| 3 | RED gate failed |
+| 4 | GREEN gate failed |
+| 5 | Gatekeeper FAIL (DOR, blockers, contracts) |
+| 6 | Dirty tree, user declined stash |
+| 7+ | Preflight failure (reserved for CI-gates spec) |
+
+---
+
+## Error Handling
+
+- If `gh` CLI not installed → hook exits 1 with install hint.
+- If `gh` not authenticated → hook exits 1 with `gh auth login` hint.
+- If issue closed → hook exits 1. Re-open first or pick a different issue.
+- If dirty tree → prompt (S)tash/(A)bort.
+- If baseline fails → exit 2. Fix baseline first.
+- If gatekeeper FAILs with DOR missing → comment posted, `needs-info` label applied, exit 5.
+- If blockers open → exit 5. Wait for blockers to close.
+- If RED/GREEN fails → exit 3/4. Actionable error with log path.
+
+---
+
+## Do Not
+
+- Run `/implement` for the same issue concurrently in two sessions.
+- Bypass the hook by invoking subagents directly.
+- Skip the RED gate for `implementation` task types — write the failing test first.

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -54,3 +54,28 @@ If no issue number found, ask: "Which issue should I implement?"
 ### Step 1: Language and mode selection
 
 If flags provided, honor them. Otherwise, ask the user.
+
+### Step 2: Pre-check hook (GATE — MANDATORY)
+
+Run the mechanical pre-check hook. Abort on non-zero exit, printing stderr verbatim.
+
+```bash
+bash .claude/hooks/implement-gates.sh "$ISSUE_NUMBER"
+```
+
+The hook prints `gate log dir: /tmp/maestro-$ISSUE_NUMBER-<ts>` on success; capture this path and `export GATE_LOG_DIR=<path>` for downstream steps.
+
+Exit codes:
+- `0` — proceed.
+- `1` — generic failure (gh missing, not authed, not in repo, closed issue). Abort with the hook's stderr.
+- `2` — baseline cargo test failing. Abort — fix the baseline before starting.
+- `6` — dirty tree, user chose abort. Abort cleanly.
+- `7+` — preflight.sh failure. Abort with its stderr.
+
+### Step 3: Read cached issue JSON
+
+The hook has cached the issue JSON at `$GATE_LOG_DIR/issue.json`. Read it directly — no second `gh` call.
+
+```bash
+cat "$GATE_LOG_DIR/issue.json"
+```


### PR DESCRIPTION
## Summary

Chunk 4 of the `/implement` harness enforcement rollout — the behavior change. Wires together everything from Chunks 1-3 into an enforced command flow.

- **`.claude/commands/implement.md` fully rewritten** (110 → 329 lines): explicit bash gates for every step, structured subagent invocations via the parser, soft-idempotency (C)/(R)/(A) prompt with the divergence-handling (R)econcile/(S)witch/(A)bort sub-prompt, `task_type`-aware RED/GREEN checkpoints, handoff + exit-code table + "Do Not" anti-patterns section. Uses `$ISSUE_NUMBER` everywhere (no bare `<n>` in gate commands).

- **`.claude/CLAUDE.md` orchestrator workflow updated**:
  - §2 numbered workflow: 10 → 11 steps. New Step 2 (pre-check hook), new Step 3 (gatekeeper). Subsequent steps renumbered.
  - §5 TDD flow diagram: replaces the "VERIFY DOR" node with the pre-check-hook + gatekeeper pair.
  - §Mandatory Subagent Sequence list: same updates for consistency.

## What changed in the command's behavior

Every gate is now mechanically enforceable:

| Step | Gate | Mechanism |
|------|------|-----------|
| 2 | Pre-check hook (git repo, gh auth, dirty tree, closed issue, baseline, preflight) | `bash .claude/hooks/implement-gates.sh "$ISSUE_NUMBER"` — exits 1/2/6/7+ |
| 4 | DOR + blockers + contracts + task-type | `subagent-gatekeeper` → JSON report → `parse_gatekeeper_report.py` → `jq` branches on status |
| 4a | DOR auto-remediation on FAIL | `gh issue comment` + `gh issue edit --add-label needs-info` using gatekeeper-drafted text |
| 5 | Idempotency | (C)/(R)/(A) prompt + typed `RESTART` confirmation + remote-deletion prompt |
| 5a | Architect/QA divergence on Continue | Secondary (R)econcile/(S)witch/(A)bort prompt |
| 6e | RED checkpoint | `cargo test` with `${PIPESTATUS[0]}` → exit 3 if unexpectedly green. Skipped for `task_type ∈ {docs, refactor}` |
| 6g | GREEN checkpoint | `cargo test` with `${PIPESTATUS[0]}` → exit 4 on failure. Skipped for `task_type == docs` |

## Commits

8 commits:

1. `7d5c594` refactor(implement): rewrite — header, Step 0-1 (WIP)
2. `76bd354` refactor(implement): rewrite — Step 2 hook + Step 3 cached issue
3. `d63e030` refactor(implement): rewrite — Step 4 gatekeeper + auto-remediation
4. `bed7062` refactor(implement): rewrite — Step 5 branch + idempotency + divergence handling
5. `4ab504e` refactor(implement): rewrite — Step 6 subagent sequence + RED/GREEN
6. `3579ec2` refactor(implement): rewrite — Step 7 handoff + exit codes table
7. `fbdbd31` fix(implement): correct exit code table and handoff summary skip notes
8. `2dd9b04` docs(claude-md): wire gatekeeper + pre-check hook into orchestrator flow

Commit 7 addresses two issues flagged during review: exit code 1's description incorrectly included "training mode rejected" (Step 0 actually uses exit 0 for that case), and the Step 7 handoff summary hardcoded RED/GREEN lines without noting the `task_type` skip rules.

## Test plan

- [x] `implement.md` rewrites through 6 incremental commits, each section self-contained
- [x] `$ISSUE_NUMBER` used in every gate command; no bare `<n>` tokens in executable blocks
- [x] Exit code table lists 0, 1, 2, 3, 4, 5, 6, 7+ with accurate descriptions
- [x] Divergence prompt present with (R)econcile/(S)witch/(A)bort action semantics
- [x] RED/GREEN bash snippets use `${PIPESTATUS[0]}` (bash-shebang noted in spec)
- [x] CLAUDE.md §2 workflow, §5 diagram, and §Mandatory Subagent Sequence all consistent with the 11-step flow
- [x] Spec + quality review approved after one round of fixes

## Scope

**Included:** command rewrite + CLAUDE.md workflow updates.
**Excluded:** acceptance checklist (Chunk 5, next).

## Next

After merge, Chunk 5 (final): `docs/harness-acceptance.md` — 10-scenario manual E2E checklist. Small PR.