### PR TITLE
feat(ci): Wave 2.1 — coverage via cargo-llvm-cov with tiered floors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,27 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ignore: RUSTSEC-2025-0141,RUSTSEC-2024-0436,RUSTSEC-2024-0320,RUSTSEC-2026-0097,RUSTSEC-2026-0098,RUSTSEC-2026-0099,RUSTSEC-2026-0104
+
+  coverage:
+    # Wave 2.1 — reporting-only during baseline phase.
+    # Once baseline coverage reaches each tier's floor, a follow-up PR
+    # removes continue-on-error per-tier (see docs/RUST-GUARDRAILS.md
+    # § CI Quality Gates Wave 2.1). Ratchet logic is deferred until
+    # after floor activation.
+    name: Coverage Tiers
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - name: Install yq
+        run: sudo apt-get update && sudo apt-get install -y yq
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --locked
+      - name: Generate lcov
+        run: cargo llvm-cov --workspace --lcov --output-path coverage.lcov
+      - name: Check coverage tiers
+        run: bash scripts/check-coverage-tiers.sh coverage.lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,8 +98,14 @@ jobs:
         with:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
-      - name: Install yq
-        run: sudo apt-get update && sudo apt-get install -y yq
+      - name: Install yq (Mike Farah Go-based, not Python apt package)
+        # Ubuntu's apt `yq` is the Python jq-wrapper, which has a different
+        # CLI from the Go-based Mike Farah yq used by check-coverage-tiers.sh.
+        # Install the Go binary directly.
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov --locked
       - name: Generate lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,14 +84,15 @@ jobs:
           ignore: RUSTSEC-2025-0141,RUSTSEC-2024-0436,RUSTSEC-2024-0320,RUSTSEC-2026-0097,RUSTSEC-2026-0098,RUSTSEC-2026-0099,RUSTSEC-2026-0104
 
   coverage:
-    # Wave 2.1 — reporting-only during baseline phase.
-    # Once baseline coverage reaches each tier's floor, a follow-up PR
-    # removes continue-on-error per-tier (see docs/RUST-GUARDRAILS.md
-    # § CI Quality Gates Wave 2.1). Ratchet logic is deferred until
-    # after floor activation.
+    # Wave 2.1 — report mode during baseline phase.
+    # The script exits 0 by default (report mode) — it prints tier
+    # percentages and VIOLATION lines for visibility but keeps the CI
+    # check green. Activation is adding `--enforce` to the final script
+    # invocation below, which flips the script to strict-exit mode.
+    # Activate once baseline reaches the floor for a tier; each tier
+    # activation is a dedicated PR.
     name: Coverage Tiers
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,5 +112,3 @@ jobs:
         run: cargo llvm-cov --workspace --lcov --output-path coverage.lcov
       - name: Check coverage tiers
         run: bash scripts/check-coverage-tiers.sh coverage.lcov
-        env:
-          COVERAGE_DEBUG: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,3 +112,5 @@ jobs:
         run: cargo llvm-cov --workspace --lcov --output-path coverage.lcov
       - name: Check coverage tiers
         run: bash scripts/check-coverage-tiers.sh coverage.lcov
+        env:
+          COVERAGE_DEBUG: "1"

--- a/docs/RUST-GUARDRAILS.md
+++ b/docs/RUST-GUARDRAILS.md
@@ -419,7 +419,11 @@ During Wave 1 implementation, `scripts/check-file-size.sh` was found to have a p
 | tui | `src/tui/**` | 70.0% | — |
 | excluded | `main.rs`, `lib.rs`, `integration_tests/**`, `*_test.rs`, `tests.rs` | — | — |
 
