### PR TITLE
feat(ci): Wave 2.3 — layer violations with manifest + debt file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,20 @@ jobs:
         run: cargo llvm-cov --workspace --lcov --output-path coverage.lcov
       - name: Check coverage tiers
         run: bash scripts/check-coverage-tiers.sh coverage.lcov
+
+  layers:
+    # Wave 2.3 — layer violation enforcement.
+    # Blocking by default (no continue-on-error). Existing violations
+    # are tolerated via docs/layers-debt.txt until their deadlines;
+    # the script fails on new violations or past-deadline debt.
+    name: Architecture Layers
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install yq (Mike Farah Go-based, not Python apt package)
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
+      - name: Check architecture layers
+        run: bash scripts/check-layers.sh

--- a/docs/RUST-GUARDRAILS.md
+++ b/docs/RUST-GUARDRAILS.md
@@ -442,6 +442,40 @@ Both tiers are within striking distance of their floors; activation is near-term
 
 **Extension policy:** unchanged from Wave 1. PR with paragraph justifying the new deadline; reviewer rejects habitual extensions in favor of re-planning the split.
 
+---
+
+## CI Quality Gates (Wave 2.3 — Layer Violations)
+
+**Status:** active (landed 2026-04-22 via chunk-4/layer-violations).
+
+**Manifest:** `scripts/architecture-layers.yml`. Enforcement: `scripts/check-layers.sh` (CI job `layers`).
+
+**Layers** (lowest to highest — a file in layer N may import from layer N or any lower layer; imports from higher layers are forbidden):
+
+1. **primitives** — `src/icons.rs`, `src/icon_mode.rs`, `src/util/**`
+2. **domain** — `src/session/**`, `src/state/**`, `src/adapt/**`, `src/turboquant/**`, `src/provider/**`, `src/gates/**`, `src/sanitize/**`, `src/work/**`, `src/config.rs`
+3. **orchestration** — `src/cli.rs`, `src/commands/**`
+4. **ui** — `src/tui/**`
+5. **entry** — `src/main.rs`, `src/lib.rs`
+
+**Forbidden pairs** catch specific disallowed imports independently of layer-number check: `session/**`, `state/**`, `provider/**`, and `config.rs` may not import from `tui/**`.
+
+**Debt file:** `docs/layers-debt.txt`. Same deadlined-tolerance pattern as `scripts/allowlist-large-files.txt` but for (importer, target) pairs instead of individual files. Format:
+
+```
+<importer> → <target> # deadline: YYYY-MM-DD, owner: @handle, ticket: #N, plan: <brief>
+```
+
+CI fails on new violations not in the debt file, or on debt entries whose deadlines have passed (surfaced as `VIOLATION (DEADLINE PAST)` or `FORBIDDEN (DEADLINE PAST)`).
+
+**Baseline (2026-04-22):** 6 unique (importer, target) pairs covering 9 import sites.
+
+- 1 pair: `config.rs → tui/theme` (2026-05-22) — resolution tied to config.rs refactor.
+- 2 pairs: `sanitize/screen.rs → tui/*` (2026-06-22) — tied to sanitize/screen.rs split.
+- 3 pairs: `commands/{run,dashboard,setup}.rs → tui/app/*` (2026-07-22) — dependency inversion.
+
+**Script v1 limitations (documented):** brace-group imports (`use crate::mod::{A, B};`) are silently skipped; `pub use` re-exports are treated like plain `use`. Addressable with a future Rust-parser upgrade; acceptable for v1 per the spec's "simple enough not to need a full parser" rationale.
+
 **Activation policy:** the `check-coverage-tiers.sh` script runs in **report mode by default** — it prints tier percentages and any VIOLATION lines but exits 0 so the CI check stays green while baseline is below floor. To activate enforcement, add `--enforce` to the script invocation in the `coverage` job (`.github/workflows/ci.yml`). Once baseline reaches a floor for a tier, a dedicated PR adds `--enforce` for that tier's first blocking run. (Per-tier activation can be modeled by running the checker twice with different manifests pointing at a subset of tiers — simplest evolution when we get there.)
 
 **Ratchet:** deferred until after floor activation. Enabling ratchet during baseline phase would block every PR that doesn't add tests, including refactors and documentation changes.
