### PR TITLE
fix(tui/settings): advertise contextual edit keybindings in footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Settings screen footer omitted edit keys (Space/Enter/←→) for non-Flags widgets — `WidgetKind::edit_hint()` now returns a contextual `(key, label)` tuple per variant; `SettingsScreen::draw` builds the footer from the focused widget's hint; `KeymapProvider::keybindings()` gains a third `"Edit"` group so the `?` help overlay stays consistent (#432)
+
 ## [0.14.0] - 2026-04-21
 
 ### Added

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-21 00:00 (UTC)
+> Last updated: 2026-04-22 00:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -228,10 +228,10 @@ maestro/
 │   │       │   ├── mod.rs                 # ReleaseNotesScreen struct with Screen trait impl
 │   │       │   └── draw.rs                # ratatui rendering for release notes display
 │   │       └── settings/                  # Settings screen components  [Issue #124, #146]
-│   │           ├── mod.rs                 # SettingsScreen: interactive settings screen with tabbed TUI widget system; Flags tab displays all feature flags with name, on/off state, source (Default/Config/Cli), and description in read-only mode; focused fields rendered with green accent; Sessions tab gains hollow-retry widgets: [policy] dropdown (always/intent-aware/never), [work_max_retries] stepper, [consultation_max_retries] stepper  [Issue #275]
+│   │           ├── mod.rs                 # SettingsScreen: interactive settings screen with tabbed TUI widget system; Flags tab displays all feature flags with name, on/off state, source (Default/Config/Cli), and description in read-only mode; focused fields rendered with green accent; Sessions tab gains hollow-retry widgets: [policy] dropdown (always/intent-aware/never), [work_max_retries] stepper, [consultation_max_retries] stepper; footer built from focused widget's edit_hint() so edit keys (Space/Enter/←→) are always advertised; KeymapProvider::keybindings() gains a third "Edit" group for consistent ? help overlay  [Issue #275, #432]
 │   │           └── validation.rs          # Settings field validation helpers
 │   │   └── widgets/                       # Reusable TUI widget components  [Issue #124]
-│   │       ├── mod.rs                     # Module re-exports for all widgets
+│   │       ├── mod.rs                     # Module re-exports for all widgets; WidgetKind::edit_hint() returns a contextual (key, label) tuple per variant used by SettingsScreen to build the footer  [Issue #432]
 │   │       ├── ci_monitor.rs              # CiMonitorWidget: compact bordered box rendering live CI check-run status for a PR; status icons, check names, elapsed times, and a summary footer
 │   │       ├── dropdown.rs                # Dropdown selection widget with keyboard navigation
 │   │       ├── list_editor.rs             # Editable list widget for adding and removing string items