-**Baseline measurement:** the CI job's first run on the introducing PR produces the measured baseline. Updated here in a follow-up commit once the numbers are known. Expected range based on codebase inspection: core ≈ 65-80%, tui ≈ 30-50%.
+**Baseline measurement (2026-04-22, PR #431):**
+- core: 87.6% (floor: 90.0%) — below by 2.4 pp
+- tui: 67.4% (floor: 70.0%) — below by 2.6 pp
+
+Both tiers are within striking distance of their floors; activation is near-term test-writing, not a multi-week project. Suggested sequence: add tests for the largest uncovered modules in each tier, rerun `coverage` to see the delta, repeat until ≥ floor, then open a follow-up PR that removes `continue-on-error` for that tier.
 
 **Activation policy:** `continue-on-error: true` is active for the `coverage` job until baseline reaches floor. At that point, a dedicated PR removes `continue-on-error` per-tier (tiers activate independently — core may be blocking while tui is still reporting-only).
 

--- a/docs/RUST-GUARDRAILS.md
+++ b/docs/RUST-GUARDRAILS.md
@@ -425,7 +425,7 @@ During Wave 1 implementation, `scripts/check-file-size.sh` was found to have a p
 
 Both tiers are within striking distance of their floors; activation is near-term test-writing, not a multi-week project. Suggested sequence: add tests for the largest uncovered modules in each tier, rerun `coverage` to see the delta, repeat until ≥ floor, then open a follow-up PR that removes `continue-on-error` for that tier.
 
-**Activation policy:** `continue-on-error: true` is active for the `coverage` job until baseline reaches floor. At that point, a dedicated PR removes `continue-on-error` per-tier (tiers activate independently — core may be blocking while tui is still reporting-only).
+**Activation policy:** the `check-coverage-tiers.sh` script runs in **report mode by default** — it prints tier percentages and any VIOLATION lines but exits 0 so the CI check stays green while baseline is below floor. To activate enforcement, add `--enforce` to the script invocation in the `coverage` job (`.github/workflows/ci.yml`). Once baseline reaches a floor for a tier, a dedicated PR adds `--enforce` for that tier's first blocking run. (Per-tier activation can be modeled by running the checker twice with different manifests pointing at a subset of tiers — simplest evolution when we get there.)
 
 **Ratchet:** deferred until after floor activation. Enabling ratchet during baseline phase would block every PR that doesn't add tests, including refactors and documentation changes.
 

--- a/docs/RUST-GUARDRAILS.md
+++ b/docs/RUST-GUARDRAILS.md
@@ -405,9 +405,34 @@ During Wave 1 implementation, `scripts/check-file-size.sh` was found to have a p
 
 ---
 
+## CI Quality Gates (Wave 2.1 — Coverage)
+
+**Status:** reporting-only during baseline phase. Per-tier floors activate when baseline reaches the respective floor.
+
+**Tool:** `cargo-llvm-cov`. Tier manifest: `scripts/coverage-tiers.yml`. Enforcement: `scripts/check-coverage-tiers.sh`. CI job: `coverage` (runs per-PR, `continue-on-error: true` during baseline).
+
+**Tier floors:**
+
+| Tier | Paths | Floor | Aspiration |
+|------|-------|-------|------------|
+| core | `session/**`, `state/**`, `adapt/**`, `turboquant/**`, `gates/**`, `provider/**`, `config.rs`, `cli.rs` | 90.0% | 96.0% |
+| tui | `src/tui/**` | 70.0% | — |
+| excluded | `main.rs`, `lib.rs`, `integration_tests/**`, `*_test.rs`, `tests.rs` | — | — |
+
+**Baseline measurement:** the CI job's first run on the introducing PR produces the measured baseline. Updated here in a follow-up commit once the numbers are known. Expected range based on codebase inspection: core ≈ 65-80%, tui ≈ 30-50%.
+
+**Activation policy:** `continue-on-error: true` is active for the `coverage` job until baseline reaches floor. At that point, a dedicated PR removes `continue-on-error` per-tier (tiers activate independently — core may be blocking while tui is still reporting-only).
+
+**Ratchet:** deferred until after floor activation. Enabling ratchet during baseline phase would block every PR that doesn't add tests, including refactors and documentation changes.
+
+**Local measurement prerequisite:** `cargo-llvm-cov` requires the `llvm-tools-preview` component, installed via `rustup component add llvm-tools-preview`. Machines without `rustup` (brew-installed Rust, Nix-installed Rust) can't run coverage locally; use CI artifacts instead.
+
+---
+
 ## Amendment history
 
 | Date | Change | Author |
 |------|--------|--------|
 | 2026-04-20 | Initial guardrails document | feat/rust-development-guardrails |
 | 2026-04-22 | Appended CI Quality Gates (Wave 1) | chunk-1/ci-wave-1 |
+| 2026-04-22 | Appended CI Quality Gates (Wave 2.1 — Coverage) | chunk-2/coverage-infrastructure |

--- a/scripts/check-coverage-tiers.sh
+++ b/scripts/check-coverage-tiers.sh
@@ -1,14 +1,29 @@
 #!/usr/bin/env bash
 # Enforce coverage floors per tier from scripts/coverage-tiers.yml
 #
-# Usage: check-coverage-tiers.sh <coverage.lcov>
+# Usage: check-coverage-tiers.sh [--enforce] <coverage.lcov>
+#
+# Modes:
+#   (default, "report"): prints tier percentages and VIOLATION lines,
+#                        but exits 0 regardless — suitable for the
+#                        baseline phase when floors aren't yet reached
+#                        and we want the CI check to stay green.
+#   --enforce:           exits 1 on any tier below floor — suitable
+#                        after a tier's baseline reaches its floor.
 #
 # Exit codes:
-#   0 — all tier floors satisfied
-#   1 — some tier below its floor
+#   0 — report mode always; enforce mode when no tier below floor
+#   1 — enforce mode, tier below floor
 #   2 — invalid input (no lcov, missing manifest, yq not installed)
 
 set -euo pipefail
+
+# Parse --enforce flag (must come before the lcov path).
+ENFORCE=false
+if [[ "${1:-}" == "--enforce" ]]; then
+  ENFORCE=true
+  shift
+fi
 
 LCOV_FILE="${1:-}"
 MANIFEST="${MANIFEST_OVERRIDE:-scripts/coverage-tiers.yml}"
@@ -215,7 +230,11 @@ done
 if (( violations > 0 )); then
   echo ""
   echo "$violations tier(s) below floor."
-  exit 1
+  if $ENFORCE; then
+    exit 1
+  else
+    echo "(report mode — not failing the check; pass --enforce to block)"
+  fi
 fi
 
 exit 0

--- a/scripts/check-coverage-tiers.sh
+++ b/scripts/check-coverage-tiers.sh
@@ -33,6 +33,18 @@ if ! command -v yq >/dev/null 2>&1; then
   exit 2
 fi
 
+# Sanity-check yq flavor. Mike Farah's Go-based yq supports `eval` as a
+# subcommand and returns a known version banner. Python's yq (ubuntu apt)
+# treats everything after the binary name as files, which breaks the
+# script in confusing ways. Detect and fail early with a clear message.
+if ! yq --version 2>&1 | grep -qi "mikefarah\|https://github.com/mikefarah/yq"; then
+  echo "error: detected Python-based yq (jq wrapper). check-coverage-tiers.sh" >&2
+  echo "       requires Mike Farah's Go-based yq. Install via:" >&2
+  echo "         brew install yq                                           # macOS" >&2
+  echo "         sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && sudo chmod +x /usr/local/bin/yq   # Linux" >&2
+  exit 2
+fi
+
 # ---------------------------------------------------------------------------
 # Read tier metadata from manifest into parallel indexed arrays (bash 3.2 safe)
 # ---------------------------------------------------------------------------
@@ -53,6 +65,15 @@ while IFS= read -r name; do
 done < <(yq eval '.tiers | keys | .[]' "$MANIFEST")
 
 n_tiers=${#tier_names[@]}
+
+# Guard: if the manifest produced zero tiers, fail loudly instead of
+# letting the downstream array accesses crash with "unbound variable"
+# under set -u.
+if (( n_tiers == 0 )); then
+  echo "error: no tiers found in manifest $MANIFEST" >&2
+  echo "       manifest must define tiers.<name> entries with paths/floor/aspiration" >&2
+  exit 2
+fi
 
 # ---------------------------------------------------------------------------
 # Build a flat "tier_index:glob" list for all non-trivial path lookups.

--- a/scripts/check-coverage-tiers.sh
+++ b/scripts/check-coverage-tiers.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Enforce coverage floors per tier from scripts/coverage-tiers.yml
+#
+# Usage: check-coverage-tiers.sh <coverage.lcov>
+#
+# Exit codes:
+#   0 — all tier floors satisfied
+#   1 — some tier below its floor
+#   2 — invalid input (no lcov, missing manifest, yq not installed)
+
+set -euo pipefail
+
+LCOV_FILE="${1:-}"
+MANIFEST="${MANIFEST_OVERRIDE:-scripts/coverage-tiers.yml}"
+
+if [[ -z "$LCOV_FILE" ]]; then
+  echo "usage: $0 <coverage.lcov>" >&2
+  exit 2
+fi
+
+if [[ ! -f "$LCOV_FILE" ]]; then
+  echo "error: lcov file not found: $LCOV_FILE" >&2
+  exit 2
+fi
+
+if [[ ! -f "$MANIFEST" ]]; then
+  echo "error: manifest not found: $MANIFEST" >&2
+  exit 2
+fi
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "error: yq required for YAML parsing; install via: brew install yq" >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Read tier metadata from manifest into parallel indexed arrays (bash 3.2 safe)
+# ---------------------------------------------------------------------------
+
+tier_names=()
+tier_floors=()
+tier_is_excluded=()
+
+while IFS= read -r name; do
+  tier_names+=("$name")
+  floor=$(yq eval ".tiers.${name}.floor // 0" "$MANIFEST")
+  tier_floors+=("$floor")
+  if [[ "$name" == "excluded" ]]; then
+    tier_is_excluded+=("true")
+  else
+    tier_is_excluded+=("false")
+  fi
+done < <(yq eval '.tiers | keys | .[]' "$MANIFEST")
+
+n_tiers=${#tier_names[@]}
+
+# ---------------------------------------------------------------------------
+# Build a flat "tier_index:glob" list for all non-trivial path lookups.
+# Format:  <tier_index> <glob_pattern>
+# We'll use this in bash case-pattern matching.
+# ---------------------------------------------------------------------------
+
+# tier_path_list is a temp file: lines of "<tier_index> <pattern>"
+TMPDIR_WORK=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_WORK"' EXIT
+
+tier_path_file="$TMPDIR_WORK/tier_paths.txt"
+: > "$tier_path_file"
+
+for i in $(seq 0 $((n_tiers - 1))); do
+  name="${tier_names[$i]}"
+  while IFS= read -r pattern; do
+    echo "$i $pattern" >> "$tier_path_file"
+  done < <(yq eval ".tiers.${name}.paths[] // \"\"" "$MANIFEST" 2>/dev/null || true)
+done
+
+# ---------------------------------------------------------------------------
+# Match a file path to a tier index (first match wins).
+# Returns the index via stdout; returns n_tiers (=no match → default core)
+# if nothing matched.
+# ---------------------------------------------------------------------------
+match_tier() {
+  local file="$1"
+  while read -r idx pattern; do
+    case "$file" in
+      $pattern)
+        echo "$idx"
+        return
+        ;;
+    esac
+  done < "$tier_path_file"
+  # Default to core (index 0)
+  echo "0"
+}
+
+# ---------------------------------------------------------------------------
+# Initialise per-tier accumulators (indexed arrays, bash 3.2 safe)
+# ---------------------------------------------------------------------------
+tier_lf=()
+tier_lh=()
+for i in $(seq 0 $((n_tiers - 1))); do
+  tier_lf+=("0")
+  tier_lh+=("0")
+done
+
+# ---------------------------------------------------------------------------
+# Parse lcov and accumulate
+# ---------------------------------------------------------------------------
+current_file=""
+current_lf=""
+current_lh=""
+in_record=false
+
+while IFS= read -r line; do
+  case "$line" in
+    "SF:"*)
+      current_file="${line#SF:}"
+      in_record=true
+      ;;
+    "LF:"*)
+      current_lf="${line#LF:}"
+      ;;
+    "LH:"*)
+      current_lh="${line#LH:}"
+      ;;
+    "end_of_record")
+      if $in_record; then
+        tidx=$(match_tier "$current_file")
+        is_exc="${tier_is_excluded[$tidx]}"
+        if [[ "$is_exc" != "true" ]]; then
+          old_lf="${tier_lf[$tidx]}"
+          old_lh="${tier_lh[$tidx]}"
+          tier_lf[$tidx]=$(( old_lf + current_lf ))
+          tier_lh[$tidx]=$(( old_lh + current_lh ))
+        fi
+      fi
+      in_record=false
+      current_file=""
+      current_lf=""
+      current_lh=""
+      ;;
+  esac
+done < "$LCOV_FILE"
+
+# ---------------------------------------------------------------------------
+# Compute coverage per tier, check floors, report
+# ---------------------------------------------------------------------------
+violations=0
+
+for i in $(seq 0 $((n_tiers - 1))); do
+  name="${tier_names[$i]}"
+  is_exc="${tier_is_excluded[$i]}"
+  [[ "$is_exc" == "true" ]] && continue
+
+  lf="${tier_lf[$i]}"
+  lh="${tier_lh[$i]}"
+  floor="${tier_floors[$i]}"
+
+  if [[ "$lf" -eq 0 ]]; then
+    echo "$name: no files measured"
+    continue
+  fi
+
+  pct=$(awk "BEGIN { printf \"%.1f\", ($lh / $lf) * 100 }")
+  printf "%s: %s%% (floor: %s%%)\n" "$name" "$pct" "$floor"
+
+  if awk "BEGIN { exit !($pct < $floor) }"; then
+    echo "  VIOLATION: below floor"
+    violations=$(( violations + 1 ))
+  fi
+done
+
+if (( violations > 0 )); then
+  echo ""
+  echo "$violations tier(s) below floor."
+  exit 1
+fi
+
+exit 0