@@ -458,3 +492,4 @@ Both tiers are within striking distance of their floors; activation is near-term
 | 2026-04-22 | Appended CI Quality Gates (Wave 1) | chunk-1/ci-wave-1 |
 | 2026-04-22 | Appended CI Quality Gates (Wave 2.1 — Coverage) | chunk-2/coverage-infrastructure |
 | 2026-04-22 | File-size hard cap tightened 500 → 400 (Wave 2.2) | chunk-3/file-size-400 |
+| 2026-04-22 | Appended CI Quality Gates (Wave 2.3 — Layer Violations) | chunk-4/layer-violations |

--- a/docs/layers-debt.txt
+++ b/docs/layers-debt.txt
@@ -1,0 +1,36 @@
+# Layer violation debt file.
+# Format: <importer> → <target> # deadline: YYYY-MM-DD, owner: @handle, ticket: #N, plan: <brief>
+#
+# Each entry is a known violation that scripts/check-layers.sh tolerates
+# until its deadline. After the deadline → CI fails with
+# "FORBIDDEN (DEADLINE PAST)" or "VIOLATION (DEADLINE PAST)".
+#
+# Generated baseline from Wave 2.3 (2026-04-22). See
+# docs/superpowers/specs/2026-04-22-ci-quality-gates-design.md § Wave 2.3
+# for the enforcement mechanism and
+# docs/RUST-GUARDRAILS.md § CI Quality Gates (Wave 2.3 — Layer Violations)
+# for policy.
+
+# --- config.rs → tui/theme.rs (4 import sites, one resolution) ---
+# Tied to the config.rs refactor already planned in
+# scripts/allowlist-large-files.txt (deadline 2026-05-22): move ThemeConfig,
+# ThemePreset, SerializableColor out of src/tui/theme.rs into a layer-2
+# module (src/theme.rs or src/config/theme.rs) so config can consume types
+# from layer 2 instead of reaching into layer 4.
+src/config.rs → src/tui/theme.rs # deadline: 2026-05-22, owner: @carlos, ticket: #TBD, plan: move ThemeConfig/ThemePreset/SerializableColor types to layer-2 module; see config.rs entry in scripts/allowlist-large-files.txt
+
+# --- sanitize/screen.rs → tui/* (2 pairs) ---
+# Tracked with sanitize/screen.rs's file-size allowlist entry (2026-06-22).
+# Resolution likely: extract the navigation/theme references into an
+# abstraction sanitize/ consumes without depending on tui/.
+src/sanitize/screen.rs → src/tui/navigation/mod.rs # deadline: 2026-06-22, owner: @carlos, ticket: #TBD, plan: extract navigation abstraction; resolve alongside sanitize/screen.rs split
+src/sanitize/screen.rs → src/tui/theme.rs # deadline: 2026-06-22, owner: @carlos, ticket: #TBD, plan: resolved by the config.rs→tui/theme fix above (ThemeConfig moves to layer 2) + sanitize/screen.rs split
+
+# --- commands/* → tui/app/* (3 pairs) ---
+# Commands are layer 3 (orchestration) but importing from layer 4 (UI) to
+# bootstrap the TUI. Inversion strategy: commands construct and return an
+# opaque "ready-to-run" value that main.rs (layer 5) hands to the TUI. Or
+# the tui/app entry points move to orchestration layer.
+src/commands/run.rs → src/tui/app/work_assigner.rs # deadline: 2026-07-22, owner: @carlos, ticket: #TBD, plan: invert dependency — commands emit events or return opaque handles; work_assigner consumers move to orchestration layer
+src/commands/dashboard.rs → src/tui/app/mod.rs # deadline: 2026-07-22, owner: @carlos, ticket: #TBD, plan: commands construct AppConfig; entry point in main.rs passes it to tui
+src/commands/setup.rs → src/tui/app/mod.rs # deadline: 2026-07-22, owner: @carlos, ticket: #TBD, plan: same pattern as dashboard — commands return config, tui consumes

