### PR TITLE
fix(icon_mode): serialize MODE-mutating tests

### DIFF
--- a/src/icon_mode.rs
+++ b/src/icon_mode.rs
@@ -43,6 +43,17 @@ pub(crate) fn use_nerd_font_from_env(get_env: impl Fn(&str) -> Option<String>) -
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    // Tests that mutate the global MODE atomic must not run in parallel
+    // with each other. Cargo runs #[test] functions concurrently by default,
+    // which lets one test's init_from_config() land between another test's
+    // write-and-assert pair and flip the answer — a deterministic-looking
+    // failure that surfaces as a race flake in CI.
+    //
+    // Guarding the MODE-mutating tests with a shared mutex serializes them
+    // without affecting tests that don't touch MODE (the env-var tests).
+    static MODE_TEST_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn env_absent_returns_nerd_font_true() {
@@ -66,6 +77,7 @@ mod tests {
 
     #[test]
     fn init_from_config_ascii_true_disables_nerd_font() {
+        let _guard = MODE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         init_from_config(true);
         assert!(!use_nerd_font());
         init_from_config(false); // restore
@@ -73,12 +85,14 @@ mod tests {
 
     #[test]
     fn init_from_config_ascii_false_enables_nerd_font() {
+        let _guard = MODE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         init_from_config(false);
         assert!(use_nerd_font());
     }
 
     #[test]
     fn use_nerd_font_reads_initialized_flag_not_env() {
+        let _guard = MODE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         init_from_config(true);
         assert!(!use_nerd_font());
         init_from_config(false);


### PR DESCRIPTION
## Summary

Three tests in `src/icon_mode.rs` mutate the global `MODE: AtomicU8` and rely on read-your-write semantics within a single `#[test]` body. Cargo runs `#[test]` functions concurrently by default, so `init_from_config()` from one test can land between another test's write and its assertion.

The race flaked the `Test` job during Chunk 1 verification (`init_from_config_ascii_true_disables_nerd_font` read `NERD_FONT` after setting `ASCII`). It wasn't introduced by Chunk 1 — pre-existing, just happened to shake out under that run's scheduling.

## Fix

One `static Mutex<()>` shared by the three MODE-touching tests. Each test acquires the lock before calling `init_from_config`. Poisoned-lock path uses `into_inner()` so a panic in one test doesn't cascade. Env-var tests (four of them) don't touch MODE and remain unguarded, so parallelism is preserved where it's safe.

## Test plan

- [x] `cargo test --lib icon_mode::tests` → 7/7 pass
- [x] Preflight green (fmt + clippy + file-size)

No new dependencies; `std::sync::Mutex` + `unwrap_or_else`.