--- a/scripts/check-coverage-tiers.sh
+++ b/scripts/check-coverage-tiers.sh
@@ -164,6 +164,21 @@ while IFS= read -r line; do
 done < "$LCOV_FILE"
 
 # ---------------------------------------------------------------------------
+# DEBUG: print tier_path_file + first few lcov file matches (remove after fix)
+# ---------------------------------------------------------------------------
+if [[ "${COVERAGE_DEBUG:-}" = "1" ]]; then
+  echo "DEBUG tier_path_file content:"
+  cat "$tier_path_file"
+  echo "DEBUG first 10 SF entries and their tier:"
+  grep -m 10 '^SF:' "$LCOV_FILE" | while IFS= read -r line; do
+    f="${line#SF:}"
+    idx=$(match_tier "$f")
+    name="${tier_names[$idx]}"
+    echo "  $f → tier[$idx] = $name"
+  done
+fi
+
+# ---------------------------------------------------------------------------
 # Compute coverage per tier, check floors, report
 # ---------------------------------------------------------------------------
 violations=0

--- a/scripts/check-coverage-tiers.sh
+++ b/scripts/check-coverage-tiers.sh
@@ -90,10 +90,30 @@ tier_path_file="$TMPDIR_WORK/tier_paths.txt"
 
 for i in $(seq 0 $((n_tiers - 1))); do
   name="${tier_names[$i]}"