--- a/scripts/architecture-layers.yml
+++ b/scripts/architecture-layers.yml
@@ -1,0 +1,65 @@
+# Module-level architecture layers.
+#
+# A file in layer N may import from layer N or any layer < N.
+# Imports from a higher layer are forbidden (by layer-number comparison).
+# Forbidden pairs catch specific disallowed imports even within the same layer.
+#
+# Enforcement: scripts/check-layers.sh (CI job `layers`).
+# Tolerance: docs/layers-debt.txt lists known violations with deadlines.
+# See docs/superpowers/specs/2026-04-22-ci-quality-gates-design.md § Wave 2.3.
+
+layers:
+  - name: primitives
+    number: 1
+    paths:
+      - "src/icons.rs"
+      - "src/icon_mode.rs"
+      - "src/util/**"
+
+  - name: domain
+    number: 2
+    paths:
+      - "src/session/**"
+      - "src/state/**"
+      - "src/adapt/**"
+      - "src/turboquant/**"
+      - "src/provider/**"
+      - "src/gates/**"
+      - "src/sanitize/**"
+      - "src/work/**"
+      - "src/config.rs"
+
+  - name: orchestration
+    number: 3
+    paths:
+      - "src/cli.rs"
+      - "src/commands/**"
+
+  - name: ui
+    number: 4
+    paths:
+      - "src/tui/**"
+
+  - name: entry
+    number: 5
+    paths:
+      - "src/main.rs"
+      - "src/lib.rs"
+
+forbidden:
+  # Specific disallowed imports that cross layer boundaries in ways
+  # that are hard to prevent with layer-number comparison alone.
+  # (These are redundant with the layer-number check for these specific
+  # cases, but are listed explicitly so the intent is documented.)
+  - from: "src/session/**"
+    to: "src/tui/**"
+    reason: "domain logic must not depend on UI rendering"
+  - from: "src/state/**"
+    to: "src/tui/**"
+    reason: "state persistence must not depend on UI rendering"
+  - from: "src/provider/**"
+    to: "src/tui/**"
+    reason: "external-service clients must not depend on UI rendering"
+  - from: "src/config.rs"
+    to: "src/tui/**"
+    reason: "config must not depend on UI (known debt: config.rs imports ThemeConfig from tui/theme; resolution via moving ThemeConfig to layer 2 — tracked in scripts/allowlist-large-files.txt config.rs deadline 2026-05-22)"

