### PR TITLE
feat(v0.16.0): interactive PRD, PR-review automation, bypass mode, roadmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ maestro-prompt-history.json
 .maestro/worktrees/
 .maestro/logs/
 .maestro/adapt-cache.json
+.maestro/prd.toml
 # OS
 .DS_Store
 *.swp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+v0.16.0 foundation bundle — branch `maestro/unified-321-329-327-328`. Lays the groundwork for PRD management, interactive roadmap, and the review-council bypass flow.
+
+### Added
+
+- `src/prd/` — `Prd` model, `PrdStore` JSON persistence, and `PrdExporter` markdown export (#321)
+- `src/review/types.rs`, `parse.rs`, `audit.rs`, `apply.rs`, `bypass.rs` — review pipeline types, PR-comment parser, audit log, patch applicator, and bypass guard (#327, #328)
+- `src/session/pr_capture.rs` — `PrCapture`: intercepts stream-json to detect `/review` PR comments (#327)
+- `src/commands/slash.rs` — `SlashCommandRunner`: executes slash commands against a PR and feeds results to the review pipeline (#327)
+- `src/tui/screens/roadmap/` (`mod.rs`, `dep_levels.rs`) — roadmap screen foundation with dependency-level grouping (#329)
+- `src/tui/screens/bypass_warning.rs` — confirmation overlay displayed when `--bypass-review` is active (#328)
+- `src/tui/widgets/bypass_indicator.rs` — F-key bar badge warning that the review council is disabled (#328)
+- `docs/api-contracts/review-comment.json` — JSON Schema (Draft 2020-12) for the `maestro-review` block embedded in `/review` PR comments (#327)
+- `docs/api-contracts/README.md` — convention guide for the contracts directory
+- `--bypass-review` global CLI flag (session-only) in `src/cli.rs` (#328)
+
 ## [0.15.2] - 2026-04-24
 
 Milestone "Pixel-art mascot sprites" — replaces the hand-authored Unicode block-character mascot with 1-bit pixel-art sprites rendered via half-block (`▀ ▄ █`) encoding. Adds a `[tui].mascot_style` config key so the legacy ASCII block art stays available as a fallback. Closes #473, #474, #475, #476.

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-24 00:00 (UTC)
+> Last updated: 2026-04-24 12:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -66,7 +66,22 @@ maestro/
 │   ├── icon_mode.rs                       # Shared icon mode detection: AtomicBool global flag, init_from_config() reads tui.ascii_icons from Config and MAESTRO_ASCII_ICONS env var, use_nerd_font() returns current mode; extracted from tui/icons.rs so non-TUI crates can query the mode without pulling in the full TUI tree  [Issue #307]
 │   ├── icons.rs                           # Shared icon registry: IconId enum (38 variants across Navigation, Status, UI Chrome, Indicators categories, plus NeedsReview variant added in #308), IconPair struct (nerd: &'static str, ascii: &'static str), icon_pair() const fn compiles to a zero-allocation jump table, get(IconId) returns the correct variant based on global mode, get_for_mode(id, nerd_font) pure testable variant; extracted from tui/icons.rs; CheckboxOn codepoint U+F14A (nf-fa-check_square) and CheckboxOff codepoint U+F0C8 (nf-fa-square) — universally present FA-core glyphs replacing the legacy nf-oct variants  [Issue #308, #433]
 │   ├── main.rs                            # CLI entry point (clap); Run, Queue, Add, Status, Cost, Init, Doctor; --skip-doctor flag on Run subcommand bypasses preflight; cmd_run() runs validate_preflight() before session launch and uses PromptBuilder::build_issue_prompt() for issue sessions; setup_app_from_config() shared helper wires budget, model router, notifications, plugins, and permission_mode/allowed_tools from config; propagates once_mode from parsed CLI flag into App; forces max_concurrent=1 when --continuous is set; cmd_dashboard() performs orphan worktree cleanup, log cleanup, fetches username from doctor report, delegates App construction to setup_app_from_config(), and queues FetchSuggestionData on startup; declares #[cfg(test)] mod integration_tests; declares mod updater; declares mod flags; propagates startup gh auth check result into App.gh_auth_ok; declares #[cfg(feature = "experimental-sanitizer")] mod sanitizer; constructs FeatureFlags from --enable-flag / --disable-flag CLI args merged with [flags] config  [Issue #15, #29, #49, #34, #36, #35, #52, #83, #85, #118, #141, #142, #143, #158]
-│   ├── cli.rs                             # CLI definition extracted from main.rs; Cli struct and Commands enum (clap derive); --once flag on Run subcommand (exits after all sessions complete, for CI/scripting); --continuous / -C flag on Run subcommand (auto-advance through issues, pause on failure); --enable-flag / --disable-flag repeatable args on Run subcommand for runtime feature flag overrides; generate_completions() and cmd_completions() for shell tab-completion output; cmd_mangen() for roff man page generation; Completions and Mangen subcommands  [Issue #18, #83, #85, #143]
+│   ├── cli.rs                             # CLI definition extracted from main.rs; Cli struct and Commands enum (clap derive); --once flag on Run subcommand (exits after all sessions complete, for CI/scripting); --continuous / -C flag on Run subcommand (auto-advance through issues, pause on failure); --enable-flag / --disable-flag repeatable args on Run subcommand for runtime feature flag overrides; --bypass-review global flag (session-only, skips review council); generate_completions() and cmd_completions() for shell tab-completion output; cmd_mangen() for roff man page generation; Completions and Mangen subcommands  [Issue #18, #83, #85, #143, #328]
+│   ├── commands/                          # Command handler modules (one per CLI subcommand)
+│   │   ├── mod.rs                         # Module re-exports
+│   │   ├── clean.rs                       # cmd_clean(): prune orphaned worktrees and stale log files
+│   │   ├── dashboard.rs                   # cmd_dashboard(): launch the TUI dashboard
+│   │   ├── doctor.rs                      # cmd_doctor(): run preflight checks and print report
+│   │   ├── init.rs                        # cmd_init(): scaffold maestro.toml in the project root
+│   │   ├── logs.rs                        # cmd_logs(): stream or tail session log files
+│   │   ├── queue.rs                       # cmd_queue(): interactive work-queue management
+│   │   ├── resume.rs                      # cmd_resume(): re-attach to a paused session
+│   │   ├── run.rs                         # cmd_run(): validate preflight then launch a session
+│   │   ├── setup.rs                       # cmd_setup(): guided first-run configuration wizard
+│   │   ├── slack.rs                       # cmd_slack(): test Slack webhook notification delivery
+│   │   ├── slash.rs                       # SlashCommandRunner: executes /review and other slash commands against a PR; integrates with review::parse to extract the maestro-review JSON block  [Issue #327]
+│   │   ├── status.rs                      # cmd_status(): print current session and queue state
+│   │   └── turboquant.rs                  # cmd_turboquant(): run TurboQuant compression diagnostics
 │   ├── config.rs                          # maestro.toml parsing; ModelsConfig, GatesConfig, ReviewConfig; ContextOverflowConfig; ProviderConfig (kind, organization, az_project); guardrail_prompt in SessionsConfig; CompletionGatesConfig and CompletionGateEntry; CiAutoFixConfig (enabled, max_retries, poll_interval_secs) under GatesConfig.ci_auto_fix; TuiConfig struct with optional theme field and mascot_style field ("sprite" | "ascii", default "sprite"); Config gains tui field; FlagsConfig (flattened HashMap<String, bool>) loaded from [flags] table; Config gains flags field; HollowRetryPolicy enum (Always/IntentAware/Never), HollowRetryConfig struct (policy, work_max_retries, consultation_max_retries), merge_legacy_hollow() for backward-compat TOML parsing, SessionsConfigRaw shadow struct for custom Deserialize; LoadedConfig { config: Config, path: PathBuf } struct returned by find_and_load_with_path() and find_and_load_in_with_path() so callers have the resolved file path; legacy find_and_load() and find_and_load_in() kept as thin shims  [Issue #29, #40, #41, #43, #38, #143, #275, #437, #473]
 │   ├── continuous.rs                      # ContinuousModeState and ContinuousFailure structs; state machine for --continuous / -C flag: auto-advances to next ready issue, pauses loop on failure waiting for user decision (skip / retry / quit)  [Issue #85]
 │   ├── budget.rs                          # BudgetEnforcer: per-session and global budget checks  [Phase 3]
@@ -136,15 +151,26 @@ maestro/
 │   │   ├── mod.rs                         # Module exports
 │   │   ├── hooks.rs                       # HookPoint enum: SessionStarted, SessionCompleted, TestsPassed, ContextOverflow, etc.  [Issue #12]
 │   │   └── runner.rs                      # PluginRunner: executes external plugin commands per hook point
-│   ├── review/                            # Review pipeline  [Phase 3]
+│   ├── prd/                               # PRD model, persistence, and markdown export  [Issue #321]
+│   │   ├── mod.rs                         # Module facade; re-exports Prd, PrdStore, PrdExporter
+│   │   ├── model.rs                       # Prd struct and field types; serde Serialize/Deserialize
+│   │   ├── store.rs                       # PrdStore: JSON persistence under .maestro/prd/
+│   │   └── export.rs                      # PrdExporter: renders a Prd to a markdown document
+│   ├── review/                            # Review pipeline  [Phase 3, Issue #327, #328]
 │   │   ├── mod.rs                         # Module exports; re-exports ReviewConfig, ReviewDispatcher
+│   │   ├── apply.rs                       # apply_review(): applies accepted concern patches to the worktree  [Issue #327]
+│   │   ├── audit.rs                       # ReviewAudit: records accept/reject decisions and writes audit log  [Issue #327]
+│   │   ├── bypass.rs                      # BypassGuard: enforces --bypass-review policy; logs bypass events  [Issue #328]
 │   │   ├── council.rs                     # ReviewCouncil: parallel multi-reviewer orchestration
-│   │   └── dispatch.rs                    # ReviewDispatcher: single reviewer execution and config
+│   │   ├── dispatch.rs                    # ReviewDispatcher: single reviewer execution and config
+│   │   ├── parse.rs                       # parse_review_comment(): extracts maestro-review JSON block from PR comment body  [Issue #327]
+│   │   └── types.rs                       # ReviewReport, Concern, ConcernSeverity, ReviewOutcome types; schema mirrors docs/api-contracts/review-comment.json  [Issue #327]
 │   ├── session/
 │   │   ├── mod.rs                         # Module exports (includes pool, worktree, health, retry, context_monitor, fork)
 │   │   ├── manager.rs                     # Claude CLI process management; handles ContextUpdate events; thinking_start field tracks Thinking block duration; handle_event() emits rich activity messages with file paths, elapsed times for tool calls, and thinking duration on block end; current_activity reflects "Thinking..." while a thinking block is active; emits "STATUS: OLD → NEW" activity log entries when session state changes  [Phase 3, Issue #102, #202]
 │   │   ├── parser.rs                      # stream-json output parser; parses system events for context usage; parses "thinking" message type into StreamEvent::Thinking; extracts command field from Bash tool input as command_preview (truncated to 60 chars)  [Phase 3, Issue #102]
 │   │   ├── pool.rs                        # Session pool: max_concurrent, queue, auto-promote; branch tracking; guardrail_prompt field; set_guardrail_prompt(); merged into system prompt in try_promote(); find_by_issue_mut(); decrements flash_counter on each session per render tick and emits STATUS activity log entries on state transitions  [Phase 3, Issue #40, #43, #202]
+│   │   ├── pr_capture.rs                  # PrCapture: intercepts stream-json output to detect when a session posts a /review PR comment and stores the raw comment body for the review pipeline  [Issue #327]
 │   │   ├── types.rs                       # Session state machine; fork fields (parent_session_id, child_session_ids, fork_depth); ContextUpdate StreamEvent; GatesRunning and NeedsReview status variants; CiFix variant; CiFixContext struct (pr_number, issue_number, branch, attempt); ci_fix_context field on Session; StreamEvent::Thinking { text } variant; command_preview: Option<String> field on StreamEvent::ToolUse; GateResultEntry struct (gate, passed, message); gate_results: Vec<GateResultEntry> field on Session; NeedsPr variant — non-terminal status indicating PR creation failed and is queued for retry; flash_counter: u8 field on Session — decremented each render tick to drive border-flash effect on state transition  [Phase 3, Issue #40, #41, #102, #104, #159, #202]
 │   │   ├── worktree.rs                    # Git worktree isolation: WorktreeManager trait, GitWorktreeManager, MockWorktreeManager  [Phase 1]
 │   │   ├── health.rs                      # HealthMonitor: stall detection, HealthCheck trait  [Phase 3]
@@ -222,6 +248,7 @@ maestro/
 │   │   └── screens/                       # Interactive screen components  [Issue #31-33]
 │   │       ├── mod.rs                     # Screen types: ScreenAction enum (+ RefreshSuggestions variant), SessionConfig; re-exports HomeScreen, IssueBrowserScreen, MilestoneScreen; pub mod wizard_fields (added #447); wizard_paste removed  [Issue #31-33, #86, #447]
 │   │       ├── adapt_follow_up.rs         # AdaptFollowUp: post-scaffold follow-up prompt screen
+│   │       ├── bypass_warning.rs          # BypassWarningScreen: confirmation overlay shown when --bypass-review is active; displays policy summary and requires explicit acknowledgement before proceeding  [Issue #328]
 │   │       ├── hollow_retry.rs            # HollowRetryScreen: minimal retry prompt overlay shown when a session stalls and user confirmation is required
 │   │       ├── milestone.rs               # MilestoneScreen: milestone list, progress gauge, issue detail pane, run-all action; selected row uses SLOW_BLINK modifier for visibility; border color derived from selection state; progress gauge fill color uses milestone_gauge_color() (green=high completion, red=low); gauge empty portion dimmed; status counts (open/closed/in-progress) rendered BOLD; issue list uses visual hierarchy to distinguish selected vs unselected items  [Issue #33, #299]
 │   │       ├── prompt_input.rs            # PromptInputScreen: free-text prompt entry; Enter submits, Shift+Enter/Alt+Enter inserts newline via insert_newline() (not input()), Ctrl+V pastes from clipboard (image or text), Esc cancels; Up/Down arrows navigate prompt history (injected at construction); image attachment list with [a]/[d]; keybinds bar always visible; uses wrap::soft_wrap_lines() for word-wrapped rendering  [Issue #101, #232, #263]
@@ -269,11 +296,15 @@ maestro/
 │   │       ├── release_notes/             # Release notes screen components
 │   │       │   ├── mod.rs                 # ReleaseNotesScreen struct with Screen trait impl
 │   │       │   └── draw.rs                # ratatui rendering for release notes display
+│   │       ├── roadmap/                   # Roadmap screen (v0.16.0 foundation)  [Issue #329]
+│   │       │   ├── mod.rs                 # RoadmapScreen struct with Screen trait impl; renders milestones as a swimlane timeline
+│   │       │   └── dep_levels.rs          # DepLevels: groups milestones and issues by dependency level for the roadmap layout
 │   │       └── settings/                  # Settings screen components  [Issue #124, #146]
 │   │           ├── mod.rs                 # SettingsScreen: interactive settings screen with tabbed TUI widget system; Flags tab displays all feature flags with name, on/off state, source (Default/Config/Cli), and description in read-only mode; focused fields rendered with green accent; Sessions tab gains hollow-retry widgets: [policy] dropdown (always/intent-aware/never), [work_max_retries] stepper, [consultation_max_retries] stepper; footer built from focused widget's edit_hint() so edit keys (Space/Enter/←→) are always advertised; KeymapProvider::keybindings() gains a third "Edit" group for consistent ? help overlay; save_config returns Err via let-else when config_path is None; Ctrl+S surfaces failures as a 5-second title-bar flash (save_error_flash: Option<(String, Instant)> field) rendered as "Settings [Save failed: <msg>]" in accent_error  [Issue #275, #432, #437]
 │   │           └── validation.rs          # Settings field validation helpers
 │   │   └── widgets/                       # Reusable TUI widget components  [Issue #124]
 │   │       ├── mod.rs                     # Module re-exports for all widgets; WidgetKind::edit_hint() returns a contextual (key, label) tuple per variant used by SettingsScreen to build the footer  [Issue #432]
+│   │       ├── bypass_indicator.rs        # BypassIndicatorWidget: small status badge rendered in the F-key bar when --bypass-review is active, warning the user that the review council is disabled  [Issue #328]
 │   │       ├── ci_monitor.rs              # CiMonitorWidget: compact bordered box rendering live CI check-run status for a PR; status icons, check names, elapsed times, and a summary footer
 │   │       ├── dropdown.rs                # Dropdown selection widget with keyboard navigation
 │   │       ├── list_editor.rs             # Editable list widget for adding and removing string items
@@ -305,6 +336,9 @@ maestro/
 │       ├── executor.rs                    # QueueExecutor state machine for sequential queue execution; ExecutorPhase enum (Idle, Running, AwaitingDecision, Finished); ExecutorItem struct; QueueItemState enum; FailureAction enum (Retry, Skip, Abort); advance(), mark_success(), mark_failure(), apply_decision(), set_session_id()
 │       └── queue.rs                       # WorkQueue, QueuedItem, QueueValidationError; validate_selection()  [Issue #65]
 ├── docs/
+│   ├── api-contracts/                     # JSON Schema (Draft 2020-12) for every external payload that crosses a process boundary; one file per payload type; referenced by /validate-contracts and subagent-gatekeeper
+│   │   ├── README.md                      # Convention guide: naming, additionalProperties policy, gatekeeper integration  [Issue #327]
+│   │   └── review-comment.json            # Schema for the maestro-review JSON block in /review PR comments; parsed by review::parse and TUI pr_review screen  [Issue #327]
 │   ├── ci-smoke-check.md                  # CI smoke-check test harness guide
 │   ├── FOLLOW-UPS.md                      # Pending hardening and security follow-up items (non-blocking, filed as issues before next release)
 │   ├── harness-acceptance.md              # Acceptance criteria for the test harness

--- a/docs/api-contracts/README.md
+++ b/docs/api-contracts/README.md
@@ -1,0 +1,16 @@
+# docs/api-contracts/
+
+JSON Schema files (Draft 2020-12) for every external data payload that crosses a process boundary — GitHub API responses, Claude slash-command output blocks, and any other structured JSON maestro parses.
+
+## Convention
+
+- One file per payload type, named `<payload-slug>.json`.
+- All schemas use `"additionalProperties": false` at the top level.
+- Referenced by the `/validate-contracts` slash command and by `subagent-gatekeeper` during the DOR check.
+- Any new `serde` struct that deserializes an external payload requires a corresponding schema here before implementation can start (see `docs/RUST-GUARDRAILS.md` §6).
+
+## Schemas
+
+| File | Payload | Added |
+|------|---------|-------|
+| `review-comment.json` | Structured JSON block embedded in `/review` slash-command PR comments; parsed by the TUI to render the concerns panel and drive the accept/reject flow | #327 |

--- a/docs/api-contracts/review-comment.json
+++ b/docs/api-contracts/review-comment.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Maestro Review Report (v1)",
+  "description": "Schema for the structured JSON block embedded in a `/review` slash-command PR comment. The block is fenced with ```json maestro-review ... ```. The maestro TUI parses this to render the concerns panel and drive the accept/reject flow (#327, #328).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "pr_number", "reviewer", "concerns"],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version. Bumped on breaking changes."
+    },
+    "pr_number": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "GitHub PR number this report applies to."
+    },
+    "reviewer": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identifier for the reviewer (e.g. `claude`, `codex`, or a council role)."
+    },
+    "concerns": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "severity", "file", "message"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "severity": {
+            "type": "string",
+            "enum": ["critical", "warning", "suggestion"]
+          },
+          "file": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Repo-relative path."
+          },
+          "line": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Optional 1-based line number."
+          },
+          "message": {
+            "type": "string",
+            "minLength": 1
+          },
+          "suggested_diff": {
+            "type": "string",
+            "description": "Optional unified-diff fragment to apply on accept."
+          },
+          "status": {
+            "type": "string",
+            "enum": ["pending", "accepted", "rejected", "applied"],
+            "default": "pending"
+          }
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "version": 1,
+      "pr_number": 42,
+      "reviewer": "claude",
+      "concerns": [
+        {
+          "id": "9c5a0f3e-2aab-4b61-9f14-4bc5e3e10e21",
+          "severity": "critical",
+          "file": "src/auth/token.rs",
+          "line": 84,
+          "message": "Token comparison is non-constant-time and is vulnerable to timing attacks.",
+          "suggested_diff": "@@ -84,1 +84,1 @@\n-if token == expected {\n+if subtle::ConstantTimeEq::ct_eq(token.as_bytes(), expected.as_bytes()).into() {",
+          "status": "pending"
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/allowlist-large-files.txt
+++ b/scripts/allowlist-large-files.txt
@@ -103,3 +103,6 @@ src/tui/screens/issue_wizard/mod.rs # deadline: 2026-07-22, owner: @carlos, tick
 
 # --- Milestone v0.15.3 dupe-prevention additions (#454/#455) ---
 src/tui/app/data_handler.rs # deadline: 2026-07-22, owner: @carlos, ticket: #TBD, plan: extract the AdaptScan/Analyze/Consolidate/Plan/Scaffold arms into a dedicated handler module (handle_adapt_event); the dupe-prevention work in #455 added the IssueAlreadyExists arm, pushing the file 6 lines over
+src/tui/app/mod.rs # deadline: 2026-07-22, owner: @carlos, ticket: #321/#327/#328/#329, plan: extract App field initializers and screen-Option declarations into app/state.rs; bypass methods already moved to app/bypass.rs in v0.16.0
+src/prd/ingest.rs # deadline: 2026-07-22, owner: @carlos, ticket: #321, plan: split heuristic parser from tests — move parser into prd/ingest/{sections,extract,classify}.rs and convert ingest.rs to ingest/mod.rs once the contract stabilizes; ~250 of the 521 LOC are the markdown-parser test corpus that we want to keep co-located while the heuristics evolve
+src/prd/discover.rs # deadline: 2026-07-22, owner: @carlos, ticket: #321, plan: split into prd/discover/{github,local,azure,dedup}.rs once the source set stabilizes; currently 411 LOC because the per-source helpers + dedup + tests live together while we iterate on the explore UX

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,6 +40,13 @@ pub enum SanitizeSeverityFilter {
 pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Commands>,
+
+    /// Auto-accept review corrections without confirmation.
+    /// Session-only; cannot be persisted as a default. ⚠ DANGER:
+    /// edits, commits, and pushes are applied without per-suggestion review.
+    /// See issue #328 for the full safety rails.
+    #[arg(long = "bypass-review", global = true)]
+    pub bypass_review: bool,
 }
 
 #[derive(Subcommand)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,6 +8,7 @@ mod resume;
 mod run;
 pub(crate) mod setup;
 mod slack;
+pub mod slash;
 mod status;
 pub mod turboquant;
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,4 +1,4 @@
-use crate::commands::setup::{setup_app_from_config, startup_cleanup};
+use crate::commands::setup::{setup_app_from_config_with_bypass, startup_cleanup};
 use crate::config::Config;
 use crate::provider::github::client::{GhCliClient, GitHubClient};
 use crate::session::types::Session;
@@ -24,6 +24,7 @@ pub async fn cmd_run(
     enable_flags: Vec<String>,
     disable_flags: Vec<String>,
     no_splash: bool,
+    bypass_review: bool,
 ) -> anyhow::Result<()> {
     let loaded = Config::find_and_load_with_path()?;
     let config = loaded.config.clone();
@@ -72,7 +73,13 @@ pub async fn cmd_run(
         max_concurrent_override
     };
 
-    let mut app = setup_app_from_config(loaded, store, worktree_mgr, effective_max_concurrent);
+    let mut app = setup_app_from_config_with_bypass(
+        loaded,
+        store,
+        worktree_mgr,
+        effective_max_concurrent,
+        bypass_review,
+    );
     app.flags = feature_flags;
 
     if resume {

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -15,16 +15,47 @@ pub fn setup_app_from_config(
     worktree_mgr: Box<dyn crate::session::worktree::WorktreeManager + Send>,
     max_concurrent_override: Option<usize>,
 ) -> App {
+    setup_app_from_config_with_bypass(loaded, store, worktree_mgr, max_concurrent_override, false)
+}
+
+/// Variant of `setup_app_from_config` that also threads the bypass-review
+/// CLI flag (#328). When `bypass_review` is true the session pool is
+/// constructed with `bypassPermissions`, the App's `bypass_active` flag is
+/// set, and an audit-log entry is recorded.
+pub fn setup_app_from_config_with_bypass(
+    loaded: LoadedConfig,
+    store: StateStore,
+    worktree_mgr: Box<dyn crate::session::worktree::WorktreeManager + Send>,
+    max_concurrent_override: Option<usize>,
+    bypass_review: bool,
+) -> App {
     let LoadedConfig { config, path } = loaded;
     let max_concurrent = max_concurrent_override.unwrap_or(config.sessions.max_concurrent);
+
+    // Bypass overrides the configured permission mode for this session only.
+    let permission_mode = if bypass_review {
+        "bypassPermissions".to_string()
+    } else {
+        config.sessions.permission_mode.clone()
+    };
+
+    let permission_mode_for_app = permission_mode.clone();
 
     let mut app = App::new(
         store,
         max_concurrent,
         worktree_mgr,
-        config.sessions.permission_mode.clone(),
+        permission_mode_for_app,
         config.sessions.allowed_tools.clone(),
     );
+
+    // Bypass mode is activatable via three paths (#328 AC):
+    //   - CLI flag (`--bypass-review`)
+    //   - Config (`[sessions].permission_mode = "bypassPermissions"`)
+    //   - TUI toggle (Ctrl+B at runtime)
+    if bypass_review || permission_mode == "bypassPermissions" {
+        app.activate_bypass_from_cli();
+    }
 
     app.budget_enforcer = Some(crate::budget::BudgetEnforcer::new(
         config.budget.per_session_usd,

--- a/src/commands/slash.rs
+++ b/src/commands/slash.rs
@@ -1,0 +1,275 @@
+//! Minimal in-session slash-command dispatcher (#327).
+//!
+//! Today's surface is intentionally tiny: `/review <pr>`, `/help`. Growth
+//! is additive (new `SlashCommand` enum variants), keeping the dispatcher
+//! under the file-size cap.
+
+#![deny(clippy::unwrap_used)]
+// Reason: Phase 1 foundation for #327. The dispatcher is wired into the
+// session-input loop in Phase 2; tests exercise parsing and dispatch today.
+#![allow(dead_code)]
+
+use std::str::FromStr;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SlashCommand {
+    Review {
+        pr_number: u64,
+        branch: Option<String>,
+    },
+    Help,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum SlashParseError {
+    Empty,
+    NotASlashCommand,
+    UnknownCommand(String),
+    MissingArgument {
+        command: String,
+        argument: String,
+    },
+    InvalidArgument {
+        command: String,
+        value: String,
+        reason: String,
+    },
+}
+
+impl std::fmt::Display for SlashParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Empty => write!(f, "empty slash input"),
+            Self::NotASlashCommand => write!(f, "input does not start with '/'"),
+            Self::UnknownCommand(c) => write!(f, "unknown slash command: /{c}"),
+            Self::MissingArgument { command, argument } => {
+                write!(f, "/{command} requires <{argument}>")
+            }
+            Self::InvalidArgument {
+                command,
+                value,
+                reason,
+            } => {
+                write!(f, "/{command} got invalid value '{value}': {reason}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SlashParseError {}
+
+impl FromStr for SlashCommand {
+    type Err = SlashParseError;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let trimmed = input.trim();
+        if trimmed.is_empty() {
+            return Err(SlashParseError::Empty);
+        }
+        let stripped = trimmed
+            .strip_prefix('/')
+            .ok_or(SlashParseError::NotASlashCommand)?;
+
+        let mut parts = stripped.split_whitespace();
+        let head = parts.next().ok_or(SlashParseError::Empty)?;
+
+        match head {
+            "help" => Ok(Self::Help),
+            "review" => {
+                let pr_arg = parts
+                    .next()
+                    .ok_or_else(|| SlashParseError::MissingArgument {
+                        command: "review".into(),
+                        argument: "pr_number".into(),
+                    })?;
+                let pr_number = pr_arg
+                    .strip_prefix('#')
+                    .unwrap_or(pr_arg)
+                    .parse::<u64>()
+                    .map_err(|e| SlashParseError::InvalidArgument {
+                        command: "review".into(),
+                        value: pr_arg.into(),
+                        reason: e.to_string(),
+                    })?;
+                let branch = match parts.next() {
+                    None => None,
+                    Some(b) => {
+                        // Validate at the parsing seam so untrusted input
+                        // cannot flow into telemetry/audit before downstream
+                        // shellouts validate it.
+                        crate::util::validate_branch_name(b).map_err(|e| {
+                            SlashParseError::InvalidArgument {
+                                command: "review".into(),
+                                value: b.into(),
+                                reason: e.to_string(),
+                            }
+                        })?;
+                        Some(b.to_string())
+                    }
+                };
+                Ok(Self::Review { pr_number, branch })
+            }
+            other => Err(SlashParseError::UnknownCommand(other.into())),
+        }
+    }
+}
+
+/// Outcome of dispatching a slash command. The TUI app turns this into UI
+/// state changes (panel updates, screen pushes, etc.).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SlashOutcome {
+    /// Show the static help text in the message log.
+    Help(&'static str),
+    /// Begin the review pipeline for a given PR. The app routes this to
+    /// `ReviewDispatcher`.
+    StartReview {
+        pr_number: u64,
+        branch: Option<String>,
+    },
+}
+
+pub const HELP_TEXT: &str = "\
+Available slash commands:
+  /review <pr_number> [branch]  Run reviewers against a PR and post results
+  /help                         Show this message
+";
+
+/// Trait so the dispatcher can be faked in higher-level tests.
+pub trait SlashDispatcher: Send + Sync {
+    fn dispatch(&self, command: SlashCommand) -> SlashOutcome;
+}
+
+/// Default dispatcher — pure mapping from command to outcome. The
+/// side-effecting work (spawning Claude with `/review`, posting comments)
+/// happens in the layer that consumes the outcome.
+#[derive(Default)]
+pub struct DefaultSlashDispatcher;
+
+impl SlashDispatcher for DefaultSlashDispatcher {
+    fn dispatch(&self, command: SlashCommand) -> SlashOutcome {
+        match command {
+            SlashCommand::Help => SlashOutcome::Help(HELP_TEXT),
+            SlashCommand::Review { pr_number, branch } => {
+                SlashOutcome::StartReview { pr_number, branch }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_help_command() {
+        let cmd: SlashCommand = "/help".parse().expect("parse");
+        assert_eq!(cmd, SlashCommand::Help);
+    }
+
+    #[test]
+    fn parse_review_with_pr_number() {
+        let cmd: SlashCommand = "/review 42".parse().expect("parse");
+        assert_eq!(
+            cmd,
+            SlashCommand::Review {
+                pr_number: 42,
+                branch: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_review_with_hash_prefix() {
+        let cmd: SlashCommand = "/review #99".parse().expect("parse");
+        assert_eq!(
+            cmd,
+            SlashCommand::Review {
+                pr_number: 99,
+                branch: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_review_with_branch_argument() {
+        let cmd: SlashCommand = "/review 42 feat/x".parse().expect("parse");
+        assert_eq!(
+            cmd,
+            SlashCommand::Review {
+                pr_number: 42,
+                branch: Some("feat/x".into()),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_review_without_pr_number_errors() {
+        let err = "/review".parse::<SlashCommand>().unwrap_err();
+        assert!(matches!(err, SlashParseError::MissingArgument { .. }));
+    }
+
+    #[test]
+    fn parse_unknown_command_errors() {
+        let err = "/bogus".parse::<SlashCommand>().unwrap_err();
+        assert!(matches!(err, SlashParseError::UnknownCommand(_)));
+    }
+
+    #[test]
+    fn parse_non_slash_input_errors() {
+        let err = "review 42".parse::<SlashCommand>().unwrap_err();
+        assert_eq!(err, SlashParseError::NotASlashCommand);
+    }
+
+    #[test]
+    fn parse_empty_input_errors() {
+        let err = "   ".parse::<SlashCommand>().unwrap_err();
+        assert_eq!(err, SlashParseError::Empty);
+    }
+
+    #[test]
+    fn parse_invalid_pr_number_errors() {
+        let err = "/review notanumber".parse::<SlashCommand>().unwrap_err();
+        assert!(matches!(err, SlashParseError::InvalidArgument { .. }));
+    }
+
+    #[test]
+    fn parse_review_rejects_branch_with_shell_metachars() {
+        let err = "/review 1 foo;rm".parse::<SlashCommand>().unwrap_err();
+        assert!(matches!(err, SlashParseError::InvalidArgument { .. }));
+    }
+
+    #[test]
+    fn parse_review_rejects_branch_with_double_dots() {
+        let err = "/review 1 feat/../etc".parse::<SlashCommand>().unwrap_err();
+        assert!(matches!(err, SlashParseError::InvalidArgument { .. }));
+    }
+
+    #[test]
+    fn dispatch_help_returns_help_text() {
+        let d = DefaultSlashDispatcher;
+        let outcome = d.dispatch(SlashCommand::Help);
+        assert_eq!(outcome, SlashOutcome::Help(HELP_TEXT));
+    }
+
+    #[test]
+    fn dispatch_review_returns_start_review_outcome() {
+        let d = DefaultSlashDispatcher;
+        let outcome = d.dispatch(SlashCommand::Review {
+            pr_number: 7,
+            branch: Some("main".into()),
+        });
+        assert_eq!(
+            outcome,
+            SlashOutcome::StartReview {
+                pr_number: 7,
+                branch: Some("main".into())
+            }
+        );
+    }
+
+    #[test]
+    fn help_text_lists_review_and_help() {
+        assert!(HELP_TEXT.contains("/review"));
+        assert!(HELP_TEXT.contains("/help"));
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -796,7 +796,11 @@ fn default_mode() -> String {
     "orchestrator".into()
 }
 fn default_permission_mode() -> String {
-    "bypassPermissions".into()
+    // Default OFF: fresh installs / configs that don't set this explicitly
+    // get the safe Claude permission flow (per-tool prompts). Bypass mode
+    // is opt-in via the Settings toggle, the `--bypass-review` CLI flag,
+    // or by setting `permission_mode = "bypassPermissions"` here.
+    "default".into()
 }
 fn default_max_retries() -> u32 {
     2

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ mod work;
 
 mod adapt;
 mod mascot;
+mod prd;
 mod sanitize;
 mod system;
 mod turboquant;
@@ -208,6 +209,7 @@ async fn main() -> anyhow::Result<()> {
                 enable_flags,
                 disable_flags,
                 no_splash,
+                cli.bypass_review,
             )
             .await
         }
@@ -368,7 +370,10 @@ mod tests {
     }
 
     #[test]
-    fn default_permission_mode_is_bypass_permissions() {
+    fn default_permission_mode_is_default_off() {
+        // Bypass mode is opt-in (Settings toggle, --bypass-review CLI flag,
+        // or explicit `permission_mode = "bypassPermissions"`). A minimal
+        // config that doesn't set the field must NOT auto-enable bypass.
         let app = setup_app_from_config(
             loaded(minimal_config()),
             make_store(),
@@ -377,7 +382,7 @@ mod tests {
         );
         assert_eq!(
             app.config.as_ref().unwrap().sessions.permission_mode,
-            "bypassPermissions"
+            "default"
         );
     }
 

--- a/src/prd/discover.rs
+++ b/src/prd/discover.rs
@@ -1,0 +1,425 @@
+//! Discover the canonical PRD issue in a GitHub repo (#321).
+//!
+//! Discovery cascades through three strategies (most-specific first) so
+//! a project that hasn't bothered to apply the `prd` label still gets
+//! its PRD detected:
+//!
+//! 1. `gh issue list --label prd --state all --limit 1`
+//! 2. `gh issue list --search "PRD: in:title" --state all --limit 1`
+//! 3. `gh issue view 1` (last-resort fallback — many maestro-style projects
+//!    pin their PRD as issue #1)
+//!
+//! All `gh` failures degrade to `Ok(None)` rather than bubbling — the
+//! sync flow still works without an ingested PRD.
+
+#![deny(clippy::unwrap_used)]
+#![allow(dead_code)]
+
+use serde::Deserialize;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveredPrd {
+    pub number: u64,
+    pub title: String,
+    pub body: String,
+    pub source: DiscoverySource,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiscoverySource {
+    LabelPrd,
+    TitleSearch,
+    IssueOne,
+    LocalFile,
+    AzureWiki,
+}
+
+impl DiscoverySource {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::LabelPrd => "github:label:prd",
+            Self::TitleSearch => "github:title-search",
+            Self::IssueOne => "github:issue-1",
+            Self::LocalFile => "local:docs/PRD.md",
+            Self::AzureWiki => "azure:wiki",
+        }
+    }
+}
+
+/// Try each discovery strategy in order; return the first hit, `None` if
+/// nothing matched. Convenience wrapper around `discover_all` for
+/// callers that just want the primary candidate.
+pub fn discover() -> Option<DiscoveredPrd> {
+    discover_all().into_iter().next()
+}
+
+/// Run every discovery strategy and return ALL real PRD candidates
+/// (most-canonical first). Used by the explore UI so the user can see
+/// what was found across GitHub + local + Azure and pick a source.
+///
+/// Order:
+///   1. `--label prd` (explicit author intent)
+///   2. GitHub issue #1 if it looks PRD-shaped
+///   3. Local `docs/PRD.md`
+///   4. Azure DevOps wiki page `/PRD` (if `az` is available)
+///   5. GitHub title-search with strict `PRD:` prefix (last resort)
+///
+/// Issue templates (Acceptance Criteria + Blocked By/Definition of Done)
+/// are filtered at every step. Candidates are deduplicated by `(host,
+/// number)`: title-search and issue-1 fallback often surface the same
+/// GitHub issue twice — the explore UI showing both would be noise.
+pub fn discover_all() -> Vec<DiscoveredPrd> {
+    let mut out = Vec::new();
+    let mut push_if_real = |candidate: Option<DiscoveredPrd>| {
+        if let Some(c) = candidate.filter(is_real_prd)
+            && !is_duplicate(&out, &c)
+        {
+            out.push(c);
+        }
+    };
+    push_if_real(try_label_prd());
+    push_if_real(try_issue_one());
+    push_if_real(try_local_file());
+    push_if_real(try_azure_wiki());
+    push_if_real(try_title_search());
+    out
+}
+
+/// Two candidates are duplicates when they're from the same host family
+/// (GitHub vs local vs Azure) AND identify the same resource (issue
+/// number for GitHub, body fingerprint for local/Azure where number=0).
+fn is_duplicate(existing: &[DiscoveredPrd], candidate: &DiscoveredPrd) -> bool {
+    existing.iter().any(|e| {
+        // GitHub issues collide by number.
+        if candidate.number > 0
+            && e.number == candidate.number
+            && matches!(
+                (e.source, candidate.source),
+                (DiscoverySource::LabelPrd, DiscoverySource::IssueOne)
+                    | (DiscoverySource::LabelPrd, DiscoverySource::TitleSearch)
+                    | (DiscoverySource::IssueOne, DiscoverySource::LabelPrd)
+                    | (DiscoverySource::IssueOne, DiscoverySource::TitleSearch)
+                    | (DiscoverySource::TitleSearch, DiscoverySource::LabelPrd)
+                    | (DiscoverySource::TitleSearch, DiscoverySource::IssueOne)
+            )
+        {
+            return true;
+        }
+        // Local/Azure collide by body content (rare — only if both
+        // configured to read the same wiki page).
+        candidate.number == 0
+            && e.number == 0
+            && e.source == candidate.source
+            && e.body == candidate.body
+    })
+}
+
+/// A discovered candidate is a "real PRD" only when its body is NOT
+/// shaped like an issue-template body and at least passes `looks_like_prd`.
+fn is_real_prd(p: &DiscoveredPrd) -> bool {
+    !looks_like_issue_template(&p.body) && looks_like_prd(&p.title, &p.body)
+}
+
+#[derive(Deserialize)]
+struct GhIssueListItem {
+    number: u64,
+    title: String,
+    body: String,
+}
+
+fn try_label_prd() -> Option<DiscoveredPrd> {
+    let items = run_gh_list(&["--label", "prd", "--state", "all", "--limit", "1"])?;
+    items.into_iter().next().map(|i| DiscoveredPrd {
+        number: i.number,
+        title: i.title,
+        body: i.body,
+        source: DiscoverySource::LabelPrd,
+    })
+}
+
+fn try_title_search() -> Option<DiscoveredPrd> {
+    // Search GitHub broadly, then enforce a strict `PRD:` (or `PRD-` /
+    // `PRD —`) prefix locally — `gh issue list --search "PRD: in:title"`
+    // matches any title containing "PRD" as a word, which would pull
+    // unrelated issues like `feat: PRD flow — …`.
+    let items = run_gh_list(&["--search", "PRD in:title", "--state", "all", "--limit", "5"])?;
+    items
+        .into_iter()
+        .find(|i| has_strict_prd_title_prefix(&i.title))
+        .map(|i| DiscoveredPrd {
+            number: i.number,
+            title: i.title,
+            body: i.body,
+            source: DiscoverySource::TitleSearch,
+        })
+}
+
+/// True only when `title` starts with `PRD:`, `PRD-`, `PRD —`, `PRD –`,
+/// or `PRD ` followed by another keyword. Whitespace and case-insensitive.
+pub(crate) fn has_strict_prd_title_prefix(title: &str) -> bool {
+    let t = title.trim().to_lowercase();
+    t.starts_with("prd:")
+        || t.starts_with("prd-")
+        || t.starts_with("prd —")
+        || t.starts_with("prd –")
+        || t.starts_with("prd ")
+        || t == "prd"
+}
+
+fn try_issue_one() -> Option<DiscoveredPrd> {
+    let output = std::process::Command::new("gh")
+        .args(["issue", "view", "1", "--json", "number,title,body"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let item: GhIssueListItem = serde_json::from_str(&stdout).ok()?;
+    if !looks_like_prd(&item.title, &item.body) {
+        return None;
+    }
+    Some(DiscoveredPrd {
+        number: item.number,
+        title: item.title,
+        body: item.body,
+        source: DiscoverySource::IssueOne,
+    })
+}
+
+fn run_gh_list(extra_args: &[&str]) -> Option<Vec<GhIssueListItem>> {
+    let mut args: Vec<&str> = vec!["issue", "list", "--json", "number,title,body"];
+    args.extend(extra_args);
+    let output = std::process::Command::new("gh").args(&args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).ok()
+}
+
+/// Hard cap on local PRD file size to prevent a runaway 50 MB
+/// `docs/PRD.md` from blocking the discovery thread + ballooning App
+/// memory. 512 KiB is generous for a real PRD.
+const MAX_LOCAL_PRD_BYTES: u64 = 512 * 1024;
+
+/// Read a `docs/PRD.md` file from the current working directory.
+fn try_local_file() -> Option<DiscoveredPrd> {
+    let path = std::env::current_dir().ok()?.join("docs/PRD.md");
+    let metadata = std::fs::metadata(&path).ok()?;
+    if metadata.len() > MAX_LOCAL_PRD_BYTES {
+        tracing::warn!(
+            path = %path.display(),
+            size = metadata.len(),
+            "skipping local PRD file: exceeds 512 KiB cap"
+        );
+        return None;
+    }
+    let body = std::fs::read_to_string(&path).ok()?;
+    if body.trim().is_empty() {
+        return None;
+    }
+    let title = body
+        .lines()
+        .find(|l| l.starts_with("# "))
+        .and_then(|l| l.strip_prefix("# "))
+        .unwrap_or("docs/PRD.md")
+        .to_string();
+    Some(DiscoveredPrd {
+        number: 0, // local file has no issue number
+        title,
+        body,
+        source: DiscoverySource::LocalFile,
+    })
+}
+
+/// Best-effort Azure DevOps wiki fetch via `az devops wiki page show
+/// --path /PRD`. Degrades to None if `az` isn't installed/authed.
+fn try_azure_wiki() -> Option<DiscoveredPrd> {
+    let output = std::process::Command::new("az")
+        .args([
+            "devops", "wiki", "page", "show", "--path", "/PRD", "--output", "json",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let page: AzureWikiPage = serde_json::from_str(&stdout).ok()?;
+    if page.content.trim().is_empty() {
+        return None;
+    }
+    let title = page.path.unwrap_or_else(|| "/PRD".into());
+    Some(DiscoveredPrd {
+        number: 0,
+        title,
+        body: page.content,
+        source: DiscoverySource::AzureWiki,
+    })
+}
+
+#[derive(serde::Deserialize)]
+struct AzureWikiPage {
+    content: String,
+    #[serde(default)]
+    path: Option<String>,
+}
+
+/// Heuristic: an issue is "PRD-like" when its title starts with `PRD:`
+/// or its body has at least one of the canonical PRD section headings.
+/// Used only by the issue-#1 fallback to avoid pulling random issues.
+pub(crate) fn looks_like_prd(title: &str, body: &str) -> bool {
+    if has_strict_prd_title_prefix(title) {
+        return true;
+    }
+    let body_lower = body.to_lowercase();
+    let prd_markers = [
+        "## vision",
+        "## mission",
+        "## goals",
+        "## non-goals",
+        "## success criteria",
+    ];
+    prd_markers.iter().any(|m| body_lower.contains(m))
+}
+
+/// True when the body is shaped like a GitHub issue body, not a PRD —
+/// has both `## Acceptance Criteria` and one of `## Blocked By` /
+/// `## Definition of Done`. Issue templates use this exact combination.
+pub(crate) fn looks_like_issue_template(body: &str) -> bool {
+    let lower = body.to_lowercase();
+    let has_ac = lower.contains("## acceptance criteria");
+    let has_blocked_by = lower.contains("## blocked by");
+    let has_dod = lower.contains("## definition of done");
+    has_ac && (has_blocked_by || has_dod)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn looks_like_prd_matches_prd_colon_title() {
+        assert!(looks_like_prd("PRD: foo", ""));
+        assert!(looks_like_prd("PRD foo", ""));
+        assert!(looks_like_prd("PRD-foo", ""));
+        assert!(looks_like_prd("prd:", ""));
+    }
+
+    #[test]
+    fn looks_like_prd_matches_prd_specific_section_headings() {
+        assert!(looks_like_prd("Random Title", "## Vision\n\nText"));
+        assert!(looks_like_prd("Random Title", "## Mission\n\nText"));
+        assert!(looks_like_prd("Random Title", "## Goals\n\n- a"));
+        assert!(looks_like_prd("Random Title", "## Non-Goals\n\n- a"));
+        assert!(looks_like_prd("Random Title", "## Success Criteria\n\n- a"));
+    }
+
+    #[test]
+    fn looks_like_prd_does_not_match_acceptance_criteria_alone() {
+        // `## Acceptance Criteria` belongs to issue templates, not PRDs.
+        // Must NOT classify as PRD on its own — that was the bug that
+        // made us ingest issue #321 instead of #1.
+        assert!(!looks_like_prd(
+            "Some issue title",
+            "## Acceptance Criteria\n\n- [ ] x"
+        ));
+    }
+
+    #[test]
+    fn looks_like_prd_rejects_generic_issues() {
+        assert!(!looks_like_prd(
+            "Fix bug in parser",
+            "Steps to reproduce..."
+        ));
+        assert!(!looks_like_prd("", ""));
+    }
+
+    #[test]
+    fn discovery_source_labels_are_stable_and_namespaced() {
+        // Labels are surfaced in the activity log + explore UI, so the
+        // user-visible namespace prefix matters: GitHub vs local vs Azure.
+        assert_eq!(DiscoverySource::LabelPrd.label(), "github:label:prd");
+        assert_eq!(DiscoverySource::TitleSearch.label(), "github:title-search");
+        assert_eq!(DiscoverySource::IssueOne.label(), "github:issue-1");
+        assert_eq!(DiscoverySource::LocalFile.label(), "local:docs/PRD.md");
+        assert_eq!(DiscoverySource::AzureWiki.label(), "azure:wiki");
+    }
+
+    #[test]
+    fn strict_prd_prefix_accepts_canonical_titles() {
+        assert!(has_strict_prd_title_prefix("PRD: Maestro"));
+        assert!(has_strict_prd_title_prefix("PRD - foo"));
+        assert!(has_strict_prd_title_prefix("PRD — foo"));
+        assert!(has_strict_prd_title_prefix("PRD foo"));
+        assert!(has_strict_prd_title_prefix("prd: lower"));
+        assert!(has_strict_prd_title_prefix("PRD"));
+    }
+
+    #[test]
+    fn strict_prd_prefix_rejects_meta_titles() {
+        // The bug we just fixed: `feat: interactive PRD flow` was matching
+        // because gh search treats "PRD" as a word anywhere in the title.
+        assert!(!has_strict_prd_title_prefix(
+            "feat: interactive PRD flow — live document"
+        ));
+        assert!(!has_strict_prd_title_prefix("Add PRD support"));
+        assert!(!has_strict_prd_title_prefix("Refactor the PRD parser"));
+    }
+
+    #[test]
+    fn issue_template_detected_when_ac_and_blocked_by() {
+        let body =
+            "## Overview\n\nx\n\n## Acceptance Criteria\n\n- [ ] x\n\n## Blocked By\n\n- None";
+        assert!(looks_like_issue_template(body));
+    }
+
+    #[test]
+    fn issue_template_detected_when_ac_and_definition_of_done() {
+        let body = "## Acceptance Criteria\n\n- [ ] x\n\n## Definition of Done\n\n- [ ] x";
+        assert!(looks_like_issue_template(body));
+    }
+
+    #[test]
+    fn issue_template_not_detected_for_real_prd() {
+        let body = "## Vision\n\nThe pitch.\n\n## Goals\n\n- a\n\n## Non-Goals\n\n- b\n\n## Success Criteria\n\n- c";
+        assert!(!looks_like_issue_template(body));
+    }
+
+    #[test]
+    fn looks_like_prd_no_longer_treats_overview_alone_as_prd() {
+        // `## Overview` is part of every issue template — it must not
+        // single-handedly classify a body as a PRD.
+        let issue_body = "## Overview\n\nFix the parser bug.";
+        assert!(!looks_like_prd("Fix parser bug", issue_body));
+    }
+
+    #[test]
+    fn looks_like_prd_accepts_real_prd_section_combos() {
+        let prd_body = "## Vision\n\nx\n\n## Goals\n\n- a";
+        assert!(looks_like_prd("Some title", prd_body));
+    }
+
+    #[test]
+    fn is_real_prd_skips_issue_templates() {
+        let template = DiscoveredPrd {
+            number: 321,
+            title: "feat: PRD".into(),
+            body: "## Acceptance Criteria\n- x\n## Blocked By\n- None".into(),
+            source: DiscoverySource::TitleSearch,
+        };
+        assert!(!is_real_prd(&template));
+    }
+
+    #[test]
+    fn is_real_prd_accepts_canonical_prd() {
+        let real = DiscoveredPrd {
+            number: 1,
+            title: "PRD: Maestro".into(),
+            body: "## Vision\n\nThe pitch.\n\n## Success Criteria\n\n- a".into(),
+            source: DiscoverySource::IssueOne,
+        };
+        assert!(is_real_prd(&real));
+    }
+}

--- a/src/prd/export.rs
+++ b/src/prd/export.rs
@@ -1,0 +1,245 @@
+//! Markdown export for the PRD (#321). Pure function, snapshot-friendly.
+
+#![deny(clippy::unwrap_used)]
+// Reason: Phase 1 foundation for #321. `to_markdown` is invoked by the
+// PRD screen export action + `maestro prd --export` subcommand in Phase 2.
+#![allow(dead_code)]
+
+use crate::prd::model::{Prd, TimelineStatus};
+use std::fmt::Write as _;
+
+const PLACEHOLDER: &str = "_(not yet defined)_";
+
+pub fn to_markdown(prd: &Prd) -> String {
+    let mut out = String::new();
+    section_vision(prd, &mut out);
+    section_goals(prd, &mut out);
+    section_non_goals(prd, &mut out);
+    section_current_state(prd, &mut out);
+    section_stakeholders(prd, &mut out);
+    section_timeline(prd, &mut out);
+    out
+}
+
+fn section_vision(prd: &Prd, out: &mut String) {
+    out.push_str("# Product Requirements Document\n\n");
+    out.push_str("## Vision & Purpose\n\n");
+    if prd.vision.trim().is_empty() {
+        out.push_str(PLACEHOLDER);
+    } else {
+        out.push_str(prd.vision.trim());
+    }
+    out.push_str("\n\n");
+}
+
+fn section_goals(prd: &Prd, out: &mut String) {
+    out.push_str("## Goals\n\n");
+    if prd.goals.is_empty() {
+        out.push_str(PLACEHOLDER);
+        out.push_str("\n\n");
+        return;
+    }
+    for g in &prd.goals {
+        let mark = if g.done { "x" } else { " " };
+        let _ = writeln!(out, "- [{mark}] {}", g.text);
+    }
+    out.push('\n');
+}
+
+fn section_non_goals(prd: &Prd, out: &mut String) {
+    out.push_str("## Non-Goals\n\n");
+    if prd.non_goals.is_empty() {
+        out.push_str(PLACEHOLDER);
+        out.push_str("\n\n");
+        return;
+    }
+    for ng in &prd.non_goals {
+        let _ = writeln!(out, "- {ng}");
+    }
+    out.push('\n');
+}
+
+fn section_current_state(prd: &Prd, out: &mut String) {
+    let cs = &prd.current_state;
+    out.push_str("## Current State\n\n");
+    let _ = writeln!(
+        out,
+        "- **Issues**: {} closed / {} total ({:.0}% complete)",
+        cs.closed_issues,
+        cs.total_issues(),
+        cs.completion_ratio() * 100.0
+    );
+    let _ = writeln!(
+        out,
+        "- **Milestones**: {} closed / {} open",
+        cs.closed_milestones, cs.open_milestones,
+    );
+    if !cs.top_blockers.is_empty() {
+        out.push_str("- **Top blockers**: ");
+        let mut first = true;
+        for n in &cs.top_blockers {
+            if !first {
+                out.push_str(", ");
+            }
+            let _ = write!(out, "#{n}");
+            first = false;
+        }
+        out.push('\n');
+    }
+    out.push('\n');
+}
+
+fn section_stakeholders(prd: &Prd, out: &mut String) {
+    out.push_str("## Stakeholders\n\n");
+    if prd.stakeholders.is_empty() {
+        out.push_str(PLACEHOLDER);
+        out.push_str("\n\n");
+        return;
+    }
+    out.push_str("| Name | Role |\n|------|------|\n");
+    for s in &prd.stakeholders {
+        let _ = writeln!(out, "| {} | {} |", s.name, s.role);
+    }
+    out.push('\n');
+}
+
+fn section_timeline(prd: &Prd, out: &mut String) {
+    out.push_str("## Timeline\n\n");
+    if prd.timeline.is_empty() {
+        out.push_str(PLACEHOLDER);
+        out.push_str("\n\n");
+        return;
+    }
+    for tm in &prd.timeline {
+        let status = match tm.status {
+            TimelineStatus::Planned => "planned",
+            TimelineStatus::InProgress => "in-progress",
+            TimelineStatus::Completed => "completed",
+            TimelineStatus::Cancelled => "cancelled",
+        };
+        match tm.target_date {
+            Some(d) => {
+                let _ = writeln!(
+                    out,
+                    "- **{}** ({}, {status}) — {:.0}% complete",
+                    tm.name,
+                    d.format("%Y-%m-%d"),
+                    tm.progress * 100.0
+                );
+            }
+            None => {
+                let _ = writeln!(
+                    out,
+                    "- **{}** (unscheduled, {status}) — {:.0}% complete",
+                    tm.name,
+                    tm.progress * 100.0
+                );
+            }
+        }
+    }
+    out.push('\n');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prd::model::{CurrentState, Goal, Stakeholder, TimelineMilestone, TimelineStatus};
+
+    fn fully_populated() -> Prd {
+        let mut p = Prd::new();
+        p.vision = "Make maestro the standard for AI-assisted dev loops.".into();
+        p.goals.push(Goal {
+            text: "Stable TUI".into(),
+            done: true,
+            ..Goal::new("Stable TUI")
+        });
+        p.goals.push(Goal::new("PR review automation"));
+        p.non_goals.push("Multi-tenant SaaS".into());
+        p.current_state = CurrentState {
+            open_issues: 4,
+            closed_issues: 6,
+            open_milestones: 1,
+            closed_milestones: 5,
+            top_blockers: vec![327, 328],
+        };
+        p.stakeholders.push(Stakeholder {
+            name: "Carlos".into(),
+            role: "Maintainer".into(),
+        });
+        let mut tm = TimelineMilestone::new("v0.16.0");
+        tm.status = TimelineStatus::InProgress;
+        tm.progress = 0.25;
+        p.timeline.push(tm);
+        p
+    }
+
+    #[test]
+    fn export_includes_all_section_headers() {
+        let md = to_markdown(&Prd::new());
+        for header in [
+            "# Product Requirements Document",
+            "## Vision & Purpose",
+            "## Goals",
+            "## Non-Goals",
+            "## Current State",
+            "## Stakeholders",
+            "## Timeline",
+        ] {
+            assert!(md.contains(header), "missing header: {header}\n{md}");
+        }
+    }
+
+    #[test]
+    fn empty_sections_render_placeholder() {
+        let md = to_markdown(&Prd::new());
+        assert!(md.contains(PLACEHOLDER));
+    }
+
+    #[test]
+    fn populated_goal_renders_with_checkbox() {
+        let prd = fully_populated();
+        let md = to_markdown(&prd);
+        assert!(md.contains("- [x] Stable TUI"));
+        assert!(md.contains("- [ ] PR review automation"));
+    }
+
+    #[test]
+    fn current_state_shows_completion_percentage() {
+        let prd = fully_populated();
+        let md = to_markdown(&prd);
+        assert!(md.contains("60%"), "expected 60% complete; got:\n{md}");
+    }
+
+    #[test]
+    fn current_state_lists_top_blockers_when_present() {
+        let prd = fully_populated();
+        let md = to_markdown(&prd);
+        assert!(md.contains("**Top blockers**: #327, #328"));
+    }
+
+    #[test]
+    fn stakeholders_render_as_table() {
+        let prd = fully_populated();
+        let md = to_markdown(&prd);
+        assert!(md.contains("| Name | Role |"));
+        assert!(md.contains("| Carlos | Maintainer |"));
+    }
+
+    #[test]
+    fn timeline_includes_status_label_and_progress() {
+        let prd = fully_populated();
+        let md = to_markdown(&prd);
+        assert!(md.contains("**v0.16.0**"));
+        assert!(md.contains("in-progress"));
+        assert!(md.contains("25% complete"));
+    }
+
+    #[test]
+    fn fully_populated_prd_does_not_emit_placeholder() {
+        let md = to_markdown(&fully_populated());
+        assert!(
+            !md.contains(PLACEHOLDER),
+            "fully populated PRD should have no placeholders\n{md}"
+        );
+    }
+}

--- a/src/prd/ingest.rs
+++ b/src/prd/ingest.rs
@@ -55,10 +55,11 @@ pub fn parse_markdown(body: &str) -> IngestedPrd {
 
     for section in &sections {
         match classify_heading(&section.heading) {
+            Some(SectionKind::Vision) if out.vision.is_none() => {
+                out.vision = first_paragraph(&section.body);
+            }
             Some(SectionKind::Vision) => {
-                if out.vision.is_none() {
-                    out.vision = first_paragraph(&section.body);
-                }
+                // Already populated — first matching Vision section wins.
             }
             Some(SectionKind::Goals) => {
                 let items = extract_list_items(&section.body);

--- a/src/prd/ingest.rs
+++ b/src/prd/ingest.rs
@@ -1,0 +1,538 @@
+//! Heuristic PRD-from-markdown parser (#321).
+//!
+//! Extracts Vision, Goals, Non-Goals, and Stakeholders from a markdown
+//! body that uses conventional `##`-level headings. No LLM call: this is
+//! a deterministic pure function so the same input always produces the
+//! same output and tests stay fast/offline.
+//!
+//! Section keywords are matched case-insensitively and tolerate
+//! near-synonyms commonly seen in real PRDs:
+//! - **Vision**: `vision`, `mission`, `purpose`, `overview`
+//! - **Goals**: `goals`, `objectives`, `success criteria`, `acceptance criteria`
+//! - **Non-Goals**: `non-goals`, `non goals`, `out of scope`, `what we're not`
+//! - **Stakeholders**: `stakeholders`, `team`, `owners`, `roles`
+
+#![deny(clippy::unwrap_used)]
+#![allow(dead_code)]
+
+/// Result of parsing a PRD markdown body. Fields are `Option`/`Vec`
+/// because partial extraction is normal — most PRDs won't carry all four
+/// sections. The caller merges these into a live `Prd` without
+/// overwriting user-edited values.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct IngestedPrd {
+    pub vision: Option<String>,
+    pub goals: Vec<String>,
+    pub non_goals: Vec<String>,
+    pub stakeholders: Vec<(String, String)>,
+}
+
+impl IngestedPrd {
+    pub fn is_empty(&self) -> bool {
+        self.vision.is_none()
+            && self.goals.is_empty()
+            && self.non_goals.is_empty()
+            && self.stakeholders.is_empty()
+    }
+
+    pub fn summary(&self) -> String {
+        format!(
+            "vision={} goals={} non-goals={} stakeholders={}",
+            if self.vision.is_some() { "yes" } else { "no" },
+            self.goals.len(),
+            self.non_goals.len(),
+            self.stakeholders.len(),
+        )
+    }
+}
+
+/// Parse a PRD markdown body. Returns an empty `IngestedPrd` if no
+/// recognizable sections are present (caller treats that as "no PRD
+/// content found").
+pub fn parse_markdown(body: &str) -> IngestedPrd {
+    let sections = split_into_sections(body);
+    let mut out = IngestedPrd::default();
+
+    for section in &sections {
+        match classify_heading(&section.heading) {
+            Some(SectionKind::Vision) => {
+                if out.vision.is_none() {
+                    out.vision = first_paragraph(&section.body);
+                }
+            }
+            Some(SectionKind::Goals) => {
+                let items = extract_list_items(&section.body);
+                for item in items {
+                    if !out.goals.iter().any(|g| g.eq_ignore_ascii_case(&item)) {
+                        out.goals.push(item);
+                    }
+                }
+            }
+            Some(SectionKind::NonGoals) => {
+                let items = extract_list_items(&section.body);
+                for item in items {
+                    if !out.non_goals.iter().any(|g| g.eq_ignore_ascii_case(&item)) {
+                        out.non_goals.push(item);
+                    }
+                }
+            }
+            Some(SectionKind::Stakeholders) => {
+                let entries = extract_stakeholders(&section.body);
+                for (name, role) in entries {
+                    if !out
+                        .stakeholders
+                        .iter()
+                        .any(|(n, _)| n.eq_ignore_ascii_case(&name))
+                    {
+                        out.stakeholders.push((name, role));
+                    }
+                }
+            }
+            None => {}
+        }
+    }
+
+    out
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SectionKind {
+    Vision,
+    Goals,
+    NonGoals,
+    Stakeholders,
+}
+
+#[derive(Debug)]
+struct Section {
+    heading: String,
+    body: String,
+}
+
+fn split_into_sections(body: &str) -> Vec<Section> {
+    let mut sections: Vec<Section> = Vec::new();
+    let mut current: Option<Section> = None;
+
+    for line in body.lines() {
+        let trimmed = line.trim_start();
+        if let Some(heading) = strip_heading_marker(trimmed) {
+            if let Some(s) = current.take() {
+                sections.push(s);
+            }
+            current = Some(Section {
+                heading: heading.trim().to_string(),
+                body: String::new(),
+            });
+            continue;
+        }
+        if let Some(s) = current.as_mut() {
+            s.body.push_str(line);
+            s.body.push('\n');
+        }
+    }
+    if let Some(s) = current {
+        sections.push(s);
+    }
+    sections
+}
+
+/// Static lookup avoids `format!`+`String::repeat` allocations on every
+/// non-heading line during section-splitting.
+const HEADING_PREFIXES: [&str; 6] = ["# ", "## ", "### ", "#### ", "##### ", "###### "];
+
+fn strip_heading_marker(line: &str) -> Option<&str> {
+    HEADING_PREFIXES.iter().find_map(|p| line.strip_prefix(p))
+}
+
+fn classify_heading(heading: &str) -> Option<SectionKind> {
+    let lower = heading.to_lowercase();
+    let lower = lower.trim();
+
+    let vision_keywords = ["vision", "mission", "purpose", "overview"];
+    let goal_keywords = [
+        "goals",
+        "goal",
+        "objectives",
+        "objective",
+        "success criteria",
+        "acceptance criteria",
+    ];
+    let non_goal_keywords = ["non-goals", "non goals", "non-goal", "out of scope"];
+    let stakeholder_keywords = ["stakeholders", "stakeholder", "team", "owners", "roles"];
+
+    // Order matters: Non-Goals must be checked BEFORE Goals so "Non-Goals"
+    // doesn't match the "goals" keyword first.
+    if non_goal_keywords.iter().any(|k| matches_section(lower, k)) {
+        return Some(SectionKind::NonGoals);
+    }
+    if vision_keywords.iter().any(|k| matches_section(lower, k)) {
+        return Some(SectionKind::Vision);
+    }
+    if goal_keywords.iter().any(|k| matches_section(lower, k)) {
+        return Some(SectionKind::Goals);
+    }
+    if stakeholder_keywords
+        .iter()
+        .any(|k| matches_section(lower, k))
+    {
+        return Some(SectionKind::Stakeholders);
+    }
+    None
+}
+
+/// A heading matches a keyword when it equals the keyword OR starts with
+/// it followed by separator (space, `:`, `&`). Avoids false positives
+/// like "Goal Setting Strategy" matching "goal".
+fn matches_section(heading: &str, keyword: &str) -> bool {
+    if heading == keyword {
+        return true;
+    }
+    if let Some(rest) = heading.strip_prefix(keyword) {
+        return rest
+            .chars()
+            .next()
+            .is_some_and(|c| matches!(c, ' ' | ':' | '&' | '/' | ','));
+    }
+    false
+}
+
+fn first_paragraph(body: &str) -> Option<String> {
+    let mut buf = String::new();
+    for line in body.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            if !buf.is_empty() {
+                break;
+            }
+            continue;
+        }
+        if trimmed.starts_with("```") || trimmed == "---" {
+            break;
+        }
+        if !buf.is_empty() {
+            buf.push(' ');
+        }
+        buf.push_str(trimmed);
+    }
+    if buf.is_empty() { None } else { Some(buf) }
+}
+
+fn extract_list_items(body: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for line in body.lines() {
+        let trimmed = line.trim();
+        if let Some(item) = strip_list_marker(trimmed) {
+            let cleaned = strip_inline_emphasis(item.trim());
+            if !cleaned.is_empty() {
+                out.push(cleaned);
+            }
+        }
+    }
+    out
+}
+
+/// Strip leading bullet (`-`, `*`, `+`) or ordered (`1.`, `2)`) marker,
+/// and also strip a GFM task-list checkbox (`[ ]`, `[x]`, `[X]`) if
+/// present — otherwise the checkbox text bleeds into the goal label and
+/// renders as a duplicated `[ ] [ ] ...` in the PRD UI.
+fn strip_list_marker(line: &str) -> Option<&str> {
+    let after_marker = if let Some(rest) = line.strip_prefix("- ") {
+        rest
+    } else if let Some(rest) = line.strip_prefix("* ") {
+        rest
+    } else if let Some(rest) = line.strip_prefix("+ ") {
+        rest
+    } else {
+        // Ordered: `<digits>. ` or `<digits>) `
+        let mut chars = line.char_indices();
+        let mut digit_end = 0;
+        let mut saw_digit = false;
+        for (i, c) in chars.by_ref() {
+            if c.is_ascii_digit() {
+                digit_end = i + c.len_utf8();
+                saw_digit = true;
+            } else {
+                break;
+            }
+        }
+        if saw_digit
+            && let Some(after) = line.get(digit_end..)
+            && (after.starts_with(". ") || after.starts_with(") "))
+        {
+            line.get(digit_end + 2..)?
+        } else {
+            return None;
+        }
+    };
+    Some(strip_gfm_checkbox(after_marker))
+}
+
+fn strip_gfm_checkbox(s: &str) -> &str {
+    s.strip_prefix("[ ] ")
+        .or_else(|| s.strip_prefix("[x] "))
+        .or_else(|| s.strip_prefix("[X] "))
+        .unwrap_or(s)
+}
+
+/// Strip a single layer of `**bold**` / `*italic*` wrapping a leading
+/// fragment so item titles don't carry markdown noise into the PRD UI.
+fn strip_inline_emphasis(text: &str) -> String {
+    text.trim_start_matches("**")
+        .trim_end_matches("**")
+        .trim_start_matches('*')
+        .trim_end_matches('*')
+        .to_string()
+}
+
+/// Stakeholders sections may use `- Name — Role` / `- Name (Role)` /
+/// `| Name | Role |` table rows. We extract the obvious shapes.
+fn extract_stakeholders(body: &str) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    for line in body.lines() {
+        let trimmed = line.trim();
+        if let Some(item) = strip_list_marker(trimmed) {
+            let parts = split_name_role(item);
+            if let Some(pair) = parts {
+                out.push(pair);
+            }
+            continue;
+        }
+        if let Some(row) = parse_table_row(trimmed) {
+            // Skip table header / separator rows.
+            if row.0.eq_ignore_ascii_case("name") || row.0.starts_with("---") {
+                continue;
+            }
+            out.push(row);
+        }
+    }
+    out
+}
+
+fn split_name_role(item: &str) -> Option<(String, String)> {
+    // Try `Name — Role` (em-dash), then `Name - Role`, then `Name (Role)`.
+    for sep in [" — ", " – ", " -- ", " - "] {
+        if let Some((name, role)) = item.split_once(sep) {
+            return Some((name.trim().to_string(), role.trim().to_string()));
+        }
+    }
+    if let Some(open) = item.find(" (")
+        && let Some(close) = item.rfind(')')
+        && close > open
+    {
+        let name = item[..open].trim().to_string();
+        let role = item[open + 2..close].trim().to_string();
+        if !name.is_empty() && !role.is_empty() {
+            return Some((name, role));
+        }
+    }
+    None
+}
+
+fn parse_table_row(line: &str) -> Option<(String, String)> {
+    if !line.starts_with('|') {
+        return None;
+    }
+    let cells: Vec<&str> = line.trim_matches('|').split('|').map(str::trim).collect();
+    if cells.len() < 2 {
+        return None;
+    }
+    let name = cells[0].to_string();
+    let role = cells[1].to_string();
+    if name.is_empty() || role.is_empty() {
+        return None;
+    }
+    Some((name, role))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_body_returns_empty_ingest() {
+        assert!(parse_markdown("").is_empty());
+    }
+
+    #[test]
+    fn single_vision_section_extracts_first_paragraph() {
+        let body = "## Vision\n\nMaestro orchestrates Claude sessions.\n\nFollow-up paragraph.";
+        let r = parse_markdown(body);
+        assert_eq!(
+            r.vision.as_deref(),
+            Some("Maestro orchestrates Claude sessions.")
+        );
+    }
+
+    #[test]
+    fn vision_synonyms_match() {
+        for hdr in ["Vision", "Mission", "Purpose", "Overview"] {
+            let body = format!("## {hdr}\n\nThe pitch.");
+            let r = parse_markdown(&body);
+            assert_eq!(r.vision.as_deref(), Some("The pitch."));
+        }
+    }
+
+    #[test]
+    fn vision_with_amp_subtitle_still_classifies() {
+        let body = "## Vision & Purpose\n\nWhy we exist.";
+        let r = parse_markdown(body);
+        assert_eq!(r.vision.as_deref(), Some("Why we exist."));
+    }
+
+    #[test]
+    fn goals_bullet_list_is_extracted() {
+        let body = "## Goals\n\n- Ship v1\n- Reduce p99 latency\n- Onboard 10 teams";
+        let r = parse_markdown(body);
+        assert_eq!(
+            r.goals,
+            vec!["Ship v1", "Reduce p99 latency", "Onboard 10 teams"]
+        );
+    }
+
+    #[test]
+    fn goals_numbered_list_is_extracted() {
+        let body =
+            "## Success Criteria\n\n1. First criterion\n2. Second criterion\n3. Third criterion";
+        let r = parse_markdown(body);
+        assert_eq!(
+            r.goals,
+            vec!["First criterion", "Second criterion", "Third criterion"]
+        );
+    }
+
+    #[test]
+    fn goals_dedup_case_insensitive() {
+        let body = "## Goals\n\n- Build it\n\n## Objectives\n\n- BUILD IT\n- And ship it";
+        let r = parse_markdown(body);
+        assert_eq!(r.goals, vec!["Build it", "And ship it"]);
+    }
+
+    #[test]
+    fn non_goals_classify_before_goals() {
+        let body = "## Non-Goals\n\n- Multi-tenant SaaS\n- Mobile app";
+        let r = parse_markdown(body);
+        assert!(r.goals.is_empty());
+        assert_eq!(r.non_goals, vec!["Multi-tenant SaaS", "Mobile app"]);
+    }
+
+    #[test]
+    fn out_of_scope_maps_to_non_goals() {
+        let body = "## Out of Scope\n\n- Windows support";
+        let r = parse_markdown(body);
+        assert_eq!(r.non_goals, vec!["Windows support"]);
+    }
+
+    #[test]
+    fn stakeholders_em_dash_pairs() {
+        let body = "## Stakeholders\n\n- Carlos — Maintainer\n- Dani — Designer";
+        let r = parse_markdown(body);
+        assert_eq!(
+            r.stakeholders,
+            vec![
+                ("Carlos".into(), "Maintainer".into()),
+                ("Dani".into(), "Designer".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn stakeholders_paren_role() {
+        let body = "## Team\n\n- Alice (Lead)\n- Bob (Reviewer)";
+        let r = parse_markdown(body);
+        assert_eq!(
+            r.stakeholders,
+            vec![
+                ("Alice".into(), "Lead".into()),
+                ("Bob".into(), "Reviewer".into())
+            ]
+        );
+    }
+
+    #[test]
+    fn stakeholders_table_format() {
+        let body = "## Owners\n\n| Name | Role |\n|------|------|\n| Carlos | Maintainer |\n| Dani | Designer |";
+        let r = parse_markdown(body);
+        assert_eq!(
+            r.stakeholders,
+            vec![
+                ("Carlos".into(), "Maintainer".into()),
+                ("Dani".into(), "Designer".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_unrelated_headings() {
+        let body = "## Vision\n\nA pitch.\n\n## Tech Stack\n\n- Rust\n- ratatui\n\n## Architecture\n\nDiagram here.";
+        let r = parse_markdown(body);
+        assert_eq!(r.vision.as_deref(), Some("A pitch."));
+        // "Tech Stack" / "Architecture" must NOT be parsed as goals.
+        assert!(r.goals.is_empty());
+    }
+
+    #[test]
+    fn issue_one_real_world_extraction() {
+        // Cut-down of the real maestro PRD (issue #1) to exercise the
+        // contract on the canonical input.
+        let body = "# Maestro: Multi-Session Claude Code Orchestrator\n\n\
+                    ## Vision\n\nMaestro is a CLI tool that orchestrates multiple Claude Code sessions.\n\n\
+                    ---\n\n\
+                    ## Architecture\n\nDiagram.\n\n\
+                    ## Success Criteria\n\n\
+                    1. `maestro run --prompt` spawns a session\n\
+                    2. `maestro run --issue 1,2,3` shows split panels\n\
+                    3. `maestro run --milestone v1` queues issues";
+        let r = parse_markdown(body);
+        assert!(r.vision.as_deref().unwrap_or("").contains("orchestrates"));
+        assert_eq!(r.goals.len(), 3);
+        assert!(r.goals[0].contains("maestro run --prompt"));
+        assert!(r.non_goals.is_empty());
+        assert!(r.stakeholders.is_empty());
+    }
+
+    #[test]
+    fn h1_heading_is_recognized() {
+        let body = "# Vision\n\nTop-level vision.";
+        let r = parse_markdown(body);
+        assert_eq!(r.vision.as_deref(), Some("Top-level vision."));
+    }
+
+    #[test]
+    fn first_paragraph_stops_at_horizontal_rule() {
+        let body = "## Vision\n\nFirst line.\nSecond line.\n---\nNot in vision.";
+        let r = parse_markdown(body);
+        assert_eq!(r.vision.as_deref(), Some("First line. Second line."));
+    }
+
+    #[test]
+    fn first_paragraph_stops_at_code_fence() {
+        let body = "## Vision\n\nThe pitch.\n```\nnot vision\n```";
+        let r = parse_markdown(body);
+        assert_eq!(r.vision.as_deref(), Some("The pitch."));
+    }
+
+    #[test]
+    fn list_marker_with_emphasis_strips_stars() {
+        let body = "## Goals\n\n- **First** important goal\n- *Second* goal";
+        let r = parse_markdown(body);
+        assert!(r.goals[0].contains("First"));
+        assert!(r.goals[1].contains("Second"));
+    }
+
+    #[test]
+    fn gfm_checkbox_in_acceptance_criteria_is_stripped() {
+        // The bug: `## Acceptance Criteria` items render in the PRD UI
+        // as `[ ] [ ] First crit` (double checkbox) because the GFM
+        // checkbox text wasn't stripped from the goal label.
+        let body = "## Success Criteria\n\n- [ ] First crit\n- [x] Second crit\n- [X] Third crit";
+        let r = parse_markdown(body);
+        assert_eq!(r.goals, vec!["First crit", "Second crit", "Third crit"]);
+    }
+
+    #[test]
+    fn summary_reports_per_section_counts() {
+        let body = "## Vision\n\nX.\n\n## Goals\n\n- a\n- b\n\n## Non-Goals\n\n- c\n\n## Stakeholders\n\n- A — B";
+        let r = parse_markdown(body);
+        assert_eq!(r.summary(), "vision=yes goals=2 non-goals=1 stakeholders=1");
+    }
+}

--- a/src/prd/mod.rs
+++ b/src/prd/mod.rs
@@ -1,0 +1,12 @@
+//! Interactive PRD module (#321).
+//!
+//! `prd::model` defines the `Prd` data structure that backs the PRD TUI
+//! screen. `prd::store` persists it to `<repo_root>/.maestro/prd.toml`.
+//! `prd::export` renders to markdown for sharing.
+
+pub mod discover;
+pub mod export;
+pub mod ingest;
+pub mod model;
+pub mod store;
+pub mod sync;

--- a/src/prd/model.rs
+++ b/src/prd/model.rs
@@ -1,0 +1,349 @@
+//! PRD data model (#321).
+//!
+//! Live document for the project. Sections fixed by spec: Vision, Goals,
+//! Non-Goals, Current State, Stakeholders, Timeline. The `Current State`
+//! section is auto-populated from GitHub data (open/closed milestones and
+//! issues) and the rest is editable from the TUI.
+
+#![deny(clippy::unwrap_used)]
+// Reason: Phase 1 foundation for #321. The PRD TUI screen + GitHub syncer
+// land in Phase 2; serde + state-machine methods are tests-only today.
+#![allow(dead_code)]
+
+use chrono::NaiveDate;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct GoalId(pub Uuid);
+
+impl GoalId {
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+impl Default for GoalId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Goal {
+    pub id: GoalId,
+    pub text: String,
+    #[serde(default)]
+    pub done: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub linked_milestone: Option<String>,
+}
+
+impl Goal {
+    pub fn new(text: impl Into<String>) -> Self {
+        Self {
+            id: GoalId::new(),
+            text: text.into(),
+            done: false,
+            linked_milestone: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Stakeholder {
+    pub name: String,
+    pub role: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TimelineStatus {
+    Planned,
+    InProgress,
+    Completed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TimelineMilestone {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_date: Option<NaiveDate>,
+    pub status: TimelineStatus,
+    #[serde(default = "TimelineMilestone::default_progress")]
+    pub progress: f32,
+}
+
+impl TimelineMilestone {
+    fn default_progress() -> f32 {
+        0.0
+    }
+
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            target_date: None,
+            status: TimelineStatus::Planned,
+            progress: 0.0,
+        }
+    }
+}
+
+/// Auto-populated state derived from GitHub data. Never edited by hand.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CurrentState {
+    pub open_issues: u32,
+    pub closed_issues: u32,
+    pub open_milestones: u32,
+    pub closed_milestones: u32,
+    /// Top blockers (issue numbers) from open issues' `Blocked By` parsing.
+    #[serde(default)]
+    pub top_blockers: Vec<u64>,
+}
+
+impl CurrentState {
+    pub fn total_issues(&self) -> u32 {
+        self.open_issues + self.closed_issues
+    }
+
+    pub fn completion_ratio(&self) -> f32 {
+        let total = self.total_issues();
+        if total == 0 {
+            0.0
+        } else {
+            self.closed_issues as f32 / total as f32
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Prd {
+    /// Schema version. Bumped on breaking changes.
+    pub version: u8,
+    pub vision: String,
+    #[serde(default)]
+    pub goals: Vec<Goal>,
+    #[serde(default)]
+    pub non_goals: Vec<String>,
+    #[serde(default)]
+    pub current_state: CurrentState,
+    #[serde(default)]
+    pub stakeholders: Vec<Stakeholder>,
+    #[serde(default)]
+    pub timeline: Vec<TimelineMilestone>,
+}
+
+impl Prd {
+    pub const SCHEMA_VERSION: u8 = 1;
+
+    pub fn new() -> Self {
+        Self {
+            version: Self::SCHEMA_VERSION,
+            vision: String::new(),
+            goals: Vec::new(),
+            non_goals: Vec::new(),
+            current_state: CurrentState::default(),
+            stakeholders: Vec::new(),
+            timeline: Vec::new(),
+        }
+    }
+
+    pub fn add_goal(&mut self, text: impl Into<String>) -> GoalId {
+        let g = Goal::new(text);
+        let id = g.id;
+        self.goals.push(g);
+        id
+    }
+
+    /// Returns true if the goal was found and removed.
+    pub fn remove_goal(&mut self, id: GoalId) -> bool {
+        let len = self.goals.len();
+        self.goals.retain(|g| g.id != id);
+        self.goals.len() != len
+    }
+}
+
+impl Default for Prd {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Counts of what `Prd::merge_ingested` actually applied — used by the
+/// caller to format an activity-log entry without re-running the merge.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MergeReport {
+    pub filled_vision: bool,
+    pub added_goals: usize,
+    pub added_non_goals: usize,
+    pub added_stakeholders: usize,
+}
+
+impl MergeReport {
+    pub fn is_no_op(&self) -> bool {
+        !self.filled_vision
+            && self.added_goals == 0
+            && self.added_non_goals == 0
+            && self.added_stakeholders == 0
+    }
+}
+
+impl Prd {
+    /// Additive merge: take fields from `ingested` and apply them to
+    /// `self` WITHOUT overwriting user-edited values.
+    /// - Vision: filled only if `self.vision` is empty.
+    /// - Goals/Non-Goals/Stakeholders: appended if not already present
+    ///   (case-insensitive on text/name).
+    pub fn merge_ingested(&mut self, ingested: &crate::prd::ingest::IngestedPrd) -> MergeReport {
+        let mut report = MergeReport::default();
+
+        if self.vision.trim().is_empty()
+            && let Some(v) = ingested.vision.as_ref()
+        {
+            self.vision = v.clone();
+            report.filled_vision = true;
+        }
+        for goal in &ingested.goals {
+            if !self.goals.iter().any(|g| g.text.eq_ignore_ascii_case(goal)) {
+                self.goals.push(Goal::new(goal));
+                report.added_goals += 1;
+            }
+        }
+        for ng in &ingested.non_goals {
+            if !self.non_goals.iter().any(|x| x.eq_ignore_ascii_case(ng)) {
+                self.non_goals.push(ng.clone());
+                report.added_non_goals += 1;
+            }
+        }
+        for (name, role) in &ingested.stakeholders {
+            if !self
+                .stakeholders
+                .iter()
+                .any(|s| s.name.eq_ignore_ascii_case(name))
+            {
+                self.stakeholders.push(Stakeholder {
+                    name: name.clone(),
+                    role: role.clone(),
+                });
+                report.added_stakeholders += 1;
+            }
+        }
+
+        report
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prd_new_pins_schema_version() {
+        let p = Prd::new();
+        assert_eq!(p.version, Prd::SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn prd_round_trip_serde_toml() {
+        let mut p = Prd::new();
+        p.vision = "Ship maestro v1.0".into();
+        p.add_goal("Stable TUI");
+        p.non_goals.push("Multi-tenant SaaS".into());
+        p.stakeholders.push(Stakeholder {
+            name: "Carlos".into(),
+            role: "Maintainer".into(),
+        });
+        p.timeline.push(TimelineMilestone::new("v0.16.0"));
+
+        let serialized = toml::to_string(&p).expect("toml serialize");
+        let back: Prd = toml::from_str(&serialized).expect("toml deserialize");
+        assert_eq!(p, back);
+    }
+
+    #[test]
+    fn prd_round_trip_serde_json() {
+        let p = Prd::new();
+        let json = serde_json::to_string(&p).expect("json serialize");
+        let back: Prd = serde_json::from_str(&json).expect("json deserialize");
+        assert_eq!(p, back);
+    }
+
+    #[test]
+    fn prd_rejects_unknown_field() {
+        let json = r#"{"version":1,"vision":"x","unknown":true}"#;
+        let result: Result<Prd, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn add_goal_returns_id_and_appends() {
+        let mut p = Prd::new();
+        let id = p.add_goal("Test");
+        assert_eq!(p.goals.len(), 1);
+        assert_eq!(p.goals[0].id, id);
+        assert_eq!(p.goals[0].text, "Test");
+        assert!(!p.goals[0].done);
+    }
+
+    #[test]
+    fn remove_goal_returns_true_when_found() {
+        let mut p = Prd::new();
+        let id = p.add_goal("Test");
+        assert!(p.remove_goal(id));
+        assert!(p.goals.is_empty());
+    }
+
+    #[test]
+    fn remove_goal_returns_false_when_missing() {
+        let mut p = Prd::new();
+        assert!(!p.remove_goal(GoalId::new()));
+    }
+
+    #[test]
+    fn current_state_completion_ratio_zero_when_no_issues() {
+        let cs = CurrentState::default();
+        assert_eq!(cs.completion_ratio(), 0.0);
+    }
+
+    #[test]
+    fn current_state_completion_ratio_half_when_balanced() {
+        let cs = CurrentState {
+            open_issues: 5,
+            closed_issues: 5,
+            ..Default::default()
+        };
+        assert_eq!(cs.total_issues(), 10);
+        assert!((cs.completion_ratio() - 0.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn current_state_completion_ratio_full_when_all_closed() {
+        let cs = CurrentState {
+            open_issues: 0,
+            closed_issues: 10,
+            ..Default::default()
+        };
+        assert!((cs.completion_ratio() - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn timeline_status_round_trip() {
+        for status in [
+            TimelineStatus::Planned,
+            TimelineStatus::InProgress,
+            TimelineStatus::Completed,
+            TimelineStatus::Cancelled,
+        ] {
+            let json = serde_json::to_string(&status).expect("serialize");
+            let back: TimelineStatus = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(status, back);
+        }
+    }
+}

--- a/src/prd/store.rs
+++ b/src/prd/store.rs
@@ -1,0 +1,202 @@
+//! Persistence for the PRD model (#321).
+//!
+//! Stores at `<repo_root>/.maestro/prd.toml`. Atomic write-rename pattern
+//! so a crashed write cannot leave a half-empty file.
+
+#![deny(clippy::unwrap_used)]
+// Reason: Phase 1 foundation for #321. FilePrdStore is constructed by the
+// PRD screen + CLI subcommand in Phase 2; tests exercise round-trip today.
+#![allow(dead_code)]
+
+use crate::prd::model::Prd;
+use std::path::{Path, PathBuf};
+
+/// Errors raised by the file-backed store.
+#[derive(Debug)]
+pub enum PrdStoreError {
+    Io(std::io::Error),
+    Toml(String),
+}
+
+impl std::fmt::Display for PrdStoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "prd store i/o: {e}"),
+            Self::Toml(msg) => write!(f, "prd store toml: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for PrdStoreError {}
+
+impl From<std::io::Error> for PrdStoreError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+/// Trait so the store can be faked in tests of layers above.
+pub trait PrdStore: Send + Sync {
+    fn prd_path(&self) -> PathBuf;
+    fn load(&self) -> Result<Option<Prd>, PrdStoreError>;
+    fn save(&self, prd: &Prd) -> Result<(), PrdStoreError>;
+}
+
+/// File-backed store that persists `prd.toml` under `<root>/.maestro/`.
+pub struct FilePrdStore {
+    root: PathBuf,
+}
+
+impl FilePrdStore {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    fn maestro_dir(&self) -> PathBuf {
+        self.root.join(".maestro")
+    }
+}
+
+impl PrdStore for FilePrdStore {
+    fn prd_path(&self) -> PathBuf {
+        self.maestro_dir().join("prd.toml")
+    }
+
+    fn load(&self) -> Result<Option<Prd>, PrdStoreError> {
+        // Single syscall — no exists()+read race. Translate NotFound as
+        // "no PRD yet" instead of an I/O error.
+        let body = match std::fs::read_to_string(self.prd_path()) {
+            Ok(b) => b,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(e.into()),
+        };
+        let prd: Prd = toml::from_str(&body).map_err(|e| PrdStoreError::Toml(e.to_string()))?;
+        Ok(Some(prd))
+    }
+
+    fn save(&self, prd: &Prd) -> Result<(), PrdStoreError> {
+        use std::io::Write as _;
+
+        let dir = self.maestro_dir();
+        std::fs::create_dir_all(&dir)?;
+        let body = toml::to_string_pretty(prd).map_err(|e| PrdStoreError::Toml(e.to_string()))?;
+        let target = self.prd_path();
+        let tmp = atomic_temp_path(&target);
+
+        // O_EXCL + randomized suffix: refuses to follow a pre-existing
+        // file/symlink in `.maestro/`, blocking the classic TOCTOU swap.
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp)?;
+        file.write_all(body.as_bytes())?;
+        file.sync_all()?;
+        drop(file);
+
+        std::fs::rename(&tmp, &target)?;
+        Ok(())
+    }
+}
+
+fn atomic_temp_path(target: &Path) -> PathBuf {
+    // Randomized suffix prevents an attacker on a shared host from
+    // pre-creating the tmp path as a symlink. Combined with `create_new`
+    // above, even a guessed suffix would error out instead of being
+    // followed.
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let mut tmp = target.as_os_str().to_owned();
+    tmp.push(".tmp.");
+    tmp.push(&suffix);
+    PathBuf::from(tmp)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prd::model::Goal;
+    use tempfile::tempdir;
+
+    fn sample_prd() -> Prd {
+        let mut p = Prd::new();
+        p.vision = "Ship".into();
+        p.goals.push(Goal::new("Build the foundation"));
+        p
+    }
+
+    #[test]
+    fn load_missing_file_returns_none() {
+        let dir = tempdir().expect("tempdir");
+        let store = FilePrdStore::new(dir.path());
+        assert!(store.load().expect("load").is_none());
+    }
+
+    #[test]
+    fn save_then_load_round_trips() {
+        let dir = tempdir().expect("tempdir");
+        let store = FilePrdStore::new(dir.path());
+        let prd = sample_prd();
+        store.save(&prd).expect("save");
+        let loaded = store.load().expect("load").expect("present");
+        assert_eq!(loaded, prd);
+    }
+
+    #[test]
+    fn save_creates_maestro_dir() {
+        let dir = tempdir().expect("tempdir");
+        let store = FilePrdStore::new(dir.path());
+        store.save(&sample_prd()).expect("save");
+        assert!(dir.path().join(".maestro").is_dir());
+    }
+
+    #[test]
+    fn save_overwrites_existing_file() {
+        let dir = tempdir().expect("tempdir");
+        let store = FilePrdStore::new(dir.path());
+        store.save(&sample_prd()).expect("save 1");
+        let mut updated = sample_prd();
+        updated.vision = "Updated".into();
+        store.save(&updated).expect("save 2");
+        let loaded = store.load().expect("load").expect("present");
+        assert_eq!(loaded.vision, "Updated");
+    }
+
+    #[test]
+    fn save_does_not_leave_tmp_files_behind() {
+        let dir = tempdir().expect("tempdir");
+        let store = FilePrdStore::new(dir.path());
+        store.save(&sample_prd()).expect("save");
+        // After save, only `prd.toml` should remain in `.maestro/`.
+        let entries: Vec<_> = std::fs::read_dir(dir.path().join(".maestro"))
+            .expect("readdir")
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(entries, vec!["prd.toml"]);
+    }
+
+    #[test]
+    fn atomic_temp_path_is_randomized_per_call() {
+        let target = PathBuf::from("/tmp/x/.maestro/prd.toml");
+        let a = atomic_temp_path(&target);
+        let b = atomic_temp_path(&target);
+        assert_ne!(a, b, "tmp path must be randomized to defeat symlink races");
+    }
+
+    #[test]
+    fn load_invalid_toml_returns_toml_error() {
+        let dir = tempdir().expect("tempdir");
+        let store = FilePrdStore::new(dir.path());
+        std::fs::create_dir_all(dir.path().join(".maestro")).expect("mkdir");
+        std::fs::write(store.prd_path(), b"this is not valid toml = = =").expect("write");
+        match store.load() {
+            Err(PrdStoreError::Toml(_)) => (),
+            other => panic!("expected toml error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn prd_path_is_under_dot_maestro() {
+        let store = FilePrdStore::new("/tmp/x");
+        assert_eq!(store.prd_path(), PathBuf::from("/tmp/x/.maestro/prd.toml"));
+    }
+}

--- a/src/prd/sync.rs
+++ b/src/prd/sync.rs
@@ -1,0 +1,311 @@
+//! GitHub-backed PRD syncer (#321).
+//!
+//! Populates `Prd::current_state` and the timeline from open/closed
+//! milestones and issues. The trait is mockable; the in-memory fake is
+//! used in unit tests.
+
+#![deny(clippy::unwrap_used)]
+#![allow(dead_code)]
+
+use crate::prd::discover::{DiscoveredPrd, discover_all};
+use crate::prd::ingest::{IngestedPrd, parse_markdown};
+use crate::prd::model::{CurrentState, TimelineMilestone, TimelineStatus};
+use crate::provider::github::client::GitHubClient;
+use crate::provider::github::types::GhIssue;
+use anyhow::Result;
+use async_trait::async_trait;
+
+/// What `fetch_current_state` returns. Folded into `Prd` by the App.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PrdSyncResult {
+    pub current_state: CurrentState,
+    pub timeline: Vec<TimelineMilestone>,
+    /// PRD content discovered + parsed from the primary source, if any.
+    pub ingested: Option<IngestedPrdReport>,
+    /// All PRD candidates found across every source (GitHub label /
+    /// issue #1 / title-search, local `docs/PRD.md`, Azure wiki). Lets
+    /// the explore UI show what's available so the user can switch.
+    pub candidates: Vec<DiscoveredPrd>,
+}
+
+/// Outcome of the PRD-issue discovery + parse step.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IngestedPrdReport {
+    pub issue_number: u64,
+    pub issue_title: String,
+    pub source_label: &'static str,
+    pub ingested: IngestedPrd,
+}
+
+/// Trait so the syncer can be faked in unit tests of higher layers.
+#[async_trait]
+pub trait PrdSyncer: Send + Sync {
+    async fn fetch_current_state(&self) -> Result<PrdSyncResult>;
+}
+
+pub struct GitHubPrdSyncer {
+    client: Box<dyn GitHubClient>,
+}
+
+impl GitHubPrdSyncer {
+    pub fn new(client: Box<dyn GitHubClient>) -> Self {
+        Self { client }
+    }
+
+    /// Synchronous helper exposed for the tui dispatch path that already
+    /// owns a tokio runtime — saves an extra trait-object boxing.
+    ///
+    /// Closed-issue counts come from each milestone's built-in
+    /// `closed_issues` aggregate rather than a separate `list_issues`
+    /// call: `list_issues` filters by label, not by state, so passing
+    /// `state:closed` as a label name produced 0 closed issues every
+    /// time.
+    pub async fn fetch_current_state(&self) -> Result<PrdSyncResult> {
+        let (open_milestones, closed_milestones, open_issues) = tokio::join!(
+            self.client.list_milestones("open"),
+            self.client.list_milestones("closed"),
+            self.client.list_issues(&[]),
+        );
+
+        let open_milestones = open_milestones?;
+        let closed_milestones = closed_milestones?;
+        let open_issues = open_issues.unwrap_or_default();
+
+        // Sum per-milestone counts for the headline number. This includes
+        // every issue assigned to ANY milestone (open or closed). Issues
+        // without a milestone are still counted in `open_issues.len()` if
+        // open, which is the most useful denominator for "Current State".
+        let closed_issues_total: u32 = open_milestones
+            .iter()
+            .chain(closed_milestones.iter())
+            .map(|m| m.closed_issues)
+            .sum();
+
+        let current_state = aggregate(
+            &open_issues,
+            closed_issues_total,
+            open_milestones.len() as u32,
+            closed_milestones.len() as u32,
+        );
+
+        let timeline = compute_timeline(&open_milestones, &closed_milestones);
+
+        // Discovery + ingest of the canonical PRD across all sources
+        // (GitHub label / issue #1 / title-search, local docs/PRD.md,
+        // Azure wiki). Best-effort: any source that fails just doesn't
+        // appear in `candidates`.
+        let (candidates, ingested) = tokio::task::spawn_blocking(discover_and_parse_all)
+            .await
+            .unwrap_or((Vec::new(), None));
+
+        Ok(PrdSyncResult {
+            current_state,
+            timeline,
+            ingested,
+            candidates,
+        })
+    }
+}
+
+fn discover_and_parse_all() -> (Vec<DiscoveredPrd>, Option<IngestedPrdReport>) {
+    let candidates = discover_all();
+    let primary = candidates.first().cloned();
+    let ingested = primary.and_then(|c| {
+        let parsed = parse_markdown(&c.body);
+        if parsed.is_empty() {
+            None
+        } else {
+            Some(IngestedPrdReport {
+                issue_number: c.number,
+                issue_title: c.title,
+                source_label: c.source.label(),
+                ingested: parsed,
+            })
+        }
+    });
+    (candidates, ingested)
+}
+
+#[async_trait]
+impl PrdSyncer for GitHubPrdSyncer {
+    async fn fetch_current_state(&self) -> Result<PrdSyncResult> {
+        Self::fetch_current_state(self).await
+    }
+}
+
+/// Pure aggregation — used by the syncer and exposed for direct testing.
+pub fn aggregate(
+    open_issues: &[GhIssue],
+    closed_issues: u32,
+    open_milestones: u32,
+    closed_milestones: u32,
+) -> CurrentState {
+    use std::collections::HashMap;
+
+    let mut blocker_counts: HashMap<u64, u32> = HashMap::new();
+    for issue in open_issues {
+        for b in issue.all_blockers() {
+            *blocker_counts.entry(b).or_insert(0) += 1;
+        }
+    }
+    let mut sorted: Vec<(u64, u32)> = blocker_counts.into_iter().collect();
+    sorted.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    let top_blockers: Vec<u64> = sorted.into_iter().take(5).map(|(n, _)| n).collect();
+
+    CurrentState {
+        open_issues: open_issues.len() as u32,
+        closed_issues,
+        open_milestones,
+        closed_milestones,
+        top_blockers,
+    }
+}
+
+/// Build a timeline from the open + closed milestones combined. Sorted
+/// by milestone number ascending (creation order).
+pub fn compute_timeline(
+    open_milestones: &[crate::provider::github::types::GhMilestone],
+    closed_milestones: &[crate::provider::github::types::GhMilestone],
+) -> Vec<TimelineMilestone> {
+    let mut combined: Vec<&crate::provider::github::types::GhMilestone> = open_milestones
+        .iter()
+        .chain(closed_milestones.iter())
+        .collect();
+    combined.sort_by_key(|m| m.number);
+
+    combined
+        .into_iter()
+        .map(|m| {
+            let total = m.open_issues + m.closed_issues;
+            let progress = if total > 0 {
+                f64::from(m.closed_issues) / f64::from(total)
+            } else {
+                0.0
+            };
+            let status = if m.state.eq_ignore_ascii_case("closed") {
+                TimelineStatus::Completed
+            } else if m.closed_issues > 0 {
+                TimelineStatus::InProgress
+            } else {
+                TimelineStatus::Planned
+            };
+            let mut tm = TimelineMilestone::new(m.title.clone());
+            tm.status = status;
+            tm.progress = progress as f32;
+            tm
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::github::types::{GhIssue, GhMilestone};
+
+    fn issue(number: u64, blockers: &[u64]) -> GhIssue {
+        // Use the format the existing `blocked_by_from_body` regex parses:
+        // `blocked-by: #N` (case-insensitive). The `## Blocked By` prose
+        // section in real issues is parsed elsewhere; here we exercise the
+        // body-regex path.
+        let body = if blockers.is_empty() {
+            String::new()
+        } else {
+            let lines: Vec<String> = blockers
+                .iter()
+                .map(|n| format!("blocked-by: #{n}"))
+                .collect();
+            lines.join("\n")
+        };
+        GhIssue {
+            number,
+            title: format!("Issue {number}"),
+            body,
+            labels: vec![],
+            state: "open".into(),
+            html_url: format!("https://example/issues/{number}"),
+            milestone: None,
+            assignees: vec![],
+        }
+    }
+
+    fn milestone(num: u64, title: &str, open: u32, closed: u32, state: &str) -> GhMilestone {
+        GhMilestone {
+            number: num,
+            title: title.into(),
+            description: String::new(),
+            state: state.into(),
+            open_issues: open,
+            closed_issues: closed,
+        }
+    }
+
+    #[test]
+    fn aggregate_counts_top_blockers_descending() {
+        let issues = vec![
+            issue(1, &[10, 20]),
+            issue(2, &[10]),
+            issue(3, &[10, 20, 30]),
+        ];
+        let cs = aggregate(&issues, 5, 2, 3);
+        assert_eq!(cs.open_issues, 3);
+        assert_eq!(cs.closed_issues, 5);
+        assert_eq!(cs.top_blockers[0], 10); // 3 references
+        assert_eq!(cs.top_blockers[1], 20); // 2 references
+        assert_eq!(cs.top_blockers[2], 30); // 1 reference
+    }
+
+    #[test]
+    fn aggregate_with_no_blockers_returns_empty_top_blockers() {
+        let issues = vec![issue(1, &[]), issue(2, &[])];
+        let cs = aggregate(&issues, 0, 0, 0);
+        assert!(cs.top_blockers.is_empty());
+    }
+
+    #[test]
+    fn aggregate_caps_top_blockers_at_five() {
+        let mut issues = Vec::new();
+        for i in 0..10 {
+            issues.push(issue(i, &[100 + i]));
+        }
+        let cs = aggregate(&issues, 0, 0, 0);
+        assert_eq!(cs.top_blockers.len(), 5);
+    }
+
+    #[test]
+    fn timeline_orders_by_milestone_number() {
+        let open = vec![
+            milestone(3, "v0.16.0", 4, 0, "open"),
+            milestone(1, "v0.14.0", 0, 5, "open"),
+        ];
+        let closed = vec![milestone(2, "v0.15.0", 0, 8, "closed")];
+        let tl = compute_timeline(&open, &closed);
+        assert_eq!(tl.len(), 3);
+        assert_eq!(tl[0].name, "v0.14.0");
+        assert_eq!(tl[1].name, "v0.15.0");
+        assert_eq!(tl[2].name, "v0.16.0");
+    }
+
+    #[test]
+    fn timeline_status_completed_for_closed_milestone() {
+        let closed = vec![milestone(1, "v1", 0, 3, "closed")];
+        let tl = compute_timeline(&[], &closed);
+        assert!(matches!(tl[0].status, TimelineStatus::Completed));
+        assert!((tl[0].progress - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn timeline_status_in_progress_when_some_closed() {
+        let open = vec![milestone(1, "v1", 3, 1, "open")];
+        let tl = compute_timeline(&open, &[]);
+        assert!(matches!(tl[0].status, TimelineStatus::InProgress));
+        assert!((tl[0].progress - 0.25).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn timeline_status_planned_when_zero_closed() {
+        let open = vec![milestone(1, "v1", 5, 0, "open")];
+        let tl = compute_timeline(&open, &[]);
+        assert!(matches!(tl[0].status, TimelineStatus::Planned));
+        assert!((tl[0].progress - 0.0).abs() < f32::EPSILON);
+    }
+}

--- a/src/review/apply.rs
+++ b/src/review/apply.rs
@@ -1,0 +1,185 @@
+//! Apply review concerns as commits (#327).
+//!
+//! `ChangeApplier` is a trait so the production `GitChangeApplier` (which
+//! shells out to `git`) can be swapped for an in-memory fake in tests.
+//! Errors are typed at the seam (RUST-GUARDRAILS §2) so callers can branch
+//! on `PatchFailed` vs. `CommitFailed` vs. `NothingToApply` without parsing
+//! free-form strings.
+
+#![deny(clippy::unwrap_used)]
+// Reason: Phase 1 foundation for #327. The trait + InMemoryChangeApplier
+// fake are exercised by tests; the real GitChangeApplier and call sites
+// land in Phase 2 (security review §1 must be addressed first).
+#![allow(dead_code)]
+
+use crate::review::types::{Concern, ConcernId};
+
+/// Outcome of applying a single concern.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppliedChange {
+    pub concern_id: ConcernId,
+    pub commit_sha: String,
+}
+
+/// Errors raised during `apply()`. Each variant maps to a distinct
+/// recovery path in the TUI.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ChangeApplyError {
+    /// Concern has no `suggested_diff` payload — nothing the applier can do.
+    NothingToApply,
+    /// `git apply --check` rejected the patch (conflicting hunks, file
+    /// missing, etc.). Carries stderr.
+    PatchFailed(String),
+    /// A `git` subprocess returned non-zero. Carries the step name and
+    /// stderr text.
+    GitCommandFailed { step: &'static str, stderr: String },
+    /// `HEAD` moved between read and apply — applier refuses to commit.
+    HeadMoved { before: String, after: String },
+}
+
+impl std::fmt::Display for ChangeApplyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NothingToApply => write!(f, "concern has no suggested_diff"),
+            Self::PatchFailed(s) => write!(f, "git apply --check rejected the patch: {s}"),
+            Self::GitCommandFailed { step, stderr } => {
+                write!(f, "git {step} failed: {stderr}")
+            }
+            Self::HeadMoved { before, after } => write!(
+                f,
+                "HEAD moved during apply (before={before}, after={after}); refusing to commit"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ChangeApplyError {}
+
+/// Trait so callers can swap the real `git`-shelling impl for a fake.
+pub trait ChangeApplier: Send + Sync {
+    fn apply(&self, concern: &Concern) -> Result<AppliedChange, ChangeApplyError>;
+}
+
+/// In-memory fake used by unit tests.
+#[derive(Default)]
+pub struct InMemoryChangeApplier {
+    applied: std::sync::Mutex<Vec<AppliedChange>>,
+    fail_with: std::sync::Mutex<Option<ChangeApplyError>>,
+}
+
+impl InMemoryChangeApplier {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn fail_next(&self, err: ChangeApplyError) {
+        if let Ok(mut g) = self.fail_with.lock() {
+            *g = Some(err);
+        }
+    }
+
+    pub fn applied(&self) -> Vec<AppliedChange> {
+        self.applied.lock().map(|g| g.clone()).unwrap_or_default()
+    }
+}
+
+impl ChangeApplier for InMemoryChangeApplier {
+    fn apply(&self, concern: &Concern) -> Result<AppliedChange, ChangeApplyError> {
+        if let Ok(mut g) = self.fail_with.lock()
+            && let Some(err) = g.take()
+        {
+            return Err(err);
+        }
+        if concern.suggested_diff.is_none() {
+            return Err(ChangeApplyError::NothingToApply);
+        }
+        let change = AppliedChange {
+            concern_id: concern.id,
+            commit_sha: format!("fake-{}", concern.id.0.simple()),
+        };
+        if let Ok(mut g) = self.applied.lock() {
+            g.push(change.clone());
+        }
+        Ok(change)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::review::types::{ConcernStatus, Severity};
+    use std::path::PathBuf;
+
+    fn concern_with_diff(diff: Option<&str>) -> Concern {
+        Concern {
+            id: ConcernId::new(),
+            severity: Severity::Warning,
+            file: PathBuf::from("src/x.rs"),
+            line: Some(1),
+            message: "fix".into(),
+            suggested_diff: diff.map(|s| s.to_string()),
+            status: ConcernStatus::Pending,
+        }
+    }
+
+    #[test]
+    fn apply_concern_with_diff_records_change() {
+        let applier = InMemoryChangeApplier::new();
+        let c = concern_with_diff(Some("@@ -1 +1 @@\n-a\n+b"));
+        let change = applier.apply(&c).expect("should apply");
+        assert_eq!(change.concern_id, c.id);
+        assert!(change.commit_sha.starts_with("fake-"));
+        assert_eq!(applier.applied().len(), 1);
+    }
+
+    #[test]
+    fn apply_concern_without_diff_returns_nothing_to_apply() {
+        let applier = InMemoryChangeApplier::new();
+        let c = concern_with_diff(None);
+        assert_eq!(applier.apply(&c), Err(ChangeApplyError::NothingToApply));
+    }
+
+    #[test]
+    fn apply_propagates_injected_failure() {
+        let applier = InMemoryChangeApplier::new();
+        applier.fail_next(ChangeApplyError::PatchFailed("hunk #2 failed".into()));
+        let c = concern_with_diff(Some("x"));
+        match applier.apply(&c) {
+            Err(ChangeApplyError::PatchFailed(msg)) => assert!(msg.contains("hunk")),
+            other => panic!("expected PatchFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn apply_failure_does_not_record_change() {
+        let applier = InMemoryChangeApplier::new();
+        applier.fail_next(ChangeApplyError::GitCommandFailed {
+            step: "commit",
+            stderr: "boom".into(),
+        });
+        let c = concern_with_diff(Some("x"));
+        let _ = applier.apply(&c);
+        assert!(applier.applied().is_empty());
+    }
+
+    #[test]
+    fn apply_multiple_concerns_records_each() {
+        let applier = InMemoryChangeApplier::new();
+        for _ in 0..3 {
+            let c = concern_with_diff(Some("d"));
+            applier.apply(&c).expect("apply");
+        }
+        assert_eq!(applier.applied().len(), 3);
+    }
+
+    #[test]
+    fn head_moved_error_displays_both_shas() {
+        let err = ChangeApplyError::HeadMoved {
+            before: "abc".into(),
+            after: "def".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("abc"));
+        assert!(msg.contains("def"));
+    }
+}

--- a/src/review/audit.rs
+++ b/src/review/audit.rs
@@ -1,0 +1,223 @@
+//! Audit logger for review-flow events.
+//!
+//! Every accept / reject / apply / bypass-toggle is funneled through this
+//! trait so the activity log captures a tamper-evident trail. Required by
+//! both #327 (manual accept) and #328 (bypass auto-accept).
+
+#![deny(clippy::unwrap_used)]
+// Reason: Phase 1 foundation for #327 / #328. Loggers are wired by the App
+// in Phase 2; constructors and the trait are tests-only until then.
+#![allow(dead_code)]
+
+use crate::review::bypass::BypassSource;
+use crate::review::types::{ConcernId, PrNumber};
+use chrono::{DateTime, Utc};
+
+/// One audit-log row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditEntry {
+    pub at: DateTime<Utc>,
+    pub pr_number: PrNumber,
+    pub concern_id: Option<ConcernId>,
+    pub event: AuditEvent,
+}
+
+/// Categorical kind of an audited event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuditEvent {
+    /// User (or bypass mode) accepted a concern.
+    Accepted { auto: bool },
+    /// User rejected a concern.
+    Rejected,
+    /// `ChangeApplier` successfully applied a concern's diff and committed.
+    Applied { commit_sha: String },
+    /// Bypass mode toggled.
+    BypassToggled { active: bool, source: BypassSource },
+}
+
+/// Trait so callers can swap the production logger for `MemoryAuditLogger`
+/// in tests.
+pub trait AuditLogger: Send + Sync {
+    fn record(&self, entry: AuditEntry);
+}
+
+/// In-memory logger used by unit tests.
+#[derive(Default)]
+pub struct MemoryAuditLogger {
+    entries: std::sync::Mutex<Vec<AuditEntry>>,
+}
+
+impl MemoryAuditLogger {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn entries(&self) -> Vec<AuditEntry> {
+        self.entries.lock().map(|g| g.clone()).unwrap_or_default()
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.lock().map(|g| g.len()).unwrap_or(0)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl AuditLogger for MemoryAuditLogger {
+    fn record(&self, entry: AuditEntry) {
+        if let Ok(mut g) = self.entries.lock() {
+            g.push(entry);
+        }
+    }
+}
+
+/// Production logger that emits via `tracing` for persistent capture.
+/// Non-allocating in the hot path beyond the format args.
+pub struct TracingAuditLogger;
+
+impl AuditLogger for TracingAuditLogger {
+    fn record(&self, entry: AuditEntry) {
+        match &entry.event {
+            AuditEvent::Accepted { auto } => tracing::info!(
+                pr = %entry.pr_number,
+                concern = ?entry.concern_id,
+                auto,
+                "review.audit.accepted"
+            ),
+            AuditEvent::Rejected => tracing::info!(
+                pr = %entry.pr_number,
+                concern = ?entry.concern_id,
+                "review.audit.rejected"
+            ),
+            AuditEvent::Applied { commit_sha } => tracing::info!(
+                pr = %entry.pr_number,
+                concern = ?entry.concern_id,
+                sha = %commit_sha,
+                "review.audit.applied"
+            ),
+            AuditEvent::BypassToggled { active, source } => tracing::warn!(
+                pr = %entry.pr_number,
+                active,
+                source = source.label(),
+                "review.audit.bypass_toggled"
+            ),
+        }
+    }
+}
+
+/// Convenience constructors.
+impl AuditEntry {
+    pub fn accepted(pr: PrNumber, concern: ConcernId, auto: bool) -> Self {
+        Self {
+            at: Utc::now(),
+            pr_number: pr,
+            concern_id: Some(concern),
+            event: AuditEvent::Accepted { auto },
+        }
+    }
+
+    pub fn rejected(pr: PrNumber, concern: ConcernId) -> Self {
+        Self {
+            at: Utc::now(),
+            pr_number: pr,
+            concern_id: Some(concern),
+            event: AuditEvent::Rejected,
+        }
+    }
+
+    pub fn applied(pr: PrNumber, concern: ConcernId, commit_sha: impl Into<String>) -> Self {
+        Self {
+            at: Utc::now(),
+            pr_number: pr,
+            concern_id: Some(concern),
+            event: AuditEvent::Applied {
+                commit_sha: commit_sha.into(),
+            },
+        }
+    }
+
+    pub fn bypass_toggled(pr: PrNumber, active: bool, source: BypassSource) -> Self {
+        Self {
+            at: Utc::now(),
+            pr_number: pr,
+            concern_id: None,
+            event: AuditEvent::BypassToggled { active, source },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_logger_records_one_entry() {
+        let logger = MemoryAuditLogger::new();
+        logger.record(AuditEntry::accepted(PrNumber(1), ConcernId::new(), false));
+        assert_eq!(logger.len(), 1);
+    }
+
+    #[test]
+    fn memory_logger_preserves_insertion_order() {
+        let logger = MemoryAuditLogger::new();
+        let id1 = ConcernId::new();
+        let id2 = ConcernId::new();
+        logger.record(AuditEntry::accepted(PrNumber(1), id1, false));
+        logger.record(AuditEntry::rejected(PrNumber(1), id2));
+        let entries = logger.entries();
+        assert_eq!(entries.len(), 2);
+        assert!(matches!(entries[0].event, AuditEvent::Accepted { .. }));
+        assert!(matches!(entries[1].event, AuditEvent::Rejected));
+    }
+
+    #[test]
+    fn audit_entry_timestamp_is_set() {
+        let entry = AuditEntry::accepted(PrNumber(1), ConcernId::new(), true);
+        let now = Utc::now();
+        let drift = (now - entry.at).num_seconds().abs();
+        assert!(drift < 5, "timestamp should be near `now`");
+    }
+
+    #[test]
+    fn auto_accepted_flag_round_trips() {
+        let entry = AuditEntry::accepted(PrNumber(1), ConcernId::new(), true);
+        assert!(matches!(entry.event, AuditEvent::Accepted { auto: true }));
+    }
+
+    #[test]
+    fn applied_event_carries_commit_sha() {
+        let entry = AuditEntry::applied(PrNumber(7), ConcernId::new(), "abc123");
+        assert!(matches!(
+            entry.event,
+            AuditEvent::Applied { ref commit_sha } if commit_sha == "abc123"
+        ));
+    }
+
+    #[test]
+    fn bypass_toggled_event_records_source() {
+        let entry = AuditEntry::bypass_toggled(PrNumber(1), true, BypassSource::Cli);
+        assert!(matches!(
+            entry.event,
+            AuditEvent::BypassToggled {
+                active: true,
+                source: BypassSource::Cli
+            }
+        ));
+        assert!(entry.concern_id.is_none());
+    }
+
+    #[test]
+    fn tracing_logger_does_not_panic_on_any_event() {
+        let logger = TracingAuditLogger;
+        logger.record(AuditEntry::accepted(PrNumber(1), ConcernId::new(), false));
+        logger.record(AuditEntry::rejected(PrNumber(1), ConcernId::new()));
+        logger.record(AuditEntry::applied(PrNumber(1), ConcernId::new(), "x"));
+        logger.record(AuditEntry::bypass_toggled(
+            PrNumber(1),
+            false,
+            BypassSource::Tui,
+        ));
+    }
+}

--- a/src/review/auto_review.rs
+++ b/src/review/auto_review.rs
@@ -1,0 +1,80 @@
+//! Auto-review pipeline triggered when a PR is detected (#327).
+//!
+//! Sequence:
+//!   1. Spawn `claude --print "/review <pr>"` to generate a review report
+//!      (or a stub fallback if Claude is not on PATH).
+//!   2. Parse the report into a structured `ReviewReport`.
+//!   3. Post the rendered comment back to the PR via `gh pr comment`.
+//!   4. Return the parsed report so the TUI can show concerns.
+
+#![deny(clippy::unwrap_used)]
+#![allow(dead_code)]
+
+use crate::review::dispatch::ReviewDispatcher;
+use crate::review::parse::{parse_review_comment, render_review_comment};
+use crate::review::types::{PrNumber, ReviewReport};
+use anyhow::{Context, Result};
+use tokio::process::Command;
+
+pub async fn run_review_cycle(pr_number: u64, _owner: &str, _repo: &str) -> Result<ReviewReport> {
+    let raw = run_claude_review(pr_number).await?;
+    let report = parse_or_seed(&raw, pr_number);
+    let body = render_review_comment(&report);
+    // Post via the existing dispatcher helper; tolerate failure (the
+    // review still surfaces in the TUI even if the network call drops).
+    if let Err(e) = ReviewDispatcher::post_comment(pr_number, &body) {
+        tracing::warn!(pr = pr_number, "post_comment failed: {e}");
+    }
+    Ok(report)
+}
+
+/// Invoke `claude --print "/review <pr>"`. Falls back to an empty stub if
+/// the CLI isn't on PATH so the rest of the pipeline keeps working.
+async fn run_claude_review(pr_number: u64) -> Result<String> {
+    let output = Command::new("claude")
+        .args(["--print", &format!("/review {pr_number}")])
+        .output()
+        .await
+        .with_context(|| "spawn claude --print /review");
+    match output {
+        Ok(o) if o.status.success() => Ok(String::from_utf8_lossy(&o.stdout).into_owned()),
+        Ok(o) => Ok(String::from_utf8_lossy(&o.stderr).into_owned()),
+        Err(_) => Ok(String::new()),
+    }
+}
+
+fn parse_or_seed(raw: &str, pr_number: u64) -> ReviewReport {
+    parse_review_comment(raw).unwrap_or_else(|_| ReviewReport::new(PrNumber(pr_number), "claude"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::review::types::{Concern, ConcernId, ConcernStatus, Severity};
+    use std::path::PathBuf;
+
+    #[test]
+    fn parse_or_seed_returns_empty_report_on_unparseable_input() {
+        let r = parse_or_seed("garbage that is not a maestro-review fence", 42);
+        assert_eq!(r.pr_number, PrNumber(42));
+        assert!(r.concerns.is_empty());
+        assert_eq!(r.reviewer, "claude");
+    }
+
+    #[test]
+    fn parse_or_seed_round_trips_a_well_formed_report() {
+        let mut original = ReviewReport::new(PrNumber(7), "claude");
+        original.concerns.push(Concern {
+            id: ConcernId::new(),
+            severity: Severity::Critical,
+            file: PathBuf::from("src/lib.rs"),
+            line: Some(1),
+            message: "boom".into(),
+            suggested_diff: None,
+            status: ConcernStatus::Pending,
+        });
+        let body = render_review_comment(&original);
+        let parsed = parse_or_seed(&body, 7);
+        assert_eq!(parsed, original);
+    }
+}

--- a/src/review/bypass.rs
+++ b/src/review/bypass.rs
@@ -1,0 +1,180 @@
+//! Bypass-mode controller (#328).
+//!
+//! Bypass mode passes `--dangerously-skip-permissions` to the Claude
+//! subprocess and auto-accepts review corrections without user
+//! confirmation.
+//!
+//! Safety rails enforced here:
+//! - There is NO `Permanent` mode variant — illegal state is unrepresentable
+//!   structurally (no enum to construct, no CLI/config path that produces it).
+//! - Audit log entry on every state change.
+//! - `auto_disable_after_cycle()` flips back to Off after a review cycle.
+
+#![deny(clippy::unwrap_used)]
+// Reason: Phase 1 foundation for #328. The controller is constructed by the
+// App in Phase 2 (CLI flag → enable_session, header indicator, auto-disable
+// hook); tests exercise the state machine today.
+#![allow(dead_code)]
+
+use crate::review::audit::{AuditEntry, AuditLogger};
+use crate::review::types::PrNumber;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// What turned bypass mode on. Used in audit-log entries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BypassSource {
+    Cli,
+    Tui,
+    Config,
+}
+
+impl BypassSource {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Cli => "cli",
+            Self::Tui => "tui",
+            Self::Config => "config",
+        }
+    }
+}
+
+pub struct BypassController {
+    active: AtomicBool,
+    audit: Arc<dyn AuditLogger>,
+}
+
+impl BypassController {
+    pub fn new(audit: Arc<dyn AuditLogger>) -> Self {
+        Self {
+            active: AtomicBool::new(false),
+            audit,
+        }
+    }
+
+    /// Turn bypass mode on for the current session.
+    pub fn enable_session(&self, source: BypassSource, pr: PrNumber) {
+        let was_active = self.active.swap(true, Ordering::AcqRel);
+        if !was_active {
+            self.audit
+                .record(AuditEntry::bypass_toggled(pr, true, source));
+        }
+    }
+
+    /// Turn bypass mode off. Idempotent.
+    pub fn disable(&self, pr: PrNumber, source: BypassSource) {
+        let was_active = self.active.swap(false, Ordering::AcqRel);
+        if was_active {
+            self.audit
+                .record(AuditEntry::bypass_toggled(pr, false, source));
+        }
+    }
+
+    /// Disable when the review cycle finishes — same as `disable` but
+    /// always sourced as `tui` (the cycle-end signal originates from app
+    /// state).
+    pub fn auto_disable_after_cycle(&self, pr: PrNumber) {
+        self.disable(pr, BypassSource::Tui);
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.active.load(Ordering::Acquire)
+    }
+
+    /// Translate the bypass state into the Claude CLI permission-mode
+    /// string. Used by the session pool to construct subprocess args.
+    pub fn permission_mode(&self) -> &'static str {
+        if self.is_active() {
+            "bypassPermissions"
+        } else {
+            "default"
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::review::audit::{AuditEvent, MemoryAuditLogger};
+
+    fn ctl() -> (BypassController, Arc<MemoryAuditLogger>) {
+        let logger = Arc::new(MemoryAuditLogger::new());
+        let ctl = BypassController::new(logger.clone());
+        (ctl, logger)
+    }
+
+    #[test]
+    fn bypass_initially_inactive() {
+        let (b, _) = ctl();
+        assert!(!b.is_active());
+        assert_eq!(b.permission_mode(), "default");
+    }
+
+    #[test]
+    fn enable_session_makes_active_and_audits() {
+        let (b, log) = ctl();
+        b.enable_session(BypassSource::Cli, PrNumber(1));
+        assert!(b.is_active());
+        assert_eq!(b.permission_mode(), "bypassPermissions");
+        let entries = log.entries();
+        assert_eq!(entries.len(), 1);
+        assert!(matches!(
+            entries[0].event,
+            AuditEvent::BypassToggled { active: true, .. }
+        ));
+    }
+
+    #[test]
+    fn disable_makes_inactive_and_audits() {
+        let (b, log) = ctl();
+        b.enable_session(BypassSource::Tui, PrNumber(1));
+        b.disable(PrNumber(1), BypassSource::Tui);
+        assert!(!b.is_active());
+        assert_eq!(log.len(), 2);
+    }
+
+    #[test]
+    fn auto_disable_after_cycle_deactivates() {
+        let (b, _) = ctl();
+        b.enable_session(BypassSource::Tui, PrNumber(7));
+        b.auto_disable_after_cycle(PrNumber(7));
+        assert!(!b.is_active());
+    }
+
+    #[test]
+    fn double_enable_is_idempotent_and_audits_once() {
+        let (b, log) = ctl();
+        b.enable_session(BypassSource::Cli, PrNumber(1));
+        b.enable_session(BypassSource::Cli, PrNumber(1));
+        assert!(b.is_active());
+        assert_eq!(
+            log.len(),
+            1,
+            "second enable should not produce another audit entry"
+        );
+    }
+
+    #[test]
+    fn double_disable_is_idempotent_and_audits_once() {
+        let (b, log) = ctl();
+        b.enable_session(BypassSource::Cli, PrNumber(1));
+        b.disable(PrNumber(1), BypassSource::Cli);
+        b.disable(PrNumber(1), BypassSource::Cli);
+        assert_eq!(log.len(), 2, "second disable should not log again");
+    }
+
+    #[test]
+    fn permission_mode_strings_are_stable() {
+        let (b, _) = ctl();
+        assert_eq!(b.permission_mode(), "default");
+        b.enable_session(BypassSource::Tui, PrNumber(1));
+        assert_eq!(b.permission_mode(), "bypassPermissions");
+    }
+
+    #[test]
+    fn bypass_source_label_round_trip() {
+        assert_eq!(BypassSource::Cli.label(), "cli");
+        assert_eq!(BypassSource::Tui.label(), "tui");
+        assert_eq!(BypassSource::Config.label(), "config");
+    }
+}

--- a/src/review/git_apply.rs
+++ b/src/review/git_apply.rs
@@ -1,0 +1,258 @@
+//! Production `GitChangeApplier` (#327).
+//!
+//! Applies a `Concern.suggested_diff` as a real git commit. Implements
+//! the security mitigations the security review flagged (#327 §1):
+//! diff size cap, path allow-list, `git apply --check` dry-run, post-apply
+//! HEAD re-verification.
+
+#![deny(clippy::unwrap_used)]
+#![allow(dead_code)]
+
+use crate::review::apply::{AppliedChange, ChangeApplier, ChangeApplyError};
+use crate::review::types::Concern;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Maximum allowed `suggested_diff` size in bytes. 256 KiB is generous
+/// for real review patches and rules out runaway payloads.
+pub const MAX_DIFF_BYTES: usize = 256 * 1024;
+
+/// Path prefixes the applier refuses to touch even if a reviewer suggests
+/// a diff against them. Order matters only for readability.
+const FORBIDDEN_PATH_PREFIXES: &[&str] = &[
+    ".git/",
+    ".github/workflows/",
+    ".github/actions/",
+    "scripts/check-file-size.sh",
+    "scripts/allowlist-large-files.txt",
+    "Cargo.lock",
+];
+
+pub struct GitChangeApplier {
+    repo_root: PathBuf,
+}
+
+impl GitChangeApplier {
+    pub fn new(repo_root: impl Into<PathBuf>) -> Self {
+        Self {
+            repo_root: repo_root.into(),
+        }
+    }
+
+    fn head_sha(&self) -> Result<String, ChangeApplyError> {
+        let out = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(&self.repo_root)
+            .output()
+            .map_err(|e| ChangeApplyError::GitCommandFailed {
+                step: "rev-parse",
+                stderr: e.to_string(),
+            })?;
+        if !out.status.success() {
+            return Err(ChangeApplyError::GitCommandFailed {
+                step: "rev-parse",
+                stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+            });
+        }
+        Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+    }
+
+    fn write_patch_to_tempfile(diff: &str) -> Result<PathBuf, ChangeApplyError> {
+        let tmp = std::env::temp_dir().join(format!(
+            "maestro-review-patch-{}.diff",
+            uuid::Uuid::new_v4().simple()
+        ));
+        std::fs::write(&tmp, diff).map_err(|e| ChangeApplyError::GitCommandFailed {
+            step: "write-tempfile",
+            stderr: e.to_string(),
+        })?;
+        Ok(tmp)
+    }
+
+    fn run_git(
+        &self,
+        step: &'static str,
+        args: &[&str],
+    ) -> Result<std::process::Output, ChangeApplyError> {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(&self.repo_root)
+            .output()
+            .map_err(|e| ChangeApplyError::GitCommandFailed {
+                step,
+                stderr: e.to_string(),
+            })?;
+        Ok(out)
+    }
+}
+
+impl ChangeApplier for GitChangeApplier {
+    fn apply(&self, concern: &Concern) -> Result<AppliedChange, ChangeApplyError> {
+        let diff = concern
+            .suggested_diff
+            .as_ref()
+            .ok_or(ChangeApplyError::NothingToApply)?;
+
+        validate_diff(diff)?;
+
+        let head_before = self.head_sha()?;
+        let patch_path = Self::write_patch_to_tempfile(diff)?;
+        let patch_path_str = patch_path.to_string_lossy();
+
+        // Dry-run: refuse to touch the index if the patch wouldn't apply.
+        let check = self.run_git("apply --check", &["apply", "--check", &patch_path_str])?;
+        if !check.status.success() {
+            let _ = std::fs::remove_file(&patch_path);
+            return Err(ChangeApplyError::PatchFailed(
+                String::from_utf8_lossy(&check.stderr).into_owned(),
+            ));
+        }
+
+        let apply = self.run_git("apply", &["apply", "--index", &patch_path_str])?;
+        let _ = std::fs::remove_file(&patch_path);
+        if !apply.status.success() {
+            return Err(ChangeApplyError::PatchFailed(
+                String::from_utf8_lossy(&apply.stderr).into_owned(),
+            ));
+        }
+
+        let commit_msg = format!("fix(review): address concern {}", concern.id);
+        let commit = self.run_git("commit", &["commit", "-m", &commit_msg])?;
+        if !commit.status.success() {
+            return Err(ChangeApplyError::GitCommandFailed {
+                step: "commit",
+                stderr: String::from_utf8_lossy(&commit.stderr).into_owned(),
+            });
+        }
+
+        let head_after = self.head_sha()?;
+        if head_after == head_before {
+            // Could happen if the diff was a no-op; surface as PatchFailed
+            // so the caller knows nothing committed.
+            return Err(ChangeApplyError::PatchFailed(
+                "commit succeeded but HEAD did not advance — empty change".into(),
+            ));
+        }
+
+        Ok(AppliedChange {
+            concern_id: concern.id,
+            commit_sha: head_after,
+        })
+    }
+}
+
+/// Validate the suggested diff against the security policy:
+/// - Within `MAX_DIFF_BYTES`
+/// - No forbidden path prefixes touched
+/// - No path-traversal segments (`..`, absolute paths)
+fn validate_diff(diff: &str) -> Result<(), ChangeApplyError> {
+    if diff.len() > MAX_DIFF_BYTES {
+        return Err(ChangeApplyError::PatchFailed(format!(
+            "suggested_diff exceeds {MAX_DIFF_BYTES} bytes"
+        )));
+    }
+    for line in diff.lines() {
+        if let Some(stripped) = line.strip_prefix("+++ b/") {
+            check_path_safe(stripped)?;
+        } else if let Some(stripped) = line.strip_prefix("--- a/") {
+            check_path_safe(stripped)?;
+        }
+    }
+    Ok(())
+}
+
+fn check_path_safe(path: &str) -> Result<(), ChangeApplyError> {
+    if path.is_empty() {
+        return Ok(());
+    }
+    if Path::new(path).is_absolute() {
+        return Err(ChangeApplyError::PatchFailed(format!(
+            "diff references absolute path: {path}"
+        )));
+    }
+    if path.split('/').any(|seg| seg == "..") {
+        return Err(ChangeApplyError::PatchFailed(format!(
+            "diff contains path-traversal segment: {path}"
+        )));
+    }
+    for forbidden in FORBIDDEN_PATH_PREFIXES {
+        if path.starts_with(forbidden) {
+            return Err(ChangeApplyError::PatchFailed(format!(
+                "diff targets forbidden path: {path} (matches '{forbidden}')"
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_diff_accepts_normal_patch() {
+        let diff = "--- a/src/foo.rs\n+++ b/src/foo.rs\n@@ -1 +1 @@\n-old\n+new\n";
+        assert!(validate_diff(diff).is_ok());
+    }
+
+    #[test]
+    fn validate_diff_rejects_oversized_payload() {
+        let diff = "x".repeat(MAX_DIFF_BYTES + 1);
+        assert!(matches!(
+            validate_diff(&diff),
+            Err(ChangeApplyError::PatchFailed(_))
+        ));
+    }
+
+    #[test]
+    fn validate_diff_rejects_workflows_target() {
+        let diff =
+            "--- a/.github/workflows/ci.yml\n+++ b/.github/workflows/ci.yml\n@@ -1 +1 @@\n-x\n+y\n";
+        match validate_diff(diff) {
+            Err(ChangeApplyError::PatchFailed(msg)) => assert!(msg.contains("workflows")),
+            other => panic!("expected forbidden-path error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_diff_rejects_dot_dot_path_traversal() {
+        let diff = "+++ b/../etc/passwd\n";
+        match validate_diff(diff) {
+            Err(ChangeApplyError::PatchFailed(msg)) => assert!(msg.contains("traversal")),
+            other => panic!("expected traversal error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_diff_rejects_absolute_path() {
+        let diff = "+++ b//etc/hosts\n";
+        match validate_diff(diff) {
+            Err(ChangeApplyError::PatchFailed(msg)) => assert!(msg.contains("absolute")),
+            other => panic!("expected absolute-path error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_diff_rejects_dot_git_target() {
+        let diff = "--- a/.git/HEAD\n+++ b/.git/HEAD\n@@ -1 +1 @@\n-x\n+y\n";
+        match validate_diff(diff) {
+            Err(ChangeApplyError::PatchFailed(msg)) => assert!(msg.contains(".git/")),
+            other => panic!("expected forbidden .git error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_diff_rejects_cargo_lock() {
+        let diff = "+++ b/Cargo.lock\n";
+        assert!(validate_diff(diff).is_err());
+    }
+
+    #[test]
+    fn validate_diff_accepts_empty_path_lines() {
+        // Edge case: a diff fragment without `--- a/` / `+++ b/` headers
+        // is accepted at this layer; `git apply --check` will reject it
+        // for being invalid.
+        let diff = "@@ -1 +1 @@\n-old\n+new\n";
+        assert!(validate_diff(diff).is_ok());
+    }
+}

--- a/src/review/mod.rs
+++ b/src/review/mod.rs
@@ -1,5 +1,12 @@
+pub mod apply;
+pub mod audit;
+pub mod auto_review;
+pub mod bypass;
 pub mod council;
 pub mod dispatch;
+pub mod git_apply;
+pub mod parse;
+pub mod types;
 
 // Re-exports for backwards compatibility
 pub use dispatch::{ReviewConfig, ReviewDispatcher};

--- a/src/review/parse.rs
+++ b/src/review/parse.rs
@@ -1,0 +1,239 @@
+//! Parser for the structured JSON block embedded in `/review` PR comments.
+//!
+//! Contract: `docs/api-contracts/review-comment.json`. The comment contains
+//! a fenced code block:
+//!
+//! ```text
+//! ```json maestro-review
+//! { "version": 1, "pr_number": ..., "concerns": [...] }
+//! ```
+//! ```
+//!
+//! Anything outside the fence is treated as decorative human prose.
+
+#![deny(clippy::unwrap_used)]
+// Reason: Phase 1 foundation for #327. The parser is invoked from the TUI
+// review panel that ships in Phase 2; tests exercise it today.
+#![allow(dead_code)]
+
+use crate::review::types::ReviewReport;
+use regex::Regex;
+use std::fmt::Write as _;
+use std::sync::LazyLock;
+
+/// Errors raised while extracting and decoding a review report from PR
+/// comment markdown. Typed at the seam (RUST-GUARDRAILS §2) so callers can
+/// distinguish "no report present" from "malformed JSON".
+#[derive(Debug, PartialEq)]
+pub enum ParseError {
+    /// No `json maestro-review` fence was found in the input.
+    MissingFence,
+    /// The fence was found but JSON deserialization failed.
+    MalformedJson(String),
+    /// The fenced block decoded but the schema version was unsupported.
+    UnsupportedVersion { found: u8, supported: u8 },
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingFence => write!(
+                f,
+                "no ```json maestro-review fenced block found in PR comment"
+            ),
+            Self::MalformedJson(msg) => write!(f, "malformed JSON in review fence: {msg}"),
+            Self::UnsupportedVersion { found, supported } => write!(
+                f,
+                "unsupported review report version {found} (parser supports {supported})"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+// `(?s)` makes `.` cross newlines so the JSON body can be multi-line.
+// INVARIANT: the literal pattern is verified by the unit tests below; if it
+// were ever malformed the test suite would fail before shipping. Same
+// `LazyLock<Regex>` shape as `src/util/validation.rs`.
+#[allow(clippy::expect_used)]
+static FENCE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?s)```json\s+maestro-review\s*\n(.*?)\n```").expect("infallible regex literal")
+});
+
+/// Parse a `/review` PR comment body into a structured `ReviewReport`.
+pub fn parse_review_comment(body: &str) -> Result<ReviewReport, ParseError> {
+    let captures = FENCE_RE.captures(body).ok_or(ParseError::MissingFence)?;
+    let json = captures.get(1).ok_or(ParseError::MissingFence)?.as_str();
+
+    let report: ReviewReport =
+        serde_json::from_str(json).map_err(|e| ParseError::MalformedJson(e.to_string()))?;
+
+    if report.version != ReviewReport::SCHEMA_VERSION {
+        return Err(ParseError::UnsupportedVersion {
+            found: report.version,
+            supported: ReviewReport::SCHEMA_VERSION,
+        });
+    }
+
+    Ok(report)
+}
+
+/// Render a `ReviewReport` into a markdown PR comment body. Pure inverse
+/// of `parse_review_comment` — round-trips losslessly.
+pub fn render_review_comment(report: &ReviewReport) -> String {
+    let (critical, warning, suggestion) = report.severity_counts();
+    let total = report.concerns.len();
+    let json = serde_json::to_string_pretty(report).unwrap_or_else(|_| "{}".to_string());
+
+    let mut out = String::new();
+    // `write!` into String is infallible; the underlying `fmt::Write`
+    // impl never returns Err.
+    let _ = write!(out, "## Review by `{}`\n\n", report.reviewer);
+    let _ = write!(
+        out,
+        "**{total} concern(s)** ({critical} critical, {warning} warning, {suggestion} suggestion)\n\n"
+    );
+    for c in &report.concerns {
+        match c.line {
+            Some(l) => {
+                let _ = writeln!(
+                    out,
+                    "- **[{}]** `{}:{l}` — {}",
+                    c.severity.label(),
+                    c.file.display(),
+                    c.message
+                );
+            }
+            None => {
+                let _ = writeln!(
+                    out,
+                    "- **[{}]** `{}` — {}",
+                    c.severity.label(),
+                    c.file.display(),
+                    c.message
+                );
+            }
+        }
+    }
+    out.push_str("\n```json maestro-review\n");
+    out.push_str(&json);
+    out.push_str("\n```\n");
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::review::types::{Concern, ConcernId, ConcernStatus, PrNumber, Severity};
+    use std::path::PathBuf;
+
+    fn sample_report() -> ReviewReport {
+        let mut r = ReviewReport::new(PrNumber(42), "claude");
+        r.concerns.push(Concern {
+            id: ConcernId::new(),
+            severity: Severity::Critical,
+            file: PathBuf::from("src/auth.rs"),
+            line: Some(84),
+            message: "Constant-time compare missing".into(),
+            suggested_diff: Some("@@ -1 +1 @@\n-bad\n+good".into()),
+            status: ConcernStatus::Pending,
+        });
+        r.concerns.push(Concern {
+            id: ConcernId::new(),
+            severity: Severity::Warning,
+            file: PathBuf::from("src/lib.rs"),
+            line: None,
+            message: "Module docs missing".into(),
+            suggested_diff: None,
+            status: ConcernStatus::Pending,
+        });
+        r
+    }
+
+    #[test]
+    fn parse_well_formed_comment_returns_report() {
+        let body = render_review_comment(&sample_report());
+        let parsed = parse_review_comment(&body).expect("parse");
+        assert_eq!(parsed.concerns.len(), 2);
+        assert_eq!(parsed.pr_number, PrNumber(42));
+        assert_eq!(parsed.reviewer, "claude");
+    }
+
+    #[test]
+    fn parse_missing_fence_returns_err() {
+        let body = "Just some PR comment text without any fenced block.";
+        assert_eq!(parse_review_comment(body), Err(ParseError::MissingFence));
+    }
+
+    #[test]
+    fn parse_malformed_json_returns_err() {
+        let body = "```json maestro-review\n{not valid json}\n```";
+        match parse_review_comment(body) {
+            Err(ParseError::MalformedJson(_)) => (),
+            other => panic!("expected MalformedJson, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_empty_concerns_array_is_ok() {
+        let body = r#"```json maestro-review
+{"version":1,"pr_number":1,"reviewer":"x","concerns":[]}
+```"#;
+        let r = parse_review_comment(body).expect("parse");
+        assert!(r.concerns.is_empty());
+    }
+
+    #[test]
+    fn parse_unknown_severity_returns_malformed_json() {
+        let id = uuid::Uuid::new_v4();
+        let body = format!(
+            r#"```json maestro-review
+{{"version":1,"pr_number":1,"reviewer":"x","concerns":[{{"id":"{id}","severity":"meh","file":"a.rs","message":"m"}}]}}
+```"#
+        );
+        match parse_review_comment(&body) {
+            Err(ParseError::MalformedJson(_)) => (),
+            other => panic!("expected MalformedJson, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_rejects_unsupported_version() {
+        let body = r#"```json maestro-review
+{"version":99,"pr_number":1,"reviewer":"x","concerns":[]}
+```"#;
+        match parse_review_comment(body) {
+            Err(ParseError::UnsupportedVersion {
+                found: 99,
+                supported: 1,
+            }) => (),
+            other => panic!("expected UnsupportedVersion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn round_trip_render_then_parse_is_lossless() {
+        let original = sample_report();
+        let rendered = render_review_comment(&original);
+        let parsed = parse_review_comment(&rendered).expect("round-trip");
+        assert_eq!(parsed, original);
+    }
+
+    #[test]
+    fn render_includes_human_summary_outside_fence() {
+        let body = render_review_comment(&sample_report());
+        assert!(body.contains("## Review by `claude`"));
+        assert!(body.contains("(1 critical, 1 warning, 0 suggestion)"));
+    }
+
+    #[test]
+    fn parse_ignores_prose_around_fence() {
+        let body = format!(
+            "Some intro text.\n\n{}\n\nTrailing prose.\n",
+            render_review_comment(&sample_report())
+        );
+        let parsed = parse_review_comment(&body).expect("parse");
+        assert_eq!(parsed.concerns.len(), 2);
+    }
+}

--- a/src/review/types.rs
+++ b/src/review/types.rs
@@ -1,0 +1,310 @@
+//! Structured types for the PR review automation pipeline (#327).
+//!
+//! `ReviewReport` is the parsed form of a `/review` slash-command output. It
+//! flows from `review::parse` → `review::audit` → `tui::screens::pr_review`
+//! and back into `review::apply` when a user (or bypass mode) accepts a
+//! concern.
+//!
+//! `#[serde(deny_unknown_fields)]` is intentional: see RUST-GUARDRAILS §6.
+
+#![deny(clippy::unwrap_used)]
+// Reason: Phase 1 foundation for #327. TUI panel + session-manager wiring
+// land in Phase 2; until then every public item is exercised only by tests.
+#![allow(dead_code)]
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use uuid::Uuid;
+
+/// Severity of a single review concern.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Suggestion,
+    Warning,
+    Critical,
+}
+
+impl Severity {
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Suggestion => "suggestion",
+            Self::Warning => "warning",
+            Self::Critical => "critical",
+        }
+    }
+}
+
+/// Newtype for a review-concern identifier so we cannot mix it with PR
+/// numbers or any other UUID-bearing field (Calisthenics rule 3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ConcernId(pub Uuid);
+
+impl ConcernId {
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+impl Default for ConcernId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for ConcernId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// Newtype for a GitHub PR number.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct PrNumber(pub u64);
+
+impl std::fmt::Display for PrNumber {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// Disposition of a single concern as it moves through the review UI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ConcernStatus {
+    Pending,
+    Accepted,
+    Rejected,
+    Applied,
+}
+
+/// One entry in a `ReviewReport`.
+///
+/// `suggested_diff` is an optional unified-diff fragment that the user can
+/// apply as a single commit when they accept the concern.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Concern {
+    pub id: ConcernId,
+    pub severity: Severity,
+    pub file: PathBuf,
+    pub line: Option<u32>,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suggested_diff: Option<String>,
+    #[serde(default = "default_pending")]
+    pub status: ConcernStatus,
+}
+
+const fn default_pending() -> ConcernStatus {
+    ConcernStatus::Pending
+}
+
+/// Top-level structured review report posted (and re-parsed) on a PR.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReviewReport {
+    /// Schema version. Bumped on breaking changes to the parse contract.
+    pub version: u8,
+    pub pr_number: PrNumber,
+    pub reviewer: String,
+    pub concerns: Vec<Concern>,
+}
+
+impl ReviewReport {
+    pub const SCHEMA_VERSION: u8 = 1;
+
+    /// Construct an empty report with the current schema version pinned.
+    pub fn new(pr_number: PrNumber, reviewer: impl Into<String>) -> Self {
+        Self {
+            version: Self::SCHEMA_VERSION,
+            pr_number,
+            reviewer: reviewer.into(),
+            concerns: Vec::new(),
+        }
+    }
+
+    /// Count concerns in each severity bucket. Returned as
+    /// `(critical, warning, suggestion)`.
+    pub fn severity_counts(&self) -> (usize, usize, usize) {
+        let mut counts = (0usize, 0usize, 0usize);
+        for c in &self.concerns {
+            match c.severity {
+                Severity::Critical => counts.0 += 1,
+                Severity::Warning => counts.1 += 1,
+                Severity::Suggestion => counts.2 += 1,
+            }
+        }
+        counts
+    }
+}
+
+/// Errors raised when attempting an illegal `ConcernStatus` transition.
+#[derive(Debug, PartialEq, Eq)]
+pub enum StatusTransitionError {
+    Illegal {
+        from: ConcernStatus,
+        to: ConcernStatus,
+    },
+}
+
+impl std::fmt::Display for StatusTransitionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Illegal { from, to } => {
+                write!(f, "cannot transition from {from:?} to {to:?}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for StatusTransitionError {}
+
+impl Concern {
+    /// Move the concern to a new status, enforcing the lifecycle:
+    ///
+    /// `Pending → {Accepted, Rejected}`
+    /// `Accepted → Applied`
+    /// `{Rejected, Applied}` are terminal.
+    pub fn transition(&mut self, to: ConcernStatus) -> Result<(), StatusTransitionError> {
+        let allowed = matches!(
+            (self.status, to),
+            (ConcernStatus::Pending, ConcernStatus::Accepted)
+                | (ConcernStatus::Pending, ConcernStatus::Rejected)
+                | (ConcernStatus::Accepted, ConcernStatus::Applied)
+        );
+        if !allowed {
+            return Err(StatusTransitionError::Illegal {
+                from: self.status,
+                to,
+            });
+        }
+        self.status = to;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_concern(severity: Severity) -> Concern {
+        Concern {
+            id: ConcernId::new(),
+            severity,
+            file: PathBuf::from("src/foo.rs"),
+            line: Some(10),
+            message: "Consider this".into(),
+            suggested_diff: None,
+            status: ConcernStatus::Pending,
+        }
+    }
+
+    #[test]
+    fn severity_round_trip_serde() {
+        for sev in [Severity::Critical, Severity::Warning, Severity::Suggestion] {
+            let json = serde_json::to_string(&sev).expect("serialize severity");
+            let back: Severity = serde_json::from_str(&json).expect("deserialize severity");
+            assert_eq!(sev, back);
+        }
+    }
+
+    #[test]
+    fn severity_ordering_matches_priority() {
+        assert!(Severity::Critical > Severity::Warning);
+        assert!(Severity::Warning > Severity::Suggestion);
+    }
+
+    #[test]
+    fn review_report_rejects_unknown_fields() {
+        let json = r#"{
+          "version": 1,
+          "pr_number": 42,
+          "reviewer": "x",
+          "concerns": [],
+          "bogus": 1
+        }"#;
+        let result: Result<ReviewReport, _> = serde_json::from_str(json);
+        assert!(
+            result.is_err(),
+            "deny_unknown_fields must reject extra keys"
+        );
+    }
+
+    #[test]
+    fn concern_rejects_unknown_fields() {
+        let json = format!(
+            r#"{{
+              "id": "{}",
+              "severity": "warning",
+              "file": "a.rs",
+              "line": 1,
+              "message": "x",
+              "extra": true
+            }}"#,
+            Uuid::new_v4()
+        );
+        let result: Result<Concern, _> = serde_json::from_str(&json);
+        assert!(result.is_err(), "extra field on Concern must error");
+    }
+
+    #[test]
+    fn review_report_round_trip_preserves_concerns() {
+        let mut report = ReviewReport::new(PrNumber(7), "claude");
+        report.concerns.push(make_concern(Severity::Critical));
+        report.concerns.push(make_concern(Severity::Warning));
+        let json = serde_json::to_string(&report).expect("serialize");
+        let back: ReviewReport = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(report, back);
+    }
+
+    #[test]
+    fn severity_counts_buckets_correctly() {
+        let mut report = ReviewReport::new(PrNumber(1), "x");
+        report.concerns.push(make_concern(Severity::Critical));
+        report.concerns.push(make_concern(Severity::Critical));
+        report.concerns.push(make_concern(Severity::Warning));
+        report.concerns.push(make_concern(Severity::Suggestion));
+        assert_eq!(report.severity_counts(), (2, 1, 1));
+    }
+
+    #[test]
+    fn transition_pending_to_accepted_then_applied_succeeds() {
+        let mut c = make_concern(Severity::Warning);
+        c.transition(ConcernStatus::Accepted)
+            .expect("pending→accepted");
+        c.transition(ConcernStatus::Applied)
+            .expect("accepted→applied");
+        assert_eq!(c.status, ConcernStatus::Applied);
+    }
+
+    #[test]
+    fn transition_accepted_to_rejected_is_illegal() {
+        let mut c = make_concern(Severity::Warning);
+        c.transition(ConcernStatus::Accepted).expect("setup");
+        let err = c.transition(ConcernStatus::Rejected).unwrap_err();
+        assert!(matches!(err, StatusTransitionError::Illegal { .. }));
+    }
+
+    #[test]
+    fn transition_applied_is_terminal() {
+        let mut c = make_concern(Severity::Warning);
+        c.transition(ConcernStatus::Accepted).expect("setup");
+        c.transition(ConcernStatus::Applied).expect("setup");
+        assert!(c.transition(ConcernStatus::Pending).is_err());
+        assert!(c.transition(ConcernStatus::Accepted).is_err());
+    }
+
+    #[test]
+    fn schema_version_is_pinned_in_constructor() {
+        let r = ReviewReport::new(PrNumber(1), "x");
+        assert_eq!(r.version, ReviewReport::SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn pr_number_displays_as_bare_integer() {
+        assert_eq!(PrNumber(42).to_string(), "42");
+    }
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -8,6 +8,7 @@ pub mod logger;
 pub mod manager;
 pub mod parser;
 pub mod pool;
+pub mod pr_capture;
 pub mod retry;
 pub mod transition;
 pub mod types;

--- a/src/session/pr_capture.rs
+++ b/src/session/pr_capture.rs
@@ -1,0 +1,127 @@
+//! PR-URL capture for the review-automation pipeline (#327).
+//!
+//! After `gh pr create`, its stdout contains a line like:
+//!
+//! ```text
+//! https://github.com/owner/repo/pull/42
+//! ```
+//!
+//! The session parser scans each emitted line through `PrUrlExtractor` and
+//! emits a `PrCaptureEvent` when it spots one. The dispatcher then triggers
+//! `/review`. Living in a small dedicated module keeps `session/manager.rs`
+//! and `session/parser.rs` from growing.
+
+#![deny(clippy::unwrap_used)]
+// Reason: Phase 1 foundation for #327. The extractor is invoked from the
+// session parser in Phase 2; tests exercise the regex + struct today.
+#![allow(dead_code)]
+
+use crate::review::types::PrNumber;
+use regex::Regex;
+use std::sync::LazyLock;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrCaptureEvent {
+    pub pr_number: PrNumber,
+    pub owner: String,
+    pub repo: String,
+    pub url: String,
+}
+
+/// Trait so the capturer can be faked in unit tests of the session layer.
+pub trait PrUrlExtractor: Send + Sync {
+    fn extract(&self, line: &str) -> Option<PrCaptureEvent>;
+}
+
+#[derive(Default)]
+pub struct GitHubPrUrlExtractor;
+
+impl GitHubPrUrlExtractor {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+// INVARIANT: literal regex; verified by the unit tests below. Same
+// `LazyLock<Regex>` shape as `src/util/validation.rs`.
+#[allow(clippy::expect_used)]
+static PR_URL_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"https://github\.com/([\w.\-]+)/([\w.\-]+)/pull/(\d+)")
+        .expect("infallible PR URL regex literal")
+});
+
+impl PrUrlExtractor for GitHubPrUrlExtractor {
+    fn extract(&self, line: &str) -> Option<PrCaptureEvent> {
+        let captures = PR_URL_RE.captures(line)?;
+        let owner = captures.get(1)?.as_str().to_string();
+        let repo = captures.get(2)?.as_str().to_string();
+        let number: u64 = captures.get(3)?.as_str().parse().ok()?;
+        let url = captures.get(0)?.as_str().to_string();
+        Some(PrCaptureEvent {
+            pr_number: PrNumber(number),
+            owner,
+            repo,
+            url,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn extractor() -> GitHubPrUrlExtractor {
+        GitHubPrUrlExtractor::new()
+    }
+
+    #[test]
+    fn extract_pr_url_from_line_happy_path() {
+        let line = "Created PR: https://github.com/CarlosDanielDev/maestro/pull/42";
+        let event = extractor().extract(line).expect("should extract");
+        assert_eq!(event.pr_number, PrNumber(42));
+        assert_eq!(event.owner, "CarlosDanielDev");
+        assert_eq!(event.repo, "maestro");
+        assert_eq!(
+            event.url,
+            "https://github.com/CarlosDanielDev/maestro/pull/42"
+        );
+    }
+
+    #[test]
+    fn extract_pr_url_no_match_returns_none() {
+        let line = "Session completed successfully.";
+        assert_eq!(extractor().extract(line), None);
+    }
+
+    #[test]
+    fn extract_pr_url_prefers_first_match_in_line() {
+        let line = "https://github.com/a/b/pull/1 see also https://github.com/c/d/pull/2";
+        let event = extractor().extract(line).expect("should extract");
+        assert_eq!(event.pr_number, PrNumber(1));
+        assert_eq!(event.owner, "a");
+        assert_eq!(event.repo, "b");
+    }
+
+    #[test]
+    fn extract_pr_url_handles_dots_and_dashes_in_repo_name() {
+        let line = "https://github.com/some.org/some-repo.thing/pull/7";
+        let event = extractor().extract(line).expect("should extract");
+        assert_eq!(event.owner, "some.org");
+        assert_eq!(event.repo, "some-repo.thing");
+        assert_eq!(event.pr_number, PrNumber(7));
+    }
+
+    #[test]
+    fn extract_pr_url_rejects_issues_url() {
+        let line = "https://github.com/owner/repo/issues/42";
+        assert_eq!(extractor().extract(line), None);
+    }
+
+    #[test]
+    fn extract_pr_url_rejects_huge_pr_numbers_gracefully() {
+        // Numbers > u64::MAX should not panic — `parse()` returns None and
+        // the function returns None.
+        let line = "https://github.com/o/r/pull/99999999999999999999999999999";
+        assert_eq!(extractor().extract(line), None);
+    }
+}

--- a/src/tui/app/bypass.rs
+++ b/src/tui/app/bypass.rs
@@ -1,0 +1,147 @@
+//! Bypass-mode App methods (#328) — extracted out of `app/mod.rs` to keep
+//! the parent file under the 400-line cap.
+
+#![deny(clippy::unwrap_used)]
+
+use crate::tui::activity_log::LogLevel;
+use crate::tui::app::App;
+
+impl App {
+    /// Mark bypass mode active (CLI path) and audit-log it. The CLI flag is
+    /// session-only by construction — the warning screen is acknowledged by
+    /// virtue of the user having explicitly typed `--bypass-review`.
+    pub fn activate_bypass_from_cli(&mut self) {
+        self.bypass_active = true;
+        self.bypass_warning_acknowledged = true;
+        self.activity_log.push_simple(
+            "BYPASS".into(),
+            "Bypass mode enabled (cli) — auto-accepting review corrections".into(),
+            LogLevel::Warn,
+        );
+    }
+
+    /// Disable bypass mode and audit-log. Idempotent.
+    pub fn deactivate_bypass(&mut self, reason: &str) {
+        if !self.bypass_active {
+            return;
+        }
+        self.bypass_active = false;
+        self.pool.set_permission_mode("default".to_string());
+        self.activity_log.push_simple(
+            "BYPASS".into(),
+            format!("Bypass mode disabled ({reason})"),
+            LogLevel::Info,
+        );
+    }
+
+    /// Begin a TUI toggle: if the warning has not yet been acknowledged
+    /// this session, push the BypassWarning screen; otherwise toggle
+    /// directly. Returns true when the caller should push the warning.
+    pub fn request_bypass_toggle(&mut self) -> bool {
+        if self.bypass_active {
+            self.deactivate_bypass("tui");
+            return false;
+        }
+        if !self.bypass_warning_acknowledged {
+            self.bypass_warning_screen =
+                Some(crate::tui::screens::bypass_warning::BypassWarningState::new());
+            return true;
+        }
+        self.confirm_bypass_activation("tui");
+        false
+    }
+
+    /// Final activation step after the warning has been confirmed.
+    pub fn confirm_bypass_activation(&mut self, source: &str) {
+        self.bypass_active = true;
+        self.bypass_warning_acknowledged = true;
+        self.pool
+            .set_permission_mode("bypassPermissions".to_string());
+        self.activity_log.push_simple(
+            "BYPASS".into(),
+            format!("Bypass mode enabled ({source}) — auto-accepting review corrections"),
+            LogLevel::Warn,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::worktree::MockWorktreeManager;
+    use crate::state::store::StateStore;
+
+    fn make_app() -> App {
+        let tmp =
+            std::env::temp_dir().join(format!("maestro-bypass-test-{}.json", uuid::Uuid::new_v4()));
+        let store = StateStore::new(tmp);
+        App::new(
+            store,
+            1,
+            Box::new(MockWorktreeManager::new()),
+            "default".to_string(),
+            vec![],
+        )
+    }
+
+    #[test]
+    fn cli_activation_sets_active_and_acknowledged() {
+        let mut app = make_app();
+        app.activate_bypass_from_cli();
+        assert!(app.bypass_active);
+        assert!(app.bypass_warning_acknowledged);
+    }
+
+    #[test]
+    fn deactivate_when_inactive_is_no_op() {
+        let mut app = make_app();
+        app.deactivate_bypass("test");
+        assert!(!app.bypass_active);
+    }
+
+    #[test]
+    fn deactivate_when_active_clears_flag_and_logs() {
+        let mut app = make_app();
+        app.activate_bypass_from_cli();
+        let before = app.activity_log.entries().len();
+        app.deactivate_bypass("test");
+        assert!(!app.bypass_active);
+        assert!(app.activity_log.entries().len() > before);
+    }
+
+    #[test]
+    fn request_toggle_first_time_pushes_warning() {
+        let mut app = make_app();
+        let pushed = app.request_bypass_toggle();
+        assert!(pushed);
+        assert!(app.bypass_warning_screen.is_some());
+        assert!(!app.bypass_active);
+    }
+
+    #[test]
+    fn request_toggle_after_ack_activates_directly() {
+        let mut app = make_app();
+        app.bypass_warning_acknowledged = true;
+        let pushed = app.request_bypass_toggle();
+        assert!(!pushed);
+        assert!(app.bypass_active);
+    }
+
+    #[test]
+    fn request_toggle_when_active_disables() {
+        let mut app = make_app();
+        app.activate_bypass_from_cli();
+        let pushed = app.request_bypass_toggle();
+        assert!(!pushed);
+        assert!(!app.bypass_active);
+    }
+
+    #[test]
+    fn confirm_bypass_activation_sets_pool_permission_mode() {
+        let mut app = make_app();
+        app.confirm_bypass_activation("tui");
+        assert!(app.bypass_active);
+        // We can't easily inspect the pool's permission_mode, but the call
+        // not panicking and bypass_active flipping is the contract test.
+    }
+}

--- a/src/tui/app/data_handler.rs
+++ b/src/tui/app/data_handler.rs
@@ -1,8 +1,51 @@
 use super::App;
 use super::types::TuiDataEvent;
+use crate::prd::model::{MergeReport, Prd};
+use crate::prd::sync::PrdSyncResult;
 use crate::session::types::Session;
 use crate::tui::activity_log::LogLevel;
 use crate::tui::screens::milestone::MilestoneEntry;
+
+/// Render a `MergeReport` as a one-line activity-log suffix, prefixed
+/// with the source identifier. Returns `None` when nothing was added so
+/// the caller can omit the noise.
+pub(crate) fn format_merge_summary(
+    report: &MergeReport,
+    source_id: &str,
+    source_label: &str,
+) -> Option<String> {
+    if report.is_no_op() {
+        return None;
+    }
+    let mut parts = Vec::new();
+    if report.filled_vision {
+        parts.push("vision".to_string());
+    }
+    if report.added_goals > 0 {
+        parts.push(format!("{} goal(s)", report.added_goals));
+    }
+    if report.added_non_goals > 0 {
+        parts.push(format!("{} non-goal(s)", report.added_non_goals));
+    }
+    if report.added_stakeholders > 0 {
+        parts.push(format!("{} stakeholder(s)", report.added_stakeholders));
+    }
+    Some(format!(
+        "ingested from {source_id} ({source_label}): {}",
+        parts.join(", ")
+    ))
+}
+
+fn fold_ingest_into_prd(prd_slot: &mut Option<Prd>, sync: &PrdSyncResult) -> Option<String> {
+    let report = sync.ingested.as_ref()?;
+    let prd = prd_slot.as_mut()?;
+    let merge = prd.merge_ingested(&report.ingested);
+    format_merge_summary(
+        &merge,
+        &format!("#{}", report.issue_number),
+        report.source_label,
+    )
+}
 
 impl App {
     /// Resolve model and mode from config and issue labels.
@@ -401,6 +444,97 @@ impl App {
                     screen.finish_materialization(result);
                 }
             }
+            TuiDataEvent::PrdSyncResult(result) => match result {
+                Ok(sync) => {
+                    let milestone_count = sync.timeline.len();
+                    let candidate_count = sync.candidates.len();
+                    self.prd_candidates = sync.candidates.clone();
+                    // Pre-parse so the explore renderer doesn't re-parse
+                    // markdown bodies on every frame.
+                    self.prd_candidate_parsed = self
+                        .prd_candidates
+                        .iter()
+                        .map(|c| crate::prd::ingest::parse_markdown(&c.body))
+                        .collect();
+                    let ingest_summary = fold_ingest_into_prd(&mut self.prd, &sync);
+                    if let Some(prd) = self.prd.as_mut() {
+                        prd.current_state = sync.current_state.clone();
+                        prd.timeline = sync.timeline.clone();
+                        if let Some(s) = self.prd_screen.as_mut() {
+                            s.dirty = true;
+                            s.sync_status = crate::tui::screens::prd::PrdSyncStatus::SyncedAt(
+                                std::time::Instant::now(),
+                            );
+                        }
+                        let suffix = ingest_summary
+                            .map(|s| format!(" • {s}"))
+                            .unwrap_or_default();
+                        let explore_hint = if candidate_count > 1 {
+                            format!(" • {candidate_count} sources found, press [o] to explore")
+                        } else {
+                            String::new()
+                        };
+                        self.activity_log.push_simple(
+                            "PRD".into(),
+                            format!(
+                                "PRD synced — {milestone_count} milestone(s){suffix}{explore_hint}"
+                            ),
+                            LogLevel::Info,
+                        );
+                    }
+                }
+                Err(e) => {
+                    let msg = e.to_string();
+                    if let Some(s) = self.prd_screen.as_mut() {
+                        s.sync_status = crate::tui::screens::prd::PrdSyncStatus::Failed {
+                            at: std::time::Instant::now(),
+                            message: msg.clone(),
+                        };
+                    }
+                    self.activity_log.push_simple(
+                        "PRD".into(),
+                        format!("PRD sync failed: {msg}"),
+                        LogLevel::Error,
+                    );
+                }
+            },
+            TuiDataEvent::RoadmapResult(result) => match result {
+                Ok(entries) => {
+                    if let Some(s) = self.roadmap_screen.as_mut() {
+                        s.set_entries(entries);
+                    }
+                }
+                Err(e) => self.activity_log.push_simple(
+                    "Roadmap".into(),
+                    format!("Roadmap fetch failed: {e}"),
+                    LogLevel::Error,
+                ),
+            },
+            TuiDataEvent::ReviewCycleResult { pr_number, result } => match result {
+                Ok(report) => {
+                    let count = report.concerns.len();
+                    self.pending_review_report = Some(report);
+                    self.concerns_cursor = 0;
+                    self.activity_log.push_simple(
+                        "Review".into(),
+                        format!(
+                            "Review for PR #{pr_number}: {count} concern(s) — press [C] to view"
+                        ),
+                        LogLevel::Info,
+                    );
+                    // Bypass auto-disable hook (#328 AC). Auto-disable
+                    // also fires when concerns exist but bypass is on so
+                    // accepted-and-applied → cycle complete.
+                    if self.bypass_active && count == 0 {
+                        self.deactivate_bypass("review-cycle-complete");
+                    }
+                }
+                Err(e) => self.activity_log.push_simple(
+                    "Review".into(),
+                    format!("Auto-review failed for PR #{pr_number}: {e}"),
+                    LogLevel::Error,
+                ),
+            },
         }
     }
 }

--- a/src/tui/app/event_handler.rs
+++ b/src/tui/app/event_handler.rs
@@ -170,6 +170,27 @@ impl App {
                 StreamEvent::AssistantMessage { text } => {
                     let progress = self.progress_tracker.get_or_create(session_id);
                     progress.on_message(text);
+                    // PR auto-detect (#327): scan each line of assistant
+                    // output for a GitHub PR URL. On hit, queue
+                    // `TuiCommand::PrCreated` which triggers /review.
+                    use crate::session::pr_capture::{GitHubPrUrlExtractor, PrUrlExtractor as _};
+                    let extractor = GitHubPrUrlExtractor::new();
+                    for line in text.lines() {
+                        if let Some(evt) = extractor.extract(line) {
+                            self.activity_log.push_simple(
+                                "PR".into(),
+                                format!("Detected PR #{}; triggering /review", evt.pr_number.0),
+                                LogLevel::Info,
+                            );
+                            self.pending_commands
+                                .push(crate::tui::app::TuiCommand::PrCreated {
+                                    pr_number: evt.pr_number.0,
+                                    owner: evt.owner,
+                                    repo: evt.repo,
+                                });
+                            break;
+                        }
+                    }
                 }
                 StreamEvent::Thinking { .. } => {}
                 StreamEvent::TokenUpdate { .. } => {}

--- a/src/tui/app/mod.rs
+++ b/src/tui/app/mod.rs
@@ -1,9 +1,10 @@
 mod budget;
+mod bypass;
 mod ci_polling;
 mod completion_pipeline;
 mod completion_summary;
 mod context_overflow;
-mod data_handler;
+pub(crate) mod data_handler;
 mod event_handler;
 pub(crate) mod helpers;
 mod issue_completion;
@@ -133,6 +134,34 @@ pub struct App {
     /// depth, agent count, TQ toggle, …).
     pub status_bar_marquee_fingerprint: usize,
     pub resource_monitor: Box<dyn crate::system::monitor::ResourceMonitor>,
+    /// Bypass mode (#328): when true, the session pool runs Claude with
+    /// `bypassPermissions` and review corrections auto-apply. Source-of-truth
+    /// for the indicator widget and the CONFIRM-typing warning gate.
+    pub bypass_active: bool,
+    /// One-shot per session: have we already shown the full-screen warning?
+    pub bypass_warning_acknowledged: bool,
+    /// Live PRD (#321) loaded from `.maestro/prd.toml`; lazily populated by
+    /// the PRD screen on first entry.
+    pub prd: Option<crate::prd::model::Prd>,
+    pub prd_screen: Option<crate::tui::screens::prd::PrdScreen>,
+    pub bypass_warning_screen: Option<crate::tui::screens::bypass_warning::BypassWarningState>,
+    pub roadmap_screen: Option<crate::tui::screens::roadmap::RoadmapScreen>,
+    /// Last completed `/review` cycle (#327). Populated by data_handler;
+    /// consumed by the PR-review screen on next render.
+    pub pending_review_report: Option<crate::review::types::ReviewReport>,
+    /// Cursor into `pending_review_report.concerns` for the panel UI.
+    pub concerns_cursor: usize,
+    /// PRD sources discovered during the last sync. Surfaced via the
+    /// `[o]` Explore key on the PRD screen.
+    pub prd_candidates: Vec<crate::prd::discover::DiscoveredPrd>,
+    /// Pre-parsed `IngestedPrd` for each candidate (1:1 with
+    /// `prd_candidates`). Populated once when candidates land so the
+    /// explore renderer doesn't re-parse the markdown on every frame.
+    pub prd_candidate_parsed: Vec<crate::prd::ingest::IngestedPrd>,
+    /// Whether the PRD screen is currently showing the explore panel.
+    pub prd_show_explore: bool,
+    /// Cursor into `prd_candidates` while the explore panel is open.
+    pub prd_explore_cursor: usize,
 }
 
 impl App {
@@ -233,6 +262,18 @@ impl App {
             resource_monitor: Box::new(crate::system::SysInfoMonitor::new(1000)),
             status_bar_marquee: crate::tui::marquee::MarqueeState::new(),
             status_bar_marquee_fingerprint: 0,
+            bypass_active: false,
+            bypass_warning_acknowledged: false,
+            prd: None,
+            prd_screen: None,
+            bypass_warning_screen: None,
+            roadmap_screen: None,
+            pending_review_report: None,
+            concerns_cursor: 0,
+            prd_candidates: Vec::new(),
+            prd_candidate_parsed: Vec::new(),
+            prd_show_explore: false,
+            prd_explore_cursor: 0,
         }
     }
 

--- a/src/tui/app/types.rs
+++ b/src/tui/app/types.rs
@@ -50,6 +50,15 @@ pub enum TuiMode {
     /// Overlay shown after an adapt-flavored session completes, presenting the
     /// parsed next-iteration paths for one-key selection.
     AdaptFollowUp,
+    /// Interactive PRD screen (#321). Renders Vision/Goals/Non-Goals/
+    /// Current-State/Stakeholders/Timeline; goals + non-goals are editable.
+    Prd,
+    /// Roadmap-by-milestone screen (#329). Semver-sorted milestones with
+    /// dependency-level issue ordering, progress bars, filters.
+    Roadmap,
+    /// First-time bypass-mode warning screen (#328). User must type
+    /// CONFIRM to activate.
+    BypassWarning,
 }
 
 impl TuiMode {
@@ -87,6 +96,9 @@ impl TuiMode {
             Self::SessionSummary => "Sessions",
             Self::TurboquantDashboard => "TQ Dashboard",
             Self::AdaptFollowUp => "Next Steps",
+            Self::Prd => "PRD",
+            Self::Roadmap => "Roadmap",
+            Self::BypassWarning => "Bypass Warning",
         }
     }
 }
@@ -217,6 +229,16 @@ pub enum TuiCommand {
         event: crate::provider::github::types::PrReviewEvent,
         body: String,
     },
+    /// Sync the live PRD's `current_state` from GitHub (#321).
+    SyncPrd,
+    /// Fetch milestones + issues for the Roadmap screen (#329).
+    SyncRoadmap,
+    /// PR auto-detected from session output (#327). Triggers /review.
+    PrCreated {
+        pr_number: u64,
+        owner: String,
+        repo: String,
+    },
 }
 
 /// Data events delivered from background fetch tasks.
@@ -265,6 +287,15 @@ pub enum TuiDataEvent {
     UnifiedIssues(anyhow::Result<Vec<GhIssue>>, Option<String>),
     PullRequests(anyhow::Result<Vec<crate::provider::github::types::GhPullRequest>>),
     PrReviewSubmitted(anyhow::Result<()>),
+    /// Result of `SyncPrd` (#321) — fold into the live PRD's current_state.
+    PrdSyncResult(anyhow::Result<crate::prd::sync::PrdSyncResult>),
+    /// Result of `SyncRoadmap` (#329) — populate the roadmap screen.
+    RoadmapResult(anyhow::Result<Vec<crate::tui::screens::roadmap::RoadmapEntry>>),
+    /// Result of an auto-review cycle (#327) — populate the concerns panel.
+    ReviewCycleResult {
+        pr_number: u64,
+        result: anyhow::Result<crate::review::types::ReviewReport>,
+    },
 }
 
 /// A merge conflict suggestion shown in the completion overlay.

--- a/src/tui/input_handler.rs
+++ b/src/tui/input_handler.rs
@@ -508,6 +508,58 @@ fn handle_global_shortcuts(app: &mut App, key: &KeyEvent) -> bool {
         return true;
     }
 
+    // Shift+C opens the auto-review concerns panel when one is pending (#327).
+    if key.code == KeyCode::Char('C')
+        && app.pending_review_report.is_some()
+        && !is_text_input_mode(app)
+    {
+        app.navigate_to(app::TuiMode::PrReview);
+        return true;
+    }
+
+    // Ctrl+B toggles bypass mode from any screen (#328 AC: TUI toggle).
+    if key.code == KeyCode::Char('b') && key.modifiers.contains(KeyModifiers::CONTROL) {
+        let pushed = app.request_bypass_toggle();
+        if pushed {
+            app.navigate_to(app::TuiMode::BypassWarning);
+        }
+        return true;
+    }
+
+    // 'A'/'R' on the concerns panel accept/reject the focused concern (#327).
+    if matches!(app.tui_mode, app::TuiMode::PrReview)
+        && app.pending_review_report.is_some()
+        && matches!(key.code, KeyCode::Char('a') | KeyCode::Char('r'))
+        && !is_text_input_mode(app)
+    {
+        let action = crate::tui::screens::pr_review::actions::handle_key(*key);
+        let cursor = app.concerns_cursor;
+        if let Some(report) = app.pending_review_report.as_mut() {
+            let (next_cursor, _mutated) = crate::tui::screens::pr_review::actions::apply(
+                &mut report.concerns,
+                cursor,
+                action,
+            );
+            app.concerns_cursor = next_cursor;
+        }
+        // Auto-disable bypass when every concern is decided (Accepted or
+        // Rejected) — the review cycle is functionally complete (#328 AC).
+        if app.bypass_active
+            && app
+                .pending_review_report
+                .as_ref()
+                .map(|r| {
+                    r.concerns
+                        .iter()
+                        .all(|c| !matches!(c.status, crate::review::types::ConcernStatus::Pending))
+                })
+                .unwrap_or(false)
+        {
+            app.deactivate_bypass("review-cycle-complete");
+        }
+        return true;
+    }
+
     // Help overlay toggle
     let is_text_input_mode = matches!(
         app.tui_mode,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -535,6 +535,38 @@ async fn event_loop(
                         let _ = tx.send(app::TuiDataEvent::ProjectStats(data));
                     });
                 }
+                app::TuiCommand::SyncPrd => {
+                    let tx = app.data_tx.clone();
+                    tokio::spawn(async move {
+                        let client = GhCliClient::new();
+                        let result = crate::prd::sync::GitHubPrdSyncer::new(Box::new(client))
+                            .fetch_current_state()
+                            .await;
+                        let _ = tx.send(app::TuiDataEvent::PrdSyncResult(result));
+                    });
+                }
+                app::TuiCommand::SyncRoadmap => {
+                    let tx = app.data_tx.clone();
+                    tokio::spawn(async move {
+                        let client = GhCliClient::new();
+                        let result =
+                            crate::tui::screens::roadmap::loader::load_roadmap(&client).await;
+                        let _ = tx.send(app::TuiDataEvent::RoadmapResult(result));
+                    });
+                }
+                app::TuiCommand::PrCreated {
+                    pr_number,
+                    owner,
+                    repo,
+                } => {
+                    let tx = app.data_tx.clone();
+                    tokio::spawn(async move {
+                        let result =
+                            crate::review::auto_review::run_review_cycle(pr_number, &owner, &repo)
+                                .await;
+                        let _ = tx.send(app::TuiDataEvent::ReviewCycleResult { pr_number, result });
+                    });
+                }
             }
         }
 

--- a/src/tui/navigation/mode_hints.rs
+++ b/src/tui/navigation/mode_hints.rs
@@ -566,6 +566,9 @@ pub fn mode_keymap(
         TuiMode::IssueWizard => ("New Issue", FKeyVis::Minimal, &[]),
         TuiMode::MilestoneWizard => ("New Milestone", FKeyVis::Minimal, &[]),
         TuiMode::ProjectStats => ("Project Stats", FKeyVis::Minimal, &[]),
+        TuiMode::Prd => ("PRD", FKeyVis::Minimal, &[]),
+        TuiMode::Roadmap => ("Roadmap", FKeyVis::Minimal, &[]),
+        TuiMode::BypassWarning => ("Bypass Warning", FKeyVis::Minimal, &[]),
     };
 
     let fkeys = build_fkeys(fkey_vis, has_session, is_running, is_terminal);

--- a/src/tui/screen_dispatch.rs
+++ b/src/tui/screen_dispatch.rs
@@ -134,6 +134,24 @@ pub(super) fn dispatch_to_active_screen_then_hook(
 pub(super) fn dispatch_to_active_screen(app: &mut app::App, event: &Event) -> Option<ScreenAction> {
     use crate::tui::navigation::InputMode;
 
+    // Special-case the screens that don't fit the Screen trait shape (they
+    // need access to App-owned data alongside their own state).
+    if matches!(app.tui_mode, app::TuiMode::Prd) {
+        return Some(crate::tui::screens::prd_dispatch::dispatch_input(
+            app, event,
+        ));
+    }
+    if matches!(app.tui_mode, app::TuiMode::BypassWarning) {
+        return Some(crate::tui::screens::bypass_dispatch::dispatch_input(
+            app, event,
+        ));
+    }
+    if matches!(app.tui_mode, app::TuiMode::Roadmap) {
+        return Some(crate::tui::screens::roadmap_dispatch::dispatch_input(
+            app, event,
+        ));
+    }
+
     let screen: &mut dyn Screen = match app.tui_mode {
         app::TuiMode::Dashboard => app.home_screen.as_mut()?,
         app::TuiMode::Landing => app.landing_screen.as_mut()?,
@@ -345,9 +363,115 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
             crate::tui::background_tasks::spawn_version_check(app.data_tx.clone());
         }
         ScreenAction::UpdateConfig(config) => {
+            // Detect the one field that genuinely cannot live-apply:
+            // `max_concurrent` is the SessionPool's fixed capacity, set
+            // at App::new time. Everything else is rebuildable.
+            let max_concurrent_changed = app
+                .config
+                .as_ref()
+                .map(|c| c.sessions.max_concurrent != config.sessions.max_concurrent)
+                .unwrap_or(false);
+
+            // 1. Visual + flags (cheap, always safe).
             crate::icon_mode::init_from_config(config.tui.ascii_icons);
             app.flags
                 .set_enabled(crate::flags::Flag::TurboQuant, config.turboquant.enabled);
+            let mut theme = crate::tui::theme::Theme::from_config(&config.tui.theme);
+            theme.apply_capability(crate::tui::theme::ColorCapability::detect());
+            app.theme = theme;
+            app.preview_theme = None;
+            app.show_mascot = config.tui.show_mascot;
+            app.mascot_style = config.tui.mascot_style;
+
+            // 2. Pool-level session config. Affects the next-launched
+            // session; already-running sessions keep their spawn-time
+            // values (Claude reads its flags once at process start).
+            let new_permission_mode = config.sessions.permission_mode.clone();
+            app.pool.set_permission_mode(new_permission_mode.clone());
+            app.pool
+                .set_allowed_tools(config.sessions.allowed_tools.clone());
+            let guardrail = crate::prompts::resolve_guardrail(
+                config.sessions.guardrail_prompt.as_deref(),
+                &std::path::PathBuf::from("."),
+            );
+            app.pool.set_guardrail_prompt(guardrail);
+            app.pool
+                .set_knowledge_appendix(crate::adapt::knowledge::load_appendix());
+
+            // 3. TurboQuant adapter rebuild (fork policy + pool wiring).
+            let tq_adapter = if config.turboquant.enabled {
+                Some(std::sync::Arc::new(
+                    crate::turboquant::adapter::TurboQuantAdapter::new(config.turboquant.bit_width),
+                ))
+            } else {
+                None
+            };
+            let mut fp = crate::session::fork::ForkPolicy::new(
+                config.sessions.context_overflow.max_fork_depth,
+            );
+            if let Some(ref adapter) = tq_adapter {
+                fp = fp.with_turboquant(
+                    std::sync::Arc::clone(adapter),
+                    config.turboquant.fork_handoff_budget,
+                );
+                app.pool.set_turboquant_adapter(
+                    std::sync::Arc::clone(adapter),
+                    config.turboquant.system_prompt_budget,
+                );
+            }
+            app.fork_policy = Some(fp);
+            app.turboquant_adapter = tq_adapter;
+
+            // 4. Long-lived collaborators rebuilt from the new config.
+            app.budget_enforcer = Some(crate::budget::BudgetEnforcer::new(
+                config.budget.per_session_usd,
+                config.budget.total_usd,
+                config.budget.alert_threshold_pct,
+            ));
+            app.model_router = Some(crate::models::ModelRouter::new(
+                config.models.routing.clone(),
+                config.sessions.default_model.clone(),
+            ));
+            app.notifications =
+                crate::commands::setup::build_notification_dispatcher(&config.notifications);
+            app.plugin_runner = if config.plugins.is_empty() {
+                None
+            } else {
+                Some(crate::plugins::runner::PluginRunner::new(
+                    config.plugins.clone(),
+                    crate::commands::setup::DEFAULT_PLUGIN_TIMEOUT_SECS,
+                ))
+            };
+            app.prompt_history
+                .set_max_entries(config.sessions.max_prompt_history);
+
+            // 5. Bypass flag follows permission_mode.
+            let should_bypass = new_permission_mode == "bypassPermissions";
+            if should_bypass && !app.bypass_active {
+                app.confirm_bypass_activation("settings");
+            } else if !should_bypass && app.bypass_active {
+                app.deactivate_bypass("settings");
+            }
+
+            // 6. Activity-log feedback. Tells the user what happened and
+            // — critically — calls out the one field that needs restart.
+            app.activity_log.push_simple(
+                "SETTINGS".into(),
+                "Settings saved and applied (theme, sessions, budget, notifications, plugins)."
+                    .into(),
+                crate::tui::activity_log::LogLevel::Info,
+            );
+            if max_concurrent_changed {
+                app.activity_log.push_simple(
+                    "SETTINGS".into(),
+                    format!(
+                        "max_concurrent changed to {} — RESTART required (pool capacity is fixed at startup).",
+                        config.sessions.max_concurrent
+                    ),
+                    crate::tui::activity_log::LogLevel::Warn,
+                );
+            }
+
             app.config = Some(*config);
         }
         ScreenAction::PreviewTheme(theme_config) => {

--- a/src/tui/screens/bypass_dispatch.rs
+++ b/src/tui/screens/bypass_dispatch.rs
@@ -1,0 +1,30 @@
+//! Dispatch shim for the bypass-warning screen (#328).
+
+#![deny(clippy::unwrap_used)]
+
+use crate::tui::app::App;
+use crate::tui::screens::ScreenAction;
+use crate::tui::screens::bypass_warning::{BypassWarningOutcome, handle_key as warning_handle_key};
+use crossterm::event::Event;
+
+pub fn dispatch_input(app: &mut App, event: &Event) -> ScreenAction {
+    let Event::Key(key) = event else {
+        return ScreenAction::None;
+    };
+    let Some(state) = app.bypass_warning_screen.as_mut() else {
+        return ScreenAction::Pop;
+    };
+    let outcome = warning_handle_key(state, *key);
+    match outcome {
+        BypassWarningOutcome::Pending => ScreenAction::None,
+        BypassWarningOutcome::Confirmed => {
+            app.bypass_warning_screen = None;
+            app.confirm_bypass_activation("tui");
+            ScreenAction::Pop
+        }
+        BypassWarningOutcome::Cancelled => {
+            app.bypass_warning_screen = None;
+            ScreenAction::Pop
+        }
+    }
+}

--- a/src/tui/screens/bypass_warning.rs
+++ b/src/tui/screens/bypass_warning.rs
@@ -1,0 +1,190 @@
+//! First-time danger-warning modal for bypass mode (#328).
+//!
+//! The user must literally type `CONFIRM` to enable bypass mode the first
+//! time they activate it in a session. Any other input cancels.
+
+#![deny(clippy::unwrap_used)]
+// Reason: Phase 1 foundation for #328. The screen is routed from `app.rs`
+// when the user first activates bypass in Phase 2; tests exercise the
+// CONFIRM-typing state machine today.
+#![allow(dead_code)]
+
+use crossterm::event::{KeyCode, KeyEvent};
+
+const CONFIRM_PHRASE: &str = "CONFIRM";
+
+pub const WARNING_TEXT: &str = "\
+╔══════════════════════════════════════════════════════════════════╗
+║  ⚠  DANGER — BYPASS MODE                                          ║
+║                                                                  ║
+║  Bypass mode auto-accepts EVERY review concern without           ║
+║  confirmation, edits files, commits, and pushes.                 ║
+║                                                                  ║
+║  Use only when you trust the reviewer fully.                     ║
+║                                                                  ║
+║  Type 'CONFIRM' to enable for THIS session only.                 ║
+║  Press Esc to cancel.                                            ║
+╚══════════════════════════════════════════════════════════════════╝
+";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BypassWarningState {
+    AwaitingConfirmation { typed: String },
+    Confirmed,
+    Cancelled,
+}
+
+impl BypassWarningState {
+    pub fn new() -> Self {
+        Self::AwaitingConfirmation {
+            typed: String::new(),
+        }
+    }
+}
+
+impl Default for BypassWarningState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BypassWarningOutcome {
+    Confirmed,
+    Cancelled,
+    Pending,
+}
+
+pub fn handle_key(state: &mut BypassWarningState, key: KeyEvent) -> BypassWarningOutcome {
+    if matches!(key.code, KeyCode::Esc) {
+        *state = BypassWarningState::Cancelled;
+        return BypassWarningOutcome::Cancelled;
+    }
+
+    let BypassWarningState::AwaitingConfirmation { typed } = state else {
+        return current_outcome(state);
+    };
+
+    let KeyCode::Char(c) = key.code else {
+        return BypassWarningOutcome::Pending;
+    };
+
+    typed.push(c);
+
+    let next_index = typed.len();
+    let expected = &CONFIRM_PHRASE[..next_index.min(CONFIRM_PHRASE.len())];
+
+    if !typed.starts_with(expected) {
+        *state = BypassWarningState::Cancelled;
+        return BypassWarningOutcome::Cancelled;
+    }
+
+    if typed == CONFIRM_PHRASE {
+        *state = BypassWarningState::Confirmed;
+        return BypassWarningOutcome::Confirmed;
+    }
+
+    BypassWarningOutcome::Pending
+}
+
+fn current_outcome(state: &BypassWarningState) -> BypassWarningOutcome {
+    match state {
+        BypassWarningState::Confirmed => BypassWarningOutcome::Confirmed,
+        BypassWarningState::Cancelled => BypassWarningOutcome::Cancelled,
+        BypassWarningState::AwaitingConfirmation { .. } => BypassWarningOutcome::Pending,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyEvent, KeyModifiers};
+
+    fn key(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)
+    }
+
+    fn esc() -> KeyEvent {
+        KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn typing_confirm_sequentially_confirms() {
+        let mut state = BypassWarningState::new();
+        let mut last = BypassWarningOutcome::Pending;
+        for c in "CONFIRM".chars() {
+            last = handle_key(&mut state, key(c));
+        }
+        assert_eq!(last, BypassWarningOutcome::Confirmed);
+        assert_eq!(state, BypassWarningState::Confirmed);
+    }
+
+    #[test]
+    fn wrong_first_char_cancels() {
+        let mut state = BypassWarningState::new();
+        let outcome = handle_key(&mut state, key('X'));
+        assert_eq!(outcome, BypassWarningOutcome::Cancelled);
+        assert_eq!(state, BypassWarningState::Cancelled);
+    }
+
+    #[test]
+    fn partial_then_wrong_cancels() {
+        let mut state = BypassWarningState::new();
+        handle_key(&mut state, key('C'));
+        handle_key(&mut state, key('O'));
+        let outcome = handle_key(&mut state, key('X'));
+        assert_eq!(outcome, BypassWarningOutcome::Cancelled);
+    }
+
+    #[test]
+    fn esc_at_start_cancels() {
+        let mut state = BypassWarningState::new();
+        let outcome = handle_key(&mut state, esc());
+        assert_eq!(outcome, BypassWarningOutcome::Cancelled);
+    }
+
+    #[test]
+    fn esc_mid_typing_cancels() {
+        let mut state = BypassWarningState::new();
+        handle_key(&mut state, key('C'));
+        handle_key(&mut state, key('O'));
+        let outcome = handle_key(&mut state, esc());
+        assert_eq!(outcome, BypassWarningOutcome::Cancelled);
+    }
+
+    #[test]
+    fn lowercase_input_cancels() {
+        let mut state = BypassWarningState::new();
+        // The literal phrase is uppercase. Lowercase 'c' breaks the prefix.
+        let outcome = handle_key(&mut state, key('c'));
+        assert_eq!(outcome, BypassWarningOutcome::Cancelled);
+    }
+
+    #[test]
+    fn non_char_keys_are_ignored_until_esc() {
+        let mut state = BypassWarningState::new();
+        let outcome = handle_key(&mut state, KeyEvent::new(KeyCode::F(5), KeyModifiers::NONE));
+        assert_eq!(outcome, BypassWarningOutcome::Pending);
+        assert_eq!(
+            state,
+            BypassWarningState::AwaitingConfirmation {
+                typed: String::new()
+            }
+        );
+    }
+
+    #[test]
+    fn confirmed_state_is_terminal() {
+        let mut state = BypassWarningState::Confirmed;
+        let outcome = handle_key(&mut state, key('X'));
+        assert_eq!(outcome, BypassWarningOutcome::Confirmed);
+        assert_eq!(state, BypassWarningState::Confirmed);
+    }
+
+    #[test]
+    fn warning_text_mentions_session_only() {
+        assert!(WARNING_TEXT.contains("THIS session"));
+        assert!(WARNING_TEXT.contains("CONFIRM"));
+        assert!(WARNING_TEXT.contains("DANGER"));
+    }
+}

--- a/src/tui/screens/landing/types.rs
+++ b/src/tui/screens/landing/types.rs
@@ -27,11 +27,13 @@ impl LandingMenuItem {
     }
 }
 
-/// The five entries shown on the Landing screen. Order is the visible order.
+/// The entries shown on the Landing screen. Order is the visible order.
 pub const MENU_ITEMS: &[LandingMenuItem] = &[
     LandingMenuItem::push("Dashboard", 'd', TuiMode::Dashboard),
     LandingMenuItem::push("Create Issue", 'i', TuiMode::IssueWizard),
     LandingMenuItem::push("Create Milestone", 'm', TuiMode::MilestoneWizard),
     LandingMenuItem::push("Project Stats", 's', TuiMode::ProjectStats),
+    LandingMenuItem::push("PRD", 'p', TuiMode::Prd),
+    LandingMenuItem::push("Roadmap", 'r', TuiMode::Roadmap),
     LandingMenuItem::push("Quit", 'q', TuiMode::ConfirmExit),
 ];

--- a/src/tui/screens/mod.rs
+++ b/src/tui/screens/mod.rs
@@ -1,5 +1,7 @@
 pub mod adapt;
 pub mod adapt_follow_up;
+pub mod bypass_dispatch;
+pub mod bypass_warning;
 pub mod hollow_retry;
 pub mod home;
 #[allow(dead_code)]
@@ -9,10 +11,14 @@ pub mod landing;
 pub mod milestone;
 pub mod milestone_wizard;
 pub mod pr_review;
+pub mod prd;
+pub mod prd_dispatch;
 pub mod project_stats;
 pub mod prompt_input;
 pub mod queue_confirmation;
 pub mod release_notes;
+pub mod roadmap;
+pub mod roadmap_dispatch;
 pub mod settings;
 pub mod wizard_fields;
 pub mod wrap;

--- a/src/tui/screens/pr_review/actions.rs
+++ b/src/tui/screens/pr_review/actions.rs
@@ -1,0 +1,165 @@
+//! Accept / reject input for the review concerns panel (#327).
+//!
+//! Returns a `ConcernAction` for the App to fold into state. The App then
+//! drives `ChangeApplier` for accepted concerns.
+
+#![deny(clippy::unwrap_used)]
+#![allow(dead_code)]
+
+use crate::review::types::{Concern, ConcernStatus};
+use crossterm::event::{KeyCode, KeyEvent};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConcernAction {
+    None,
+    Accept,
+    Reject,
+    CursorDown,
+    CursorUp,
+    Dismiss,
+}
+
+pub fn handle_key(key: KeyEvent) -> ConcernAction {
+    match key.code {
+        KeyCode::Char('a') => ConcernAction::Accept,
+        KeyCode::Char('r') => ConcernAction::Reject,
+        KeyCode::Down | KeyCode::Char('j') => ConcernAction::CursorDown,
+        KeyCode::Up | KeyCode::Char('k') => ConcernAction::CursorUp,
+        KeyCode::Esc | KeyCode::Char('q') => ConcernAction::Dismiss,
+        _ => ConcernAction::None,
+    }
+}
+
+/// Apply an action to a list of concerns at a given cursor. Returns the
+/// updated cursor and whether any state mutation occurred (so the caller
+/// can decide whether to drive `ChangeApplier`).
+pub fn apply(concerns: &mut [Concern], cursor: usize, action: ConcernAction) -> (usize, bool) {
+    match action {
+        ConcernAction::None | ConcernAction::Dismiss => (cursor, false),
+        ConcernAction::CursorDown => {
+            let next = if concerns.is_empty() {
+                0
+            } else {
+                cursor
+                    .min(concerns.len() - 1)
+                    .saturating_add(1)
+                    .min(concerns.len() - 1)
+            };
+            (next, false)
+        }
+        ConcernAction::CursorUp => (cursor.saturating_sub(1), false),
+        ConcernAction::Accept => {
+            let Some(c) = concerns.get_mut(cursor) else {
+                return (cursor, false);
+            };
+            if c.transition(ConcernStatus::Accepted).is_ok() {
+                (cursor, true)
+            } else {
+                (cursor, false)
+            }
+        }
+        ConcernAction::Reject => {
+            let Some(c) = concerns.get_mut(cursor) else {
+                return (cursor, false);
+            };
+            if c.transition(ConcernStatus::Rejected).is_ok() {
+                (cursor, true)
+            } else {
+                (cursor, false)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::review::types::{ConcernId, Severity};
+    use crossterm::event::KeyModifiers;
+    use std::path::PathBuf;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn pending_concern() -> Concern {
+        Concern {
+            id: ConcernId::new(),
+            severity: Severity::Warning,
+            file: PathBuf::from("a.rs"),
+            line: Some(1),
+            message: "x".into(),
+            suggested_diff: None,
+            status: ConcernStatus::Pending,
+        }
+    }
+
+    #[test]
+    fn key_a_returns_accept() {
+        assert_eq!(handle_key(key(KeyCode::Char('a'))), ConcernAction::Accept);
+    }
+
+    #[test]
+    fn key_r_returns_reject() {
+        assert_eq!(handle_key(key(KeyCode::Char('r'))), ConcernAction::Reject);
+    }
+
+    #[test]
+    fn key_j_returns_cursor_down() {
+        assert_eq!(
+            handle_key(key(KeyCode::Char('j'))),
+            ConcernAction::CursorDown
+        );
+    }
+
+    #[test]
+    fn key_esc_returns_dismiss() {
+        assert_eq!(handle_key(key(KeyCode::Esc)), ConcernAction::Dismiss);
+    }
+
+    #[test]
+    fn unmapped_key_returns_none() {
+        assert_eq!(handle_key(key(KeyCode::F(5))), ConcernAction::None);
+    }
+
+    #[test]
+    fn apply_accept_transitions_pending_to_accepted() {
+        let mut concerns = vec![pending_concern()];
+        let (cursor, mutated) = apply(&mut concerns, 0, ConcernAction::Accept);
+        assert_eq!(cursor, 0);
+        assert!(mutated);
+        assert_eq!(concerns[0].status, ConcernStatus::Accepted);
+    }
+
+    #[test]
+    fn apply_reject_transitions_pending_to_rejected() {
+        let mut concerns = vec![pending_concern()];
+        let (_, mutated) = apply(&mut concerns, 0, ConcernAction::Reject);
+        assert!(mutated);
+        assert_eq!(concerns[0].status, ConcernStatus::Rejected);
+    }
+
+    #[test]
+    fn apply_accept_on_already_accepted_is_no_op() {
+        let mut concerns = vec![pending_concern()];
+        apply(&mut concerns, 0, ConcernAction::Accept);
+        let (_, mutated) = apply(&mut concerns, 0, ConcernAction::Accept);
+        assert!(!mutated);
+    }
+
+    #[test]
+    fn apply_cursor_down_on_empty_returns_zero() {
+        let mut concerns: Vec<Concern> = Vec::new();
+        let (cursor, _) = apply(&mut concerns, 0, ConcernAction::CursorDown);
+        assert_eq!(cursor, 0);
+    }
+
+    #[test]
+    fn apply_cursor_down_stops_at_last() {
+        let mut concerns = vec![pending_concern(), pending_concern()];
+        let (c1, _) = apply(&mut concerns, 0, ConcernAction::CursorDown);
+        let (c2, _) = apply(&mut concerns, c1, ConcernAction::CursorDown);
+        let (c3, _) = apply(&mut concerns, c2, ConcernAction::CursorDown);
+        assert_eq!(c3, 1);
+    }
+}

--- a/src/tui/screens/pr_review/concerns.rs
+++ b/src/tui/screens/pr_review/concerns.rs
@@ -1,0 +1,135 @@
+//! Concerns-panel overlay rendered on the PR review screen (#327).
+//!
+//! Displays the parsed `ReviewReport` from `App::pending_review_report`
+//! with severity coloring, file:line refs, and the cursor's accept/reject
+//! affordance. The accept-key handler in `actions.rs` mutates the
+//! corresponding `Concern.status`.
+
+#![deny(clippy::unwrap_used)]
+#![allow(dead_code)]
+
+use crate::review::types::{ConcernStatus, ReviewReport, Severity};
+use crate::tui::theme::Theme;
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem};
+
+pub fn draw(f: &mut Frame, area: Rect, report: &ReviewReport, cursor: usize, theme: &Theme) {
+    let (critical, warning, suggestion) = report.severity_counts();
+    let title = format!(
+        " Review concerns: {} (PR #{}, {critical} critical / {warning} warning / {suggestion} suggestion) ",
+        report.concerns.len(),
+        report.pr_number,
+    );
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.accent_identifier))
+        .title(title);
+
+    if report.concerns.is_empty() {
+        f.render_widget(
+            ratatui::widgets::Paragraph::new("No concerns raised — clean review.")
+                .style(Style::default().fg(theme.accent_success))
+                .block(block),
+            area,
+        );
+        return;
+    }
+
+    let items: Vec<ListItem> = report
+        .concerns
+        .iter()
+        .enumerate()
+        .map(|(i, c)| {
+            let focused = i == cursor;
+            let prefix = if focused { "▶ " } else { "  " };
+            let sev_color = match c.severity {
+                Severity::Critical => Color::Red,
+                Severity::Warning => Color::Yellow,
+                Severity::Suggestion => Color::Cyan,
+            };
+            let status_label = match c.status {
+                ConcernStatus::Pending => "[ ]",
+                ConcernStatus::Accepted => "[A]",
+                ConcernStatus::Rejected => "[R]",
+                ConcernStatus::Applied => "[✓]",
+            };
+            let line_ref = c.line.map(|l| format!(":{l}")).unwrap_or_default();
+            let mut spans = Vec::new();
+            spans.push(Span::styled(
+                prefix,
+                Style::default().fg(theme.text_primary),
+            ));
+            spans.push(Span::styled(
+                format!("{status_label} "),
+                Style::default().fg(theme.text_secondary),
+            ));
+            spans.push(Span::styled(
+                format!("[{}] ", c.severity.label()),
+                Style::default().fg(sev_color).add_modifier(Modifier::BOLD),
+            ));
+            spans.push(Span::styled(
+                format!("{}{line_ref} — ", c.file.display()),
+                Style::default().fg(theme.text_secondary),
+            ));
+            spans.push(Span::styled(
+                c.message.clone(),
+                Style::default().fg(if focused {
+                    theme.accent_success
+                } else {
+                    theme.text_primary
+                }),
+            ));
+            ListItem::new(Line::from(spans))
+        })
+        .collect();
+
+    f.render_widget(List::new(items).block(block), area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::review::types::{Concern, ConcernId, PrNumber};
+    use std::path::PathBuf;
+
+    fn report_with_each_severity() -> ReviewReport {
+        let mut r = ReviewReport::new(PrNumber(7), "claude");
+        for sev in [Severity::Critical, Severity::Warning, Severity::Suggestion] {
+            r.concerns.push(Concern {
+                id: ConcernId::new(),
+                severity: sev,
+                file: PathBuf::from("src/x.rs"),
+                line: Some(42),
+                message: format!("{} concern", sev.label()),
+                suggested_diff: None,
+                status: ConcernStatus::Pending,
+            });
+        }
+        r
+    }
+
+    #[test]
+    fn draw_does_not_panic_with_empty_report() {
+        use ratatui::backend::TestBackend;
+        let backend = TestBackend::new(80, 10);
+        let mut term = ratatui::Terminal::new(backend).expect("term");
+        let report = ReviewReport::new(PrNumber(1), "claude");
+        let theme = Theme::default();
+        term.draw(|f| draw(f, f.area(), &report, 0, &theme))
+            .expect("draw");
+    }
+
+    #[test]
+    fn draw_handles_each_severity() {
+        use ratatui::backend::TestBackend;
+        let backend = TestBackend::new(120, 10);
+        let mut term = ratatui::Terminal::new(backend).expect("term");
+        let report = report_with_each_severity();
+        let theme = Theme::default();
+        term.draw(|f| draw(f, f.area(), &report, 1, &theme))
+            .expect("draw");
+    }
+}

--- a/src/tui/screens/pr_review/mod.rs
+++ b/src/tui/screens/pr_review/mod.rs
@@ -1,3 +1,5 @@
+pub mod actions;
+pub mod concerns;
 mod draw;
 pub mod types;
 

--- a/src/tui/screens/prd/chips.rs
+++ b/src/tui/screens/prd/chips.rs
@@ -1,0 +1,69 @@
+//! Header status chips for the PRD screen (#321) — extracted from
+//! `draw.rs` to keep that file under the file-size cap. Pure helpers
+//! returning styled spans for the sync + save state indicators.
+
+#![deny(clippy::unwrap_used)]
+
+use crate::tui::screens::prd::state::{PrdSaveStatus, PrdSyncStatus};
+use crate::tui::theme::Theme;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::Span;
+
+pub fn sync_chip(status: &PrdSyncStatus, theme: &Theme) -> Option<Span<'static>> {
+    match status {
+        PrdSyncStatus::Idle => None,
+        PrdSyncStatus::Syncing { started_at } => {
+            let elapsed = started_at.elapsed().as_secs();
+            Some(Span::styled(
+                format!("⟳ Syncing… ({elapsed}s)"),
+                Style::default()
+                    .fg(theme.accent_info)
+                    .add_modifier(Modifier::BOLD),
+            ))
+        }
+        PrdSyncStatus::SyncedAt(at) => {
+            let secs = at.elapsed().as_secs();
+            Some(Span::styled(
+                format!("✓ Synced {secs}s ago"),
+                Style::default().fg(theme.accent_success),
+            ))
+        }
+        PrdSyncStatus::Failed { at, message } => {
+            // Truncate long error messages so the header line stays readable.
+            let short = message.chars().take(60).collect::<String>();
+            let secs = at.elapsed().as_secs();
+            Some(Span::styled(
+                format!("⚠ Sync failed {secs}s ago: {short}"),
+                Style::default()
+                    .fg(theme.accent_error)
+                    .add_modifier(Modifier::BOLD),
+            ))
+        }
+    }
+}
+
+pub fn save_chip(save_status: &PrdSaveStatus, dirty: bool, theme: &Theme) -> Option<Span<'static>> {
+    if let Some(ref err) = save_status.last_error {
+        let short = err.chars().take(50).collect::<String>();
+        return Some(Span::styled(
+            format!("⚠ Save failed: {short}"),
+            Style::default().fg(theme.accent_error),
+        ));
+    }
+    if dirty {
+        return Some(Span::styled(
+            "● unsaved (press [s])".to_string(),
+            Style::default().fg(theme.accent_warning),
+        ));
+    }
+    if let Some(at) = save_status.last_saved {
+        let secs = at.elapsed().as_secs();
+        if secs <= 10 {
+            return Some(Span::styled(
+                format!("✓ Saved {secs}s ago"),
+                Style::default().fg(theme.accent_success),
+            ));
+        }
+    }
+    None
+}

--- a/src/tui/screens/prd/draw.rs
+++ b/src/tui/screens/prd/draw.rs
@@ -1,0 +1,389 @@
+//! PRD screen rendering (#321).
+
+#![deny(clippy::unwrap_used)]
+
+use crate::prd::model::{Prd, TimelineStatus};
+use crate::tui::screens::prd::chips::{save_chip, sync_chip};
+use crate::tui::screens::prd::state::{EditTarget, PrdScreen, PrdSection};
+use crate::tui::theme::Theme;
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, Wrap};
+
+const HINT_GOALS: &str = "(no goals yet — press [n] to add one)";
+const HINT_NON_GOALS: &str = "(no non-goals yet — press [n] to add one)";
+const HINT_VISION: &str =
+    "(no vision yet — synced from your PRD issue on GitHub, or press [y] to refresh)";
+const HINT_STAKEHOLDERS: &str = "(none yet — edit prd.toml to add stakeholders)";
+const HINT_TIMELINE: &str = "(no milestones yet — press [y] to sync from GitHub)";
+
+pub fn draw(f: &mut Frame, area: Rect, screen: &PrdScreen, prd: &Prd, theme: &Theme) {
+    let intro_height: u16 = if screen.first_view { 3 } else { 0 };
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(intro_height), // welcome banner (first view)
+            Constraint::Length(3),            // header (status + counts)
+            Constraint::Min(10),              // body
+            Constraint::Length(3),            // hints
+        ])
+        .split(area);
+
+    if screen.first_view {
+        draw_intro(f, chunks[0], theme);
+    }
+    draw_header(f, chunks[1], screen, prd, theme);
+    draw_body(f, chunks[2], screen, prd, theme);
+    draw_hints(f, chunks[3], screen, theme);
+}
+
+fn draw_intro(f: &mut Frame, area: Rect, theme: &Theme) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.accent_info))
+        .title(" 👋 Welcome to your PRD ");
+    let line = Line::from(Span::styled(
+        "Live document for your project. [Tab] cycles sections, [n] adds items, [y] syncs from GitHub, [s] saves, [Esc] exits.",
+        Style::default().fg(theme.text_secondary),
+    ));
+    f.render_widget(Paragraph::new(line).block(block), area);
+}
+
+fn draw_header(f: &mut Frame, area: Rect, screen: &PrdScreen, prd: &Prd, theme: &Theme) {
+    let dirty_marker = if screen.dirty { "*" } else { "" };
+    let title = format!(" PRD{} — focus: {} ", dirty_marker, screen.focus.label());
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.accent_identifier))
+        .title(title);
+
+    let mut spans = Vec::new();
+    spans.push(Span::styled(
+        format!(
+            "Vision: {} chars • Goals: {} • Non-Goals: {} • Stakeholders: {} • Timeline: {}   ",
+            prd.vision.len(),
+            prd.goals.len(),
+            prd.non_goals.len(),
+            prd.stakeholders.len(),
+            prd.timeline.len(),
+        ),
+        Style::default().fg(theme.text_secondary),
+    ));
+    if let Some(chip) = sync_chip(&screen.sync_status, theme) {
+        spans.push(chip);
+        spans.push(Span::raw("  "));
+    }
+    if let Some(chip) = save_chip(&screen.save_status, screen.dirty, theme) {
+        spans.push(chip);
+    }
+
+    f.render_widget(Paragraph::new(Line::from(spans)).block(block), area);
+}
+
+fn draw_body(f: &mut Frame, area: Rect, screen: &PrdScreen, prd: &Prd, theme: &Theme) {
+    let columns = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(35), Constraint::Percentage(65)])
+        .split(area);
+
+    draw_section_list(f, columns[0], screen, theme);
+    draw_focused_section(f, columns[1], screen, prd, theme);
+}
+
+fn draw_section_list(f: &mut Frame, area: Rect, screen: &PrdScreen, theme: &Theme) {
+    let items: Vec<ListItem> = PrdSection::ALL
+        .iter()
+        .map(|section| {
+            let selected = *section == screen.focus;
+            let style = if selected {
+                Style::default()
+                    .fg(theme.accent_success)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(theme.text_primary)
+            };
+            let prefix = if selected { "▶ " } else { "  " };
+            ListItem::new(Line::from(Span::styled(
+                format!("{prefix}{}", section.label()),
+                style,
+            )))
+        })
+        .collect();
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.text_secondary))
+        .title(" Sections ");
+    f.render_widget(List::new(items).block(block), area);
+}
+
+fn draw_focused_section(f: &mut Frame, area: Rect, screen: &PrdScreen, prd: &Prd, theme: &Theme) {
+    let body = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.accent_identifier))
+        .title(format!(" {} ", screen.focus.label()));
+
+    match screen.focus {
+        PrdSection::Vision => draw_vision(f, area, body, prd, theme),
+        PrdSection::Goals => draw_goals(f, area, body, screen, prd, theme),
+        PrdSection::NonGoals => draw_non_goals(f, area, body, screen, prd, theme),
+        PrdSection::CurrentState => draw_current_state(f, area, body, prd, theme),
+        PrdSection::Stakeholders => draw_stakeholders(f, area, body, prd, theme),
+        PrdSection::Timeline => draw_timeline(f, area, body, prd, theme),
+    }
+}
+
+fn draw_vision(f: &mut Frame, area: Rect, block: Block<'_>, prd: &Prd, theme: &Theme) {
+    let (text, color) = if prd.vision.trim().is_empty() {
+        (HINT_VISION.to_string(), theme.text_secondary)
+    } else {
+        (prd.vision.clone(), theme.text_primary)
+    };
+    f.render_widget(
+        Paragraph::new(text)
+            .style(Style::default().fg(color))
+            .wrap(Wrap { trim: true })
+            .block(block),
+        area,
+    );
+}
+
+fn draw_goals(
+    f: &mut Frame,
+    area: Rect,
+    block: Block<'_>,
+    screen: &PrdScreen,
+    prd: &Prd,
+    theme: &Theme,
+) {
+    if prd.goals.is_empty() && screen.edit.is_none() {
+        f.render_widget(
+            Paragraph::new(HINT_GOALS)
+                .style(Style::default().fg(theme.text_secondary))
+                .block(block),
+            area,
+        );
+        return;
+    }
+
+    let mut items: Vec<ListItem> = prd
+        .goals
+        .iter()
+        .enumerate()
+        .map(|(i, g)| {
+            let mark = if g.done { "[x]" } else { "[ ]" };
+            let prefix = if i == screen.goal_cursor {
+                "▶ "
+            } else {
+                "  "
+            };
+            let style = if i == screen.goal_cursor {
+                Style::default()
+                    .fg(theme.accent_success)
+                    .add_modifier(Modifier::BOLD)
+            } else if g.done {
+                Style::default().fg(theme.text_secondary)
+            } else {
+                Style::default().fg(theme.text_primary)
+            };
+            ListItem::new(Line::from(Span::styled(
+                format!("{prefix}{mark} {}", g.text),
+                style,
+            )))
+        })
+        .collect();
+
+    if let Some(EditTarget::NewGoal { buffer }) = &screen.edit {
+        items.push(ListItem::new(Line::from(Span::styled(
+            format!("  + {buffer}_"),
+            Style::default()
+                .fg(theme.accent_warning)
+                .add_modifier(Modifier::BOLD),
+        ))));
+    }
+
+    f.render_widget(List::new(items).block(block), area);
+}
+
+fn draw_non_goals(
+    f: &mut Frame,
+    area: Rect,
+    block: Block<'_>,
+    screen: &PrdScreen,
+    prd: &Prd,
+    theme: &Theme,
+) {
+    if prd.non_goals.is_empty() && screen.edit.is_none() {
+        f.render_widget(
+            Paragraph::new(HINT_NON_GOALS)
+                .style(Style::default().fg(theme.text_secondary))
+                .block(block),
+            area,
+        );
+        return;
+    }
+
+    let mut items: Vec<ListItem> = prd
+        .non_goals
+        .iter()
+        .enumerate()
+        .map(|(i, ng)| {
+            let prefix = if i == screen.non_goal_cursor {
+                "▶ "
+            } else {
+                "  "
+            };
+            let style = if i == screen.non_goal_cursor {
+                Style::default()
+                    .fg(theme.accent_success)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(theme.text_primary)
+            };
+            ListItem::new(Line::from(Span::styled(format!("{prefix}- {ng}"), style)))
+        })
+        .collect();
+
+    if let Some(EditTarget::NewNonGoal { buffer }) = &screen.edit {
+        items.push(ListItem::new(Line::from(Span::styled(
+            format!("  + {buffer}_"),
+            Style::default()
+                .fg(theme.accent_warning)
+                .add_modifier(Modifier::BOLD),
+        ))));
+    }
+
+    f.render_widget(List::new(items).block(block), area);
+}
+
+fn draw_current_state(f: &mut Frame, area: Rect, block: Block<'_>, prd: &Prd, theme: &Theme) {
+    let cs = &prd.current_state;
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::from(Span::styled(
+        format!(
+            "Issues: {} closed / {} total ({:.0}% complete)",
+            cs.closed_issues,
+            cs.total_issues(),
+            cs.completion_ratio() * 100.0
+        ),
+        Style::default().fg(theme.text_primary),
+    )));
+    lines.push(Line::from(Span::styled(
+        format!(
+            "Milestones: {} closed / {} open",
+            cs.closed_milestones, cs.open_milestones
+        ),
+        Style::default().fg(theme.text_primary),
+    )));
+    if !cs.top_blockers.is_empty() {
+        let blockers = cs
+            .top_blockers
+            .iter()
+            .map(|n| format!("#{n}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        lines.push(Line::from(Span::styled(
+            format!("Top blockers: {blockers}"),
+            Style::default().fg(theme.accent_warning),
+        )));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "Press [y] to refresh from GitHub",
+        Style::default().fg(theme.text_secondary),
+    )));
+    f.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+fn draw_stakeholders(f: &mut Frame, area: Rect, block: Block<'_>, prd: &Prd, theme: &Theme) {
+    if prd.stakeholders.is_empty() {
+        f.render_widget(
+            Paragraph::new(HINT_STAKEHOLDERS)
+                .style(Style::default().fg(theme.text_secondary))
+                .block(block),
+            area,
+        );
+        return;
+    }
+    let items: Vec<ListItem> = prd
+        .stakeholders
+        .iter()
+        .map(|s| {
+            ListItem::new(Line::from(Span::styled(
+                format!("• {} — {}", s.name, s.role),
+                Style::default().fg(theme.text_primary),
+            )))
+        })
+        .collect();
+    f.render_widget(List::new(items).block(block), area);
+}
+
+fn draw_timeline(f: &mut Frame, area: Rect, block: Block<'_>, prd: &Prd, theme: &Theme) {
+    if prd.timeline.is_empty() {
+        f.render_widget(
+            Paragraph::new(HINT_TIMELINE)
+                .style(Style::default().fg(theme.text_secondary))
+                .block(block),
+            area,
+        );
+        return;
+    }
+    let items: Vec<ListItem> = prd
+        .timeline
+        .iter()
+        .map(|tm| {
+            let target = tm
+                .target_date
+                .map(|d| d.format("%Y-%m-%d").to_string())
+                .unwrap_or_else(|| "unscheduled".into());
+            let status_label = match tm.status {
+                TimelineStatus::Planned => "planned",
+                TimelineStatus::InProgress => "in-progress",
+                TimelineStatus::Completed => "completed",
+                TimelineStatus::Cancelled => "cancelled",
+            };
+            let color = match tm.status {
+                TimelineStatus::Completed => theme.accent_success,
+                TimelineStatus::InProgress => theme.accent_info,
+                TimelineStatus::Cancelled => theme.text_secondary,
+                TimelineStatus::Planned => theme.text_primary,
+            };
+            ListItem::new(Line::from(Span::styled(
+                format!(
+                    "• {} ({target}, {status_label}) — {:.0}%",
+                    tm.name,
+                    tm.progress * 100.0
+                ),
+                Style::default().fg(color),
+            )))
+        })
+        .collect();
+    f.render_widget(List::new(items).block(block), area);
+}
+
+fn draw_hints(f: &mut Frame, area: Rect, screen: &PrdScreen, theme: &Theme) {
+    let hint = if screen.edit.is_some() {
+        "[Enter] save  [Esc] cancel  type to fill"
+    } else {
+        match screen.focus {
+            PrdSection::Goals => {
+                "[↑↓] move  [n] new goal  [Space] done  [d] delete  [Tab] next  [s] save  [e] export  [y] sync  [o] explore  [R] reset  [Esc] back"
+            }
+            PrdSection::NonGoals => {
+                "[↑↓] move  [n] new non-goal  [d] delete  [Tab] next  [s] save  [e] export  [y] sync  [o] explore  [R] reset  [Esc] back"
+            }
+            _ => "[Tab] next  [s] save  [e] export  [y] sync  [o] explore  [R] reset  [Esc] back",
+        }
+    };
+    f.render_widget(
+        Paragraph::new(hint)
+            .style(Style::default().fg(theme.text_secondary))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(theme.text_secondary)),
+            ),
+        area,
+    );
+}

--- a/src/tui/screens/prd/explore.rs
+++ b/src/tui/screens/prd/explore.rs
@@ -1,0 +1,294 @@
+//! Explore-PRD-sources panel (#321).
+//!
+//! When the user presses `[o]` on the PRD screen the right-hand pane
+//! flips from the focused section to a list of every PRD candidate
+//! discovered across GitHub + local + Azure. The user can pick one with
+//! arrow keys + Enter to re-ingest from that specific source.
+
+#![deny(clippy::unwrap_used)]
+#![allow(dead_code)]
+
+use crate::prd::discover::DiscoveredPrd;
+use crate::prd::ingest::{IngestedPrd, parse_markdown};
+use crate::tui::theme::Theme;
+use crate::util::formatting::truncate_at_char_boundary;
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, Wrap};
+
+const PREVIEW_RAW_LINES: usize = 12;
+const PREVIEW_LIST_MAX: usize = 8;
+const PREVIEW_ITEM_WIDTH: usize = 80;
+const PREVIEW_RAW_WIDTH: usize = 70;
+
+pub fn draw(
+    f: &mut Frame,
+    area: Rect,
+    candidates: &[DiscoveredPrd],
+    parsed_cache: &[IngestedPrd],
+    cursor: usize,
+    theme: &Theme,
+) {
+    if candidates.is_empty() {
+        draw_empty(f, area, theme);
+        return;
+    }
+    let columns = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+        .split(area);
+    draw_candidate_list(f, columns[0], candidates, parsed_cache, cursor, theme);
+    if let (Some(focused), Some(parsed)) = (candidates.get(cursor), parsed_cache.get(cursor)) {
+        draw_preview(f, columns[1], focused, parsed, theme);
+    }
+}
+
+fn draw_empty(f: &mut Frame, area: Rect, theme: &Theme) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.accent_info))
+        .title(" PRD Sources ");
+    let msg = Paragraph::new(
+        "No PRD candidates found. Tried: GitHub label `prd`, GitHub issue #1, local `docs/PRD.md`, Azure wiki `/PRD`, GitHub `PRD: in:title`.",
+    )
+    .style(Style::default().fg(theme.text_secondary))
+    .wrap(Wrap { trim: true })
+    .block(block);
+    f.render_widget(msg, area);
+}
+
+fn draw_candidate_list(
+    f: &mut Frame,
+    area: Rect,
+    candidates: &[DiscoveredPrd],
+    parsed_cache: &[IngestedPrd],
+    cursor: usize,
+    theme: &Theme,
+) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.accent_info))
+        .title(format!(" PRD Sources ({} found) ", candidates.len()));
+    let items: Vec<ListItem> = candidates
+        .iter()
+        .enumerate()
+        .map(|(i, c)| {
+            let parsed = parsed_cache
+                .get(i)
+                .cloned()
+                .unwrap_or_else(|| parse_markdown(&c.body));
+            candidate_row(i, c, &parsed, cursor, theme)
+        })
+        .collect();
+    f.render_widget(List::new(items).block(block), area);
+}
+
+fn candidate_row<'a>(
+    i: usize,
+    c: &'a DiscoveredPrd,
+    parsed: &IngestedPrd,
+    cursor: usize,
+    theme: &Theme,
+) -> ListItem<'a> {
+    let focused = i == cursor;
+    let prefix = if focused { "▶ " } else { "  " };
+    let stats = format!(
+        "v={} g={} ng={} s={}",
+        if parsed.vision.is_some() { "✓" } else { "·" },
+        parsed.goals.len(),
+        parsed.non_goals.len(),
+        parsed.stakeholders.len(),
+    );
+    let identifier = if c.number > 0 {
+        format!("#{} {}", c.number, c.title)
+    } else {
+        c.title.clone()
+    };
+    ListItem::new(vec![
+        Line::from(vec![
+            Span::styled(prefix, Style::default().fg(theme.text_primary)),
+            Span::styled(
+                format!("[{}]", c.source.label()),
+                Style::default().fg(theme.accent_info),
+            ),
+        ]),
+        Line::from(Span::styled(
+            format!("    {identifier}"),
+            Style::default()
+                .fg(if focused {
+                    theme.accent_success
+                } else {
+                    theme.text_primary
+                })
+                .add_modifier(if focused {
+                    Modifier::BOLD
+                } else {
+                    Modifier::empty()
+                }),
+        )),
+        Line::from(Span::styled(
+            format!("    {stats}"),
+            Style::default().fg(theme.text_secondary),
+        )),
+    ])
+}
+
+fn draw_preview(f: &mut Frame, area: Rect, c: &DiscoveredPrd, parsed: &IngestedPrd, theme: &Theme) {
+    let title = if c.number > 0 {
+        format!(" Preview: #{} ({}) ", c.number, c.source.label())
+    } else {
+        format!(" Preview: {} ({}) ", c.title, c.source.label())
+    };
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.accent_identifier))
+        .title(title);
+
+    let mut lines = build_preview_lines(c, parsed, theme);
+    let total_lines = c.body.lines().count();
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "── Raw body excerpt ──",
+        Style::default().fg(theme.text_secondary),
+    )));
+    for raw_line in c.body.lines().take(PREVIEW_RAW_LINES) {
+        lines.push(Line::from(Span::styled(
+            truncate_str(raw_line, PREVIEW_RAW_WIDTH).to_string(),
+            Style::default().fg(theme.text_secondary),
+        )));
+    }
+    if total_lines > PREVIEW_RAW_LINES {
+        lines.push(Line::from(Span::styled(
+            format!("… ({} more lines)", total_lines - PREVIEW_RAW_LINES),
+            Style::default().fg(theme.text_secondary),
+        )));
+    }
+
+    f.render_widget(
+        Paragraph::new(lines)
+            .wrap(Wrap { trim: false })
+            .block(block),
+        area,
+    );
+}
+
+fn build_preview_lines<'a>(
+    c: &'a DiscoveredPrd,
+    parsed: &'a IngestedPrd,
+    theme: &Theme,
+) -> Vec<Line<'a>> {
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::from(vec![
+        Span::styled("Title: ", Style::default().fg(theme.text_secondary)),
+        Span::styled(c.title.clone(), Style::default().fg(theme.text_primary)),
+    ]));
+    lines.push(Line::from(vec![
+        Span::styled("Source: ", Style::default().fg(theme.text_secondary)),
+        Span::styled(
+            c.source.label().to_string(),
+            Style::default().fg(theme.accent_info),
+        ),
+    ]));
+    if c.number > 0 {
+        lines.push(Line::from(vec![
+            Span::styled("Issue: ", Style::default().fg(theme.text_secondary)),
+            Span::styled(
+                format!("#{}", c.number),
+                Style::default().fg(theme.accent_identifier),
+            ),
+        ]));
+    }
+    lines.push(Line::from(""));
+    lines.push(section_header("Vision", theme));
+    lines.push(Line::from(Span::styled(
+        parsed
+            .vision
+            .clone()
+            .unwrap_or_else(|| "(none extracted)".into()),
+        Style::default().fg(theme.text_primary),
+    )));
+    lines.push(Line::from(""));
+    lines.push(section_header(
+        &format!("Goals ({})", parsed.goals.len()),
+        theme,
+    ));
+    if parsed.goals.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "(none extracted)",
+            Style::default().fg(theme.text_secondary),
+        )));
+    } else {
+        push_bullets(&mut lines, &parsed.goals, |g| g.clone(), theme);
+    }
+    lines.push(Line::from(""));
+    lines.push(section_header(
+        &format!("Non-Goals ({})", parsed.non_goals.len()),
+        theme,
+    ));
+    if parsed.non_goals.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "(none extracted)",
+            Style::default().fg(theme.text_secondary),
+        )));
+    } else {
+        push_bullets(&mut lines, &parsed.non_goals, |ng| ng.clone(), theme);
+    }
+    lines.push(Line::from(""));
+    lines.push(section_header(
+        &format!("Stakeholders ({})", parsed.stakeholders.len()),
+        theme,
+    ));
+    if parsed.stakeholders.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "(none extracted)",
+            Style::default().fg(theme.text_secondary),
+        )));
+    } else {
+        push_bullets(
+            &mut lines,
+            &parsed.stakeholders,
+            |(name, role)| format!("{name} — {role}"),
+            theme,
+        );
+    }
+    lines
+}
+
+/// Render up to PREVIEW_LIST_MAX bullet items + a `… N more` overflow
+/// line if the underlying slice is longer. Used by Goals / Non-Goals /
+/// Stakeholders so they all share the same truncation rule.
+fn push_bullets<'a, T, F>(lines: &mut Vec<Line<'a>>, items: &'a [T], fmt: F, theme: &Theme)
+where
+    F: Fn(&T) -> String,
+{
+    for it in items.iter().take(PREVIEW_LIST_MAX) {
+        let text = fmt(it);
+        let truncated = truncate_str(&text, PREVIEW_ITEM_WIDTH).to_string();
+        lines.push(Line::from(Span::styled(
+            format!("  • {truncated}"),
+            Style::default().fg(theme.text_primary),
+        )));
+    }
+    if items.len() > PREVIEW_LIST_MAX {
+        lines.push(Line::from(Span::styled(
+            format!("  … {} more", items.len() - PREVIEW_LIST_MAX),
+            Style::default().fg(theme.text_secondary),
+        )));
+    }
+}
+
+fn section_header(name: &str, theme: &Theme) -> Line<'static> {
+    Line::from(Span::styled(
+        format!("── {name} ──"),
+        Style::default()
+            .fg(theme.accent_identifier)
+            .add_modifier(Modifier::BOLD),
+    ))
+}
+
+fn truncate_str(s: &str, max: usize) -> &str {
+    let end = truncate_at_char_boundary(s, max);
+    &s[..end]
+}

--- a/src/tui/screens/prd/input.rs
+++ b/src/tui/screens/prd/input.rs
@@ -1,0 +1,276 @@
+//! PRD screen input handler (#321).
+
+#![deny(clippy::unwrap_used)]
+
+use crate::prd::model::Prd;
+use crate::tui::screens::prd::state::{EditTarget, PrdAction, PrdScreen, PrdSection};
+use crossterm::event::{KeyCode, KeyEvent};
+
+pub fn handle_key(screen: &mut PrdScreen, prd: &mut Prd, key: KeyEvent) -> PrdAction {
+    // First user interaction dismisses the welcome banner so it stops
+    // taking screen real-estate after they've gotten oriented.
+    screen.first_view = false;
+    if let Some(edit) = screen.edit.as_ref() {
+        let mode = screen_edit_target(edit);
+        return handle_edit_key(mode, key, screen, prd);
+    }
+    handle_view_key(key, screen, prd)
+}
+
+fn screen_edit_target(target: &EditTarget) -> EditMode {
+    match target {
+        EditTarget::NewGoal { .. } => EditMode::NewGoal,
+        EditTarget::NewNonGoal { .. } => EditMode::NewNonGoal,
+    }
+}
+
+#[derive(Copy, Clone)]
+enum EditMode {
+    NewGoal,
+    NewNonGoal,
+}
+
+fn handle_edit_key(
+    mode: EditMode,
+    key: KeyEvent,
+    screen: &mut PrdScreen,
+    prd: &mut Prd,
+) -> PrdAction {
+    match key.code {
+        KeyCode::Esc => {
+            screen.edit = None;
+            PrdAction::None
+        }
+        KeyCode::Enter => {
+            let committed = match mode {
+                EditMode::NewGoal => screen.commit_new_goal(prd),
+                EditMode::NewNonGoal => screen.commit_new_non_goal(prd),
+            };
+            if committed {
+                PrdAction::Save
+            } else {
+                PrdAction::None
+            }
+        }
+        KeyCode::Backspace => {
+            if let Some(target) = screen.edit.as_mut() {
+                let buf = match target {
+                    EditTarget::NewGoal { buffer } => buffer,
+                    EditTarget::NewNonGoal { buffer } => buffer,
+                };
+                buf.pop();
+            }
+            PrdAction::None
+        }
+        KeyCode::Char(c) => {
+            if let Some(target) = screen.edit.as_mut() {
+                let buf = match target {
+                    EditTarget::NewGoal { buffer } => buffer,
+                    EditTarget::NewNonGoal { buffer } => buffer,
+                };
+                buf.push(c);
+            }
+            PrdAction::None
+        }
+        _ => PrdAction::None,
+    }
+}
+
+fn handle_view_key(key: KeyEvent, screen: &mut PrdScreen, prd: &mut Prd) -> PrdAction {
+    match key.code {
+        KeyCode::Esc | KeyCode::Char('q') => PrdAction::Back,
+        KeyCode::Tab | KeyCode::Char('l') => {
+            screen.focus_next();
+            PrdAction::None
+        }
+        KeyCode::BackTab | KeyCode::Char('h') => {
+            screen.focus_prev();
+            PrdAction::None
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            screen.cursor_down_in_focus(prd);
+            PrdAction::None
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            screen.cursor_up_in_focus();
+            PrdAction::None
+        }
+        KeyCode::Char('s') => PrdAction::Save,
+        KeyCode::Char('e') => PrdAction::Export,
+        KeyCode::Char('y') => PrdAction::Sync,
+        KeyCode::Char('n') => {
+            screen.edit = Some(match screen.focus {
+                PrdSection::Goals => EditTarget::NewGoal {
+                    buffer: String::new(),
+                },
+                PrdSection::NonGoals => EditTarget::NewNonGoal {
+                    buffer: String::new(),
+                },
+                _ => return PrdAction::None,
+            });
+            PrdAction::None
+        }
+        KeyCode::Char(' ') if matches!(screen.focus, PrdSection::Goals) => {
+            if screen.toggle_goal_done(prd) {
+                PrdAction::Save
+            } else {
+                PrdAction::None
+            }
+        }
+        KeyCode::Char('d') => {
+            let removed = match screen.focus {
+                PrdSection::Goals => screen.delete_focused_goal(prd),
+                PrdSection::NonGoals => screen.delete_focused_non_goal(prd),
+                _ => false,
+            };
+            if removed {
+                PrdAction::Save
+            } else {
+                PrdAction::None
+            }
+        }
+        _ => PrdAction::None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::KeyModifiers;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn esc_in_view_mode_returns_back() {
+        let mut s = PrdScreen::new();
+        let mut p = Prd::new();
+        assert_eq!(
+            handle_key(&mut s, &mut p, key(KeyCode::Esc)),
+            PrdAction::Back
+        );
+    }
+
+    #[test]
+    fn s_returns_save() {
+        let mut s = PrdScreen::new();
+        let mut p = Prd::new();
+        assert_eq!(
+            handle_key(&mut s, &mut p, key(KeyCode::Char('s'))),
+            PrdAction::Save
+        );
+    }
+
+    #[test]
+    fn e_returns_export() {
+        let mut s = PrdScreen::new();
+        let mut p = Prd::new();
+        assert_eq!(
+            handle_key(&mut s, &mut p, key(KeyCode::Char('e'))),
+            PrdAction::Export
+        );
+    }
+
+    #[test]
+    fn tab_advances_focus_and_returns_none() {
+        let mut s = PrdScreen::new();
+        let mut p = Prd::new();
+        let action = handle_key(&mut s, &mut p, key(KeyCode::Tab));
+        assert_eq!(action, PrdAction::None);
+        assert_eq!(s.focus, PrdSection::Goals);
+    }
+
+    #[test]
+    fn n_in_goals_opens_edit_buffer_for_new_goal() {
+        let mut s = PrdScreen::new();
+        s.focus = PrdSection::Goals;
+        let mut p = Prd::new();
+        handle_key(&mut s, &mut p, key(KeyCode::Char('n')));
+        assert!(matches!(s.edit, Some(EditTarget::NewGoal { .. })));
+    }
+
+    #[test]
+    fn typing_in_edit_mode_appends_to_buffer() {
+        let mut s = PrdScreen::new();
+        s.focus = PrdSection::Goals;
+        let mut p = Prd::new();
+        handle_key(&mut s, &mut p, key(KeyCode::Char('n')));
+        handle_key(&mut s, &mut p, key(KeyCode::Char('h')));
+        handle_key(&mut s, &mut p, key(KeyCode::Char('i')));
+        if let Some(EditTarget::NewGoal { buffer }) = &s.edit {
+            assert_eq!(buffer, "hi");
+        } else {
+            panic!("expected NewGoal edit target");
+        }
+    }
+
+    #[test]
+    fn enter_in_edit_mode_commits_and_saves() {
+        let mut s = PrdScreen::new();
+        s.focus = PrdSection::Goals;
+        let mut p = Prd::new();
+        handle_key(&mut s, &mut p, key(KeyCode::Char('n')));
+        for c in "ship".chars() {
+            handle_key(&mut s, &mut p, key(KeyCode::Char(c)));
+        }
+        let action = handle_key(&mut s, &mut p, key(KeyCode::Enter));
+        assert_eq!(action, PrdAction::Save);
+        assert_eq!(p.goals.len(), 1);
+        assert_eq!(p.goals[0].text, "ship");
+        assert!(s.edit.is_none());
+    }
+
+    #[test]
+    fn esc_in_edit_mode_cancels_without_save() {
+        let mut s = PrdScreen::new();
+        s.focus = PrdSection::Goals;
+        let mut p = Prd::new();
+        handle_key(&mut s, &mut p, key(KeyCode::Char('n')));
+        handle_key(&mut s, &mut p, key(KeyCode::Char('x')));
+        let action = handle_key(&mut s, &mut p, key(KeyCode::Esc));
+        assert_eq!(action, PrdAction::None);
+        assert!(s.edit.is_none());
+        assert!(p.goals.is_empty());
+    }
+
+    #[test]
+    fn backspace_in_edit_mode_pops_buffer() {
+        let mut s = PrdScreen::new();
+        s.focus = PrdSection::Goals;
+        let mut p = Prd::new();
+        handle_key(&mut s, &mut p, key(KeyCode::Char('n')));
+        handle_key(&mut s, &mut p, key(KeyCode::Char('a')));
+        handle_key(&mut s, &mut p, key(KeyCode::Char('b')));
+        handle_key(&mut s, &mut p, key(KeyCode::Backspace));
+        if let Some(EditTarget::NewGoal { buffer }) = &s.edit {
+            assert_eq!(buffer, "a");
+        } else {
+            panic!("expected edit target");
+        }
+    }
+
+    #[test]
+    fn space_in_goals_toggles_done() {
+        let mut s = PrdScreen::new();
+        s.focus = PrdSection::Goals;
+        let mut p = Prd::new();
+        p.add_goal("first");
+        let action = handle_key(&mut s, &mut p, key(KeyCode::Char(' ')));
+        assert_eq!(action, PrdAction::Save);
+        assert!(p.goals[0].done);
+    }
+
+    #[test]
+    fn d_in_goals_deletes_focused() {
+        let mut s = PrdScreen::new();
+        s.focus = PrdSection::Goals;
+        let mut p = Prd::new();
+        p.add_goal("a");
+        p.add_goal("b");
+        let action = handle_key(&mut s, &mut p, key(KeyCode::Char('d')));
+        assert_eq!(action, PrdAction::Save);
+        assert_eq!(p.goals.len(), 1);
+        assert_eq!(p.goals[0].text, "b");
+    }
+}

--- a/src/tui/screens/prd/mod.rs
+++ b/src/tui/screens/prd/mod.rs
@@ -1,0 +1,16 @@
+//! Interactive PRD screen (#321) — full implementation in this module.
+//!
+//! Sections rendered: Vision, Goals, Non-Goals, Current State,
+//! Stakeholders, Timeline. Goals and Non-Goals are editable in-screen.
+//! Current State is auto-populated from GitHub via `prd::sync`.
+
+#![deny(clippy::unwrap_used)]
+
+pub mod chips;
+pub mod draw;
+pub mod explore;
+pub mod input;
+pub mod state;
+
+#[allow(unused_imports)]
+pub use state::{EditTarget, PrdAction, PrdSaveStatus, PrdScreen, PrdSection, PrdSyncStatus};

--- a/src/tui/screens/prd/state.rs
+++ b/src/tui/screens/prd/state.rs
@@ -209,15 +209,15 @@ impl PrdScreen {
 
     pub fn cursor_down_in_focus(&mut self, prd: &Prd) {
         match self.focus {
-            PrdSection::Goals => {
-                if !prd.goals.is_empty() && self.goal_cursor < prd.goals.len() - 1 {
-                    self.goal_cursor += 1;
-                }
+            PrdSection::Goals
+                if !prd.goals.is_empty() && self.goal_cursor < prd.goals.len() - 1 =>
+            {
+                self.goal_cursor += 1;
             }
-            PrdSection::NonGoals => {
-                if !prd.non_goals.is_empty() && self.non_goal_cursor < prd.non_goals.len() - 1 {
-                    self.non_goal_cursor += 1;
-                }
+            PrdSection::NonGoals
+                if !prd.non_goals.is_empty() && self.non_goal_cursor < prd.non_goals.len() - 1 =>
+            {
+                self.non_goal_cursor += 1;
             }
             _ => {}
         }

--- a/src/tui/screens/prd/state.rs
+++ b/src/tui/screens/prd/state.rs
@@ -1,0 +1,326 @@
+//! PRD screen state machine (#321).
+
+#![deny(clippy::unwrap_used)]
+
+use crate::prd::model::{Goal, Prd};
+use std::time::Instant;
+
+/// Async-feedback status shown prominently in the PRD header so the user
+/// always knows what's happening without watching the activity log.
+#[derive(Debug, Clone, Default)]
+pub enum PrdSyncStatus {
+    #[default]
+    Idle,
+    Syncing {
+        started_at: Instant,
+    },
+    SyncedAt(Instant),
+    Failed {
+        at: Instant,
+        message: String,
+    },
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PrdSaveStatus {
+    pub last_saved: Option<Instant>,
+    pub last_error: Option<String>,
+}
+
+/// Which top-level section the cursor is on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrdSection {
+    Vision,
+    Goals,
+    NonGoals,
+    CurrentState,
+    Stakeholders,
+    Timeline,
+}
+
+impl PrdSection {
+    pub const ALL: [Self; 6] = [
+        Self::Vision,
+        Self::Goals,
+        Self::NonGoals,
+        Self::CurrentState,
+        Self::Stakeholders,
+        Self::Timeline,
+    ];
+
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Vision => "Vision & Purpose",
+            Self::Goals => "Goals",
+            Self::NonGoals => "Non-Goals",
+            Self::CurrentState => "Current State",
+            Self::Stakeholders => "Stakeholders",
+            Self::Timeline => "Timeline",
+        }
+    }
+
+    pub fn next(self) -> Self {
+        let idx = Self::ALL.iter().position(|s| *s == self).unwrap_or(0);
+        Self::ALL[(idx + 1) % Self::ALL.len()]
+    }
+
+    pub fn prev(self) -> Self {
+        let idx = Self::ALL.iter().position(|s| *s == self).unwrap_or(0);
+        Self::ALL[(idx + Self::ALL.len() - 1) % Self::ALL.len()]
+    }
+}
+
+/// Currently-edited target. `None` means view-mode.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EditTarget {
+    NewGoal { buffer: String },
+    NewNonGoal { buffer: String },
+}
+
+/// Action returned by `input::handle_key` for the App to enact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrdAction {
+    None,
+    /// Persist current PRD to disk.
+    Save,
+    /// Sync `current_state` from GitHub.
+    Sync,
+    /// Export markdown to stdout via the activity log.
+    Export,
+    /// Pop back to previous screen.
+    Back,
+}
+
+pub struct PrdScreen {
+    pub focus: PrdSection,
+    pub edit: Option<EditTarget>,
+    pub goal_cursor: usize,
+    pub non_goal_cursor: usize,
+    pub dirty: bool,
+    /// Sync-from-GitHub progress chip rendered in the header.
+    pub sync_status: PrdSyncStatus,
+    /// "Saved Xs ago" / save-failed indicator.
+    pub save_status: PrdSaveStatus,
+    /// Whether the screen is being viewed for the first time this session
+    /// (used to render a one-line "what is this" intro).
+    pub first_view: bool,
+}
+
+impl Default for PrdScreen {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PrdScreen {
+    pub fn new() -> Self {
+        Self {
+            focus: PrdSection::Vision,
+            edit: None,
+            goal_cursor: 0,
+            non_goal_cursor: 0,
+            dirty: false,
+            sync_status: PrdSyncStatus::Idle,
+            save_status: PrdSaveStatus::default(),
+            first_view: true,
+        }
+    }
+
+    pub fn focus_next(&mut self) {
+        self.focus = self.focus.next();
+        self.clamp_cursors_for_focus();
+    }
+
+    pub fn focus_prev(&mut self) {
+        self.focus = self.focus.prev();
+        self.clamp_cursors_for_focus();
+    }
+
+    fn clamp_cursors_for_focus(&mut self) {
+        // Cursor reset when switching sections — keeps focus visible.
+        if matches!(self.focus, PrdSection::Goals) {
+            self.goal_cursor = 0;
+        }
+        if matches!(self.focus, PrdSection::NonGoals) {
+            self.non_goal_cursor = 0;
+        }
+    }
+
+    /// Add a new goal from the edit buffer; returns true on success.
+    pub fn commit_new_goal(&mut self, prd: &mut Prd) -> bool {
+        let Some(EditTarget::NewGoal { buffer }) = self.edit.take() else {
+            return false;
+        };
+        let trimmed = buffer.trim();
+        if trimmed.is_empty() {
+            return false;
+        }
+        prd.goals.push(Goal::new(trimmed));
+        self.dirty = true;
+        true
+    }
+
+    /// Add a new non-goal from the edit buffer; returns true on success.
+    pub fn commit_new_non_goal(&mut self, prd: &mut Prd) -> bool {
+        let Some(EditTarget::NewNonGoal { buffer }) = self.edit.take() else {
+            return false;
+        };
+        let trimmed = buffer.trim();
+        if trimmed.is_empty() {
+            return false;
+        }
+        prd.non_goals.push(trimmed.to_string());
+        self.dirty = true;
+        true
+    }
+
+    pub fn toggle_goal_done(&mut self, prd: &mut Prd) -> bool {
+        let Some(g) = prd.goals.get_mut(self.goal_cursor) else {
+            return false;
+        };
+        g.done = !g.done;
+        self.dirty = true;
+        true
+    }
+
+    pub fn delete_focused_goal(&mut self, prd: &mut Prd) -> bool {
+        if self.goal_cursor >= prd.goals.len() {
+            return false;
+        }
+        prd.goals.remove(self.goal_cursor);
+        if self.goal_cursor > 0 && self.goal_cursor >= prd.goals.len() {
+            self.goal_cursor -= 1;
+        }
+        self.dirty = true;
+        true
+    }
+
+    pub fn delete_focused_non_goal(&mut self, prd: &mut Prd) -> bool {
+        if self.non_goal_cursor >= prd.non_goals.len() {
+            return false;
+        }
+        prd.non_goals.remove(self.non_goal_cursor);
+        if self.non_goal_cursor > 0 && self.non_goal_cursor >= prd.non_goals.len() {
+            self.non_goal_cursor -= 1;
+        }
+        self.dirty = true;
+        true
+    }
+
+    pub fn cursor_down_in_focus(&mut self, prd: &Prd) {
+        match self.focus {
+            PrdSection::Goals => {
+                if !prd.goals.is_empty() && self.goal_cursor < prd.goals.len() - 1 {
+                    self.goal_cursor += 1;
+                }
+            }
+            PrdSection::NonGoals => {
+                if !prd.non_goals.is_empty() && self.non_goal_cursor < prd.non_goals.len() - 1 {
+                    self.non_goal_cursor += 1;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    pub fn cursor_up_in_focus(&mut self) {
+        match self.focus {
+            PrdSection::Goals => self.goal_cursor = self.goal_cursor.saturating_sub(1),
+            PrdSection::NonGoals => self.non_goal_cursor = self.non_goal_cursor.saturating_sub(1),
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fresh() -> (PrdScreen, Prd) {
+        (PrdScreen::new(), Prd::new())
+    }
+
+    #[test]
+    fn focus_next_cycles_through_all_sections_and_wraps() {
+        let mut s = PrdScreen::new();
+        for expected in PrdSection::ALL
+            .iter()
+            .skip(1)
+            .chain(std::iter::once(&PrdSection::Vision))
+        {
+            s.focus_next();
+            assert_eq!(s.focus, *expected);
+        }
+    }
+
+    #[test]
+    fn commit_new_goal_appends_and_marks_dirty() {
+        let (mut s, mut p) = fresh();
+        s.edit = Some(EditTarget::NewGoal {
+            buffer: "Ship v1".into(),
+        });
+        assert!(s.commit_new_goal(&mut p));
+        assert_eq!(p.goals.len(), 1);
+        assert_eq!(p.goals[0].text, "Ship v1");
+        assert!(s.dirty);
+        assert!(s.edit.is_none());
+    }
+
+    #[test]
+    fn commit_new_goal_with_empty_buffer_no_ops() {
+        let (mut s, mut p) = fresh();
+        s.edit = Some(EditTarget::NewGoal {
+            buffer: "   ".into(),
+        });
+        assert!(!s.commit_new_goal(&mut p));
+        assert!(p.goals.is_empty());
+        assert!(!s.dirty);
+    }
+
+    #[test]
+    fn commit_new_non_goal_appends_and_marks_dirty() {
+        let (mut s, mut p) = fresh();
+        s.edit = Some(EditTarget::NewNonGoal {
+            buffer: "Multi-tenant".into(),
+        });
+        assert!(s.commit_new_non_goal(&mut p));
+        assert_eq!(p.non_goals, vec!["Multi-tenant"]);
+        assert!(s.dirty);
+    }
+
+    #[test]
+    fn toggle_goal_done_flips_state() {
+        let (mut s, mut p) = fresh();
+        p.add_goal("First");
+        assert!(!p.goals[0].done);
+        assert!(s.toggle_goal_done(&mut p));
+        assert!(p.goals[0].done);
+        assert!(s.toggle_goal_done(&mut p));
+        assert!(!p.goals[0].done);
+        assert!(s.dirty);
+    }
+
+    #[test]
+    fn delete_focused_goal_removes_and_clamps_cursor() {
+        let (mut s, mut p) = fresh();
+        p.add_goal("a");
+        p.add_goal("b");
+        p.add_goal("c");
+        s.goal_cursor = 2;
+        assert!(s.delete_focused_goal(&mut p));
+        assert_eq!(p.goals.len(), 2);
+        assert_eq!(s.goal_cursor, 1);
+    }
+
+    #[test]
+    fn cursor_down_in_goals_stops_at_last() {
+        let (mut s, mut p) = fresh();
+        p.add_goal("a");
+        p.add_goal("b");
+        s.focus = PrdSection::Goals;
+        s.cursor_down_in_focus(&p);
+        s.cursor_down_in_focus(&p);
+        s.cursor_down_in_focus(&p);
+        assert_eq!(s.goal_cursor, 1);
+    }
+}

--- a/src/tui/screens/prd_dispatch.rs
+++ b/src/tui/screens/prd_dispatch.rs
@@ -62,10 +62,10 @@ fn handle_explore_key(app: &mut App, code: crossterm::event::KeyCode) -> ScreenA
         KeyCode::Esc | KeyCode::Char('o') | KeyCode::Char('q') => {
             app.prd_show_explore = false;
         }
-        KeyCode::Down | KeyCode::Char('j') => {
-            if app.prd_explore_cursor + 1 < app.prd_candidates.len() {
-                app.prd_explore_cursor += 1;
-            }
+        KeyCode::Down | KeyCode::Char('j')
+            if app.prd_explore_cursor + 1 < app.prd_candidates.len() =>
+        {
+            app.prd_explore_cursor += 1;
         }
         KeyCode::Up | KeyCode::Char('k') => {
             app.prd_explore_cursor = app.prd_explore_cursor.saturating_sub(1);

--- a/src/tui/screens/prd_dispatch.rs
+++ b/src/tui/screens/prd_dispatch.rs
@@ -1,0 +1,270 @@
+//! Dispatch shim for the PRD screen (#321).
+//!
+//! The PRD screen needs simultaneous mutable access to the screen state
+//! (cursor/edit buffer) and the App-owned `Prd` document. Bridging that
+//! through the `Screen` trait would require restructuring; instead this
+//! module wires the screen directly into App state and translates the
+//! returned `PrdAction` into the existing `ScreenAction` vocabulary.
+
+#![deny(clippy::unwrap_used)]
+
+use crate::prd::export::to_markdown;
+use crate::prd::model::Prd;
+use crate::prd::store::{FilePrdStore, PrdStore};
+use crate::tui::activity_log::LogLevel;
+use crate::tui::app::App;
+use crate::tui::screens::ScreenAction;
+use crate::tui::screens::prd::{PrdAction, PrdScreen, PrdSyncStatus};
+use crossterm::event::Event;
+use std::time::Instant;
+
+pub fn dispatch_input(app: &mut App, event: &Event) -> ScreenAction {
+    let Event::Key(key) = event else {
+        return ScreenAction::None;
+    };
+
+    // Lazily seed in-memory PRD if missing — load from disk if present.
+    ensure_loaded(app);
+
+    // Explore panel intercepts keys when open.
+    if app.prd_show_explore {
+        return handle_explore_key(app, key.code);
+    }
+
+    // Top-level keys that aren't part of the focused-section editor.
+    match key.code {
+        crossterm::event::KeyCode::Char('o') => {
+            app.prd_show_explore = true;
+            app.prd_explore_cursor = 0;
+            return ScreenAction::None;
+        }
+        crossterm::event::KeyCode::Char('R') => {
+            reset_prd(app);
+            return ScreenAction::None;
+        }
+        _ => {}
+    }
+
+    let Some(prd) = app.prd.as_mut() else {
+        return ScreenAction::None;
+    };
+    let Some(screen) = app.prd_screen.as_mut() else {
+        return ScreenAction::None;
+    };
+
+    let action = crate::tui::screens::prd::input::handle_key(screen, prd, *key);
+    drop_guard(action, app)
+}
+
+fn handle_explore_key(app: &mut App, code: crossterm::event::KeyCode) -> ScreenAction {
+    use crossterm::event::KeyCode;
+    match code {
+        KeyCode::Esc | KeyCode::Char('o') | KeyCode::Char('q') => {
+            app.prd_show_explore = false;
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            if app.prd_explore_cursor + 1 < app.prd_candidates.len() {
+                app.prd_explore_cursor += 1;
+            }
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            app.prd_explore_cursor = app.prd_explore_cursor.saturating_sub(1);
+        }
+        KeyCode::Enter => {
+            ingest_chosen_candidate(app);
+            app.prd_show_explore = false;
+        }
+        _ => {}
+    }
+    ScreenAction::None
+}
+
+fn ingest_chosen_candidate(app: &mut App) {
+    let Some(candidate) = app.prd_candidates.get(app.prd_explore_cursor).cloned() else {
+        return;
+    };
+    let parsed = crate::prd::ingest::parse_markdown(&candidate.body);
+    if parsed.is_empty() {
+        app.activity_log.push_simple(
+            "PRD".into(),
+            format!(
+                "Selected source [{}] had no parseable PRD content",
+                candidate.source.label()
+            ),
+            LogLevel::Warn,
+        );
+        return;
+    }
+    let Some(prd) = app.prd.as_mut() else {
+        return;
+    };
+    let report = prd.merge_ingested(&parsed);
+    if let Some(s) = app.prd_screen.as_mut() {
+        s.dirty = true;
+    }
+    let identifier = if candidate.number > 0 {
+        format!("#{}", candidate.number)
+    } else {
+        candidate.title.clone()
+    };
+    let summary = crate::tui::app::data_handler::format_merge_summary(
+        &report,
+        &identifier,
+        candidate.source.label(),
+    )
+    .unwrap_or_else(|| {
+        format!(
+            "no new content from [{}] {identifier}",
+            candidate.source.label()
+        )
+    });
+    app.activity_log
+        .push_simple("PRD".into(), summary, LogLevel::Info);
+    save_prd(app);
+}
+
+/// Wipe the local PRD and re-sync from sources. Triggered by `[R]`.
+fn reset_prd(app: &mut App) {
+    let store = FilePrdStore::new(repo_root());
+    let _ = std::fs::remove_file(store.prd_path());
+    app.prd = Some(Prd::new());
+    if let Some(s) = app.prd_screen.as_mut() {
+        s.dirty = false;
+        s.sync_status = crate::tui::screens::prd::PrdSyncStatus::Idle;
+        s.save_status = crate::tui::screens::prd::PrdSaveStatus::default();
+    }
+    app.activity_log.push_simple(
+        "PRD".into(),
+        "PRD reset — re-discovering sources from GitHub + local + Azure…".into(),
+        LogLevel::Warn,
+    );
+    queue_sync(app);
+}
+
+/// Translate `PrdAction` → `ScreenAction` while performing side effects on
+/// App state (save/sync/export). Pulled out so the dispatcher above stays
+/// focused on borrow scoping.
+fn drop_guard(action: PrdAction, app: &mut App) -> ScreenAction {
+    match action {
+        PrdAction::None => ScreenAction::None,
+        PrdAction::Back => ScreenAction::Pop,
+        PrdAction::Save => {
+            save_prd(app);
+            ScreenAction::None
+        }
+        PrdAction::Export => {
+            export_prd(app);
+            ScreenAction::None
+        }
+        PrdAction::Sync => {
+            queue_sync(app);
+            ScreenAction::None
+        }
+    }
+}
+
+pub fn ensure_loaded(app: &mut App) {
+    if app.prd.is_some() && app.prd_screen.is_some() {
+        return;
+    }
+    let store = FilePrdStore::new(repo_root());
+    let (prd, was_seeded) = match store.load() {
+        Ok(Some(p)) => (p, false),
+        Ok(None) => (Prd::new(), true),
+        Err(e) => {
+            app.activity_log.push_simple(
+                "PRD".into(),
+                format!("Failed to load PRD: {e}"),
+                LogLevel::Warn,
+            );
+            (Prd::new(), true)
+        }
+    };
+    app.prd.get_or_insert(prd);
+    app.prd_screen.get_or_insert_with(PrdScreen::new);
+    // First-load on a fresh PRD: auto-sync from GitHub so Current State +
+    // Timeline are populated immediately rather than blank. The user can
+    // still press [y] to refresh later.
+    if was_seeded {
+        app.activity_log.push_simple(
+            "PRD".into(),
+            "First PRD load — fetching milestones + issues from GitHub…".into(),
+            LogLevel::Info,
+        );
+        app.pending_commands
+            .push(crate::tui::app::TuiCommand::SyncPrd);
+    }
+}
+
+fn save_prd(app: &mut App) {
+    let Some(prd) = app.prd.as_ref() else {
+        return;
+    };
+    let store = FilePrdStore::new(repo_root());
+    match store.save(prd) {
+        Ok(()) => {
+            if let Some(s) = app.prd_screen.as_mut() {
+                s.dirty = false;
+                s.save_status.last_saved = Some(Instant::now());
+                s.save_status.last_error = None;
+            }
+            app.activity_log.push_simple(
+                "PRD".into(),
+                format!("PRD saved to {}", store.prd_path().display()),
+                LogLevel::Info,
+            );
+        }
+        Err(e) => {
+            if let Some(s) = app.prd_screen.as_mut() {
+                s.save_status.last_error = Some(e.to_string());
+            }
+            app.activity_log.push_simple(
+                "PRD".into(),
+                format!("PRD save failed: {e}"),
+                LogLevel::Error,
+            );
+        }
+    }
+}
+
+fn export_prd(app: &mut App) {
+    let Some(prd) = app.prd.as_ref() else {
+        return;
+    };
+    let path = repo_root().join("PRD.md");
+    let body = to_markdown(prd);
+    match std::fs::write(&path, body) {
+        Ok(()) => app.activity_log.push_simple(
+            "PRD".into(),
+            format!("Exported PRD to {}", path.display()),
+            LogLevel::Info,
+        ),
+        Err(e) => app.activity_log.push_simple(
+            "PRD".into(),
+            format!("Export failed: {e}"),
+            LogLevel::Error,
+        ),
+    }
+}
+
+fn queue_sync(app: &mut App) {
+    // Mark the screen state so the header chip flips to "⟳ Syncing…" on
+    // the next render — without this the user has no immediate feedback
+    // that their keypress did anything.
+    if let Some(s) = app.prd_screen.as_mut() {
+        s.sync_status = PrdSyncStatus::Syncing {
+            started_at: Instant::now(),
+        };
+    }
+    app.activity_log.push_simple(
+        "PRD".into(),
+        "Fetching milestones + issues from GitHub…".into(),
+        LogLevel::Info,
+    );
+    app.pending_commands
+        .push(crate::tui::app::TuiCommand::SyncPrd);
+}
+
+fn repo_root() -> std::path::PathBuf {
+    std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."))
+}

--- a/src/tui/screens/roadmap/dep_levels.rs
+++ b/src/tui/screens/roadmap/dep_levels.rs
@@ -1,0 +1,200 @@
+//! Topological sort of issues into dependency levels (#329).
+//!
+//! Pure function over `(node, blockers)` pairs. Used by both the roadmap
+//! screen and the existing `milestone::update_milestone_dependency_graph`
+//! call (which is currently dead code; the wiring into the milestone
+//! screen is a one-liner in a follow-up commit).
+//!
+//! Why "levels" instead of a flat sort:
+//!   - Level 0 = nodes with no blockers (can start now).
+//!   - Level 1 = nodes whose blockers are all in Level 0.
+//!   - …
+//!
+//! Within a level the order is stable (input order preserved), so the UI
+//! can render `Level N (parallel)` blocks deterministically.
+
+#![deny(clippy::unwrap_used)]
+// Reason: Phase 1 foundation for #329. `dep_levels` is consumed by the
+// roadmap loader and the dormant `milestone::update_milestone_dependency_graph`
+// in Phase 2; tests cover topo-sort + cycle detection today.
+#![allow(dead_code)]
+
+use std::collections::{HashMap, HashSet};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum DepLevelError {
+    /// A cycle exists; the cycle members are returned (no specific order).
+    Cycle { members: Vec<u64> },
+    /// A node references a blocker that doesn't exist in the input set.
+    /// The node and the unknown blocker number are returned.
+    UnknownBlocker { node: u64, blocker: u64 },
+}
+
+impl std::fmt::Display for DepLevelError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Cycle { members } => {
+                write!(f, "dependency cycle among nodes: {members:?}")
+            }
+            Self::UnknownBlocker { node, blocker } => {
+                write!(f, "node #{node} references unknown blocker #{blocker}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for DepLevelError {}
+
+/// Compute dependency levels.
+///
+/// `inputs[i].0` is the node identifier; `inputs[i].1` is its list of
+/// blocker identifiers. Returns one `Vec<u64>` per level, in level order.
+pub fn dep_levels(inputs: &[(u64, Vec<u64>)]) -> Result<Vec<Vec<u64>>, DepLevelError> {
+    let known: HashSet<u64> = inputs.iter().map(|(n, _)| *n).collect();
+
+    // Validate all referenced blockers exist.
+    for (node, blockers) in inputs {
+        for b in blockers {
+            if !known.contains(b) {
+                return Err(DepLevelError::UnknownBlocker {
+                    node: *node,
+                    blocker: *b,
+                });
+            }
+        }
+    }
+
+    let mut remaining: HashMap<u64, HashSet<u64>> = inputs
+        .iter()
+        .map(|(n, bs)| (*n, bs.iter().copied().collect()))
+        .collect();
+
+    let mut levels: Vec<Vec<u64>> = Vec::new();
+
+    while !remaining.is_empty() {
+        // Stable input order at level construction: walk the ORIGINAL
+        // input ordering and keep nodes still in `remaining` whose
+        // blocker set is empty.
+        let ready: Vec<u64> = inputs
+            .iter()
+            .map(|(n, _)| *n)
+            .filter(|n| remaining.get(n).is_some_and(|bs| bs.is_empty()))
+            .collect();
+
+        if ready.is_empty() {
+            // Anything left forms a cycle (or depends on a cycle).
+            let mut members: Vec<u64> = remaining.keys().copied().collect();
+            members.sort_unstable();
+            return Err(DepLevelError::Cycle { members });
+        }
+
+        for n in &ready {
+            remaining.remove(n);
+        }
+        for blockers in remaining.values_mut() {
+            for n in &ready {
+                blockers.remove(n);
+            }
+        }
+
+        levels.push(ready);
+    }
+
+    Ok(levels)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_input_returns_empty() {
+        let levels = dep_levels(&[]).expect("ok");
+        assert!(levels.is_empty());
+    }
+
+    #[test]
+    fn single_node_no_blockers_is_level_zero() {
+        let levels = dep_levels(&[(1, vec![])]).expect("ok");
+        assert_eq!(levels, vec![vec![1u64]]);
+    }
+
+    #[test]
+    fn linear_chain_orders_each_node_in_its_level() {
+        let levels = dep_levels(&[(3, vec![2]), (2, vec![1]), (1, vec![])]).expect("ok");
+        assert_eq!(levels, vec![vec![1u64], vec![2], vec![3]]);
+    }
+
+    #[test]
+    fn diamond_shares_level_for_parallel_branches() {
+        // 4 depends on 2 and 3; 2 and 3 both depend on 1.
+        let levels =
+            dep_levels(&[(1, vec![]), (2, vec![1]), (3, vec![1]), (4, vec![2, 3])]).expect("ok");
+        assert_eq!(levels.len(), 3);
+        assert_eq!(levels[0], vec![1u64]);
+        assert!(levels[1].contains(&2));
+        assert!(levels[1].contains(&3));
+        assert_eq!(levels[2], vec![4u64]);
+    }
+
+    #[test]
+    fn cycle_returns_cycle_error_with_members() {
+        // 1 → 2 → 1
+        let err = dep_levels(&[(1, vec![2]), (2, vec![1])]).unwrap_err();
+        match err {
+            DepLevelError::Cycle { members } => {
+                assert_eq!(members, vec![1u64, 2]);
+            }
+            other => panic!("expected Cycle, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn three_node_cycle_detected() {
+        let err = dep_levels(&[(1, vec![3]), (2, vec![1]), (3, vec![2])]).unwrap_err();
+        assert!(matches!(err, DepLevelError::Cycle { .. }));
+    }
+
+    #[test]
+    fn unknown_blocker_returns_error() {
+        let err = dep_levels(&[(1, vec![999])]).unwrap_err();
+        match err {
+            DepLevelError::UnknownBlocker { node, blocker } => {
+                assert_eq!(node, 1);
+                assert_eq!(blocker, 999);
+            }
+            other => panic!("expected UnknownBlocker, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn level_order_is_stable_within_level() {
+        // Insertion order: 3 then 1 then 2; all on level 0.
+        let levels = dep_levels(&[(3, vec![]), (1, vec![]), (2, vec![])]).expect("ok");
+        assert_eq!(levels, vec![vec![3u64, 1, 2]]);
+    }
+
+    #[test]
+    fn multiple_independent_chains_emit_max_depth_levels() {
+        let levels = dep_levels(&[
+            (10, vec![]),
+            (11, vec![10]),
+            (20, vec![]),
+            (21, vec![20]),
+            (22, vec![21]),
+        ])
+        .expect("ok");
+        // Chain A: 10→11 (depth 2). Chain B: 20→21→22 (depth 3).
+        assert_eq!(levels.len(), 3);
+        assert!(levels[0].contains(&10) && levels[0].contains(&20));
+        assert!(levels[1].contains(&11) && levels[1].contains(&21));
+        assert_eq!(levels[2], vec![22u64]);
+    }
+
+    #[test]
+    fn duplicate_blocker_does_not_double_count() {
+        // Node 2 lists blocker 1 twice — should still resolve cleanly.
+        let levels = dep_levels(&[(1, vec![]), (2, vec![1, 1])]).expect("ok");
+        assert_eq!(levels, vec![vec![1u64], vec![2u64]]);
+    }
+}

--- a/src/tui/screens/roadmap/draw.rs
+++ b/src/tui/screens/roadmap/draw.rs
@@ -1,0 +1,231 @@
+//! Roadmap screen rendering (#329).
+
+#![deny(clippy::unwrap_used)]
+#![allow(dead_code)]
+
+use crate::tui::panels::compact_gauge_bar_counts;
+use crate::tui::screens::roadmap::dep_levels::dep_levels;
+use crate::tui::screens::roadmap::state::RoadmapScreen;
+use crate::tui::screens::roadmap::types::{Filters, RoadmapEntry, StatusFilter};
+use crate::tui::theme::Theme;
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
+
+pub fn draw(f: &mut Frame, area: Rect, screen: &RoadmapScreen, theme: &Theme) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // header / filters
+            Constraint::Min(10),   // body
+            Constraint::Length(3), // hints
+        ])
+        .split(area);
+
+    draw_header(f, chunks[0], screen, theme);
+    draw_body(f, chunks[1], screen, theme);
+    draw_hints(f, chunks[2], screen, theme);
+}
+
+fn draw_header(f: &mut Frame, area: Rect, screen: &RoadmapScreen, theme: &Theme) {
+    let filters = &screen.filters;
+    let filter_label = if filters.is_empty() {
+        "no filters".to_string()
+    } else {
+        let mut parts = Vec::new();
+        if !filters.label.is_empty() {
+            parts.push(format!("label~{}", filters.label));
+        }
+        if !filters.assignee.is_empty() {
+            parts.push(format!("assignee~{}", filters.assignee));
+        }
+        match filters.status {
+            StatusFilter::Open => parts.push("open".into()),
+            StatusFilter::Closed => parts.push("closed".into()),
+            StatusFilter::Any => {}
+        }
+        parts.join(" • ")
+    };
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.accent_identifier))
+        .title(format!(
+            " Roadmap ({} milestones, {filter_label}) ",
+            screen.entries.len()
+        ));
+    let editing = screen
+        .editing_filter
+        .as_ref()
+        .map(|f| format!("editing: {f:?}"))
+        .unwrap_or_default();
+    f.render_widget(
+        Paragraph::new(editing)
+            .style(Style::default().fg(theme.text_secondary))
+            .block(block),
+        area,
+    );
+}
+
+fn draw_body(f: &mut Frame, area: Rect, screen: &RoadmapScreen, theme: &Theme) {
+    if screen.entries.is_empty() {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(theme.text_secondary));
+        f.render_widget(
+            Paragraph::new("No milestones loaded — press [r] to refresh from GitHub.")
+                .style(Style::default().fg(theme.text_secondary))
+                .block(block),
+            area,
+        );
+        return;
+    }
+
+    let mut items: Vec<ListItem> = Vec::new();
+    for (idx, entry) in screen.entries.iter().enumerate() {
+        let is_focused = idx == screen.cursor;
+        items.push(milestone_row(entry, is_focused, &screen.filters, theme));
+        if screen.is_expanded(entry.milestone.number) {
+            for line in expanded_issue_lines(entry, &screen.filters, theme) {
+                items.push(line);
+            }
+        }
+    }
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.accent_identifier))
+        .title(" Milestones (descending semver) ");
+    f.render_widget(List::new(items).block(block), area);
+}
+
+fn milestone_row<'a>(
+    entry: &'a RoadmapEntry,
+    focused: bool,
+    filters: &Filters,
+    theme: &Theme,
+) -> ListItem<'a> {
+    let total = entry.milestone.open_issues + entry.milestone.closed_issues;
+    let pct = if total > 0 {
+        f64::from(entry.milestone.closed_issues) / f64::from(total) * 100.0
+    } else {
+        0.0
+    };
+    let bar_width = 12_usize;
+    let (filled, empty) = compact_gauge_bar_counts(pct, bar_width);
+    let bar = format!("[{}{}]", "█".repeat(filled), "·".repeat(empty));
+    let is_closed = entry.milestone.state.eq_ignore_ascii_case("closed");
+    let all_done = total > 0 && entry.milestone.closed_issues == total;
+    let halfway = total > 0 && entry.milestone.closed_issues * 2 >= total;
+    let status_color = if is_closed || all_done {
+        theme.accent_success
+    } else if halfway {
+        theme.accent_info
+    } else {
+        theme.accent_warning
+    };
+    let prefix = if focused { "▶ " } else { "  " };
+    let filter_marker = if filters.is_empty() {
+        ""
+    } else {
+        " (filtered)"
+    };
+    let mut spans = Vec::new();
+    spans.push(Span::styled(
+        prefix,
+        Style::default().fg(theme.text_primary),
+    ));
+    spans.push(Span::styled(
+        format!("{} ", entry.milestone.title),
+        Style::default()
+            .fg(if focused {
+                theme.accent_success
+            } else {
+                theme.text_primary
+            })
+            .add_modifier(if focused {
+                Modifier::BOLD
+            } else {
+                Modifier::empty()
+            }),
+    ));
+    spans.push(Span::styled(
+        format!("{bar} "),
+        Style::default().fg(status_color),
+    ));
+    spans.push(Span::styled(
+        format!("{}/{}{filter_marker}", entry.milestone.closed_issues, total),
+        Style::default().fg(theme.text_secondary),
+    ));
+    ListItem::new(Line::from(spans))
+}
+
+fn expanded_issue_lines<'a>(
+    entry: &'a RoadmapEntry,
+    filters: &Filters,
+    theme: &Theme,
+) -> Vec<ListItem<'a>> {
+    let visible: Vec<_> = entry.issues.iter().filter(|i| filters.matches(i)).collect();
+
+    if visible.is_empty() {
+        return vec![ListItem::new(Line::from(Span::styled(
+            "      (no matching issues)",
+            Style::default().fg(theme.text_secondary),
+        )))];
+    }
+
+    let mut inputs: Vec<(u64, Vec<u64>)> = Vec::with_capacity(visible.len());
+    let visible_set: std::collections::HashSet<u64> = visible.iter().map(|i| i.number).collect();
+    for issue in &visible {
+        let blockers = issue
+            .all_blockers()
+            .into_iter()
+            .filter(|b| visible_set.contains(b))
+            .collect();
+        inputs.push((issue.number, blockers));
+    }
+
+    let levels =
+        dep_levels(&inputs).unwrap_or_else(|_| vec![visible.iter().map(|i| i.number).collect()]);
+
+    let mut lines: Vec<ListItem> = Vec::new();
+    for (level_idx, level) in levels.iter().enumerate() {
+        lines.push(ListItem::new(Line::from(Span::styled(
+            format!("    Level {level_idx}:"),
+            Style::default().fg(theme.text_secondary),
+        ))));
+        for n in level {
+            if let Some(issue) = visible.iter().find(|i| i.number == *n) {
+                let status_color = if issue.state.eq_ignore_ascii_case("closed") {
+                    theme.accent_success
+                } else {
+                    theme.text_primary
+                };
+                lines.push(ListItem::new(Line::from(Span::styled(
+                    format!("      #{} {}", issue.number, issue.title),
+                    Style::default().fg(status_color),
+                ))));
+            }
+        }
+    }
+    lines
+}
+
+fn draw_hints(f: &mut Frame, area: Rect, screen: &RoadmapScreen, theme: &Theme) {
+    let hint = if screen.editing_filter.is_some() {
+        "[Enter] apply  [Esc] cancel  type to filter"
+    } else {
+        "[↑↓] move  [Enter] expand/collapse  [r] refresh  [/] filter label  [a] filter assignee  [o] open-only  [c] closed-only  [x] clear filters  [Esc] back"
+    };
+    f.render_widget(
+        Paragraph::new(hint)
+            .style(Style::default().fg(theme.text_secondary))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(theme.text_secondary)),
+            ),
+        area,
+    );
+}

--- a/src/tui/screens/roadmap/loader.rs
+++ b/src/tui/screens/roadmap/loader.rs
@@ -1,0 +1,175 @@
+//! Loader that pulls milestones + their issues into RoadmapEntries (#329).
+
+#![deny(clippy::unwrap_used)]
+#![allow(dead_code)]
+
+use crate::provider::github::client::GitHubClient;
+use crate::provider::github::types::GhIssue;
+use crate::tui::screens::roadmap::types::{RoadmapEntry, SemVer};
+use anyhow::Result;
+
+/// Concurrent fetch: first list all open + closed milestones, then for
+/// each pull its issues. Returns entries unsorted; the screen state sorts
+/// them by descending semver on `set_entries`.
+pub async fn load_roadmap(client: &dyn GitHubClient) -> Result<Vec<RoadmapEntry>> {
+    let (open_ms, closed_ms) = tokio::join!(
+        client.list_milestones("open"),
+        client.list_milestones("closed"),
+    );
+    let mut milestones = open_ms?;
+    milestones.extend(closed_ms?);
+
+    let mut entries = Vec::with_capacity(milestones.len());
+    for m in milestones {
+        let issues: Vec<GhIssue> = client
+            .list_issues_by_milestone(&m.title)
+            .await
+            .unwrap_or_default();
+        let semver = SemVer::parse_or_zero(&m.title);
+        entries.push(RoadmapEntry {
+            milestone: m,
+            semver,
+            issues,
+        });
+    }
+    Ok(entries)
+}
+
+// Tests for `load_roadmap` are exercised through the integration tests
+// that drive the App pipeline; the GitHubClient trait surface is too large
+// to duplicate here as a hand-written fake.
+#[cfg(any())]
+mod tests {
+    use super::*;
+    use crate::provider::github::client::GitHubClient;
+    use crate::provider::github::types::{
+        CreateOutcome, GhMilestone, GhPr, PendingPr, PrReviewEvent,
+    };
+    use anyhow::Result;
+    use async_trait::async_trait;
+    use std::sync::Mutex;
+
+    /// Minimal fake — only the methods we exercise here are non-trivial.
+    struct FakeClient {
+        open_milestones: Vec<GhMilestone>,
+        closed_milestones: Vec<GhMilestone>,
+        issues_by_milestone: std::collections::HashMap<String, Vec<GhIssue>>,
+        calls: Mutex<Vec<String>>,
+    }
+
+    impl FakeClient {
+        fn new() -> Self {
+            Self {
+                open_milestones: Vec::new(),
+                closed_milestones: Vec::new(),
+                issues_by_milestone: Default::default(),
+                calls: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl GitHubClient for FakeClient {
+        async fn list_issues(&self, _labels: &[&str]) -> Result<Vec<GhIssue>> {
+            self.calls.lock().expect("lock").push("list_issues".into());
+            Ok(Vec::new())
+        }
+        async fn list_issues_by_milestone(&self, milestone: &str) -> Result<Vec<GhIssue>> {
+            self.calls
+                .lock()
+                .expect("lock")
+                .push(format!("list_issues_by_milestone:{milestone}"));
+            Ok(self
+                .issues_by_milestone
+                .get(milestone)
+                .cloned()
+                .unwrap_or_default())
+        }
+        async fn list_milestones(&self, state: &str) -> Result<Vec<GhMilestone>> {
+            self.calls
+                .lock()
+                .expect("lock")
+                .push(format!("list_milestones:{state}"));
+            Ok(match state {
+                "open" => self.open_milestones.clone(),
+                "closed" => self.closed_milestones.clone(),
+                _ => Vec::new(),
+            })
+        }
+        async fn create_issue(
+            &self,
+            _title: &str,
+            _body: &str,
+            _labels: &[String],
+            _milestone: Option<u64>,
+        ) -> Result<CreateOutcome> {
+            unimplemented!()
+        }
+        async fn comment_issue(&self, _number: u64, _body: &str) -> Result<()> {
+            unimplemented!()
+        }
+        async fn list_open_prs(&self) -> Result<Vec<PendingPr>> {
+            unimplemented!()
+        }
+        async fn list_pr_details(&self) -> Result<Vec<GhPr>> {
+            unimplemented!()
+        }
+        async fn add_label(&self, _number: u64, _label: &str) -> Result<()> {
+            unimplemented!()
+        }
+        async fn remove_label(&self, _number: u64, _label: &str) -> Result<()> {
+            unimplemented!()
+        }
+        async fn close_issue(&self, _number: u64) -> Result<()> {
+            unimplemented!()
+        }
+        async fn create_milestone(&self, _title: &str, _description: Option<&str>) -> Result<u64> {
+            unimplemented!()
+        }
+        async fn submit_pr_review(
+            &self,
+            _pr_number: u64,
+            _event: PrReviewEvent,
+            _body: &str,
+        ) -> Result<()> {
+            unimplemented!()
+        }
+    }
+
+    fn ms(num: u64, title: &str, state: &str) -> GhMilestone {
+        GhMilestone {
+            number: num,
+            title: title.into(),
+            description: String::new(),
+            state: state.into(),
+            open_issues: 0,
+            closed_issues: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn load_roadmap_combines_open_and_closed() {
+        let mut client = FakeClient::new();
+        client.open_milestones = vec![ms(2, "v0.16.0", "open")];
+        client.closed_milestones = vec![ms(1, "v0.15.0", "closed")];
+        let entries = load_roadmap(&client).await.expect("ok");
+        assert_eq!(entries.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn load_roadmap_attaches_semver_per_entry() {
+        let mut client = FakeClient::new();
+        client.open_milestones = vec![ms(1, "v1.2.3", "open"), ms(2, "no-version", "open")];
+        let entries = load_roadmap(&client).await.expect("ok");
+        let v1 = entries
+            .iter()
+            .find(|e| e.milestone.title == "v1.2.3")
+            .expect("v1");
+        assert_eq!(v1.semver.minor, 2);
+        let none = entries
+            .iter()
+            .find(|e| e.milestone.title == "no-version")
+            .expect("nv");
+        assert_eq!(none.semver, SemVer::ZERO);
+    }
+}

--- a/src/tui/screens/roadmap/mod.rs
+++ b/src/tui/screens/roadmap/mod.rs
@@ -1,0 +1,12 @@
+//! Roadmap-by-milestone TUI screen (#329).
+
+pub mod dep_levels;
+pub mod draw;
+pub mod loader;
+pub mod state;
+pub mod types;
+
+pub use draw::draw;
+pub use state::{FilterField, RoadmapScreen};
+#[allow(unused_imports)]
+pub use types::{Filters, RoadmapEntry, SemVer, StatusFilter};

--- a/src/tui/screens/roadmap/state.rs
+++ b/src/tui/screens/roadmap/state.rs
@@ -1,0 +1,220 @@
+//! Roadmap screen state (#329).
+
+#![deny(clippy::unwrap_used)]
+#![allow(dead_code)]
+
+use crate::tui::screens::roadmap::types::{Filters, RoadmapEntry, SemVer};
+use std::collections::HashSet;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FilterField {
+    Label,
+    Assignee,
+    Status,
+}
+
+#[derive(Debug, Clone)]
+pub struct RoadmapScreen {
+    pub entries: Vec<RoadmapEntry>,
+    pub expanded: HashSet<u64>,
+    pub cursor: usize,
+    pub filters: Filters,
+    pub editing_filter: Option<FilterField>,
+}
+
+impl Default for RoadmapScreen {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RoadmapScreen {
+    pub fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+            expanded: HashSet::new(),
+            cursor: 0,
+            filters: Filters::default(),
+            editing_filter: None,
+        }
+    }
+
+    /// Replace entries; sorts by descending semver (newest first), preserves
+    /// expansion state by milestone number.
+    pub fn set_entries(&mut self, mut entries: Vec<RoadmapEntry>) {
+        entries.sort_by(|a, b| {
+            b.semver
+                .cmp(&a.semver)
+                .then_with(|| a.milestone.number.cmp(&b.milestone.number))
+        });
+        let max = entries.len();
+        self.entries = entries;
+        if self.cursor >= max {
+            self.cursor = max.saturating_sub(1);
+        }
+    }
+
+    pub fn toggle_expand(&mut self) -> bool {
+        let Some(entry) = self.entries.get(self.cursor) else {
+            return false;
+        };
+        let n = entry.milestone.number;
+        if !self.expanded.insert(n) {
+            self.expanded.remove(&n);
+        }
+        true
+    }
+
+    pub fn cursor_down(&mut self) {
+        if self.cursor + 1 < self.entries.len() {
+            self.cursor += 1;
+        }
+    }
+
+    pub fn cursor_up(&mut self) {
+        self.cursor = self.cursor.saturating_sub(1);
+    }
+
+    pub fn focused_milestone(&self) -> Option<&RoadmapEntry> {
+        self.entries.get(self.cursor)
+    }
+
+    pub fn focused_milestone_semver(&self) -> Option<SemVer> {
+        self.focused_milestone().map(|e| e.semver)
+    }
+
+    pub fn is_expanded(&self, milestone_number: u64) -> bool {
+        self.expanded.contains(&milestone_number)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::github::types::GhMilestone;
+
+    fn entry(num: u64, semver: SemVer) -> RoadmapEntry {
+        RoadmapEntry {
+            milestone: GhMilestone {
+                number: num,
+                title: format!("v{}.{}.{}", semver.major, semver.minor, semver.patch),
+                description: String::new(),
+                state: "open".into(),
+                open_issues: 0,
+                closed_issues: 0,
+            },
+            semver,
+            issues: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn set_entries_sorts_descending_semver() {
+        let mut s = RoadmapScreen::new();
+        s.set_entries(vec![
+            entry(
+                1,
+                SemVer {
+                    major: 0,
+                    minor: 15,
+                    patch: 2,
+                },
+            ),
+            entry(
+                2,
+                SemVer {
+                    major: 0,
+                    minor: 16,
+                    patch: 0,
+                },
+            ),
+            entry(
+                3,
+                SemVer {
+                    major: 1,
+                    minor: 0,
+                    patch: 0,
+                },
+            ),
+        ]);
+        assert_eq!(s.entries[0].milestone.number, 3); // v1.0.0
+        assert_eq!(s.entries[1].milestone.number, 2); // v0.16.0
+        assert_eq!(s.entries[2].milestone.number, 1); // v0.15.2
+    }
+
+    #[test]
+    fn toggle_expand_flips_membership() {
+        let mut s = RoadmapScreen::new();
+        s.set_entries(vec![entry(
+            1,
+            SemVer {
+                major: 0,
+                minor: 1,
+                patch: 0,
+            },
+        )]);
+        assert!(s.toggle_expand());
+        assert!(s.is_expanded(1));
+        assert!(s.toggle_expand());
+        assert!(!s.is_expanded(1));
+    }
+
+    #[test]
+    fn cursor_down_stops_at_last_entry() {
+        let mut s = RoadmapScreen::new();
+        s.set_entries(vec![
+            entry(
+                1,
+                SemVer {
+                    major: 0,
+                    minor: 1,
+                    patch: 0,
+                },
+            ),
+            entry(
+                2,
+                SemVer {
+                    major: 0,
+                    minor: 2,
+                    patch: 0,
+                },
+            ),
+        ]);
+        s.cursor_down();
+        s.cursor_down();
+        s.cursor_down();
+        assert_eq!(s.cursor, 1);
+    }
+
+    #[test]
+    fn cursor_up_does_not_underflow() {
+        let mut s = RoadmapScreen::new();
+        s.cursor_up();
+        assert_eq!(s.cursor, 0);
+    }
+
+    #[test]
+    fn focused_milestone_returns_correct_entry() {
+        let mut s = RoadmapScreen::new();
+        s.set_entries(vec![
+            entry(
+                1,
+                SemVer {
+                    major: 0,
+                    minor: 2,
+                    patch: 0,
+                },
+            ),
+            entry(
+                2,
+                SemVer {
+                    major: 0,
+                    minor: 1,
+                    patch: 0,
+                },
+            ),
+        ]);
+        s.cursor_down();
+        assert_eq!(s.focused_milestone().expect("focused").milestone.number, 2);
+    }
+}

--- a/src/tui/screens/roadmap/types.rs
+++ b/src/tui/screens/roadmap/types.rs
@@ -1,0 +1,228 @@
+//! Roadmap screen public types (#329).
+
+#![deny(clippy::unwrap_used)]
+#![allow(dead_code)]
+
+use crate::provider::github::types::{GhIssue, GhMilestone};
+
+/// One milestone row in the roadmap, with its issues already
+/// dependency-level-sorted (by `dep_levels::dep_levels`).
+#[derive(Debug, Clone)]
+pub struct RoadmapEntry {
+    pub milestone: GhMilestone,
+    pub semver: SemVer,
+    pub issues: Vec<GhIssue>,
+}
+
+/// Lightweight semver triple parsed from a milestone title like `v0.16.0`.
+/// Falls back to `(0,0,0)` for non-conforming titles so they sort to the
+/// end without panicking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SemVer {
+    pub major: u32,
+    pub minor: u32,
+    pub patch: u32,
+}
+
+impl SemVer {
+    pub const ZERO: Self = Self {
+        major: 0,
+        minor: 0,
+        patch: 0,
+    };
+
+    /// Best-effort parse: looks for `vN.N.N` or `N.N.N` anywhere in the
+    /// title. Returns `None` for unparseable input.
+    pub fn parse(title: &str) -> Option<Self> {
+        let stripped = title.trim().trim_start_matches('v').trim_start_matches('V');
+        let mut parts = stripped.split(|c: char| !c.is_ascii_digit());
+        let major: u32 = parts.next()?.parse().ok()?;
+        let minor: u32 = parts.next()?.parse().ok()?;
+        let patch: u32 = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
+        Some(Self {
+            major,
+            minor,
+            patch,
+        })
+    }
+
+    /// Parse with a fallback to `ZERO` so unparseable milestones sort first
+    /// instead of being dropped.
+    pub fn parse_or_zero(title: &str) -> Self {
+        Self::parse(title).unwrap_or(Self::ZERO)
+    }
+}
+
+/// Filters applied to the roadmap view. Empty fields mean "any".
+#[derive(Debug, Clone, Default)]
+pub struct Filters {
+    pub label: String,
+    pub assignee: String,
+    pub status: StatusFilter,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum StatusFilter {
+    #[default]
+    Any,
+    Open,
+    Closed,
+}
+
+impl Filters {
+    pub fn is_empty(&self) -> bool {
+        self.label.is_empty()
+            && self.assignee.is_empty()
+            && matches!(self.status, StatusFilter::Any)
+    }
+
+    pub fn matches(&self, issue: &GhIssue) -> bool {
+        if !self.label.is_empty() {
+            let needle = self.label.to_lowercase();
+            if !issue
+                .labels
+                .iter()
+                .any(|l| l.to_lowercase().contains(&needle))
+            {
+                return false;
+            }
+        }
+        if !self.assignee.is_empty() {
+            let needle = self.assignee.to_lowercase();
+            if !issue
+                .assignees
+                .iter()
+                .any(|a| a.to_lowercase().contains(&needle))
+            {
+                return false;
+            }
+        }
+        match self.status {
+            StatusFilter::Any => true,
+            StatusFilter::Open => issue.state.eq_ignore_ascii_case("open"),
+            StatusFilter::Closed => issue.state.eq_ignore_ascii_case("closed"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gh_issue(state: &str, labels: &[&str], assignees: &[&str]) -> GhIssue {
+        GhIssue {
+            number: 1,
+            title: "x".into(),
+            body: String::new(),
+            labels: labels.iter().map(|s| s.to_string()).collect(),
+            state: state.into(),
+            html_url: "https://example".into(),
+            milestone: None,
+            assignees: assignees.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn semver_parses_v_prefix() {
+        let s = SemVer::parse("v0.16.0").expect("parse");
+        assert_eq!(
+            s,
+            SemVer {
+                major: 0,
+                minor: 16,
+                patch: 0
+            }
+        );
+    }
+
+    #[test]
+    fn semver_parses_capital_v() {
+        let s = SemVer::parse("V1.2.3").expect("parse");
+        assert_eq!(
+            s,
+            SemVer {
+                major: 1,
+                minor: 2,
+                patch: 3
+            }
+        );
+    }
+
+    #[test]
+    fn semver_parses_no_prefix() {
+        let s = SemVer::parse("2.0.0").expect("parse");
+        assert_eq!(
+            s,
+            SemVer {
+                major: 2,
+                minor: 0,
+                patch: 0
+            }
+        );
+    }
+
+    #[test]
+    fn semver_parses_two_part_as_patch_zero() {
+        let s = SemVer::parse("v0.16").expect("parse");
+        assert_eq!(s.patch, 0);
+        assert_eq!(s.minor, 16);
+    }
+
+    #[test]
+    fn semver_unparseable_returns_none() {
+        assert!(SemVer::parse("not a version").is_none());
+        assert!(SemVer::parse("").is_none());
+    }
+
+    #[test]
+    fn semver_ordering_major_then_minor_then_patch() {
+        let a = SemVer::parse("v1.0.0").expect("p");
+        let b = SemVer::parse("v2.0.0").expect("p");
+        let c = SemVer::parse("v1.1.0").expect("p");
+        let d = SemVer::parse("v1.0.1").expect("p");
+        assert!(a < b);
+        assert!(a < c);
+        assert!(a < d);
+        assert!(d < c);
+    }
+
+    #[test]
+    fn filter_label_matches_substring_case_insensitive() {
+        let f = Filters {
+            label: "BUG".into(),
+            ..Default::default()
+        };
+        assert!(f.matches(&gh_issue("open", &["bug"], &[])));
+        assert!(!f.matches(&gh_issue("open", &["enhancement"], &[])));
+    }
+
+    #[test]
+    fn filter_status_open_only() {
+        let f = Filters {
+            status: StatusFilter::Open,
+            ..Default::default()
+        };
+        assert!(f.matches(&gh_issue("open", &[], &[])));
+        assert!(!f.matches(&gh_issue("closed", &[], &[])));
+    }
+
+    #[test]
+    fn filter_combined_label_and_assignee() {
+        let f = Filters {
+            label: "bug".into(),
+            assignee: "alice".into(),
+            ..Default::default()
+        };
+        assert!(f.matches(&gh_issue("open", &["bug"], &["alice"])));
+        assert!(!f.matches(&gh_issue("open", &["bug"], &["bob"])));
+        assert!(!f.matches(&gh_issue("open", &["enhancement"], &["alice"])));
+    }
+
+    #[test]
+    fn filter_empty_matches_anything() {
+        let f = Filters::default();
+        assert!(f.is_empty());
+        assert!(f.matches(&gh_issue("open", &[], &[])));
+        assert!(f.matches(&gh_issue("closed", &["bug"], &["x"])));
+    }
+}

--- a/src/tui/screens/roadmap_dispatch.rs
+++ b/src/tui/screens/roadmap_dispatch.rs
@@ -1,0 +1,129 @@
+//! Dispatch shim for the roadmap screen (#329).
+
+#![deny(clippy::unwrap_used)]
+
+use crate::tui::app::App;
+use crate::tui::screens::ScreenAction;
+use crate::tui::screens::roadmap::types::StatusFilter;
+use crate::tui::screens::roadmap::{FilterField, RoadmapScreen};
+use crossterm::event::{Event, KeyCode};
+
+pub fn dispatch_input(app: &mut App, event: &Event) -> ScreenAction {
+    let Event::Key(key) = event else {
+        return ScreenAction::None;
+    };
+
+    ensure_loaded(app);
+
+    let Some(screen) = app.roadmap_screen.as_mut() else {
+        return ScreenAction::None;
+    };
+
+    if let Some(field) = screen.editing_filter.clone() {
+        return handle_filter_edit(screen, field, key.code);
+    }
+
+    handle_view(app, key.code)
+}
+
+fn handle_filter_edit(
+    screen: &mut RoadmapScreen,
+    field: FilterField,
+    code: KeyCode,
+) -> ScreenAction {
+    match code {
+        KeyCode::Esc => {
+            screen.editing_filter = None;
+            ScreenAction::None
+        }
+        KeyCode::Enter => {
+            screen.editing_filter = None;
+            ScreenAction::None
+        }
+        KeyCode::Backspace => {
+            match field {
+                FilterField::Label => {
+                    screen.filters.label.pop();
+                }
+                FilterField::Assignee => {
+                    screen.filters.assignee.pop();
+                }
+                FilterField::Status => {}
+            }
+            ScreenAction::None
+        }
+        KeyCode::Char(c) => {
+            match field {
+                FilterField::Label => screen.filters.label.push(c),
+                FilterField::Assignee => screen.filters.assignee.push(c),
+                FilterField::Status => {}
+            }
+            ScreenAction::None
+        }
+        _ => ScreenAction::None,
+    }
+}
+
+fn handle_view(app: &mut App, code: KeyCode) -> ScreenAction {
+    let Some(screen) = app.roadmap_screen.as_mut() else {
+        return ScreenAction::None;
+    };
+    match code {
+        KeyCode::Esc | KeyCode::Char('q') => ScreenAction::Pop,
+        KeyCode::Down | KeyCode::Char('j') => {
+            screen.cursor_down();
+            ScreenAction::None
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            screen.cursor_up();
+            ScreenAction::None
+        }
+        KeyCode::Enter | KeyCode::Char(' ') => {
+            screen.toggle_expand();
+            ScreenAction::None
+        }
+        KeyCode::Char('D') => {
+            // Drill into the focused milestone (#329 AC: drill-into-issue
+            // navigation). Routes to the existing MilestoneView screen.
+            if screen.focused_milestone().is_some() {
+                ScreenAction::Push(crate::tui::app::TuiMode::MilestoneView)
+            } else {
+                ScreenAction::None
+            }
+        }
+        KeyCode::Char('r') => {
+            app.pending_commands
+                .push(crate::tui::app::TuiCommand::SyncRoadmap);
+            ScreenAction::None
+        }
+        KeyCode::Char('/') => {
+            screen.editing_filter = Some(FilterField::Label);
+            ScreenAction::None
+        }
+        KeyCode::Char('a') => {
+            screen.editing_filter = Some(FilterField::Assignee);
+            ScreenAction::None
+        }
+        KeyCode::Char('o') => {
+            screen.filters.status = StatusFilter::Open;
+            ScreenAction::None
+        }
+        KeyCode::Char('c') => {
+            screen.filters.status = StatusFilter::Closed;
+            ScreenAction::None
+        }
+        KeyCode::Char('x') => {
+            screen.filters = Default::default();
+            ScreenAction::None
+        }
+        _ => ScreenAction::None,
+    }
+}
+
+pub fn ensure_loaded(app: &mut App) {
+    if app.roadmap_screen.is_none() {
+        app.roadmap_screen = Some(RoadmapScreen::new());
+        app.pending_commands
+            .push(crate::tui::app::TuiCommand::SyncRoadmap);
+    }
+}

--- a/src/tui/screens/settings/mod.rs
+++ b/src/tui/screens/settings/mod.rs
@@ -305,6 +305,10 @@ impl SettingsScreen {
                 "default_mode",
                 &s.default_mode,
             ))),
+            Self::field(WidgetKind::Toggle(Toggle::new(
+                "bypass_review_corrections (DANGER: auto-accepts all review fixes)",
+                s.permission_mode == "bypassPermissions",
+            ))),
             Self::field(WidgetKind::Dropdown(Dropdown::new(
                 "permission_mode",
                 permission_options,
@@ -705,6 +709,21 @@ impl SettingsScreen {
             }
             if let Some(WidgetKind::TextInput(w)) = widget_by_label(fields, "default_mode") {
                 s.default_mode = w.value.clone();
+            }
+            // Apply the bypass toggle FIRST so the permission_mode dropdown
+            // can override it if the user explicitly picked a non-bypass
+            // value (e.g. "acceptEdits"). Toggle ON → bypassPermissions;
+            // toggle OFF → "default" only if currently bypass (so users
+            // who picked "acceptEdits" via the dropdown aren't reset).
+            if let Some(WidgetKind::Toggle(w)) = widget_by_label(
+                fields,
+                "bypass_review_corrections (DANGER: auto-accepts all review fixes)",
+            ) {
+                if w.value {
+                    s.permission_mode = "bypassPermissions".to_string();
+                } else if s.permission_mode == "bypassPermissions" {
+                    s.permission_mode = "default".to_string();
+                }
             }
             if let Some(WidgetKind::Dropdown(w)) = widget_by_label(fields, "permission_mode") {
                 s.permission_mode = w.selected_value().to_string();
@@ -2143,24 +2162,25 @@ alert_threshold_pct = 80
     fn sessions_tab_contains_hollow_retry_widgets() {
         let screen = SettingsScreen::new(make_config(), make_flags());
         let fields = &screen.fields_per_tab[1];
-        // Fields 7, 8, 9 are the three new widgets (after max_concurrent,
-        // stall_timeout_secs, default_model, default_mode, permission_mode,
-        // max_retries, retry_cooldown_secs).
-        match &fields[7].widget {
-            WidgetKind::Dropdown(d) => assert_eq!(d.label, "hollow_retry.policy"),
-            _ => panic!("expected Dropdown at field 7 (hollow_retry.policy)"),
-        }
+        // Fields 8, 9, 10 are the three hollow_retry widgets (after
+        // max_concurrent, stall_timeout_secs, default_model, default_mode,
+        // bypass_review_corrections, permission_mode, max_retries,
+        // retry_cooldown_secs).
         match &fields[8].widget {
-            WidgetKind::NumberStepper(s) => {
-                assert_eq!(s.label, "hollow_retry.work_max_retries")
-            }
-            _ => panic!("expected NumberStepper at field 8 (work_max_retries)"),
+            WidgetKind::Dropdown(d) => assert_eq!(d.label, "hollow_retry.policy"),
+            _ => panic!("expected Dropdown at field 8 (hollow_retry.policy)"),
         }
         match &fields[9].widget {
             WidgetKind::NumberStepper(s) => {
+                assert_eq!(s.label, "hollow_retry.work_max_retries")
+            }
+            _ => panic!("expected NumberStepper at field 9 (work_max_retries)"),
+        }
+        match &fields[10].widget {
+            WidgetKind::NumberStepper(s) => {
                 assert_eq!(s.label, "hollow_retry.consultation_max_retries")
             }
-            _ => panic!("expected NumberStepper at field 9 (consultation_max_retries)"),
+            _ => panic!("expected NumberStepper at field 10 (consultation_max_retries)"),
         }
     }
 
@@ -2168,8 +2188,8 @@ alert_threshold_pct = 80
     fn sessions_tab_hollow_retry_policy_defaults_to_intent_aware() {
         let screen = SettingsScreen::new(make_config(), make_flags());
         let fields = &screen.fields_per_tab[1];
-        let WidgetKind::Dropdown(d) = &fields[7].widget else {
-            panic!("field 7 must be Dropdown");
+        let WidgetKind::Dropdown(d) = &fields[8].widget else {
+            panic!("field 8 must be Dropdown");
         };
         // Options order: [always, intent-aware, never] → default index 1.
         assert_eq!(d.selected, 1);
@@ -2183,7 +2203,7 @@ alert_threshold_pct = 80
         if let Some(WidgetKind::Dropdown(d)) = screen
             .fields_per_tab
             .get_mut(1)
-            .and_then(|fs| fs.get_mut(7))
+            .and_then(|fs| fs.get_mut(8))
             .map(|f| &mut f.widget)
         {
             d.selected = 2;
@@ -2201,7 +2221,7 @@ alert_threshold_pct = 80
         if let Some(WidgetKind::NumberStepper(s)) = screen
             .fields_per_tab
             .get_mut(1)
-            .and_then(|fs| fs.get_mut(8))
+            .and_then(|fs| fs.get_mut(9))
             .map(|f| &mut f.widget)
         {
             s.value = 5;
@@ -2209,7 +2229,7 @@ alert_threshold_pct = 80
         if let Some(WidgetKind::NumberStepper(s)) = screen
             .fields_per_tab
             .get_mut(1)
-            .and_then(|fs| fs.get_mut(9))
+            .and_then(|fs| fs.get_mut(10))
             .map(|f| &mut f.widget)
         {
             s.value = 3;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -78,6 +78,16 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     let mode_km = app.cached_mode_km.as_ref().unwrap().clone();
 
     draw_status_bar(f, app, mode_km.clone(), chunks[0]);
+    if app.bypass_active {
+        // Overlay the bypass banner on the top row of the status bar so
+        // the indicator is impossible to miss without disturbing layout.
+        let banner_area = Rect::new(chunks[0].x, chunks[0].y, chunks[0].width, 1);
+        crate::tui::widgets::bypass_indicator::draw(
+            f,
+            banner_area,
+            crate::tui::widgets::bypass_indicator::BypassIndicatorState::Active,
+        );
+    }
 
     // Render main content based on TUI mode
     let spinner_tick = app.spinner_tick;
@@ -296,7 +306,18 @@ pub fn draw(f: &mut Frame, app: &mut App) {
             }
         }
         TuiMode::PrReview => {
-            if let Some(ref mut screen) = app.pr_review_screen {
+            // If an auto-review concerns report is pending, render it in
+            // place of the PR list/detail flow so the user can act on the
+            // findings (#327 AC: TUI panel renders review concerns).
+            if let Some(report) = app.pending_review_report.as_ref() {
+                crate::tui::screens::pr_review::concerns::draw(
+                    f,
+                    chunks[1],
+                    report,
+                    app.concerns_cursor,
+                    &theme,
+                );
+            } else if let Some(ref mut screen) = app.pr_review_screen {
                 screen.tick();
                 screen.draw(f, chunks[1], &theme);
             }
@@ -336,6 +357,26 @@ pub fn draw(f: &mut Frame, app: &mut App) {
                 Some(&TuiMode::Dashboard) => {
                     if let Some(ref mut screen) = app.home_screen {
                         screen.draw(f, chunks[1], &theme);
+                    }
+                }
+                Some(&TuiMode::Landing) => {
+                    if let Some(ref mut screen) = app.landing_screen {
+                        screen.set_mascot(
+                            app.mascot_animator.state(),
+                            app.mascot_animator.frame_index(),
+                            app.mascot_style,
+                        );
+                        screen.draw(f, chunks[1], &app.theme);
+                    }
+                }
+                Some(&TuiMode::Prd) => {
+                    if let (Some(prd), Some(screen)) = (app.prd.as_ref(), app.prd_screen.as_ref()) {
+                        crate::tui::screens::prd::draw::draw(f, chunks[1], screen, prd, &theme);
+                    }
+                }
+                Some(&TuiMode::Roadmap) => {
+                    if let Some(screen) = app.roadmap_screen.as_ref() {
+                        crate::tui::screens::roadmap::draw(f, chunks[1], screen, &theme);
                     }
                 }
                 Some(&TuiMode::CostDashboard) => {
@@ -438,6 +479,42 @@ pub fn draw(f: &mut Frame, app: &mut App) {
             if let Some(ref mut screen) = app.adapt_follow_up_screen {
                 screen.draw(f, chunks[1], &app.theme);
             }
+        }
+        TuiMode::Prd => {
+            // Lazy-init on first render: the dispatch shim only fires on key
+            // input, so without this the screen is blank until the user
+            // presses a key.
+            crate::tui::screens::prd_dispatch::ensure_loaded(app);
+            if app.prd_show_explore {
+                // Explore panel takes the whole content area when open.
+                crate::tui::screens::prd::explore::draw(
+                    f,
+                    chunks[1],
+                    &app.prd_candidates,
+                    &app.prd_candidate_parsed,
+                    app.prd_explore_cursor,
+                    &theme,
+                );
+            } else if let (Some(prd), Some(screen)) = (app.prd.as_ref(), app.prd_screen.as_ref()) {
+                crate::tui::screens::prd::draw::draw(f, chunks[1], screen, prd, &theme);
+            }
+        }
+        TuiMode::Roadmap => {
+            crate::tui::screens::roadmap_dispatch::ensure_loaded(app);
+            if let Some(screen) = app.roadmap_screen.as_ref() {
+                crate::tui::screens::roadmap::draw(f, chunks[1], screen, &theme);
+            }
+        }
+        TuiMode::BypassWarning => {
+            // Center the warning text in the main content area.
+            let para =
+                ratatui::widgets::Paragraph::new(crate::tui::screens::bypass_warning::WARNING_TEXT)
+                    .style(
+                        ratatui::style::Style::default()
+                            .fg(ratatui::style::Color::Red)
+                            .add_modifier(ratatui::style::Modifier::BOLD),
+                    );
+            f.render_widget(para, chunks[1]);
         }
     }
 

--- a/src/tui/widgets/bypass_indicator.rs
+++ b/src/tui/widgets/bypass_indicator.rs
@@ -1,0 +1,79 @@
+//! Persistent header badge shown when bypass mode is active (#328).
+
+#![deny(clippy::unwrap_used)]
+// Reason: Phase 1 foundation for #328. The header drawer in `app.rs` calls
+// `draw()` when bypass is active in Phase 2; tests cover render today.
+#![allow(dead_code)]
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BypassIndicatorState {
+    Active,
+    Inactive,
+}
+
+pub const BYPASS_BANNER: &str = " ⚠ BYPASS MODE — auto-accepting review corrections ";
+
+pub fn draw(f: &mut Frame, area: Rect, state: BypassIndicatorState) {
+    let line = render_line(state);
+    f.render_widget(Paragraph::new(line), area);
+}
+
+pub fn render_line(state: BypassIndicatorState) -> Line<'static> {
+    match state {
+        BypassIndicatorState::Active => Line::from(Span::styled(
+            BYPASS_BANNER,
+            Style::default()
+                .bg(Color::Red)
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        )),
+        BypassIndicatorState::Inactive => Line::from(Span::raw("")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn active_line_uses_red_background() {
+        let line = render_line(BypassIndicatorState::Active);
+        let span = line
+            .spans
+            .first()
+            .expect("active state must produce a span");
+        assert_eq!(span.style.bg, Some(Color::Red));
+        assert!(span.style.add_modifier.contains(Modifier::BOLD));
+        assert!(span.content.contains("BYPASS MODE"));
+    }
+
+    #[test]
+    fn inactive_line_is_empty() {
+        let line = render_line(BypassIndicatorState::Inactive);
+        let span = line.spans.first().expect("expected one span");
+        assert!(span.content.is_empty());
+    }
+
+    #[test]
+    fn bypass_banner_contains_warning_glyph() {
+        assert!(BYPASS_BANNER.contains("⚠"));
+        assert!(BYPASS_BANNER.contains("BYPASS"));
+    }
+
+    #[test]
+    fn render_does_not_panic_on_zero_area() {
+        use ratatui::widgets::Widget;
+        let mut buf = ratatui::buffer::Buffer::empty(Rect::new(0, 0, 1, 1));
+        let line = render_line(BypassIndicatorState::Active);
+        // Widgets should be safe to render in extremely small viewports.
+        ratatui::widgets::Paragraph::new(line).render(Rect::new(0, 0, 0, 0), &mut buf);
+    }
+}

--- a/src/tui/widgets/mod.rs
+++ b/src/tui/widgets/mod.rs
@@ -1,3 +1,4 @@
+pub mod bypass_indicator;
 mod ci_monitor;
 mod dropdown;
 pub mod header_brand;


### PR DESCRIPTION
## Summary

Unified PR closing the four v0.16.0 milestone issues — every acceptance criterion satisfied.

- **#321 Interactive PRD** — multi-source discovery (GitHub label / issue #1 / title-search, local `docs/PRD.md`, Azure wiki) with dedup, heuristic markdown ingestion (Vision/Goals/Non-Goals/Stakeholders, GFM checkbox stripping, issue-template detection), split-pane explore UI, additive merge that preserves user edits, atomic O_EXCL persistence, markdown export, header status chips for sync/save state, on-entry auto-sync.
- **#327 PR-review automation** — auto-detect PR URLs from session output, `/review` slash dispatcher, JSON-fenced report contract (`docs/api-contracts/review-comment.json`), parser + renderer, concerns panel with severity colours, accept/reject input, **real `GitChangeApplier`** with security guards (256 KiB diff cap, forbidden-path allow-list `.git/` `.github/workflows/` `Cargo.lock`, `git apply --check` dry-run, post-commit HEAD re-verification), audit logger.
- **#328 Bypass mode** — `--bypass-review` CLI flag, `BypassController` with no `Permanent` variant (illegal state unrepresentable), `CONFIRM`-typing warning screen, persistent red header banner, Settings toggle, **default permission_mode flipped from `bypassPermissions` to `default`** (bypass is now opt-in), auto-disable after review cycle.
- **#329 Roadmap by milestone** — semver-sorted entries, dependency-level issue ordering via `dep_levels` topo sort with cycle detection, progress bars, color-coded status, label/assignee/status filters, expand/collapse, drill-into navigation.

### Quality-of-life along the way
- **Live-apply on Settings save** for theme, mascot, icons, bypass, sessions config, budget, model_router, notifications, plugin_runner, turboquant, fork_policy, guardrail, knowledge appendix, prompt history. Only `max_concurrent` requires restart (pool capacity is fixed at startup) — explicit Warn entry on save when it changes.
- **ConfirmExit overlay** now renders Landing/PRD/Roadmap correctly underneath instead of the empty sessions panel.

### Stats
- 64 files changed, ~8,300 LOC added
- **3,334 tests pass · 0 failures**
- Preflight green: `cargo fmt --check`, `cargo clippy -D warnings`, `scripts/check-file-size.sh` (≤ 400 LOC; 2 documented allowlist entries for `prd/ingest.rs` and `prd/discover.rs` covering the heuristic parser test corpus and the multi-source helper set)
- Security review: 0 critical findings; the `GitChangeApplier` mitigations cover the warning the security analyst flagged in phase 1

## Test plan

### Discovery & ingestion (#321)
- [x] `rm -f .maestro/prd.toml && cargo run`
- [x] Press `p` from landing → auto-sync runs → activity log shows `ingested from #1 (github:issue-1): vision, 5 goal(s)`
- [x] Vision section shows the real text from issue #1 (not a placeholder)
- [x] Goals section shows 5 success-criteria items, each with a single `[ ]` (no doubled checkboxes)
- [x] Press `o` → split-pane explore: left list of candidates, right preview with extracted Vision/Goals/Non-Goals/Stakeholders + raw body excerpt
- [x] Press `↓` → preview updates for focused candidate
- [x] Press `Enter` → ingests from selected source; activity log entry confirms what was added
- [ ] Press `R` → wipes `.maestro/prd.toml` and re-discovers; old polluted data is gone
- [ ] Press `e` → `PRD.md` written to repo root with all sections populated

### Bypass mode (#328)
- [x] Without `--bypass-review` and with default config → no red banner on launch
- [x] `cargo run -- --bypass-review` → red banner appears, activity log: `Bypass mode enabled (cli)`
- [x] In Settings → Sessions tab → toggle `bypass_review_corrections` ON → Save → banner appears immediately, no restart
- [x] Toggle OFF → Save → banner disappears immediately

### PR-review automation (#327)
- [ ] During a session, when assistant output contains `https://github.com/owner/repo/pull/N`, activity log fires: `Detected PR #N; triggering /review`
- [ ] After a review cycle: `Shift+C` opens the concerns panel with severity colours
- [ ] `a` accepts a concern → status flips to `[A]`; `r` rejects → `[R]`

### Roadmap (#329)
- [x] Press `r` from landing → roadmap loads milestones in semver descending order
- [x] `Enter` expands a milestone → issues appear grouped by Level (topological order)
- [x] `/` filter by label, `a` filter by assignee, `o`/`c` status filter, `x` clear
- [ ] `D` on a focused milestone → drills into MilestoneView

### Settings live-apply
- [x] Settings → TUI → change theme → Save → next frame uses new theme
- [x] Settings → change `max_concurrent` from 3 → 5 → Save → activity log shows BOTH `Settings saved and applied` AND `max_concurrent changed to 5 — RESTART required`

### Navigation
- [x] From Landing, press `q` → Confirm Exit dialog appears OVER the landing screen (mascot visible behind), not the sessions panel