### PR TITLE
feat(ci): Wave 2.2 — file size cap 500 → 400

### DIFF
--- a/docs/RUST-GUARDRAILS.md
+++ b/docs/RUST-GUARDRAILS.md
@@ -25,7 +25,7 @@ Grounding sources:
 4. **Ownership over aliasing.** Minimize `Arc<Mutex<...>>`. Prefer channels + owned state machines (maestro's session pool pattern). If `Arc` is used, it must be justified in a comment.
 5. **Tests as specification.** Unit tests inline (`#[cfg(test)] mod tests`); integration tests under `src/integration_tests/`. Real fakes preferred over mocks. Insta for user-visible output. `#[tokio::test]` for async. No `#[ignore]` without a linked issue.
 6. **Supply-chain caution.** MSRV pinned via `rust-toolchain.toml`. `cargo deny` in CI. No wildcard versions. Licenses on an allow list.
-7. **Readability is a feature.** rustfmt non-negotiable. clippy `-D warnings` non-negotiable. File ≤ 500 LOC target (hard cap enforced by `scripts/check-file-size.sh`). Function ≤ 80 LOC soft cap.
+7. **Readability is a feature.** rustfmt non-negotiable. clippy `-D warnings` non-negotiable. File ≤ 400 LOC hard cap (enforced by `scripts/check-file-size.sh`; soft target 300 LOC). Function ≤ 80 LOC soft cap.
 8. **Observability.** `tracing` over `println!` / `eprintln!` / `dbg!` in committed code. Structured fields with context. Error paths log at `warn` or `error` with enough detail to diagnose without a debugger.
 
 ---
@@ -54,7 +54,7 @@ src/
 
 **Visibility.** `pub mod` is explicit. No `pub use super::*`. Re-exports name their targets. New modules start private (`mod foo`) and are promoted to `pub mod foo` only when another module needs them.
 
-**File size.** Soft target 500 LOC; hard cap enforced by `scripts/check-file-size.sh` (CI job `file-size`). Files approaching the cap (`config.rs` at ~1,623 LOC, `cli.rs` at ~1,009 LOC) must be split before adding new responsibilities.
+**File size.** Hard cap 400 LOC; soft target 300 LOC. Enforced by `scripts/check-file-size.sh` (CI job `file-size`). Files approaching the cap (`config.rs`, `cli.rs`, the TUI screens) are on `scripts/allowlist-large-files.txt` with deadlines — extensions require a PR with justification; reviewers push back on habitual extensions.
 
 **Function size.** Soft cap 80 LOC. A function over 80 LOC is a review signal, not a violation. Break out helpers named after what they compute (not `do_stuff`).
 
@@ -423,7 +423,24 @@ During Wave 1 implementation, `scripts/check-file-size.sh` was found to have a p
 - core: 87.6% (floor: 90.0%) — below by 2.4 pp
 - tui: 67.4% (floor: 70.0%) — below by 2.6 pp
 
-Both tiers are within striking distance of their floors; activation is near-term test-writing, not a multi-week project. Suggested sequence: add tests for the largest uncovered modules in each tier, rerun `coverage` to see the delta, repeat until ≥ floor, then open a follow-up PR that removes `continue-on-error` for that tier.
+Both tiers are within striking distance of their floors; activation is near-term test-writing, not a multi-week project. Suggested sequence: add tests for the largest uncovered modules in each tier, rerun `coverage` to see the delta, repeat until ≥ floor, then open a follow-up PR that adds `--enforce` to the coverage script invocation for that tier.
+
+---
+
+## CI Quality Gates (Wave 2.2 — File Size 500 → 400)
+
+**Status:** active (landed 2026-04-22 via chunk-3/file-size-400).
+
+**Hard cap:** 400 LOC per `.rs` file under `src/`. Enforced by `scripts/check-file-size.sh`. Soft target is 300 LOC — anything approaching 400 is a review signal to split before adding responsibilities.
+
+**Allowlist growth:** the cap flip added 16 files that were previously in the 400-500 band. Combined with Wave 1's 43 entries, the allowlist has 59 entries after Wave 2.2. Every entry has a deadline, owner, and plan field. Deadline tranches:
+
+- **1 month** (2026-05-22): 4 outlier files (>1500 LOC).
+- **2 months** (2026-06-22): 34 core modules (20 from Wave 1 + 14 from Wave 2.2 — note 1 of the 16 new entries is a test file).
+- **3 months** (2026-07-22): 23 TUI files (18 from Wave 1 + 5 from Wave 2.2).
+- **4 months** (2026-08-22): 3 test files (2 from Wave 1 + 1 new).
+
+**Extension policy:** unchanged from Wave 1. PR with paragraph justifying the new deadline; reviewer rejects habitual extensions in favor of re-planning the split.
 
 **Activation policy:** the `check-coverage-tiers.sh` script runs in **report mode by default** — it prints tier percentages and any VIOLATION lines but exits 0 so the CI check stays green while baseline is below floor. To activate enforcement, add `--enforce` to the script invocation in the `coverage` job (`.github/workflows/ci.yml`). Once baseline reaches a floor for a tier, a dedicated PR adds `--enforce` for that tier's first blocking run. (Per-tier activation can be modeled by running the checker twice with different manifests pointing at a subset of tiers — simplest evolution when we get there.)
 
@@ -440,3 +457,4 @@ Both tiers are within striking distance of their floors; activation is near-term
 | 2026-04-20 | Initial guardrails document | feat/rust-development-guardrails |
 | 2026-04-22 | Appended CI Quality Gates (Wave 1) | chunk-1/ci-wave-1 |
 | 2026-04-22 | Appended CI Quality Gates (Wave 2.1 — Coverage) | chunk-2/coverage-infrastructure |
+| 2026-04-22 | File-size hard cap tightened 500 → 400 (Wave 2.2) | chunk-3/file-size-400 |

--- a/scripts/allowlist-large-files.txt
+++ b/scripts/allowlist-large-files.txt
@@ -63,3 +63,29 @@ src/tui/screens/pr_review/mod.rs # deadline: 2026-07-22, owner: @carlos, ticket:
 
 # --- Test files (4-month deadline — lower priority, but tracked) ---
 src/integration_tests/stream_parsing.rs # deadline: 2026-08-22, owner: @carlos, ticket: #TBD, plan: break by scenario (happy path / error recovery / edge cases) into separate test files
+
+# --- 400-500 LOC band (added in Wave 2.2 when MAX_LINES flipped 500 → 400) ---
+# These files didn't violate the 500 LOC cap but do violate the tightened
+# 400 LOC cap. Triaged using the same Phase 1b heuristic.
+
+# Test files (lower priority, 4 months):
+src/mascot/tests.rs # deadline: 2026-08-22, owner: @carlos, ticket: #TBD, plan: break mascot tests by sub-feature; low priority
+
+# TUI (3 months):
+src/tui/activity_log.rs # deadline: 2026-07-22, owner: @carlos, ticket: #TBD, plan: split log-state from draw
+src/tui/app/completion_pipeline.rs # deadline: 2026-07-22, owner: @carlos, ticket: #TBD, plan: split pipeline stages into submodules
+src/tui/app/types.rs # deadline: 2026-07-22, owner: @carlos, ticket: #TBD, plan: split action types from event types from state types
+src/tui/screens/settings/validation.rs # deadline: 2026-07-22, owner: @carlos, ticket: #TBD, plan: split per-field validation rules into separate modules
+src/tui/turboquant_dashboard.rs # deadline: 2026-07-22, owner: @carlos, ticket: #TBD, plan: split dashboard-state from per-widget draw
+
+# Core modules (2 months):
+src/adapt/scaffolder.rs # deadline: 2026-06-22, owner: @carlos, ticket: #TBD, plan: split template expansion from directory materialization
+src/notifications/slack.rs # deadline: 2026-06-22, owner: @carlos, ticket: #TBD, plan: split webhook-client from message-building
+src/provider/azure_devops/mod.rs # deadline: 2026-06-22, owner: @carlos, ticket: #TBD, plan: split by resource type (work-items, PRs, pipelines)
+src/provider/github/pr.rs # deadline: 2026-06-22, owner: @carlos, ticket: #TBD, plan: split PR-fetching from PR-mutation verbs
+src/sanitize/screen.rs # deadline: 2026-06-22, owner: @carlos, ticket: #TBD, plan: split screen-rendering from match-reporting
+src/sanitize/types.rs # deadline: 2026-06-22, owner: @carlos, ticket: #TBD, plan: split pattern types from match result types
+src/state/file_claims.rs # deadline: 2026-06-22, owner: @carlos, ticket: #TBD, plan: split claim-state from lock-file handling
+src/updater/checker.rs # deadline: 2026-06-22, owner: @carlos, ticket: #TBD, plan: split version-check from download/install
+src/work/executor.rs # deadline: 2026-06-22, owner: @carlos, ticket: #TBD, plan: split execution loop from retry/backoff
+src/main.rs # deadline: 2026-06-22, owner: @carlos, ticket: #TBD, plan: extract dispatch logic into src/cli/dispatch.rs (keep main.rs minimal — crate entry only)

--- a/scripts/check-file-size.sh
+++ b/scripts/check-file-size.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-MAX_LINES=500
+MAX_LINES=400
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 ALLOWLIST="$SCRIPT_DIR/allowlist-large-files.txt"

--- a/tests/scripts/check-file-size.bats
+++ b/tests/scripts/check-file-size.bats
@@ -56,3 +56,19 @@ teardown() {
   [ "$status" -ne 0 ]
   [[ "$output" == *"VIOLATION"* ]]
 }
+
+@test "new 400 LOC cap: file at 450 LOC not on allowlist fails" {
+  printf 'line\n%.0s' {1..450} > src/new_bigfile.rs
+  echo "# empty" > scripts/allowlist-large-files.txt
+  run bash scripts/check-file-size.sh
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"VIOLATION"* ]]
+  [[ "$output" == *"max 400"* ]]
+}
+
+@test "new 400 LOC cap: file at 390 LOC passes without allowlist" {
+  printf 'line\n%.0s' {1..390} > src/small_file.rs
+  echo "# empty" > scripts/allowlist-large-files.txt
+  run bash scripts/check-file-size.sh
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Wave 2.2 of the CI quality-gate rollout — tightens the per-file LOC cap from 500 to 400.

### Changes

- **`scripts/check-file-size.sh`**: `MAX_LINES` 500 → 400.
- **`scripts/allowlist-large-files.txt`**: 16 new entries for files in the 400-500 band that were previously passing. All triaged per the Phase 1b heuristic.
- **`tests/scripts/check-file-size.bats`**: 2 new scenarios asserting the 400 cap (file at 450 fails; file at 390 passes).
- **`docs/RUST-GUARDRAILS.md`**:
  - §0.7 updated: 400 LOC hard cap.
  - §1 file-size section: 400 hard / 300 soft.
  - Appended Wave 2.2 section with allowlist structure + tranche breakdown.

### Allowlist structure after this chunk (59 entries)

| Deadline | Count | Category |
|----------|-------|----------|
| 2026-05-22 | 4 | Outliers (>1500 LOC): settings/mod.rs, config.rs, provider/github/client.rs, turboquant/adapter.rs |
| 2026-06-22 | 34 | Core modules (20 from Wave 1 + 14 new in 400-500 band) |
| 2026-07-22 | 23 | TUI (18 from Wave 1 + 5 new) |
| 2026-08-22 | 3 | Test files (2 from Wave 1 + 1 new: mascot/tests.rs) |

16 new entries added by this PR cover: `adapt/scaffolder`, `main.rs`, `mascot/tests`, `notifications/slack`, `provider/azure_devops/mod`, `provider/github/pr`, `sanitize/{screen,types}`, `state/file_claims`, `tui/{activity_log, app/completion_pipeline, app/types, screens/settings/validation, turboquant_dashboard}`, `updater/checker`, `work/executor`.

### First deadline fires in 30 days

2026-05-22 is when the 4 outliers (settings/mod.rs at 2080, config.rs at 1883, provider/github/client.rs at 1622, turboquant/adapter.rs at 1244) must be split. Total ~7000 LOC of refactoring across those 4 files — the forcing function is real.

## Test plan

- [x] `bats tests/scripts/check-file-size.bats` → 7/7 pass (5 existing + 2 new)
- [x] `bash scripts/check-file-size.sh` on real repo → exit 0 (all 59 allowlisted files covered)
- [x] `.claude/hooks/preflight.sh` → all clear