--- a/scripts/check-layers.sh
+++ b/scripts/check-layers.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+# Enforce architecture layer rules from scripts/architecture-layers.yml.
+#
+# Usage: check-layers.sh [<manifest>]
+#   Default manifest: scripts/architecture-layers.yml
+#
+# Scans every .rs file under src/, extracts `use crate::...` statements,
+# checks layer ordering and forbidden pairs.
+#
+# Exit codes:
+#   0 — no violations
+#   1 — one or more violations
+#   2 — invalid input (missing manifest, missing yq)
+#
+# Known v1 limitations (intentional — "simple enough not to need a full
+# Rust parser" per spec):
+#   - Brace-group imports (`use crate::mod::{TypeA, TypeB};`) are not
+#     expanded. The extracted path becomes "{TypeA, TypeB}" which
+#     use_to_path can't resolve; the import is silently ignored.
+#     Such imports exist in this codebase. Addressable in a future
+#     version by pre-expanding braces or switching to syn-based parsing.
+#   - Nested `use` blocks and `pub use` re-exports are treated the same
+#     as plain `use`; re-exports from TUI into domain layers would be
+#     flagged incorrectly if they occur.
+
+set -euo pipefail
+
+MANIFEST="${1:-scripts/architecture-layers.yml}"
+DEBT_FILE="${DEBT_FILE_OVERRIDE:-docs/layers-debt.txt}"
+
+if [[ ! -f "$MANIFEST" ]]; then
+  echo "error: manifest not found: $MANIFEST" >&2
+  exit 2
+fi
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "error: yq required for YAML parsing; install via: brew install yq" >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Glob-match helper (bash 3.2 safe — uses case statement).
+# ---------------------------------------------------------------------------
+matches_any_glob() {
+  local file="$1"
+  shift
+  local pattern
+  for pattern in "$@"; do
+    case "$file" in
+      $pattern) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Read layer metadata into parallel indexed arrays (bash 3.2 safe).
+# No declare -A, no mapfile.
+# ---------------------------------------------------------------------------
+layer_nums=()
+layer_path_counts=()
+# We'll build a flat list of all paths per layer as layer_paths_N_I variables
+# by storing them in named variables via eval, because bash 3.2 has no arrays
+# of arrays. Instead we use a flat encoded approach:
+#   layer_paths_<layer_index>_<path_index> = path
+# We track how many paths each layer has in layer_path_counts.
+
+layer_count=$(yq eval '.layers | length' "$MANIFEST")
+
+for (( i=0; i<layer_count; i++ )); do
+  num=$(yq eval ".layers[$i].number" "$MANIFEST")
+  layer_nums+=("$num")
+  pcount=$(yq eval ".layers[$i].paths | length" "$MANIFEST")
+  layer_path_counts+=("$pcount")
+  for (( p=0; p<pcount; p++ )); do
+    pval=$(yq eval ".layers[$i].paths[$p]" "$MANIFEST")
+    # Strip surrounding quotes if yq outputs them (it shouldn't for scalars,
+    # but be defensive).
+    pval="${pval#\"}"
+    pval="${pval%\"}"
+    # Store as a named variable: layer_path_I_J
+    eval "layer_path_${i}_${p}=\"\$pval\""
+  done
+done
+
+# ---------------------------------------------------------------------------
+# Given a relative file path, return its layer number (empty = unclassified).
+# ---------------------------------------------------------------------------
+file_to_layer_num() {
+  local file="$1"
+  for (( i=0; i<layer_count; i++ )); do
+    local num="${layer_nums[$i]}"
+    local pcount="${layer_path_counts[$i]}"
+    for (( p=0; p<pcount; p++ )); do
+      eval "local pval=\"\${layer_path_${i}_${p}}\""
+      case "$file" in
+        $pval) echo "$num"; return 0 ;;
+      esac
+    done
+  done
+  echo ""
+}
+
+# ---------------------------------------------------------------------------
+# Read forbidden pairs into parallel indexed arrays.
+# ---------------------------------------------------------------------------
+forbidden_count=$(yq eval '.forbidden | length' "$MANIFEST")
+forbidden_from=()
+forbidden_to=()
+forbidden_reason=()
+
+for (( i=0; i<forbidden_count; i++ )); do
+  fval=$(yq eval ".forbidden[$i].from" "$MANIFEST")
+  tval=$(yq eval ".forbidden[$i].to" "$MANIFEST")
+  rval=$(yq eval ".forbidden[$i].reason" "$MANIFEST")
+  forbidden_from+=("$fval")
+  forbidden_to+=("$tval")
+  forbidden_reason+=("$rval")
+done
+
+# ---------------------------------------------------------------------------
+# Load debt file (known violations that are tolerated until deadline).
+# Parallel arrays: debt_importers, debt_targets, debt_deadlines.
+# ---------------------------------------------------------------------------
+debt_importers=()
+debt_targets=()
+debt_deadlines=()
+
+if [[ -f "$DEBT_FILE" ]]; then
+  while IFS= read -r line; do
+    # Skip comment lines and blank lines.
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+    [[ -z "${line// }" ]] && continue
+    # Strip trailing comment: everything after " # "
+    local_stripped="${line%% # *}"
+    importer="${local_stripped% → *}"
+    # Handle both ASCII arrow ' → ' and the actual unicode arrow
+    # The debt file uses the unicode arrow character →
+    if [[ "$local_stripped" == *" → "* ]]; then
+      importer="${local_stripped%% → *}"
+      target="${local_stripped##* → }"
+    else
+      # Fallback: split on " -> "
+      importer="${local_stripped%% -> *}"
+      target="${local_stripped##* -> }"
+    fi
+    importer="${importer## }"
+    importer="${importer%% }"
+    target="${target## }"
+    target="${target%% }"
+    # Extract deadline from original line.
+    deadline=""
+    if [[ "$line" == *"deadline:"* ]]; then
+      deadline="${line##*deadline: }"
+      deadline="${deadline%%,*}"
+      deadline="${deadline%% *}"
+    fi
+    debt_importers+=("$importer")
+    debt_targets+=("$target")
+    debt_deadlines+=("$deadline")
+  done < "$DEBT_FILE"
+fi
+
+# Check if a pair is in the debt file. If deadline is past, return 2.
+# Returns: 0 = in debt (future), 1 = not in debt, 2 = in debt but past deadline
+# NOTE: uses 'di' as loop variable (not 'i') to avoid clobbering the caller's $i.
+is_in_debt() {
+  local importer="$1"
+  local target="$2"
+  local today
+  today=$(date +%Y-%m-%d)
+  local di
+  for (( di=0; di<${#debt_importers[@]}; di++ )); do
+    if [[ "${debt_importers[$di]}" == "$importer" && "${debt_targets[$di]}" == "$target" ]]; then
+      local dl="${debt_deadlines[$di]}"
+      if [[ -n "$dl" && "$dl" < "$today" ]]; then
+        return 2
+      fi
+      return 0
+    fi
+  done
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# For a `use crate::X::...` line, return the first-matching source file path
+# (best-effort — maps `crate::session::manager` to `src/session/manager.rs`
+# or `src/session/manager/mod.rs`).
+# Brace-group imports (`{TypeA, TypeB}`) can't be resolved; returns empty.
+# ---------------------------------------------------------------------------
+use_to_path() {
+  local use_line="$1"
+  # Extract everything after `use crate::` and before the terminating `;`
+  # or end of line. Strip leading whitespace first.
+  local stripped
+  stripped=$(printf '%s' "$use_line" | sed -E 's/^[[:space:]]*use crate:://')
+  stripped=$(printf '%s' "$stripped" | sed -E 's/;[[:space:]]*$//')
+
+  # If this contains a brace group, we can't resolve it — skip.
+  if [[ "$stripped" == *"{"* ]]; then
+    echo ""
+    return 0
+  fi
+
+  # Convert `::` separators to `/` path separators.
+  local path
+  path=$(printf '%s' "$stripped" | sed 's/::/\//g')
+
+  # Try direct file path.
+  if [[ -f "src/${path}.rs" ]]; then
+    echo "src/${path}.rs"
+    return 0
+  fi
+  # Try mod.rs directory form.
+  if [[ -f "src/${path}/mod.rs" ]]; then
+    echo "src/${path}/mod.rs"
+    return 0
+  fi
+  # Strip last segment — handles `session::manager::SessionManager` where
+  # `SessionManager` is a type exported from `session/manager.rs`.
+  local stripped_path
+  stripped_path=$(printf '%s' "$path" | rev | cut -d/ -f2- | rev)
+  if [[ -n "$stripped_path" ]]; then
+    if [[ -f "src/${stripped_path}.rs" ]]; then
+      echo "src/${stripped_path}.rs"
+      return 0
+    fi
+    if [[ -f "src/${stripped_path}/mod.rs" ]]; then
+      echo "src/${stripped_path}/mod.rs"
+      return 0
+    fi
+  fi
+
+  echo ""  # can't resolve; silently ignored
+}
+
+# ---------------------------------------------------------------------------
+# Main scan loop.
+# ---------------------------------------------------------------------------
+violations=0
+
+while IFS= read -r -d '' src_file; do
+  importer_rel="${src_file#./}"
+  importer_layer=$(file_to_layer_num "$importer_rel")
+  [[ -z "$importer_layer" ]] && continue
+
+  while IFS= read -r use_line; do
+    [[ -z "$use_line" ]] && continue
+    target=$(use_to_path "$use_line")
+    [[ -z "$target" ]] && continue
+    target_layer=$(file_to_layer_num "$target")
+    [[ -z "$target_layer" ]] && continue
+
+    # Forbidden pair check takes precedence over generic layer ordering —
+    # emit the more-specific FORBIDDEN message when both would apply.
+    forbidden_matched=false
+    for (( i=0; i<forbidden_count; i++ )); do
+      from_glob="${forbidden_from[$i]}"
+      to_glob="${forbidden_to[$i]}"
+      if matches_any_glob "$importer_rel" "$from_glob" && matches_any_glob "$target" "$to_glob"; then
+        forbidden_matched=true
+        debt_status=1
+        is_in_debt "$importer_rel" "$target" && debt_status=$? || debt_status=$?
+        if (( debt_status == 0 )); then
+          # Tolerated — future deadline.
+          break
+        elif (( debt_status == 2 )); then
+          reason="${forbidden_reason[$i]}"
+          echo "FORBIDDEN (DEADLINE PAST): $importer_rel → $target ($reason)"
+          violations=$((violations + 1))
+          break
+        else
+          reason="${forbidden_reason[$i]}"
+          echo "FORBIDDEN: $importer_rel → $target ($reason)"
+          violations=$((violations + 1))
+          break
+        fi
+      fi
+    done
+
+    # If a forbidden pair already fired, skip the generic layer ordering check.
+    $forbidden_matched && continue
+
+    # Layer ordering check: importer (lower number = lower layer) MUST NOT
+    # import from a higher layer number.
+    if (( importer_layer < target_layer )); then
+      debt_status=1
+      is_in_debt "$importer_rel" "$target" && debt_status=$? || debt_status=$?
+      if (( debt_status == 0 )); then
+        # Tolerated — future deadline.
+        continue
+      elif (( debt_status == 2 )); then
+        echo "VIOLATION (DEADLINE PAST): $importer_rel (layer $importer_layer) imports $target (layer $target_layer)"
+        violations=$((violations + 1))
+      else
+        echo "VIOLATION: $importer_rel (layer $importer_layer) imports $target (layer $target_layer)"
+        violations=$((violations + 1))
+      fi
+    fi
+  done < <(grep -E '^[[:space:]]*use crate::' "$src_file" 2>/dev/null || true)
+
+done < <(find src -name '*.rs' -print0 2>/dev/null)
+
+if (( violations > 0 )); then
+  echo ""
+  echo "$violations violation(s) found."
+  exit 1
+fi
+
+exit 0

--- a/tests/scripts/check-layers.bats
+++ b/tests/scripts/check-layers.bats
@@ -52,3 +52,26 @@ teardown() {
   [ "$status" -eq 1 ]
   [[ "$output" == *"FORBIDDEN"* ]]
 }
+
+@test "known-debt entry with future deadline is tolerated" {
+  mkdir -p src/state src/tui
+  cp "$FIXTURES/layers-forbiddenpair-fail.rs" src/state/store.rs
+  echo "pub struct SerializableColor;" > src/tui/theme.rs
+  cat > layers-debt.txt <<'EOF'
+src/state/store.rs → src/tui/theme.rs # deadline: 2099-12-31, owner: @test, ticket: #TEST, plan: resolve later
+EOF
+  DEBT_FILE_OVERRIDE="$PWD/layers-debt.txt" run bash "$SCRIPT" "$MANIFEST"
+  [ "$status" -eq 0 ]
+}
+
+@test "known-debt entry with past deadline fails with DEADLINE PAST" {
+  mkdir -p src/state src/tui
+  cp "$FIXTURES/layers-forbiddenpair-fail.rs" src/state/store.rs
+  echo "pub struct SerializableColor;" > src/tui/theme.rs
+  cat > layers-debt.txt <<'EOF'
+src/state/store.rs → src/tui/theme.rs # deadline: 2000-01-01, owner: @test, ticket: #TEST, plan: overdue
+EOF
+  DEBT_FILE_OVERRIDE="$PWD/layers-debt.txt" run bash "$SCRIPT" "$MANIFEST"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"DEADLINE PAST"* ]]
+}

--- a/tests/scripts/check-layers.bats
+++ b/tests/scripts/check-layers.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  SCRIPT="$REPO_ROOT/scripts/check-layers.sh"
+  MANIFEST="$REPO_ROOT/scripts/architecture-layers.yml"
+  FIXTURES="$REPO_ROOT/tests/scripts/fixtures"
+  # Each test runs in a clean tempdir with a faked src/ layout.
+  TEST_ROOT="$(mktemp -d -t layers-test-XXXXXX)"
+  cd "$TEST_ROOT"
+  mkdir -p src/session src/state src/tui
+}
+
+teardown() {
+  cd /
+  rm -rf "$TEST_ROOT"
+}
+
+@test "same-layer import passes (domain → domain)" {
+  mkdir -p src/session
+  cp "$FIXTURES/layers-samelayer-ok.rs" src/session/module_a.rs
+  run bash "$SCRIPT" "$MANIFEST"
+  [ "$status" -eq 0 ]
+}
+
+@test "lower-layer import passes (ui → domain)" {
+  mkdir -p src/tui
+  cp "$FIXTURES/layers-lowerlayer-ok.rs" src/tui/screen.rs
+  # Stub the target.
+  mkdir -p src/session
+  echo "pub struct SessionManager;" > src/session/manager.rs
+  run bash "$SCRIPT" "$MANIFEST"
+  [ "$status" -eq 0 ]
+}
+
+@test "higher-layer import fails (domain → ui)" {
+  mkdir -p src/session src/tui
+  cp "$FIXTURES/layers-higherlayer-fail.rs" src/session/naughty.rs
+  echo "pub struct ThemeConfig;" > src/tui/theme.rs
+  run bash "$SCRIPT" "$MANIFEST"
+  [ "$status" -eq 1 ]
+  # session→tui matches both the layer-ordering rule and the explicit forbidden pair;
+  # the script emits FORBIDDEN (more specific) so we accept either keyword.
+  [[ "$output" == *"VIOLATION"* || "$output" == *"FORBIDDEN"* ]]
+}
+
+@test "forbidden pair fails (state → tui)" {
+  mkdir -p src/state src/tui
+  cp "$FIXTURES/layers-forbiddenpair-fail.rs" src/state/store.rs
+  echo "pub struct SerializableColor;" > src/tui/theme.rs
+  run bash "$SCRIPT" "$MANIFEST"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"FORBIDDEN"* ]]
+}