+  # Use command substitution + here-string rather than process substitution;
+  # avoids subtle `set -e` interactions that were dropping the output on CI.
+  paths_output=$(yq eval ".tiers.${name}.paths[]" "$MANIFEST" 2>&1 || echo "")
   while IFS= read -r pattern; do
+    [[ -z "$pattern" ]] && continue
+    # Skip yq error output if any leaked through.
+    [[ "$pattern" == Error* ]] && continue
     echo "$i $pattern" >> "$tier_path_file"
-  done < <(yq eval ".tiers.${name}.paths[] // \"\"" "$MANIFEST" 2>/dev/null || true)
+  done <<< "$paths_output"
 done
+
+# ---------------------------------------------------------------------------
+# Normalize a file path from lcov SF entry to repo-relative form.
+# cargo-llvm-cov emits absolute paths (e.g. /home/runner/work/maestro/maestro/src/tui/app.rs);
+# our glob manifest uses repo-relative forms (src/tui/**). Strip a known
+# repo-root prefix so globs match.
+# ---------------------------------------------------------------------------
+REPO_ROOT_PREFIX="${REPO_ROOT_PREFIX:-$(pwd)/}"
+normalize_path() {
+  local file="$1"
+  # Strip a literal repo-root prefix if present.
+  file="${file#$REPO_ROOT_PREFIX}"
+  echo "$file"
+}
 
 # ---------------------------------------------------------------------------
 # Match a file path to a tier index (first match wins).
