### PR TITLE
feat(skills): add caveman skill for compressed orchestrator prose

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -356,6 +356,13 @@ Skills are reusable knowledge bases that subagents consult for best practices an
 | `api-contract-validation` | 1.0.0 | API contract enforcement | Orchestrator (via `/validate-contracts`) |
 | `security-patterns` | 1.0.0 | OWASP Top 10, security best practices | `subagent-security-analyst` |
 | `provider-resilience` | 1.0.0 | Defensive `gh`/`az` CLI patterns, error handling, idempotency | `subagent-architect`, `subagent-qa` |
+| `caveman` | 1.0.0 | Compressed orchestrator prose (opt-in) | Orchestrator (instruction) |
+
+### Caveman Mode
+
+At session start, read `.claude/settings.json`. If `behavior.caveman_mode === true`, apply `.claude/skills/caveman/SKILL.md` for the rest of the session. Default is `false`; the flag is read once per session. See SKILL.md for the full compress/preserve rules and non-goals. Reviewers touching CLAUDE.md or settings.json should confirm both this section and the `behavior.caveman_mode` key still exist — drift is detected only by review.
+
+**`behavior.*` namespace policy:** keys under `behavior` in `.claude/settings.json` are reserved for non-security-relevant style and UX toggles only (e.g. response formatting, verbosity, tone). Anything that gates a security control — auth bypass, permission grants, security-review skips, hook disabling — MUST be enforced in code or in a runtime hook, never by an instruction-only flag the orchestrator reads from a JSON file.
 
 ---
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,9 @@
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
   "alwaysThinkingEnabled": true,