--- a/tests/scripts/fixtures/layers-forbiddenpair-fail.rs
+++ b/tests/scripts/fixtures/layers-forbiddenpair-fail.rs
@@ -1,0 +1,2 @@
+// A state-layer file importing tui (forbidden pair) → should fail.
+use crate::tui::theme::SerializableColor;

--- a/tests/scripts/fixtures/layers-higherlayer-fail.rs
+++ b/tests/scripts/fixtures/layers-higherlayer-fail.rs
@@ -1,0 +1,2 @@
+// A domain-layer file importing a UI-layer module → should fail.
+use crate::tui::theme::ThemeConfig;

--- a/tests/scripts/fixtures/layers-lowerlayer-ok.rs
+++ b/tests/scripts/fixtures/layers-lowerlayer-ok.rs
@@ -1,0 +1,2 @@
+// A UI-layer file importing a domain-layer module → should pass.
+use crate::session::manager::SessionManager;

--- a/tests/scripts/fixtures/layers-samelayer-ok.rs
+++ b/tests/scripts/fixtures/layers-samelayer-ok.rs
@@ -1,0 +1,2 @@
+// A domain-layer file importing another domain-layer module → should pass.
+use crate::session::manager::SessionManager;


### PR DESCRIPTION
## Summary

Wave 2.3 of the CI quality-gate rollout — module-level layer enforcement via a YAML manifest + debt-file tolerance pattern.