@@ -395,7 +395,7 @@ maestro/
 | `src/tui/screens/wrap.rs` | Soft-wrap utilities: `soft_wrap_lines()` splits a multi-line string into display lines that fit within a given column width using `unicode-width` for correct grapheme measurement (Issue #263) |
 | `src/tui/screens/hollow_retry.rs` | `HollowRetryScreen`: minimal retry prompt overlay for stalled sessions awaiting user confirmation |
 | `src/tui/screens/queue_confirmation.rs` | `QueueConfirmationScreen`: confirmation overlay before bulk-queuing selected issues from the issue browser |
-| `src/tui/screens/settings/mod.rs` | `SettingsScreen`: tabbed interactive settings UI; `Flags` tab shows all feature flags with name, state, source (`Default`/`Config`/`Cli`), and description; read-only display with green accent on focused fields (Issues #124, #146) |
+| `src/tui/screens/settings/mod.rs` | `SettingsScreen`: tabbed interactive settings UI; `Flags` tab shows all feature flags with name, state, source (`Default`/`Config`/`Cli`), and description; footer built from focused widget's `edit_hint()` so edit keys (`Space`/`Enter`/`←→`) are always advertised; `KeymapProvider::keybindings()` gains a third `"Edit"` group for the `?` help overlay (Issues #124, #146, #432) |
 | `src/icon_mode.rs` | Shared icon mode detection: `AtomicBool` global, `init_from_config()`, `use_nerd_font()`; reads `tui.ascii_icons` config and `MAESTRO_ASCII_ICONS` env var (Issue #307) |
 | `src/icons.rs` | Shared icon registry: `IconId` enum (38 variants + `NeedsReview`), `IconPair` struct, `icon_pair()` const jump table, `get(IconId)`, `get_for_mode(id, nerd_font)` (Issue #308) |
 | `src/tui/icons.rs` | Thin re-export shim: re-exports all public items from `src/icon_mode.rs` and `src/icons.rs` so existing `tui::icons::` import paths remain valid (Issues #307, #308) |

--- a/src/tui/screens/settings/mod.rs
+++ b/src/tui/screens/settings/mod.rs
@@ -1229,17 +1229,19 @@ impl Screen for SettingsScreen {
                 theme,
             );
         } else {
-            draw_keybinds_bar(
-                f,
-                chunks[3],
-                &[
-                    ("Tab", "Tab"),
-                    ("↑/↓", "Field"),
-                    ("Esc", "Back"),
-                    ("Ctrl+s", "Save"),
-                ],
-                theme,
-            );
+            let edit_hint = self
+                .current_fields()
+                .get(self.field_index)
+                .map(|field| field.widget.edit_hint());
+            let mut entries: Vec<(&str, &str)> = Vec::with_capacity(5);
+            entries.push(("Tab", "Tab"));
+            entries.push(("↑/↓", "Field"));
+            if let Some((key, label)) = edit_hint {
+                entries.push((key, label));
+            }
+            entries.push(("Ctrl+s", "Save"));
+            entries.push(("Esc", "Back"));
+            draw_keybinds_bar(f, chunks[3], &entries, theme);
         }
     }
 
@@ -1273,6 +1275,23 @@ impl KeymapProvider for SettingsScreen {
                 ],
             },
             KeyBindingGroup {
+                title: "Edit",
+                bindings: vec![
+                    KeyBinding {
+                        key: "Space/Enter",
+                        description: "Toggle or begin editing focused field",
+                    },
+                    KeyBinding {
+                        key: "←/→ or h/l",
+                        description: "Adjust dropdown / number",
+                    },
+                    KeyBinding {
+                        key: "Enter",
+                        description: "Edit text / list field",
+                    },
+                ],
+            },
+            KeyBindingGroup {
                 title: "Actions",
                 bindings: vec![
                     KeyBinding {
@@ -1295,6 +1314,7 @@ mod tests {
     use crate::flags::store::FeatureFlags as TestFeatureFlags;
     use crate::tui::screens::test_helpers::key_event;
     use crossterm::event::{KeyEventKind, KeyEventState};
+    use ratatui::{Terminal, backend::TestBackend};
 
     fn make_flags() -> TestFeatureFlags {
         TestFeatureFlags::default()
@@ -1767,11 +1787,13 @@ alert_threshold_pct = 80
     fn integration_keybindings_grouped_logically() {
         let screen = SettingsScreen::new(make_config(), make_flags());
         let groups = screen.keybindings();
-        assert_eq!(groups.len(), 2);
+        assert_eq!(groups.len(), 3);
         assert_eq!(groups[0].title, "Navigation");
-        assert_eq!(groups[1].title, "Actions");
+        assert_eq!(groups[1].title, "Edit");
+        assert_eq!(groups[2].title, "Actions");
         assert!(groups[0].bindings.len() >= 3);
         assert!(groups[1].bindings.len() >= 2);
+        assert!(groups[2].bindings.len() >= 2);
     }
 
     // --- Issue #146: Feature flags display tests ---
@@ -2076,5 +2098,140 @@ alert_threshold_pct = 80
             screen.config.sessions.hollow_retry.consultation_max_retries,
             3
         );
+    }
+
+    fn render_settings_to_string(screen: &mut SettingsScreen, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let theme = Theme::dark();
+        terminal
+            .draw(|f| {
+                screen.draw(f, f.area(), &theme);
+            })
+            .unwrap();
+        let buf = terminal.backend().buffer().clone();
+        let mut out = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                out.push_str(buf[(x, y)].symbol());
+            }
+            out.push('\n');
+        }
+        out
+    }
+
+    /// Return the keybinds bar row — the second-to-last line of the rendered
+    /// output. The final line is the outer block's bottom border.
+    fn keybinds_row(s: &str) -> String {
+        let lines: Vec<&str> = s.lines().collect();
+        lines
+            .get(lines.len().saturating_sub(2))
+            .copied()
+            .unwrap_or("")
+            .to_string()
+    }
+
+    #[test]
+    fn keybind_bar_project_text_input_shows_enter_edit() {
+        let mut screen = SettingsScreen::new(make_config(), make_flags());
+        let output = render_settings_to_string(&mut screen, 80, 10);
+        let row = keybinds_row(&output);
+        assert!(
+            row.contains("Enter"),
+            "expected 'Enter' in keybinds row: {row}"
+        );
+        assert!(
+            row.contains("Edit"),
+            "expected 'Edit' in keybinds row: {row}"
+        );
+    }
+
+    #[test]
+    fn keybind_bar_turboquant_toggle_shows_space_toggle() {
+        let mut screen = SettingsScreen::new(make_config(), make_flags());
+        for _ in 0..10 {
+            screen.handle_input(&key_event(KeyCode::Tab), InputMode::Normal);
+        }
+        assert_eq!(screen.active_tab(), SettingsTab::TurboQuant);
+        assert_eq!(screen.field_index, 0);
+        let output = render_settings_to_string(&mut screen, 80, 10);
+        let row = keybinds_row(&output);
+        assert!(
+            row.contains("Space"),
+            "expected 'Space' in keybinds row: {row}"
+        );
+        assert!(
+            row.contains("Toggle"),
+            "expected 'Toggle' in keybinds row: {row}"
+        );
+    }
+
+    #[test]
+    fn keybind_bar_turboquant_dropdown_shows_arrows_change() {
+        let mut screen = SettingsScreen::new(make_config(), make_flags());
+        for _ in 0..10 {
+            screen.handle_input(&key_event(KeyCode::Tab), InputMode::Normal);
+        }
+        screen.handle_input(&key_event(KeyCode::Down), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Down), InputMode::Normal);
+        assert_eq!(screen.field_index, 2);
+        let output = render_settings_to_string(&mut screen, 80, 10);
+        let row = keybinds_row(&output);
+        assert!(row.contains("←/→"), "expected '←/→' in keybinds row: {row}");
+        assert!(
+            row.contains("Change"),
+            "expected 'Change' in keybinds row: {row}"
+        );
+    }
+
+    #[test]
+    fn keybind_bar_flags_tab_has_no_widget_hints() {
+        let mut screen = SettingsScreen::new(make_config(), make_flags());
+        for _ in 0..9 {
+            screen.handle_input(&key_event(KeyCode::Tab), InputMode::Normal);
+        }
+        assert_eq!(screen.active_tab(), SettingsTab::Flags);
+        let output = render_settings_to_string(&mut screen, 80, 10);
+        let row = keybinds_row(&output);
+        assert!(
+            !row.contains("Space"),
+            "Flags bar must not contain 'Space': {row}"
+        );
+        assert!(
+            !row.contains("Change"),
+            "Flags bar must not contain 'Change': {row}"
+        );
+    }
+
+    #[test]
+    fn keybind_bar_list_editor_still_shows_save_esc_at_80_cols() {
+        let mut screen = SettingsScreen::new(make_config(), make_flags());
+        for _ in 0..11 {
+            screen.handle_input(&key_event(KeyCode::Tab), InputMode::Normal);
+        }
+        assert_eq!(screen.active_tab(), SettingsTab::Advanced);
+        screen.handle_input(&key_event(KeyCode::Down), InputMode::Normal);
+        screen.handle_input(&key_event(KeyCode::Down), InputMode::Normal);
+        assert_eq!(screen.field_index, 2);
+        let output = render_settings_to_string(&mut screen, 80, 10);
+        let row = keybinds_row(&output);
+        assert!(
+            row.contains("Ctrl+s"),
+            "expected 'Ctrl+s' in keybinds row: {row}"
+        );
+        assert!(row.contains("Esc"), "expected 'Esc' in keybinds row: {row}");
+    }
+
+    #[test]
+    fn keybindings_includes_edit_group() {
+        let screen = SettingsScreen::new(make_config(), make_flags());
+        let groups = screen.keybindings();
+        assert!(
+            groups.len() >= 3,
+            "expected at least 3 keybinding groups, got {}",
+            groups.len()
+        );
+        let has_edit = groups.iter().any(|g| g.title == "Edit");
+        assert!(has_edit, "expected a group titled 'Edit' in keybindings");
     }
 }

--- a/src/tui/widgets/mod.rs
+++ b/src/tui/widgets/mod.rs
@@ -89,4 +89,50 @@ impl WidgetKind {
             _ => false,
         }
     }
