### PR TITLE
fix(tui/settings): surface validation errors when Ctrl+S is blocked

### DIFF
--- a/src/tui/screens/settings/mod.rs
+++ b/src/tui/screens/settings/mod.rs
@@ -198,6 +198,38 @@ impl SettingsScreen {
         self.validation_results.values().any(|v| v.is_error())
     }
 
+    fn validation_error_summary(&self) -> Option<String> {
+        let mut errors: Vec<((usize, usize), &ValidationFeedback)> = self
+            .validation_results
+            .iter()
+            .filter(|(_, v)| v.is_error())
+            .map(|(k, v)| (*k, v))
+            .collect();
+        errors.sort_by_key(|&(k, _)| k);
+        let first = errors.first()?;
+        let ((tab_idx, field_idx), feedback) = *first;
+        let tab_label = SettingsTab::ALL
+            .get(tab_idx)
+            .map(|t| t.label())
+            .unwrap_or("?");
+        let field_label = self
+            .fields_per_tab
+            .get(tab_idx)
+            .and_then(|fs| fs.get(field_idx))
+            .map(|f| f.widget.label())
+            .unwrap_or("?");
+        let msg = if feedback.message.is_empty() {
+            "validation failed"
+        } else {
+            feedback.message.as_str()
+        };
+        let mut summary = format!("{}.{}: {}", tab_label, field_label, msg);
+        if errors.len() > 1 {
+            summary.push_str(&format!(" (+{} more)", errors.len() - 1));
+        }
+        Some(summary)
+    }
+
     fn feedback_for(&self, tab: usize, field: usize) -> Option<&ValidationFeedback> {
         self.validation_results.get(&(tab, field))
     }
@@ -1106,6 +1138,10 @@ impl Screen for SettingsScreen {
             }
             (KeyCode::Char('s'), KeyModifiers::CONTROL) => {
                 if self.has_validation_errors() {
+                    let summary = self
+                        .validation_error_summary()
+                        .unwrap_or_else(|| "validation failed".to_string());
+                    self.save_error_flash = Some((summary, std::time::Instant::now()));
                     return ScreenAction::None;
                 }
                 match self.save_config() {
@@ -2011,6 +2047,52 @@ alert_threshold_pct = 80
         });
         let action = screen.handle_input(&ctrl_s, InputMode::Normal);
         assert_eq!(action, ScreenAction::None);
+    }
+
+    #[test]
+    fn save_with_validation_errors_populates_save_error_flash() {
+        let mut screen = SettingsScreen::new(make_config(), make_flags());
+        screen.config.project.base_branch = String::new();
+        screen.run_all_validations();
+        assert!(screen.has_validation_errors());
+        assert!(screen.save_error_flash.is_none());
+
+        let ctrl_s = Event::Key(KeyEvent {
+            code: KeyCode::Char('s'),
+            modifiers: KeyModifiers::CONTROL,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        });
+        screen.handle_input(&ctrl_s, InputMode::Normal);
+
+        let flash = screen
+            .save_error_flash
+            .as_ref()
+            .expect("save_error_flash must be set when validation blocks the save");
+        assert!(
+            flash.0.to_lowercase().contains("base_branch"),
+            "flash message must name the failing field, got: {:?}",
+            flash.0
+        );
+    }
+
+    #[test]
+    fn save_with_no_validation_errors_does_not_set_error_flash() {
+        let (mut screen, _f) = screen_with_config_path();
+        assert!(!screen.has_validation_errors());
+
+        let ctrl_s = Event::Key(KeyEvent {
+            code: KeyCode::Char('s'),
+            modifiers: KeyModifiers::CONTROL,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        });
+        screen.handle_input(&ctrl_s, InputMode::Normal);
+
+        assert!(
+            screen.save_error_flash.is_none(),
+            "valid save must not set save_error_flash"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `Ctrl+S` in the Settings screen previously silently no-opped whenever any validator was in the error state — the user saw `[Errors]` in the title but got no feedback about *what* was wrong, so the screen looked broken in the release binary. This was a perception regression vs. #437, whose `[Save failed: …]` flash only covered actual save failures, not pre-save validation blocks.
- New `SettingsScreen::validation_error_summary()` formats the first failing validator as `"<Tab>.<field>: <message>"` (e.g., `"Project.base_branch: base_branch cannot be empty"`), with a `" (+N more)"` suffix when multiple validators fail.
- The `Ctrl+S` handler now populates `save_error_flash` with the summary before returning, so the existing 5-second title flash (`Settings [Save failed: …]`) now surfaces the real reason.
- 2 new unit tests cover the flash population on blocked save and the non-regression path (clean save leaves `save_error_flash` None). Full suite: 2849 passed.

Closes #444

## Test plan

- [x] `cargo test` — 2849 passed (2 new)
- [x] `cargo clippy -- -D warnings -A dead_code`
- [x] `cargo fmt --check`
- [x] `scripts/check-file-size.sh`
- [x] Manual QA: run the release binary against a `maestro.toml` with an intentionally-empty `base_branch`; open Settings; press Ctrl+S; confirm the title flashes `Settings [Save failed: Project.base_branch: base_branch cannot be empty]` for ~5s.