### Changes

- **`scripts/architecture-layers.yml`**: 5 layers (primitives → domain → orchestration → ui → entry) + 4 forbidden pairs (domain/state/provider/config may not import tui).
- **`scripts/check-layers.sh`**: bash+yq enforcer — parses manifest, scans `src/**/*.rs` for `use crate::...` imports, checks layer ordering + forbidden pairs, honors the debt file. Bash 3.2 compatible (no `mapfile`/`declare -A`).
- **`docs/layers-debt.txt`**: baseline absorbed from current main — 6 unique (importer, target) pairs, 9 import sites, deadlines aligned with the file-size allowlist where possible.
- **`.github/workflows/ci.yml`**: new `layers` job (blocking — no `continue-on-error`).
- **`docs/RUST-GUARDRAILS.md`**: appended Wave 2.3 section.
- **`tests/scripts/check-layers.bats`**: 6 scenarios (4 initial + 2 new for debt-file handling).
- **`tests/scripts/fixtures/layers-*.rs`**: 4 fixture Rust files.

### Baseline debt (absorbed from current main)

| Deadline | Pair | Count |
|----------|------|-------|
| 2026-05-22 | `config.rs → tui/theme.rs` | 1 pair (4 import sites) |
| 2026-06-22 | `sanitize/screen.rs → tui/*` | 2 pairs |
| 2026-07-22 | `commands/{run,dashboard,setup}.rs → tui/app/*` | 3 pairs |