@@ -101,7 +121,8 @@ done
 # if nothing matched.
 # ---------------------------------------------------------------------------
 match_tier() {
-  local file="$1"
+  local file
+  file=$(normalize_path "$1")
   while read -r idx pattern; do
     case "$file" in
       $pattern)
@@ -162,21 +183,6 @@ while IFS= read -r line; do
       ;;
   esac
 done < "$LCOV_FILE"
-
-# ---------------------------------------------------------------------------
-# DEBUG: print tier_path_file + first few lcov file matches (remove after fix)
-# ---------------------------------------------------------------------------
-if [[ "${COVERAGE_DEBUG:-}" = "1" ]]; then
-  echo "DEBUG tier_path_file content:"
-  cat "$tier_path_file"
-  echo "DEBUG first 10 SF entries and their tier:"
-  grep -m 10 '^SF:' "$LCOV_FILE" | while IFS= read -r line; do
-    f="${line#SF:}"
-    idx=$(match_tier "$f")
-    name="${tier_names[$idx]}"
-    echo "  $f → tier[$idx] = $name"
-  done
-fi
 
 # ---------------------------------------------------------------------------
 # Compute coverage per tier, check floors, report

--- a/scripts/coverage-tiers.yml
+++ b/scripts/coverage-tiers.yml
@@ -1,0 +1,39 @@
+# Coverage tiers for scripts/check-coverage-tiers.sh.
+#
+# Each tier has a floor (enforced once baseline is at or above it)
+# and an aspiration (documentary, not enforced).
+# Paths use glob patterns; a file is classified into the first tier
+# whose glob matches.
+#
+# Special tier "excluded" — files NOT counted toward total coverage.
+# (Binary wiring, integration tests, trivial mod.rs re-exports.)
+#
+# See docs/superpowers/specs/2026-04-22-ci-quality-gates-design.md
+# § Wave 2.1 for policy.
+
+tiers:
+  core:
+    floor: 90.0
+    aspiration: 96.0
+    paths:
+      - "src/session/**"
+      - "src/state/**"
+      - "src/adapt/**"
+      - "src/turboquant/**"
+      - "src/gates/**"
+      - "src/provider/**"
+      - "src/config.rs"
+      - "src/cli.rs"
+
+  tui:
+    floor: 70.0
+    paths:
+      - "src/tui/**"
+
+  excluded:
+    paths:
+      - "src/main.rs"
+      - "src/lib.rs"
+      - "src/integration_tests/**"
+      - "**/tests.rs"
+      - "**/*_test.rs"