+  "behavior": {
+    "caveman_mode": false
+  },
   "hooks": {
     "Notification": [
       {

--- a/.claude/skills/caveman/SKILL.md
+++ b/.claude/skills/caveman/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: caveman
+version: "1.0.0"
+description: Compressed-prose response style for the orchestrator (opt-in via behavior.caveman_mode). Drops articles, fillers, and transitional prose; preserves code, paths, JSON/TOML, and quoted text verbatim.
+allowed-tools: Read
+---
+
+# Caveman — Compressed Response Style
+
+> Compress orchestrator prose to the minimum tokens that preserve meaning.
+> Never compress code, identifiers, paths, or structured data.
+
+## When this skill applies
+
+- `behavior.caveman_mode: true` in `.claude/settings.json`. Default `false`; absent key ≡ `false`.
+- Read once at session start. Mid-session toggles take effect on next session.
+
+Scope: orchestrator user-facing prose only. Excluded:
+
+- Subagent-to-subagent messages (architect, qa, security, docs prompts go verbatim).
+- System prompts, CLAUDE.md, memory files, any other input.
+- Tool-call arguments and tool results.
+- Code blocks, JSON, TOML, file paths, command names, identifiers, log-quoted errors.
+
+## Compression rules (apply to prose only)
+
+1. **Drop articles** — omit "a", "an", "the" when meaning stays unambiguous.
+2. **Drop conversational scaffolding** — kill fillers ("certainly", "of course", "I'd be happy to", "let me", "absolutely"), greetings, sign-offs, and apologies. State the correction and move on.
+3. **Drop response-meta narration** — no transitional prose ("first, let's…", "moving on…", "in summary…"), no narrating what you are about to do. Do it.
+4. **Prefer imperative verbs** — "Run X" not "You could try running X".
+5. **One declarative sentence per fact.** No padding clauses.
+6. **Lists over paragraphs** when enumerating three or more items. Numerals over spelled-out numbers.
+
+## Verbatim-preserve rules (NEVER compress)
+
+Reproduce byte-for-byte:
+
+- Fenced code blocks (` ``` … ``` `).
+- Inline code spans (`` `like this` ``).
+- File paths, URLs, command invocations.
+- JSON, TOML, YAML, XML payloads.
+- Symbol names, type names, function signatures.
+- Quoted strings from logs, error messages, or user input.
+- Tool-call arguments and tool results.
+- Risk warnings, security advisories, and destructive-action confirmations — preserve full wording; do not condense them into a single imperative.
+- Epistemic hedges when the orchestrator is genuinely uncertain ("unverified", "assumed", "not tested", "I have not verified X") — these carry meaning, not filler.
+- Orchestrator-authored audit text — PR titles and bodies, commit messages, GitHub issue/PR comments, and any payload destined for a `gh` CLI invocation. Audit trails stay full-fidelity regardless of `caveman_mode`.
+
+## Non-goals (explicit)
+
+- No per-session override — global flag only.
+- No rewriting of input; user messages are never modified.
+- No per-language tuning; untested languages out of scope.
+- No automatic compression of subagent prompts.
+- Cannot rewrite the system prompt or CLAUDE.md content.
+
+## Flag plumbing
+
+`caveman_mode` is project convention; Claude Code does not dispatch on it. The orchestrator reads `.claude/settings.json` at session start per the `### Caveman Mode` instruction in `.claude/CLAUDE.md`:
+
+```json
+{
+  "behavior": {
+    "caveman_mode": false
+  }
+}
+```
+
+Enforcement is instruction-only — no compile-time or runtime gate. Drift detected by PR review of `.claude/CLAUDE.md` and `.claude/settings.json`, plus periodic manual sample. Migrate to a project-specific namespace (e.g. `maestro.caveman_mode`) if a future Claude Code release introduces a conflicting `behavior` key.
+
+## Example: same answer, two styles
+
+**Question:** "How do I run the tests?"
+
+**Normal:** "Sure! You can run the test suite with the following command: `cargo test`."
+
+**Caveman:** "Run `cargo test`."

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-24 12:00 (UTC)
+> Last updated: 2026-04-25 00:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -40,6 +40,8 @@ maestro/
 │       ├── README.md                      # Skills system documentation
 │       ├── api-contract-validation/
 │       │   └── SKILL.md                   # API contract enforcement patterns
+│       ├── caveman/
+│       │   └── SKILL.md                   # Compressed-prose response style (opt-in via behavior.caveman_mode)
 │       ├── example-backend-patterns/
 │       │   └── SKILL.md                   # Example backend skill template
 │       ├── example-frontend-patterns/
@@ -48,6 +50,8 @@ maestro/
 │       │   └── SKILL.md                   # Example mobile skill template
 │       ├── project-patterns/
 │       │   └── SKILL.md                   # Maestro-specific patterns and conventions
+│       ├── provider-resilience/
+│       │   └── SKILL.md                   # Defensive gh/az CLI patterns, error handling, idempotency
 │       ├── security-patterns/
 │       │   └── SKILL.md                   # OWASP Top 10 and security best practices
 │       └── video-frame-extractor/


### PR DESCRIPTION
## Summary

- New opt-in Claude Code skill at `.claude/skills/caveman/SKILL.md` — instructs the orchestrator to drop articles, fillers, pleasantries, and transitional prose while preserving code blocks, file paths, JSON/TOML, identifiers, log-quoted errors, security warnings, epistemic hedges, and orchestrator-authored audit text (PR/commit/CLI payloads) verbatim.
- New `behavior.caveman_mode` boolean (default `false`) in `.claude/settings.json` under a top-level `behavior` block. Read once at session start; mid-session toggles take effect on next session.
- `.claude/CLAUDE.md` gains a `### Caveman Mode` activation pointer plus a `behavior.*` namespace policy reserving the bucket for non-security-relevant style/UX toggles only (security controls must be enforced in code or runtime hooks, never instruction-only flags).
- `directory-tree.md` updated with the new `caveman/` entry; also fixes a pre-existing `provider-resilience/` omission found during the docs pass.

Closes #481

## Approach

Pure prompt-engineering deliverable — no Rust source touched. Gatekeeper classified as `task_type=docs`, so cargo RED/GREEN gates are skipped per the `/implement` spec. Verified instead with 8 deterministic static checks (file existence, frontmatter parse, JSON parse, `behavior.caveman_mode === false` default, CLAUDE.md skills-table row, Caveman Mode heading, key reference, body-length floor).

Enforcement is instruction-only by design. There is no compile-time gate that fires when the flag is `true` but the orchestrator ignores the skill — drift is detected only by PR review of `.claude/CLAUDE.md` and `.claude/settings.json`. The `behavior.*` namespace policy paragraph in CLAUDE.md keeps this pattern bounded to cosmetic/UX flags.

Two security-review findings applied during implementation: (1) verbatim-preserve list extended to cover security warnings, epistemic hedges, and audit text so caveman compression cannot silently strip risk-relevant context or full-fidelity audit trails; (2) `behavior.*` namespace policy added to CLAUDE.md. A `/simplify` review-and-cleanup pass after the initial implementation tightened the SKILL.md frontmatter description (290 → 197 chars), merged 9 → 6 compression rules to remove overlap, and collapsed the CLAUDE.md `### Caveman Mode` subsection from a 12-line restatement of SKILL.md into a 3-line activation pointer plus the load-bearing namespace policy.

## Test plan

- [ ] Static checks pass — run the verification script in `/tmp/maestro-481-1777153058` (or re-run inline: file exists, frontmatter parses with `name=caveman, version=1.0.0, allowed-tools=Read`, settings.json parses, `behavior.caveman_mode === false`, CLAUDE.md skills-table row present, "Caveman Mode" heading present, `caveman_mode` referenced in CLAUDE.md, SKILL.md body ≥ 100 chars).
- [ ] Manual acceptance (post-merge): set `"caveman_mode": true` in `.claude/settings.json`, start a fresh Claude Code session, ask a neutral question (e.g. "How do I run the tests?"), eyeball the response for absent fillers ("certainly", "of course", "I'd be happy to") and for verbatim code/path preservation. Restore the flag to `false` after the check.
- [ ] Confirm `cargo fmt --check`, `cargo clippy -- -D warnings -A dead_code`, and `scripts/check-file-size.sh` are all green (they were at commit time).
- [ ] Reviewer spot-check: SKILL.md does not violate its own compression rules; `behavior.*` namespace policy paragraph is present in CLAUDE.md.