### PR TITLE
feat(tui): add 'improve with AI' step to Issue Wizard

### DIFF
--- a/directory-tree.md
+++ b/directory-tree.md
@@ -226,10 +226,14 @@ maestro/
 │   │       │   ├── mod.rs                 # IssueBrowserScreen: navigable issue list, multi-select, label/milestone filters, preview pane; set_issues() for async data delivery; reapply_filters() honours active filters on new data  [Issue #32, #46, #117]
 │   │       │   └── draw.rs                # ratatui rendering for issue browser layout and panels
 │   │       ├── issue_wizard/              # Issue creation wizard screen components  [Issue #447]
-│   │       │   ├── mod.rs                 # IssueWizardScreen: multi-step wizard using WizardFields; sync_fields_into_payload(), rebuild_fields_for_step(), field_text(), refresh_field_blocks()  [Issue #447]
+│   │       │   ├── mod.rs                 # IssueWizardScreen: multi-step wizard using WizardFields; sync_fields_into_payload(), rebuild_fields_for_step(), field_text(), refresh_field_blocks(); improve state fields and lifecycle methods  [Issue #447, #450]
 │   │       │   ├── types.rs               # IssueWizardStep state machine and form payload types
+│   │       │   ├── ai_improve.rs          # Improve prompt builder + JSON parser for AI-rewrite flow; pure logic, no I/O  [Issue #450]
 │   │       │   ├── ai_review.rs           # AI-assisted review step: calls LLM to review draft issue fields before submission
-│   │       │   └── draw.rs                # ratatui rendering; renders TextArea widgets via refresh_field_blocks() mutable draw entry point  [Issue #447]
+│   │       │   ├── draw.rs                # ratatui rendering; renders TextArea widgets via refresh_field_blocks() mutable draw entry point  [Issue #447]
+│   │       │   ├── draw_ai_review.rs      # Renders AiReview step and its improve sub-states (loading / error / diff / default review)  [Issue #450]
+│   │       │   ├── draw_diff.rs           # 8-field red/green before-after diff renderer  [Issue #450]
+│   │       │   └── prompt_common.rs       # Shared format_payload_for_prompt used by both review and improve flows  [Issue #450]
 │   │       ├── landing/                   # Landing screen components
 │   │       │   ├── mod.rs                 # LandingScreen struct with Screen trait impl
 │   │       │   ├── types.rs               # Landing screen type definitions