--- a/tests/manifests/validate_manifests_test.py
+++ b/tests/manifests/validate_manifests_test.py
@@ -1,0 +1,68 @@
+"""Schema validation for scripts/coverage-tiers.yml and (later)
+scripts/architecture-layers.yml.
+
+Uses `yq` via subprocess since the project avoids pyyaml (stdlib-only
+Python policy).
+"""
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def yq_json(yaml_path: Path, expr: str = ".") -> object:
+    """Return the parsed YAML as a Python object via yq + json round-trip."""
+    result = subprocess.run(
+        ["yq", "eval", "-o", "json", expr, str(yaml_path)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+class CoverageTiersTest(unittest.TestCase):
+    manifest_path = REPO_ROOT / "scripts" / "coverage-tiers.yml"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.data = yq_json(cls.manifest_path)
+
+    def test_top_level_has_tiers(self):
+        self.assertIn("tiers", self.data)
+
+    def test_required_tiers_present(self):
+        tiers = self.data["tiers"]
+        self.assertIn("core", tiers)
+        self.assertIn("tui", tiers)
+        self.assertIn("excluded", tiers)
+
+    def test_core_has_floor_and_aspiration(self):
+        core = self.data["tiers"]["core"]
+        self.assertIn("floor", core)
+        self.assertIn("aspiration", core)
+        self.assertIsInstance(core["floor"], (int, float))
+        self.assertIsInstance(core["aspiration"], (int, float))
+        self.assertGreaterEqual(core["aspiration"], core["floor"])
+
+    def test_tui_has_floor(self):
+        tui = self.data["tiers"]["tui"]
+        self.assertIn("floor", tui)
+        self.assertIsInstance(tui["floor"], (int, float))
+
+    def test_excluded_has_paths(self):
+        excluded = self.data["tiers"]["excluded"]
+        self.assertIn("paths", excluded)
+        self.assertIsInstance(excluded["paths"], list)
+        self.assertGreater(len(excluded["paths"]), 0)
+
+    def test_all_paths_are_strings(self):
+        for tier_name, tier in self.data["tiers"].items():
+            for path in tier.get("paths", []):
+                self.assertIsInstance(path, str, f"tier={tier_name}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/check-coverage-tiers.bats
+++ b/tests/scripts/check-coverage-tiers.bats
@@ -30,3 +30,15 @@ setup() {
   # main.rs is excluded, should not appear.
   [[ "$output" != *"main.rs"* ]]
 }
+
+@test "absolute lcov paths are normalized via REPO_ROOT_PREFIX env" {
+  # cargo-llvm-cov on CI emits absolute paths like
+  # /home/runner/work/maestro/maestro/src/tui/app.rs. The script's
+  # normalize_path strips a configurable prefix so globs like src/tui/**
+  # can match.
+  REPO_ROOT_PREFIX="/home/runner/work/maestro/maestro/" run bash "$SCRIPT" "$FIXTURES/lcov-absolute-paths.info"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"core: 95.0%"* ]]
+  [[ "$output" == *"tui: 40.0%"* ]]
+  [[ "$output" != *"main.rs"* ]]
+}

--- a/tests/scripts/check-coverage-tiers.bats
+++ b/tests/scripts/check-coverage-tiers.bats
@@ -14,21 +14,37 @@ setup() {
   [[ "$output" == *"core: 100.0%"* ]]
 }
 
-@test "70% coverage fails core floor of 90%" {
+@test "70% core: report mode (default) exits 0 but prints VIOLATION" {
   run bash "$SCRIPT" "$FIXTURES/lcov-70pct-core.info"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"VIOLATION"* ]]
+  [[ "$output" == *"core: 70.0%"* ]]
+  [[ "$output" == *"report mode"* ]]
+}
+
+@test "70% core: --enforce mode exits 1 on violation" {
+  run bash "$SCRIPT" --enforce "$FIXTURES/lcov-70pct-core.info"
   [ "$status" -eq 1 ]
   [[ "$output" == *"VIOLATION"* ]]
   [[ "$output" == *"core: 70.0%"* ]]
+  # Should NOT show the "report mode" hint in enforce mode.
+  [[ "$output" != *"report mode"* ]]
 }
 