Total: 6 unique pairs. Each entry has a split plan; the config.rs one is tied to the config.rs file-size allowlist deadline (same refactor resolves both).

### Script v1 limitations (documented in script header)

- Brace-group imports (`use crate::mod::{A, B};`) silently skipped — would need a Rust parser to expand reliably.
- `pub use` re-exports treated like plain `use`.

Per the spec, these are acceptable for v1; the debt-file pattern catches the important cases we could detect without a full parser.

### CI behavior

- **Blocking by default.** Unlike the coverage job (which ships with report-mode), the layers job enforces strictly because the debt file explicitly tolerates existing violations. A new violation not in the debt file blocks the PR.
- Script uses Mike Farah Go-based yq (same install path as the coverage job).

## Test plan

- [x] `bats tests/scripts/check-layers.bats` → 6/6 pass
- [x] `bash scripts/check-layers.sh` on real main → exit 0 (9 violations absorbed by debt file)
- [x] `.claude/hooks/preflight.sh` → all clear
- [x] Removing any debt entry triggers the expected VIOLATION/FORBIDDEN output

## Forcing function summary after Wave 2.3

The first file-size allowlist deadline (2026-05-22) now doubles as a layer-debt deadline — `config.rs`'s split will resolve both file-size AND the config.rs → tui/theme layer violation in one refactor.