@@ -440,11 +444,15 @@ maestro/
 | `src/tui/screens/home/mod.rs` | `HomeScreen`: idle dashboard with 3-column layout (Quick Actions 30% / Suggestions 35% / Recent Activity 35%); `SuggestionKind` enum (`ReadyIssues`, `MilestoneProgress`, `IdleSessions`, `FailedIssues`); `Suggestion` struct with `build_suggestions()` factory; `HomeSection` enum for Tab-based focus toggle; `draw_suggestions()` renderer; `@username` display in project info bar (Issues #31, #34, #35, #49) |
 | `src/tui/screens/issue_browser/` | Issue browser screen: navigable issue list with multi-select, label/milestone filters, and preview pane |
 | `src/tui/screens/issue_browser/mod.rs` | `IssueBrowserScreen`: multi-select list with label/milestone filters; `set_issues()` delivers async data; `reapply_filters()` honours active filters when new data arrives (Issues #32, #46, #117) |
-| `src/tui/screens/issue_wizard/` | Issue creation wizard screen: multi-step TUI wizard for authoring GitHub issues (Issue #447) |
-| `src/tui/screens/issue_wizard/mod.rs` | `IssueWizardScreen`: replaced hand-rolled `String` buffer with `WizardFields`; adds `sync_fields_into_payload()`, `rebuild_fields_for_step()`, `field_text()`, `refresh_field_blocks()`; paste path via `insert_sanitized()` (Issue #447) |
+| `src/tui/screens/issue_wizard/` | Issue creation wizard screen: multi-step TUI wizard for authoring GitHub issues (Issues #447, #450) |
+| `src/tui/screens/issue_wizard/mod.rs` | `IssueWizardScreen`: `WizardFields`-backed wizard; `sync_fields_into_payload()`, `rebuild_fields_for_step()`, `field_text()`, `refresh_field_blocks()`; improve state fields (`improve_loading`, `improve_candidate`, `improve_error`, `improve_enqueued`, `diff_scroll`) and lifecycle methods (`begin_improve`, `apply_improve_result`, `accept_improve`, `discard_improve`); `AiReview` step key handler (`i`/`a`/`d`/`r`/`Esc`/`j`/`k`) (Issues #447, #450) |
 | `src/tui/screens/issue_wizard/types.rs` | `IssueWizardStep` state machine and form payload types |
-| `src/tui/screens/issue_wizard/ai_review.rs` | AI-assisted review step: calls LLM to review draft issue fields before submission |
+| `src/tui/screens/issue_wizard/ai_improve.rs` | Improve prompt builder (`build_improve_prompt`) and JSON parser (`parse_improve_response`); pure logic, no I/O; 13 unit tests (Issue #450) |
+| `src/tui/screens/issue_wizard/ai_review.rs` | AI-assisted review step: calls LLM to review draft issue fields; refactored to use shared `format_payload_for_prompt` |
 | `src/tui/screens/issue_wizard/draw.rs` | ratatui rendering; renders `TextArea` widget directly; blocks set via `refresh_field_blocks()` on mutable draw entry point (Issue #447) |
+| `src/tui/screens/issue_wizard/draw_ai_review.rs` | Renders `AiReview` step and its improve sub-states: loading spinner, error view, before/after diff, and default review display (Issue #450) |
+| `src/tui/screens/issue_wizard/draw_diff.rs` | 8-field red/green before-after diff renderer; 3 unit tests (Issue #450) |
+| `src/tui/screens/issue_wizard/prompt_common.rs` | Shared `format_payload_for_prompt` helper used by both review and improve flows; 3 unit tests (Issue #450) |
 | `src/tui/screens/landing/` | Landing screen components |
 | `src/tui/screens/landing/mod.rs` | `LandingScreen` struct with `Screen` trait impl |
 | `src/tui/screens/landing/types.rs` | Landing screen type definitions |

--- a/src/tui/app/data_handler.rs
+++ b/src/tui/app/data_handler.rs
@@ -382,6 +382,11 @@ impl App {
                     screen.apply_ai_review(result);
                 }
             }
+            TuiDataEvent::AiImproveResult(result) => {
+                if let Some(ref mut screen) = self.issue_wizard_screen {
+                    screen.apply_improve_result(result);
+                }
+            }
             TuiDataEvent::MilestonePlanCreated(result) => {
                 if let Some(ref mut screen) = self.milestone_wizard_screen {
                     screen.finish_materialization(result);

--- a/src/tui/app/types.rs
+++ b/src/tui/app/types.rs
@@ -191,6 +191,12 @@ pub enum TuiCommand {
     FetchWizardDependencies,
     /// Run the AI review companion against the current draft (#296).
     LaunchAiReview(crate::tui::screens::issue_wizard::IssueCreationPayload),
+    /// Run the AI improve companion — rewrite the draft using the prior
+    /// critique as guidance, return an improved payload (#450).
+    LaunchAiImprove(
+        crate::tui::screens::issue_wizard::IssueCreationPayload,
+        String,
+    ),
     /// Materialize a Milestone Wizard plan into GitHub (#297). Creates
     /// the milestone first, then each accepted issue with its
     /// `Blocked By` rewritten to actual issue numbers.
@@ -228,6 +234,10 @@ pub enum TuiDataEvent {
     /// AI review companion result (#296). Carries the raw response text
     /// or a human-readable failure reason.
     AiReviewResult(Result<String, String>),
+    /// AI improve companion result (#450). Carries the rewritten payload
+    /// (with trusted seats re-stamped by the parser) or a human-readable
+    /// failure reason (subprocess error or JSON parse failure).
+    AiImproveResult(Result<crate::tui::screens::issue_wizard::IssueCreationPayload, String>),
     /// Result of materializing a milestone plan into GitHub (#297).
     MilestonePlanCreated(
         Result<crate::tui::screens::milestone_wizard::MilestoneCreationResult, String>,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -455,6 +455,21 @@ async fn event_loop(
                         let _ = tx.send(app::TuiDataEvent::AiReviewResult(res));
                     });
                 }
+                app::TuiCommand::LaunchAiImprove(payload, critique) => {
+                    let tx = app.data_tx.clone();
+                    tokio::spawn(async move {
+                        let prompt = crate::tui::screens::issue_wizard::build_improve_prompt(
+                            &payload, &critique,
+                        );
+                        let res = run_claude_print_for_wizard(&prompt).await;
+                        let parsed = res.and_then(|raw| {
+                            crate::tui::screens::issue_wizard::parse_improve_response(
+                                &payload, &raw,
+                            )
+                        });
+                        let _ = tx.send(app::TuiDataEvent::AiImproveResult(parsed));
+                    });
+                }
                 app::TuiCommand::CreateMilestoneWithIssues(plan) => {
                     let tx = app.data_tx.clone();
                     tokio::spawn(async move {

--- a/src/tui/screen_dispatch.rs
+++ b/src/tui/screen_dispatch.rs
@@ -11,9 +11,13 @@ pub(super) fn tick_wizard_step_hooks(app: &mut app::App) {
     if app.tui_mode != app::TuiMode::IssueWizard {
         return;
     }
-    let (start_dep_fetch, start_review) = match app.issue_wizard_screen.as_ref() {
-        Some(s) => (s.entered_dependencies_step(), s.entered_ai_review_step()),
-        None => (false, false),
+    let (start_dep_fetch, start_review, start_improve) = match app.issue_wizard_screen.as_ref() {
+        Some(s) => (
+            s.entered_dependencies_step(),
+            s.entered_ai_review_step(),
+            s.improve_requested(),
+        ),
+        None => (false, false, false),
     };
     if start_dep_fetch {
         if let Some(ref mut s) = app.issue_wizard_screen {
@@ -33,6 +37,21 @@ pub(super) fn tick_wizard_step_hooks(app: &mut app::App) {
             }
             app.pending_commands
                 .push(app::TuiCommand::LaunchAiReview(payload));
+        }
+    }
+    if start_improve {
+        let pair = app.issue_wizard_screen.as_ref().map(|s| {
+            (
+                s.payload().clone(),
+                s.review_text().unwrap_or("").to_string(),
+            )
+        });
+        if let Some((payload, critique)) = pair {
+            if let Some(ref mut s) = app.issue_wizard_screen {
+                s.mark_improve_enqueued();
+            }
+            app.pending_commands
+                .push(app::TuiCommand::LaunchAiImprove(payload, critique));
         }
     }
 

--- a/src/tui/screens/issue_wizard/ai_improve.rs
+++ b/src/tui/screens/issue_wizard/ai_improve.rs
@@ -1,0 +1,268 @@
+//! Prompt building and response parsing for the Issue Wizard's AI
+//! *improve* companion step (#450). The improve flow asks the model to
+//! rewrite the draft using its own critique as guidance, then shows the
+//! user a before/after diff for atomic accept/discard.
+//!
+//! Trusted-seat contract: `issue_type`, `blocked_by`, `milestone`, and
+//! `image_paths` are NEVER asked from the model. The parser re-stamps
+//! those fields from the caller-supplied `original` payload regardless
+//! of what the JSON emits. This keeps the AI strictly inside its lane
+//! (the 8 text fields) and prevents hallucinated dependencies or typed
+//! drift from leaking into the wizard state.
+
+use super::IssueCreationPayload;
+use super::prompt_common::format_payload_for_prompt;
+use serde::Deserialize;
+
+/// AI-authored subset of `IssueCreationPayload`: the 8 text fields the
+/// model is allowed to rewrite. Everything else (`issue_type`,
+/// `blocked_by`, `milestone`, `image_paths`) is a trusted seat that the
+/// parser re-stamps from the caller's `original` — the model cannot
+/// reach those fields even if it tries.
+#[derive(Debug, Deserialize)]
+struct ImproveResponse {
+    title: String,
+    overview: String,
+    expected_behavior: String,
+    current_behavior: String,
+    steps_to_reproduce: String,
+    acceptance_criteria: String,
+    files_to_modify: String,
+    test_hints: String,
+}
+
+/// Build the structured prompt sent to `claude --print` for the AI
+/// improve step. Embeds the current draft plus the previous critique,
+/// asks for a JSON object with exactly 8 string fields.
+pub fn build_improve_prompt(payload: &IssueCreationPayload, critique: &str) -> String {
+    let mut s = String::new();
+    s.push_str(
+        "You are rewriting a draft GitHub issue using your own prior critique as guidance.\n",
+    );
+    s.push_str(
+        "Apply the critique. Improve clarity, completeness, testability, and acceptance criteria.\n",
+    );
+    s.push_str(
+        "Preserve the user's intent — do not change the scope or the chosen issue type.\n\n",
+    );
+    s.push_str(
+        "Output ONLY a JSON object with this exact shape, no markdown fences, no commentary:\n",
+    );
+    s.push_str("{\n");
+    s.push_str("  \"title\": \"…\",\n");
+    s.push_str("  \"overview\": \"…\",\n");
+    s.push_str("  \"expected_behavior\": \"…\",\n");
+    s.push_str("  \"current_behavior\": \"…\",\n");
+    s.push_str("  \"steps_to_reproduce\": \"…\",\n");
+    s.push_str("  \"acceptance_criteria\": \"…\",\n");
+    s.push_str("  \"files_to_modify\": \"…\",\n");
+    s.push_str("  \"test_hints\": \"…\"\n");
+    s.push_str("}\n");
+    s.push_str(
+        "All eight keys are required. Use empty strings for fields that don't apply (e.g. bug-only fields on a feature issue).\n\n",
+    );
+    s.push_str("--- PRIOR CRITIQUE ---\n");
+    s.push_str(critique.trim());
+    s.push_str("\n--- END CRITIQUE ---\n");
+    s.push_str("\n--- CURRENT DRAFT ---\n");
+    s.push_str(&format!("Title: {}\n", payload.title));
+    s.push_str(&format_payload_for_prompt(payload));
+    s.push_str("\n--- END DRAFT ---\n");
+    s
+}
+
+/// Parse the AI's JSON response into an improved `IssueCreationPayload`.
+/// Trusted seats (`issue_type`, `blocked_by`, `milestone`, `image_paths`)
+/// are re-stamped from `original` regardless of what the response contains.
+/// Tolerates markdown fences, surrounding text, and other artefacts via
+/// `adapt::prompts::parse_json_response`.
+pub fn parse_improve_response(
+    original: &IssueCreationPayload,
+    raw: &str,
+) -> Result<IssueCreationPayload, String> {
+    let r: ImproveResponse = crate::adapt::prompts::parse_json_response(raw)
+        .map_err(|e| format!("invalid JSON: {e}"))?;
+    Ok(IssueCreationPayload {
+        title: r.title,
+        overview: r.overview,
+        expected_behavior: r.expected_behavior,
+        current_behavior: r.current_behavior,
+        steps_to_reproduce: r.steps_to_reproduce,
+        acceptance_criteria: r.acceptance_criteria,
+        files_to_modify: r.files_to_modify,
+        test_hints: r.test_hints,
+        issue_type: original.issue_type,
+        blocked_by: original.blocked_by.clone(),
+        milestone: original.milestone,
+        image_paths: original.image_paths.clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::IssueType;
+    use super::*;
+
+    fn sample_payload_full() -> IssueCreationPayload {
+        IssueCreationPayload {
+            issue_type: IssueType::Feature,
+            title: "Add gauge widget".into(),
+            overview: "Render a horizontal gauge.".into(),
+            expected_behavior: "Fills 0–100%.".into(),
+            current_behavior: String::new(),
+            steps_to_reproduce: String::new(),
+            acceptance_criteria: "- Renders correctly\n- Handles overflow".into(),
+            files_to_modify: "src/widgets/gauge.rs".into(),
+            test_hints: "Test boundary values.".into(),
+            blocked_by: vec![10],
+            milestone: Some(42),
+            image_paths: vec!["/tmp/a.png".into()],
+        }
+    }
+
+    // ── build_improve_prompt ───────────────────────────────────────────
+
+    #[test]
+    fn build_improve_prompt_contains_critique_verbatim() {
+        let p = sample_payload_full();
+        let critique = "The AC is weak and misses error paths.";
+        let out = build_improve_prompt(&p, critique);
+        assert!(out.contains(critique));
+    }
+
+    #[test]
+    fn build_improve_prompt_contains_all_eight_field_headers() {
+        let mut p = sample_payload_full();
+        p.current_behavior = "Crashes.".into();
+        p.steps_to_reproduce = "1. Open".into();
+        let out = build_improve_prompt(&p, "critique");
+        assert!(out.contains("Title:"));
+        assert!(out.contains("## Overview"));
+        assert!(out.contains("## Expected Behavior"));
+        assert!(out.contains("## Acceptance Criteria"));
+        assert!(out.contains("## Files to Modify"));
+        assert!(out.contains("## Test Hints"));
+    }
+
+    #[test]
+    fn build_improve_prompt_omits_trusted_seats() {
+        let p = sample_payload_full();
+        let out = build_improve_prompt(&p, "c");
+        assert!(!out.contains("\"blocked_by\""));
+        assert!(!out.contains("\"milestone\""));
+        assert!(!out.contains("\"image_paths\""));
+        assert!(!out.contains("## Blocked By"));
+    }
+
+    #[test]
+    fn build_improve_prompt_instructs_json_only_output() {
+        let p = sample_payload_full();
+        let out = build_improve_prompt(&p, "c");
+        assert!(out.contains("JSON"));
+        assert!(out.contains("no markdown"));
+    }
+
+    #[test]
+    fn build_improve_prompt_omits_bug_headers_when_empty() {
+        let p = sample_payload_full();
+        let out = build_improve_prompt(&p, "c");
+        assert!(!out.contains("## Current Behavior"));
+        assert!(!out.contains("## Steps to Reproduce"));
+    }
+
+    #[test]
+    fn build_improve_prompt_includes_bug_headers_when_filled() {
+        let mut p = sample_payload_full();
+        p.issue_type = IssueType::Bug;
+        p.current_behavior = "Crashes.".into();
+        p.steps_to_reproduce = "1. Open".into();
+        let out = build_improve_prompt(&p, "c");
+        assert!(out.contains("## Current Behavior"));
+        assert!(out.contains("## Steps to Reproduce"));
+    }
+
+    // ── parse_improve_response ─────────────────────────────────────────
+
+    fn valid_json() -> &'static str {
+        r#"{
+          "title": "New title",
+          "overview": "new overview",
+          "expected_behavior": "new expected",
+          "current_behavior": "",
+          "steps_to_reproduce": "",
+          "acceptance_criteria": "- new ac",
+          "files_to_modify": "new files",
+          "test_hints": "new hints"
+        }"#
+    }
+
+    #[test]
+    fn parse_improve_response_accepts_bare_json() {
+        let p = sample_payload_full();
+        let got = parse_improve_response(&p, valid_json()).unwrap();
+        assert_eq!(got.title, "New title");
+        assert_eq!(got.overview, "new overview");
+        assert_eq!(got.acceptance_criteria, "- new ac");
+    }
+
+    #[test]
+    fn parse_improve_response_accepts_fenced_json() {
+        let p = sample_payload_full();
+        let raw = format!("```json\n{}\n```", valid_json());
+        let got = parse_improve_response(&p, &raw).unwrap();
+        assert_eq!(got.title, "New title");
+    }
+
+    #[test]
+    fn parse_improve_response_restamps_trusted_seats_from_original() {
+        let original = sample_payload_full(); // blocked_by=[10], milestone=Some(42), issue_type=Feature, image_paths=["/tmp/a.png"]
+        // Give the model a JSON that tries to overwrite every trusted seat.
+        let raw = r#"{
+          "title": "t",
+          "overview": "o",
+          "expected_behavior": "e",
+          "current_behavior": "",
+          "steps_to_reproduce": "",
+          "acceptance_criteria": "ac",
+          "files_to_modify": "f",
+          "test_hints": "th",
+          "blocked_by": [999],
+          "milestone": 1,
+          "issue_type": "Bug",
+          "image_paths": ["/evil.png"]
+        }"#;
+        let got = parse_improve_response(&original, raw).unwrap();
+        assert_eq!(got.blocked_by, vec![10]);
+        assert_eq!(got.milestone, Some(42));
+        assert_eq!(got.issue_type, IssueType::Feature);
+        assert_eq!(got.image_paths, vec!["/tmp/a.png".to_string()]);
+    }
+
+    #[test]
+    fn parse_improve_response_returns_err_on_missing_required_key() {
+        let p = sample_payload_full();
+        let raw = r#"{"overview":"o","expected_behavior":"e","current_behavior":"","steps_to_reproduce":"","acceptance_criteria":"ac","files_to_modify":"f","test_hints":"th"}"#;
+        assert!(parse_improve_response(&p, raw).is_err());
+    }
+
+    #[test]
+    fn parse_improve_response_returns_err_on_wrong_type() {
+        let p = sample_payload_full();
+        let raw = r#"{"title":123,"overview":"o","expected_behavior":"e","current_behavior":"","steps_to_reproduce":"","acceptance_criteria":"ac","files_to_modify":"f","test_hints":"th"}"#;
+        assert!(parse_improve_response(&p, raw).is_err());
+    }
+
+    #[test]
+    fn parse_improve_response_returns_err_on_invalid_json() {
+        let p = sample_payload_full();
+        assert!(parse_improve_response(&p, "not json at all").is_err());
+    }
+
+    #[test]
+    fn parse_improve_response_accepts_empty_strings_for_optional_fields() {
+        let p = sample_payload_full();
+        let got = parse_improve_response(&p, valid_json()).unwrap();
+        assert_eq!(got.current_behavior, "");
+        assert_eq!(got.steps_to_reproduce, "");
+    }
+}

--- a/src/tui/screens/issue_wizard/ai_review.rs
+++ b/src/tui/screens/issue_wizard/ai_review.rs
@@ -2,6 +2,7 @@
 //! Pure string helpers, no I/O — keeps the prompt logic unit-testable.
 
 use super::IssueCreationPayload;
+use super::prompt_common::format_payload_for_prompt;
 
 /// Build the structured prompt sent to `claude --print` for the AI
 /// review step. The model is asked to critique completeness, testability,
@@ -17,36 +18,20 @@ pub fn build_review_prompt(payload: &IssueCreationPayload) -> String {
     s.push_str("--- DRAFT ISSUE ---\n");
     s.push_str(&format!("Type: {:?}\n", payload.issue_type));
     s.push_str(&format!("Title: {}\n", payload.title));
-    push_section(&mut s, "Overview", &payload.overview);
-    push_section(&mut s, "Expected Behavior", &payload.expected_behavior);
-    if !payload.current_behavior.trim().is_empty() {
-        push_section(&mut s, "Current Behavior", &payload.current_behavior);
-    }
-    if !payload.steps_to_reproduce.trim().is_empty() {
-        push_section(&mut s, "Steps to Reproduce", &payload.steps_to_reproduce);
-    }
-    push_section(&mut s, "Acceptance Criteria", &payload.acceptance_criteria);
-    push_section(&mut s, "Files to Modify", &payload.files_to_modify);
-    push_section(&mut s, "Test Hints", &payload.test_hints);
+    s.push_str(&format_payload_for_prompt(payload));
     if !payload.blocked_by.is_empty() {
         let refs: Vec<String> = payload
             .blocked_by
             .iter()
             .map(|n| format!("#{}", n))
             .collect();
-        push_section(&mut s, "Blocked By", &refs.join(", "));
+        s.push('\n');
+        s.push_str("## Blocked By\n");
+        s.push_str(&refs.join(", "));
+        s.push('\n');
     }
     s.push_str("\n--- END DRAFT ---\n");
     s
-}
-
-fn push_section(out: &mut String, title: &str, body: &str) {
-    out.push('\n');
-    out.push_str("## ");
-    out.push_str(title);
-    out.push('\n');
-    out.push_str(body.trim());
-    out.push('\n');
 }
 
 #[cfg(test)]

--- a/src/tui/screens/issue_wizard/draw.rs
+++ b/src/tui/screens/issue_wizard/draw.rs
@@ -228,49 +228,6 @@ impl IssueWizardScreen {
         f.render_widget(Paragraph::new(lines).alignment(Alignment::Center), inner);
     }
 
-    fn draw_ai_review(&self, f: &mut Frame, area: Rect) {
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .title("AI Review  (r: revise, s: skip, Enter: continue, R: retry on error)");
-        let inner = block.inner(area);
-        f.render_widget(block, area);
-
-        if let Some(err) = self.review_error() {
-            let lines = vec![
-                Line::from(""),
-                Line::from(Span::styled(
-                    "AI review failed:",
-                    Style::default()
-                        .fg(Color::LightRed)
-                        .add_modifier(Modifier::BOLD),
-                )),
-                Line::from(err.to_string()),
-                Line::from(""),
-                Line::from("Press R to retry, s to skip, Esc to go back."),
-            ];
-            f.render_widget(Paragraph::new(lines).alignment(Alignment::Center), inner);
-            return;
-        }
-
-        if self.review_loading() {
-            let lines = vec![
-                Line::from(""),
-                Line::from(Span::styled(
-                    "AI is reviewing your issue…",
-                    Style::default().add_modifier(Modifier::BOLD),
-                )),
-            ];
-            f.render_widget(Paragraph::new(lines).alignment(Alignment::Center), inner);
-            return;
-        }
-
-        let body: Vec<Line> = match self.review_text() {
-            Some(text) => text.lines().map(Line::from).collect(),
-            None => vec![Line::from("Press Enter to continue (no review run yet).")],
-        };
-        f.render_widget(Paragraph::new(body), inner);
-    }
-
     fn draw_dependencies(&self, f: &mut Frame, area: Rect) {
         let block = Block::default()
             .borders(Borders::ALL)

--- a/src/tui/screens/issue_wizard/draw_ai_review.rs
+++ b/src/tui/screens/issue_wizard/draw_ai_review.rs
@@ -1,0 +1,112 @@
+//! Rendering for the `AiReview` step. Owns the review-text view plus
+//! the three improve sub-states (loading, error, diff) landed in #450.
+//! Kept in its own file so `draw.rs` stays under the 400-LOC guardrail.
+
+use super::IssueWizardScreen;
+use super::draw_diff::build_diff_lines;
+use ratatui::{
+    Frame,
+    layout::{Alignment, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph},
+};
+
+impl IssueWizardScreen {
+    pub(super) fn draw_ai_review(&self, f: &mut Frame, area: Rect) {
+        // Improve sub-state takes precedence over the default review
+        // view — loading, error, and diff are exclusive with each other
+        // and with the underlying review text.
+        if self.improve_loading() {
+            let block = Block::default()
+                .borders(Borders::ALL)
+                .title("AI Review · Improving…");
+            let inner = block.inner(area);
+            f.render_widget(block, area);
+            let lines = vec![
+                Line::from(""),
+                Line::from(Span::styled(
+                    "AI is rewriting your issue using its own feedback…",
+                    Style::default().add_modifier(Modifier::BOLD),
+                )),
+            ];
+            f.render_widget(Paragraph::new(lines).alignment(Alignment::Center), inner);
+            return;
+        }
+
+        if let Some(err) = self.improve_error() {
+            let block = Block::default()
+                .borders(Borders::ALL)
+                .title("AI Review · Improve failed");
+            let inner = block.inner(area);
+            f.render_widget(block, area);
+            let lines = vec![
+                Line::from(""),
+                Line::from(Span::styled(
+                    "AI improve failed:",
+                    Style::default()
+                        .fg(Color::LightRed)
+                        .add_modifier(Modifier::BOLD),
+                )),
+                Line::from(err.to_string()),
+                Line::from(""),
+                Line::from("r: retry    Esc: back to review"),
+            ];
+            f.render_widget(Paragraph::new(lines).alignment(Alignment::Center), inner);
+            return;
+        }
+
+        if let Some(candidate) = self.improve_candidate() {
+            let block = Block::default().borders(Borders::ALL).title(
+                "AI Review · Proposed changes  (a: accept, d: discard, r: retry, j/k: scroll)",
+            );
+            let inner = block.inner(area);
+            f.render_widget(block, area);
+            let lines = build_diff_lines(self.payload(), candidate);
+            let para = Paragraph::new(lines).scroll((self.diff_scroll(), 0));
+            f.render_widget(para, inner);
+            return;
+        }
+
+        let block = Block::default().borders(Borders::ALL).title(
+            "AI Review  (r: revise, s: skip, i: improve with AI, Enter: continue, R: retry on error)",
+        );
+        let inner = block.inner(area);
+        f.render_widget(block, area);
+
+        if let Some(err) = self.review_error() {
+            let lines = vec![
+                Line::from(""),
+                Line::from(Span::styled(
+                    "AI review failed:",
+                    Style::default()
+                        .fg(Color::LightRed)
+                        .add_modifier(Modifier::BOLD),
+                )),
+                Line::from(err.to_string()),
+                Line::from(""),
+                Line::from("Press R to retry, s to skip, Esc to go back."),
+            ];
+            f.render_widget(Paragraph::new(lines).alignment(Alignment::Center), inner);
+            return;
+        }
+
+        if self.review_loading() {
+            let lines = vec![
+                Line::from(""),
+                Line::from(Span::styled(
+                    "AI is reviewing your issue…",
+                    Style::default().add_modifier(Modifier::BOLD),
+                )),
+            ];
+            f.render_widget(Paragraph::new(lines).alignment(Alignment::Center), inner);
+            return;
+        }
+
+        let body: Vec<Line> = match self.review_text() {
+            Some(text) => text.lines().map(Line::from).collect(),
+            None => vec![Line::from("Press Enter to continue (no review run yet).")],
+        };
+        f.render_widget(Paragraph::new(body), inner);
+    }
+}

--- a/src/tui/screens/issue_wizard/draw_diff.rs
+++ b/src/tui/screens/issue_wizard/draw_diff.rs
@@ -1,0 +1,182 @@
+//! Diff rendering for the Issue Wizard's AI improve step (#450). Pure
+//! formatting helpers kept separate from the main `draw.rs` so the draw
+//! surface stays within the 400-LOC project guardrail.
+
+use super::IssueCreationPayload;
+use ratatui::{
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+};
+
+/// Canonical 8-field diff tuple: `(label, before, after)` in display order.
+/// Callers render `before == after` as a single dim line and render the
+/// rest with red-strikethrough old + green-prefixed new.
+fn diff_fields<'a>(
+    original: &'a IssueCreationPayload,
+    candidate: &'a IssueCreationPayload,
+) -> [(&'static str, &'a str, &'a str); 8] {
+    [
+        ("Title", &original.title, &candidate.title),
+        ("Overview", &original.overview, &candidate.overview),
+        (
+            "Expected Behavior",
+            &original.expected_behavior,
+            &candidate.expected_behavior,
+        ),
+        (
+            "Current Behavior",
+            &original.current_behavior,
+            &candidate.current_behavior,
+        ),
+        (
+            "Steps to Reproduce",
+            &original.steps_to_reproduce,
+            &candidate.steps_to_reproduce,
+        ),
+        (
+            "Acceptance Criteria",
+            &original.acceptance_criteria,
+            &candidate.acceptance_criteria,
+        ),
+        (
+            "Files to Modify",
+            &original.files_to_modify,
+            &candidate.files_to_modify,
+        ),
+        ("Test Hints", &original.test_hints, &candidate.test_hints),
+    ]
+}
+
+pub(super) fn build_diff_lines<'a>(
+    original: &'a IssueCreationPayload,
+    candidate: &'a IssueCreationPayload,
+) -> Vec<Line<'a>> {
+    let mut lines: Vec<Line<'a>> = Vec::new();
+    for (label, before, after) in diff_fields(original, candidate) {
+        if before == after {
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("  {}:", label),
+                    Style::default().add_modifier(Modifier::DIM),
+                ),
+                Span::styled(" unchanged", Style::default().add_modifier(Modifier::DIM)),
+            ]));
+            continue;
+        }
+        lines.push(Line::from(Span::styled(
+            format!("▼ {}", label),
+            Style::default().add_modifier(Modifier::BOLD),
+        )));
+        for l in before.lines() {
+            lines.push(Line::from(Span::styled(
+                format!("  - {}", l),
+                Style::default()
+                    .fg(Color::Red)
+                    .add_modifier(Modifier::CROSSED_OUT),
+            )));
+        }
+        if before.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "  - (empty)",
+                Style::default()
+                    .fg(Color::Red)
+                    .add_modifier(Modifier::CROSSED_OUT | Modifier::DIM),
+            )));
+        }
+        for l in after.lines() {
+            lines.push(Line::from(Span::styled(
+                format!("  + {}", l),
+                Style::default().fg(Color::Green),
+            )));
+        }
+        if after.is_empty() {
+            lines.push(Line::from(Span::styled(
+                "  + (empty)",
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::DIM),
+            )));
+        }
+        lines.push(Line::from(""));
+    }
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{IssueCreationPayload, IssueType};
+    use super::*;
+
+    fn baseline() -> IssueCreationPayload {
+        IssueCreationPayload {
+            issue_type: IssueType::Feature,
+            title: "Title".into(),
+            overview: "Overview".into(),
+            expected_behavior: "EB".into(),
+            current_behavior: String::new(),
+            steps_to_reproduce: String::new(),
+            acceptance_criteria: "AC".into(),
+            files_to_modify: "FTM".into(),
+            test_hints: "TH".into(),
+            blocked_by: vec![],
+            milestone: None,
+            image_paths: vec![],
+        }
+    }
+
+    #[test]
+    fn unchanged_field_renders_single_dim_line() {
+        let p = baseline();
+        let lines = build_diff_lines(&p, &p);
+        // 8 unchanged fields → 8 lines, none of which contain `▼` or `+`.
+        assert_eq!(lines.len(), 8);
+        for line in &lines {
+            let rendered: String = line
+                .spans
+                .iter()
+                .map(|s| s.content.as_ref())
+                .collect::<Vec<&str>>()
+                .join("");
+            assert!(rendered.contains("unchanged"), "got: {rendered:?}");
+            assert!(!rendered.contains("▼"));
+            assert!(!rendered.contains("+"));
+        }
+    }
+
+    #[test]
+    fn changed_field_renders_old_red_and_new_green() {
+        let before = baseline();
+        let mut after = before.clone();
+        after.title = "New title".into();
+        let lines = build_diff_lines(&before, &after);
+        let flat: Vec<String> = lines
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<Vec<&str>>()
+                    .join("")
+            })
+            .collect();
+        let joined = flat.join("\n");
+        assert!(joined.contains("▼ Title"), "got:\n{joined}");
+        assert!(joined.contains("- Title"));
+        assert!(joined.contains("+ New title"));
+    }
+
+    #[test]
+    fn empty_to_filled_renders_empty_placeholder_and_new_content() {
+        let before = baseline(); // current_behavior = ""
+        let mut after = before.clone();
+        after.current_behavior = "Now crashes".into();
+        let lines = build_diff_lines(&before, &after);
+        let flat: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+            .collect::<Vec<&str>>()
+            .join("\n");
+        assert!(flat.contains("- (empty)"));
+        assert!(flat.contains("+ Now crashes"));
+    }
+}

--- a/src/tui/screens/issue_wizard/mod.rs
+++ b/src/tui/screens/issue_wizard/mod.rs
@@ -898,15 +898,15 @@ impl Screen for IssueWizardScreen {
                 KeyCode::Char('R') if self.review_error.is_some() => {
                     self.begin_ai_review();
                 }
-                KeyCode::Enter => {
+                KeyCode::Enter
                     if !self.review_loading
                         && self.review_error.is_none()
-                        && !self.improve_sub_state_active()
-                    {
-                        self.try_advance();
-                    }
-                    // else: block advance; use 'R'/'r'/'a'/'d' to resolve.
+                        && !self.improve_sub_state_active() =>
+                {
+                    self.try_advance();
                 }
+                // else: Enter is blocked while loading / error / improve sub-state;
+                // use 'R'/'r'/'a'/'d' to resolve.
                 _ => {}
             },
             IssueWizardStep::Preview => match code {

--- a/src/tui/screens/issue_wizard/mod.rs
+++ b/src/tui/screens/issue_wizard/mod.rs
@@ -1,7 +1,12 @@
+pub mod ai_improve;
 pub mod ai_review;
 mod draw;
+mod draw_ai_review;
+mod draw_diff;
+mod prompt_common;
 pub mod types;
 
+pub use ai_improve::{build_improve_prompt, parse_improve_response};
 pub use ai_review::build_review_prompt;
 pub use types::{IssueCreationPayload, IssueType, IssueWizardStep};
 
@@ -95,6 +100,19 @@ pub struct IssueWizardScreen {
     pub(super) review_loading: bool,
     pub(super) review_text: Option<String>,
     pub(super) review_error: Option<String>,
+    /// #450 AI Improve sub-state (layered on top of AiReview). When a
+    /// candidate is present the draw layer swaps the review-text view
+    /// for the diff view; when loading, the spinner renders; when
+    /// error, the error banner renders. All exclusive with each other.
+    pub(super) improve_loading: bool,
+    pub(super) improve_candidate: Option<IssueCreationPayload>,
+    pub(super) improve_error: Option<String>,
+    /// Guards against `tick_wizard_step_hooks` dispatching a second
+    /// `LaunchAiImprove` before the first one's result lands. Cleared
+    /// when `apply_improve_result` fires.
+    pub(super) improve_enqueued: bool,
+    /// Vertical scroll offset for the improve diff view.
+    pub(super) diff_scroll: u16,
     /// Clipboard provider for Ctrl+V. Injected as a trait object so
     /// tests can supply a deterministic fake.
     clipboard: Box<dyn ClipboardProvider>,
@@ -126,6 +144,11 @@ impl IssueWizardScreen {
             review_loading: false,
             review_text: None,
             review_error: None,
+            improve_loading: false,
+            improve_candidate: None,
+            improve_error: None,
+            improve_enqueued: false,
+            diff_scroll: 0,
             clipboard,
             create_in_flight: false,
             create_enqueued: false,
@@ -264,6 +287,118 @@ impl IssueWizardScreen {
             && self.review_text.is_none()
             && !self.review_loading
             && self.review_error.is_none()
+    }
+
+    // ---- #450 AI Improve ----
+
+    /// True when the user could legally press `i` to start the improve
+    /// flow: review text is loaded without error, no improve call is
+    /// already in flight, and no candidate/error modal is showing. Used
+    /// by both `begin_improve` and the `i` key handler so the two can't
+    /// drift apart.
+    pub fn can_begin_improve(&self) -> bool {
+        self.review_text.is_some()
+            && !self.review_loading
+            && self.review_error.is_none()
+            && !self.improve_loading
+            && self.improve_candidate.is_none()
+            && self.improve_error.is_none()
+    }
+
+    /// True when ANY improve sub-state is active (loading, candidate
+    /// diff, or error banner). Used to block `Enter`-advance and to
+    /// route `Esc` to the sub-state's dismissal instead of the normal
+    /// retreat-to-Dependencies.
+    pub fn improve_sub_state_active(&self) -> bool {
+        self.improve_loading || self.improve_candidate.is_some() || self.improve_error.is_some()
+    }
+
+    /// Launch the improve flow if the state machine allows it. Silently
+    /// no-ops when `can_begin_improve` fails.
+    pub fn begin_improve(&mut self) {
+        if !self.can_begin_improve() {
+            return;
+        }
+        self.sync_fields_into_payload();
+        self.improve_loading = true;
+        self.improve_candidate = None;
+        self.improve_error = None;
+        self.diff_scroll = 0;
+    }
+
+    /// Apply a result coming back from the background tokio task.
+    /// `Ok(candidate)` shows the diff view; `Err(msg)` shows the error
+    /// banner with retry/Esc affordances.
+    pub fn apply_improve_result(&mut self, result: Result<IssueCreationPayload, String>) {
+        self.improve_loading = false;
+        self.improve_enqueued = false;
+        match result {
+            Ok(candidate) => {
+                self.improve_candidate = Some(candidate);
+                self.improve_error = None;
+            }
+            Err(e) => {
+                self.improve_candidate = None;
+                self.improve_error = Some(e);
+            }
+        }
+    }
+
+    /// Replace the wizard's payload with the improved candidate and
+    /// drop the candidate. Keeps `review_text` visible so the user sees
+    /// the original critique beside the new draft.
+    pub fn accept_improve(&mut self) {
+        if let Some(cand) = self.improve_candidate.take() {
+            self.payload = cand;
+            self.diff_scroll = 0;
+        }
+    }
+
+    /// Drop the candidate and any error. The wizard's payload is unchanged.
+    pub fn discard_improve(&mut self) {
+        self.improve_candidate = None;
+        self.improve_error = None;
+        self.diff_scroll = 0;
+    }
+
+    /// True when `tick_wizard_step_hooks` should enqueue a new
+    /// `LaunchAiImprove`. Flips to false after `mark_improve_enqueued`
+    /// so the hook doesn't dispatch twice for the same request.
+    pub fn improve_requested(&self) -> bool {
+        self.improve_loading
+            && self.improve_candidate.is_none()
+            && self.improve_error.is_none()
+            && !self.improve_enqueued
+    }
+
+    /// Latch set by the dispatch hook so subsequent ticks skip re-dispatch.
+    pub fn mark_improve_enqueued(&mut self) {
+        self.improve_enqueued = true;
+    }
+
+    pub fn improve_loading(&self) -> bool {
+        self.improve_loading
+    }
+
+    pub fn improve_candidate(&self) -> Option<&IssueCreationPayload> {
+        self.improve_candidate.as_ref()
+    }
+
+    pub fn improve_error(&self) -> Option<&str> {
+        self.improve_error.as_deref()
+    }
+
+    pub fn diff_scroll(&self) -> u16 {
+        self.diff_scroll
+    }
+
+    /// Test helper — lets unit tests short-circuit to `AiReview` (or any
+    /// other step) without walking the form's validation. Not exposed
+    /// outside test builds.
+    #[cfg(test)]
+    pub fn set_step_for_tests(&mut self, step: IssueWizardStep) {
+        self.step = step;
+        self.rebuild_fields_for_step();
     }
 
     fn jump_to(&mut self, target: IssueWizardStep) {
@@ -722,28 +857,55 @@ impl Screen for IssueWizardScreen {
                 }
             },
             IssueWizardStep::AiReview => match code {
+                KeyCode::Esc if self.improve_error.is_some() => {
+                    self.improve_error = None;
+                }
+                KeyCode::Esc if self.improve_candidate.is_some() => {
+                    self.discard_improve();
+                }
                 KeyCode::Esc => {
                     self.retreat();
+                }
+                KeyCode::Char('i') if self.can_begin_improve() => {
+                    self.begin_improve();
+                }
+                KeyCode::Char('a') if self.improve_candidate.is_some() => {
+                    self.accept_improve();
+                }
+                KeyCode::Char('d') if self.improve_candidate.is_some() => {
+                    self.discard_improve();
+                }
+                KeyCode::Char('r')
+                    if self.improve_candidate.is_some() || self.improve_error.is_some() =>
+                {
+                    self.improve_candidate = None;
+                    self.improve_error = None;
+                    self.begin_improve();
                 }
                 KeyCode::Char('r') => {
                     // "Revise" — jump back to BasicInfo so the user can edit.
                     self.jump_to(IssueWizardStep::BasicInfo);
                 }
+                KeyCode::Char('j') | KeyCode::Down if self.improve_candidate.is_some() => {
+                    self.diff_scroll = self.diff_scroll.saturating_add(1);
+                }
+                KeyCode::Char('k') | KeyCode::Up if self.improve_candidate.is_some() => {
+                    self.diff_scroll = self.diff_scroll.saturating_sub(1);
+                }
                 KeyCode::Char('s') => {
-                    // Skip the review and head straight to Preview.
                     self.jump_to(IssueWizardStep::Preview);
                 }
                 KeyCode::Char('R') if self.review_error.is_some() => {
-                    // Retry on error.
                     self.begin_ai_review();
                 }
                 KeyCode::Enter => {
-                    if self.review_loading || self.review_error.is_some() {
-                        // Block advance while loading or after an error
-                        // (use 'R' to retry, 's' to skip).
-                    } else {
+                    if !self.review_loading
+                        && self.review_error.is_none()
+                        && !self.improve_sub_state_active()
+                    {
                         self.try_advance();
                     }
+                    // else: block advance; use 'R'/'r'/'a'/'d' to resolve.
                 }
                 _ => {}
             },
@@ -1510,5 +1672,196 @@ mod tests {
         s.apply_dep_issues(vec![make_open_issue(10), make_open_issue(11)]);
         assert!(s.dep_is_checked(11));
         assert!(!s.dep_is_checked(10));
+    }
+
+    // ---- #450 AI Improve companion ----
+
+    fn at_ai_review_with_critique() -> IssueWizardScreen {
+        let mut s = IssueWizardScreen::new();
+        s.payload_mut().issue_type = IssueType::Feature;
+        s.payload_mut().title = "Original title".into();
+        s.payload_mut().overview = "original".into();
+        s.payload_mut().expected_behavior = "orig".into();
+        s.payload_mut().acceptance_criteria = "orig ac".into();
+        s.payload_mut().files_to_modify = "orig".into();
+        s.payload_mut().test_hints = "orig".into();
+        s.payload_mut().blocked_by = vec![10];
+        s.payload_mut().milestone = Some(42);
+        s.set_step_for_tests(IssueWizardStep::AiReview);
+        s.begin_ai_review();
+        s.apply_ai_review(Ok("critique text".into()));
+        s
+    }
+
+    fn sample_improved() -> IssueCreationPayload {
+        IssueCreationPayload {
+            issue_type: IssueType::Feature,
+            title: "Improved title".into(),
+            overview: "improved".into(),
+            expected_behavior: "improved".into(),
+            current_behavior: String::new(),
+            steps_to_reproduce: String::new(),
+            acceptance_criteria: "improved ac".into(),
+            files_to_modify: "improved".into(),
+            test_hints: "improved".into(),
+            blocked_by: vec![10],
+            milestone: Some(42),
+            image_paths: vec![],
+        }
+    }
+
+    #[test]
+    fn begin_improve_sets_loading_clears_candidate_and_error() {
+        let mut s = at_ai_review_with_critique();
+        s.begin_improve();
+        assert!(s.improve_loading());
+        assert!(s.improve_candidate().is_none());
+        assert!(s.improve_error().is_none());
+    }
+
+    #[test]
+    fn begin_improve_is_noop_while_review_still_loading() {
+        let mut s = IssueWizardScreen::new();
+        s.set_step_for_tests(IssueWizardStep::AiReview);
+        s.begin_ai_review(); // review_loading=true, review_text=None
+        s.begin_improve();
+        assert!(
+            !s.improve_loading(),
+            "begin_improve should be a no-op while review is loading"
+        );
+    }
+
+    #[test]
+    fn begin_improve_is_noop_when_review_has_error() {
+        let mut s = IssueWizardScreen::new();
+        s.set_step_for_tests(IssueWizardStep::AiReview);
+        s.begin_ai_review();
+        s.apply_ai_review(Err("review failed".into()));
+        s.begin_improve();
+        assert!(!s.improve_loading());
+    }
+
+    #[test]
+    fn begin_improve_is_noop_when_candidate_already_present() {
+        let mut s = at_ai_review_with_critique();
+        s.apply_improve_result(Ok(sample_improved()));
+        assert!(s.improve_candidate().is_some());
+        s.begin_improve();
+        assert!(
+            !s.improve_loading(),
+            "begin_improve must not re-fire while a candidate is on screen"
+        );
+    }
+
+    #[test]
+    fn apply_improve_result_ok_populates_candidate() {
+        let mut s = at_ai_review_with_critique();
+        s.begin_improve();
+        s.apply_improve_result(Ok(sample_improved()));
+        assert!(!s.improve_loading());
+        assert!(s.improve_candidate().is_some());
+        assert!(s.improve_error().is_none());
+    }
+
+    #[test]
+    fn apply_improve_result_err_populates_error() {
+        let mut s = at_ai_review_with_critique();
+        s.begin_improve();
+        s.apply_improve_result(Err("bad JSON".into()));
+        assert!(!s.improve_loading());
+        assert!(s.improve_candidate().is_none());
+        assert_eq!(s.improve_error(), Some("bad JSON"));
+    }
+
+    #[test]
+    fn accept_improve_replaces_payload_and_drops_candidate() {
+        let mut s = at_ai_review_with_critique();
+        s.apply_improve_result(Ok(sample_improved()));
+        s.accept_improve();
+        assert_eq!(s.payload().title, "Improved title");
+        assert!(s.improve_candidate().is_none());
+        assert_eq!(
+            s.review_text(),
+            Some("critique text"),
+            "critique stays visible after accept"
+        );
+    }
+
+    #[test]
+    fn discard_improve_drops_candidate_leaves_payload_intact() {
+        let mut s = at_ai_review_with_critique();
+        let original_title = s.payload().title.clone();
+        s.apply_improve_result(Ok(sample_improved()));
+        s.discard_improve();
+        assert_eq!(s.payload().title, original_title);
+        assert!(s.improve_candidate().is_none());
+        assert!(s.improve_error().is_none());
+    }
+
+    #[test]
+    fn improve_requested_returns_true_exactly_once_per_begin() {
+        let mut s = at_ai_review_with_critique();
+        s.begin_improve();
+        assert!(s.improve_requested());
+        s.mark_improve_enqueued();
+        assert!(
+            !s.improve_requested(),
+            "after marking enqueued, the tick hook must not re-dispatch"
+        );
+    }
+
+    #[test]
+    fn i_key_calls_begin_improve_when_guard_passes() {
+        let mut s = at_ai_review_with_critique();
+        s.handle_input(&key_event(KeyCode::Char('i')), InputMode::Normal);
+        assert!(s.improve_loading());
+    }
+
+    #[test]
+    fn i_key_is_ignored_while_review_loading() {
+        let mut s = IssueWizardScreen::new();
+        s.set_step_for_tests(IssueWizardStep::AiReview);
+        s.begin_ai_review(); // review_loading=true
+        s.handle_input(&key_event(KeyCode::Char('i')), InputMode::Normal);
+        assert!(!s.improve_loading());
+    }
+
+    #[test]
+    fn a_and_d_keys_are_silently_ignored_without_candidate() {
+        let mut s = at_ai_review_with_critique();
+        let original_title = s.payload().title.clone();
+        s.handle_input(&key_event(KeyCode::Char('a')), InputMode::Normal);
+        s.handle_input(&key_event(KeyCode::Char('d')), InputMode::Normal);
+        assert_eq!(s.payload().title, original_title);
+        assert!(s.improve_candidate().is_none());
+    }
+
+    #[test]
+    fn a_key_accepts_candidate_when_present() {
+        let mut s = at_ai_review_with_critique();
+        s.apply_improve_result(Ok(sample_improved()));
+        s.handle_input(&key_event(KeyCode::Char('a')), InputMode::Normal);
+        assert_eq!(s.payload().title, "Improved title");
+        assert!(s.improve_candidate().is_none());
+    }
+
+    #[test]
+    fn d_key_discards_candidate_when_present() {
+        let mut s = at_ai_review_with_critique();
+        let original_title = s.payload().title.clone();
+        s.apply_improve_result(Ok(sample_improved()));
+        s.handle_input(&key_event(KeyCode::Char('d')), InputMode::Normal);
+        assert_eq!(s.payload().title, original_title);
+        assert!(s.improve_candidate().is_none());
+    }
+
+    #[test]
+    fn esc_with_improve_error_clears_error() {
+        let mut s = at_ai_review_with_critique();
+        s.begin_improve();
+        s.apply_improve_result(Err("boom".into()));
+        assert!(s.improve_error().is_some());
+        s.handle_input(&key_event(KeyCode::Esc), InputMode::Normal);
+        assert!(s.improve_error().is_none());
     }
 }

--- a/src/tui/screens/issue_wizard/prompt_common.rs
+++ b/src/tui/screens/issue_wizard/prompt_common.rs
@@ -1,0 +1,95 @@
+//! Shared prompt-body formatting for the Issue Wizard's AI-assisted steps
+//! (#296 review companion + #450 improve companion). Keeps the payload
+//! serialization in one place so adding a DOR field only touches one site.
+
+use super::IssueCreationPayload;
+
+/// Render the 8 DOR text sections of `payload` as `## Header\n<body>` blocks
+/// in the canonical order. Bug-only fields (`Current Behavior`,
+/// `Steps to Reproduce`) are omitted when their trimmed body is empty.
+///
+/// Does NOT include scalars like `issue_type`, `title`, `blocked_by`,
+/// `milestone`, or `image_paths` — callers prepend/append those as needed.
+/// This keeps the improve flow's trusted-seat contract (it must never ask
+/// the AI to rewrite `blocked_by` or `milestone`) independent from the
+/// review flow's informational inclusion of those scalars.
+pub(super) fn format_payload_for_prompt(p: &IssueCreationPayload) -> String {
+    let mut s = String::new();
+    push_section(&mut s, "Overview", &p.overview);
+    push_section(&mut s, "Expected Behavior", &p.expected_behavior);
+    if !p.current_behavior.trim().is_empty() {
+        push_section(&mut s, "Current Behavior", &p.current_behavior);
+    }
+    if !p.steps_to_reproduce.trim().is_empty() {
+        push_section(&mut s, "Steps to Reproduce", &p.steps_to_reproduce);
+    }
+    push_section(&mut s, "Acceptance Criteria", &p.acceptance_criteria);
+    push_section(&mut s, "Files to Modify", &p.files_to_modify);
+    push_section(&mut s, "Test Hints", &p.test_hints);
+    s
+}
+
+fn push_section(out: &mut String, title: &str, body: &str) {
+    out.push('\n');
+    out.push_str("## ");
+    out.push_str(title);
+    out.push('\n');
+    out.push_str(body.trim());
+    out.push('\n');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::IssueType;
+    use super::*;
+
+    fn sample_payload_full() -> IssueCreationPayload {
+        IssueCreationPayload {
+            issue_type: IssueType::Feature,
+            title: "Add gauge widget".into(),
+            overview: "Render progress as a horizontal gauge.".into(),
+            expected_behavior: "Gauge fills proportionally.".into(),
+            current_behavior: String::new(),
+            steps_to_reproduce: String::new(),
+            acceptance_criteria: "- Renders 0..=100%\n- Handles overflow".into(),
+            files_to_modify: "src/widgets/gauge.rs".into(),
+            test_hints: "Test boundary values.".into(),
+            blocked_by: vec![10],
+            milestone: Some(42),
+            image_paths: vec![],
+        }
+    }
+
+    #[test]
+    fn format_payload_includes_all_eight_text_fields_when_filled() {
+        let mut p = sample_payload_full();
+        p.current_behavior = "It crashes.".into();
+        p.steps_to_reproduce = "1. open".into();
+        let out = format_payload_for_prompt(&p);
+        assert!(out.contains("## Overview"));
+        assert!(out.contains("## Expected Behavior"));
+        assert!(out.contains("## Current Behavior"));
+        assert!(out.contains("## Steps to Reproduce"));
+        assert!(out.contains("## Acceptance Criteria"));
+        assert!(out.contains("## Files to Modify"));
+        assert!(out.contains("## Test Hints"));
+    }
+
+    #[test]
+    fn format_payload_omits_bug_fields_when_empty() {
+        let p = sample_payload_full();
+        let out = format_payload_for_prompt(&p);
+        assert!(!out.contains("## Current Behavior"));
+        assert!(!out.contains("## Steps to Reproduce"));
+    }
+
+    #[test]
+    fn format_payload_omits_scalar_seats() {
+        let p = sample_payload_full();
+        let out = format_payload_for_prompt(&p);
+        assert!(!out.contains("Title:"));
+        assert!(!out.contains("Type:"));
+        assert!(!out.contains("Blocked By"));
+        assert!(!out.contains("milestone"));
+    }
+}

--- a/src/tui/screens/milestone_wizard/ai_planning.rs
+++ b/src/tui/screens/milestone_wizard/ai_planning.rs
@@ -45,7 +45,7 @@ pub fn build_planning_prompt(payload: &MilestonePlanPayload) -> String {
 /// Parse the AI's JSON response into an `AiGeneratedPlan`. Tolerates a
 /// trailing markdown fence the model may emit despite instructions.
 pub fn parse_planning_response(raw: &str) -> Result<AiGeneratedPlan, String> {
-    let trimmed = strip_fences(raw.trim());
+    let trimmed = crate::tui::screens::strip_fences(raw.trim());
     let value: serde_json::Value =
         serde_json::from_str(trimmed).map_err(|e| format!("invalid JSON: {e}"))?;
 
@@ -95,19 +95,6 @@ pub fn parse_planning_response(raw: &str) -> Result<AiGeneratedPlan, String> {
         milestone_description: description,
         issues,
     })
-}
-
-fn strip_fences(s: &str) -> &str {
-    let mut t = s.trim();
-    if let Some(stripped) = t.strip_prefix("```json") {
-        t = stripped;
-    } else if let Some(stripped) = t.strip_prefix("```") {
-        t = stripped;
-    }
-    if let Some(stripped) = t.strip_suffix("```") {
-        t = stripped;
-    }
-    t.trim()
 }
 
 #[cfg(test)]

--- a/src/tui/screens/mod.rs
+++ b/src/tui/screens/mod.rs
@@ -67,6 +67,22 @@ pub fn sanitize_for_terminal(s: &str) -> String {
         .collect()
 }
 
+/// Strip markdown code fences (```json, ```, trailing ```) from a Claude
+/// response before JSON parsing. Shared by the Milestone Wizard planning
+/// flow and the Issue Wizard improve flow (#450).
+pub(crate) fn strip_fences(s: &str) -> &str {
+    let mut t = s.trim();
+    if let Some(stripped) = t.strip_prefix("```json") {
+        t = stripped;
+    } else if let Some(stripped) = t.strip_prefix("```") {
+        t = stripped;
+    }
+    if let Some(stripped) = t.strip_suffix("```") {
+        t = stripped;
+    }
+    t.trim()
+}
+
 /// Render a keybindings help bar at the bottom of a screen.
 pub fn draw_keybinds_bar(f: &mut Frame, area: Rect, bindings: &[(&str, &str)], theme: &Theme) {
     let spans: Vec<Span> = bindings


### PR DESCRIPTION
## Summary

- New `i` keybinding on the Issue Wizard's AI Review step launches a second `claude --print` call that rewrites the draft using the prior critique as guidance, surfaces the result as a field-by-field red/green diff, and lets the user accept (`a`), discard (`d`), retry (`r`), or scroll (`j`/`k`) atomically.
- Trusted-seat contract: the AI only rewrites the 8 DOR text fields. `issue_type`, `blocked_by`, `milestone`, and `image_paths` are re-stamped by the parser from the original payload regardless of what Claude emits — so a rogue response cannot inject dependencies, switch type, or add image attachments.
- Shared prompt/formatting helpers (`format_payload_for_prompt`, promoted `strip_fences`) extracted so future DOR-field additions are single-site edits. The parser reuses the existing `adapt::prompts::parse_json_response::<T>` (four-strategy fence/fallback tolerance) instead of hand-rolling extraction.

Closes #450

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --bin maestro -- -D warnings -A dead_code` clean
- [x] `cargo test --bin maestro` — 3048 passed, 0 failed (+31 from this PR: 13 in `ai_improve`, 15 in `issue_wizard/mod` tests module, 3 in `draw_diff`, 3 in `prompt_common`, dispatch/data-handler coverage via existing screen tests)
- [x] `scripts/check-file-size.sh` clean (diff rendering split into `draw_diff.rs` + `draw_ai_review.rs` to honour the 400-LOC guardrail)
- [ ] Manual: walk the Issue Wizard end-to-end with a weak draft — run AI review, hit `i`, see the diff, accept → final body reflects the improved content.
- [ ] Manual: hit `i`, then `d` → original payload + critique intact.
- [ ] Manual: hit `i`, then `r` on the diff view → second rewrite fires without double-dispatch.
- [ ] Manual: force a parse failure (e.g. claude returns non-JSON) → error banner renders with `r: retry    Esc: back to review`; Esc clears error.
- [ ] Manual: verify `i` is inert while `review_loading` / `review_error` / a candidate is already showing.
- [ ] Manual: diff view `j`/`k` scrolls past a long `acceptance_criteria`.

## Security review summary

Internal review: 0 Critical / 0 High / 1 Medium / 2 Low.
- **Medium (pre-existing, not introduced here)**: `run_claude_print` has no response-size cap — affects the AI Review companion too. Worth a separate issue to cap stdout in `src/adapt/prompts.rs`; not a scope item for #450.
- **Low (self-inflicted, neutralised)**: user can embed `--- END CRITIQUE ---` in a text field and confuse the LLM prompt delimiters; the trusted-seat re-stamping makes the attack uninteresting (AI can't reach `blocked_by` / `milestone` / `issue_type` regardless of what it emits).
- **Low**: `claude` stderr is surfaced raw into `improve_error`. Local-only TUI; minor screenshot/screen-share exposure.
- Race/double-fire guards and AI-JSON leakage confirmed safe (tested in `improve_requested_returns_true_exactly_once_per_begin` and `parse_improve_response_restamps_trusted_seats_from_original`).