-@test "mixed tiers: core passes, tui fails floor, excluded ignored" {
+@test "mixed tiers: report mode exits 0, still prints violations" {
   run bash "$SCRIPT" "$FIXTURES/lcov-mixed-tiers.info"
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 0 ]
   [[ "$output" == *"core: 95.0%"* ]]
   [[ "$output" == *"tui: 50.0%"* ]]
   [[ "$output" == *"VIOLATION"* ]]
-  # main.rs is excluded, should not appear.
   [[ "$output" != *"main.rs"* ]]
+}
+
+@test "mixed tiers: --enforce mode exits 1" {
+  run bash "$SCRIPT" --enforce "$FIXTURES/lcov-mixed-tiers.info"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"core: 95.0%"* ]]
+  [[ "$output" == *"tui: 50.0%"* ]]
 }
 
 @test "absolute lcov paths are normalized via REPO_ROOT_PREFIX env" {
@@ -36,7 +52,7 @@ setup() {
   # /home/runner/work/maestro/maestro/src/tui/app.rs. The script's
   # normalize_path strips a configurable prefix so globs like src/tui/**
   # can match.
-  REPO_ROOT_PREFIX="/home/runner/work/maestro/maestro/" run bash "$SCRIPT" "$FIXTURES/lcov-absolute-paths.info"
+  REPO_ROOT_PREFIX="/home/runner/work/maestro/maestro/" run bash "$SCRIPT" --enforce "$FIXTURES/lcov-absolute-paths.info"
   [ "$status" -eq 1 ]
   [[ "$output" == *"core: 95.0%"* ]]
   [[ "$output" == *"tui: 40.0%"* ]]

--- a/tests/scripts/check-coverage-tiers.bats
+++ b/tests/scripts/check-coverage-tiers.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  SCRIPT="$REPO_ROOT/scripts/check-coverage-tiers.sh"
+  MANIFEST="$REPO_ROOT/scripts/coverage-tiers.yml"
+  FIXTURES="$REPO_ROOT/tests/scripts/fixtures"
+  cd "$REPO_ROOT"
+}
+
+@test "100% coverage passes core floor of 90%" {
+  run bash "$SCRIPT" "$FIXTURES/lcov-100pct-core.info"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"core: 100.0%"* ]]
+}
+
+@test "70% coverage fails core floor of 90%" {
+  run bash "$SCRIPT" "$FIXTURES/lcov-70pct-core.info"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"VIOLATION"* ]]
+  [[ "$output" == *"core: 70.0%"* ]]
+}
+
+@test "mixed tiers: core passes, tui fails floor, excluded ignored" {
+  run bash "$SCRIPT" "$FIXTURES/lcov-mixed-tiers.info"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"core: 95.0%"* ]]
+  [[ "$output" == *"tui: 50.0%"* ]]
+  [[ "$output" == *"VIOLATION"* ]]
+  # main.rs is excluded, should not appear.
+  [[ "$output" != *"main.rs"* ]]
+}

--- a/tests/scripts/fixtures/lcov-100pct-core.info
+++ b/tests/scripts/fixtures/lcov-100pct-core.info
@@ -1,0 +1,9 @@
+TN:
+SF:src/session/manager.rs
+LF:50
+LH:50
+end_of_record
+SF:src/state/store.rs
+LF:30
+LH:30
+end_of_record

--- a/tests/scripts/fixtures/lcov-70pct-core.info
+++ b/tests/scripts/fixtures/lcov-70pct-core.info
@@ -1,0 +1,5 @@
+TN:
+SF:src/session/manager.rs
+LF:100
+LH:70
+end_of_record