+
+    /// Short `(key, label)` hint describing how to edit the focused widget.
+    pub fn edit_hint(&self) -> (&'static str, &'static str) {
+        match self {
+            Self::Toggle(_) => ("Space", "Toggle"),
+            Self::Dropdown(_) => ("←/→", "Change"),
+            Self::NumberStepper(_) => ("←/→", "Adjust"),
+            Self::TextInput(_) => ("Enter", "Edit"),
+            Self::ListEditor(_) => ("Enter", "Edit list"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn edit_hint_toggle() {
+        let w = WidgetKind::Toggle(Toggle::new("x", false));
+        assert_eq!(w.edit_hint(), ("Space", "Toggle"));
+    }
+
+    #[test]
+    fn edit_hint_dropdown() {
+        let w = WidgetKind::Dropdown(Dropdown::new("x", vec!["a".into()], 0));
+        assert_eq!(w.edit_hint(), ("←/→", "Change"));
+    }
+
+    #[test]
+    fn edit_hint_number_stepper() {
+        let w = WidgetKind::NumberStepper(NumberStepper::new("x", 1, 0, 10));
+        assert_eq!(w.edit_hint(), ("←/→", "Adjust"));
+    }
+
+    #[test]
+    fn edit_hint_text_input() {
+        let w = WidgetKind::TextInput(TextInput::new("x", ""));
+        assert_eq!(w.edit_hint(), ("Enter", "Edit"));
+    }
+
+    #[test]
+    fn edit_hint_list_editor() {
+        let w = WidgetKind::ListEditor(ListEditor::new("x", vec![]));
+        assert_eq!(w.edit_hint(), ("Enter", "Edit list"));
+    }
 }


### PR DESCRIPTION
## Summary
- `WidgetKind::edit_hint()` returns a contextual `(key, label)` pair per variant (Toggle → Space/Toggle, Dropdown → ←→/Change, NumberStepper → ←→/Adjust, TextInput → Enter/Edit, ListEditor → Enter/Edit list).
- Non-Flags Settings keybinds footer now inserts the hint for the focused widget between the navigation and save entries, within 80 columns.
- `KeymapProvider::keybindings()` gains an "Edit" group so the `?` help overlay stays consistent with the footer.

Closes #432

## Test plan
- [x] `cargo test` — 2813 tests pass (11 new: 5 unit tests on `edit_hint`, 6 render tests covering Project/TextInput, TurboQuant/Toggle, TurboQuant/Dropdown, Flags regression, 80-col width, and the new KeyBindingGroup).
- [x] `cargo fmt && cargo clippy -- -D warnings -A dead_code` — clean.
- [x] File-size allowlist respected (settings/mod.rs still allowlisted with its existing split deadline).
- [ ] Manual smoke in release build: edit keys visible on Project, Sessions, Budget, GitHub, Notifications, Gates, Review, Theme, Layout, TurboQuant, Advanced; Flags tab unchanged.