--- a/tests/scripts/fixtures/lcov-absolute-paths.info
+++ b/tests/scripts/fixtures/lcov-absolute-paths.info
@@ -1,0 +1,13 @@
+TN:
+SF:/home/runner/work/maestro/maestro/src/tui/app.rs
+LF:100
+LH:40
+end_of_record
+SF:/home/runner/work/maestro/maestro/src/session/manager.rs
+LF:100
+LH:95
+end_of_record
+SF:/home/runner/work/maestro/maestro/src/main.rs
+LF:50
+LH:0
+end_of_record

--- a/tests/scripts/fixtures/lcov-mixed-tiers.info
+++ b/tests/scripts/fixtures/lcov-mixed-tiers.info
@@ -1,0 +1,13 @@
+TN:
+SF:src/session/manager.rs
+LF:100
+LH:95
+end_of_record
+SF:src/tui/app.rs
+LF:200
+LH:100
+end_of_record
+SF:src/main.rs
+LF:50
+LH:0
+end_of_record


### PR DESCRIPTION
## Summary

Wave 2.1 of the CI quality-gate rollout (spec: `docs/superpowers/specs/2026-04-22-ci-quality-gates-design.md`).

### Changes

- **`scripts/coverage-tiers.yml`**: tier manifest. Core 90%/96% aspiration (session, state, adapt, turboquant, gates, provider, config.rs, cli.rs); TUI 70% (`src/tui/**`); binary wiring + integration tests + `*_test.rs` excluded.
- **`scripts/check-coverage-tiers.sh`**: bash+yq enforcer. Parses lcov (SF/LF/LH markers), groups files by tier via glob match, computes weighted mean per tier, fails when below floor.
- **`tests/scripts/check-coverage-tiers.bats`**: 3 bats scenarios (100%-core, 70%-core, mixed with excluded file).
- **`.github/workflows/ci.yml`**: new `coverage` job. Installs `cargo-llvm-cov` + `yq`, generates lcov, runs the checker. **`continue-on-error: true` during baseline phase** — see activation plan below.
- **`tests/manifests/validate_manifests_test.py`**: 6 Python unittests validating the manifest schema (stdlib-only, via `yq` subprocess).
- **`docs/RUST-GUARDRAILS.md`**: appended "CI Quality Gates (Wave 2.1 — Coverage)" section.

### Activation plan

`coverage` job is `continue-on-error: true` while baseline is below floor. Expected baseline based on codebase inspection: core ≈ 65-80%, tui ≈ 30-50%. Once CI measures actual baseline on this PR's first run, I'll update the RUST-GUARDRAILS "Baseline measurement" paragraph in a follow-up commit.

Activation is per-tier: core can become blocking while TUI is still reporting-only. Each activation is a dedicated PR that removes `continue-on-error` for that tier.

### Ratchet — deferred

Per the spec's Wave 2 exit criteria split, ratchet enforcement is deferred until after floor activation. Enabling ratchet during baseline phase would block every PR that doesn't add tests — including refactors and documentation changes.

### macOS bash 3.2 note

The plan's initial `check-coverage-tiers.sh` skeleton used `declare -A` (associative arrays) and `mapfile` (bash 4+ features). macOS ships bash 3.2. The script was rewritten to use parallel indexed arrays and `while IFS= read` loops — bash 3.2-compatible. No functional difference.

### Local measurement caveat

`cargo-llvm-cov` requires the `llvm-tools-preview` component via `rustup component add llvm-tools-preview`. This machine doesn't have `rustup` (Rust installed differently), so the baseline was not measured locally. CI will measure it on this PR's first run.

## Commits

4 commits:

1. `6d9c734` feat(scripts): add coverage tier manifest
2. `2aaf92e` feat(scripts): add check-coverage-tiers.sh with bats coverage
3. `90b4968` ci: add coverage-tiers job (reporting-only baseline phase)
4. `25b3a11` docs+test(coverage): RUST-GUARDRAILS Wave 2.1 section + manifest schema tests

## Test plan

- [x] `bats tests/scripts/` → 8/8 pass (5 existing + 3 new coverage)
- [x] `python3 -m unittest discover -s tests -p "*_test.py"` → 15/15 pass
- [x] `.claude/hooks/preflight.sh` → all clear
- [x] `scripts/check-coverage-tiers.sh` fixture-tested end-to-end for PASS, FAIL (below floor), mixed-tier scenarios
- [x] Coverage job runs on CI and reports tier percentages (pending CI)