### PR TITLE
feat(hooks): add parse_idea_triager_report hook with fixtures

### DIFF
--- a/.claude/hooks/fixtures/idea_triager_fail_bad_enum.txt
+++ b/.claude/hooks/fixtures/idea_triager_fail_bad_enum.txt
@@ -1,0 +1,16 @@
+```json idea-triager
+{
+  "report_version": 1,
+  "recommendation": "maybe",
+  "checks": {
+    "whose_problem": { "verdict": "pass", "note": "" },
+    "smallest_proof": { "verdict": "pass", "note": "" },
+    "success_signal": { "verdict": "pass", "note": "" },
+    "cost_of_skipping": { "verdict": "pass", "note": "" },
+    "vision_alignment": { "verdict": "pass", "note": "" }
+  },
+  "score": { "pass": 5, "weak": 0, "fail": 0 },
+  "remediation": { "comment_body": "", "labels_to_add": [], "labels_to_remove": [] },
+  "reasons": []
+}
+```

--- a/.claude/hooks/fixtures/idea_triager_fail_missing_fence.txt
+++ b/.claude/hooks/fixtures/idea_triager_fail_missing_fence.txt
@@ -1,0 +1,2 @@
+The triager forgot to emit a fenced block.
+This is plain prose with no JSON anywhere.

--- a/.claude/hooks/fixtures/idea_triager_pass.txt
+++ b/.claude/hooks/fixtures/idea_triager_pass.txt
@@ -1,0 +1,40 @@
+Triager findings for idea #999:
+
+Q1 names me as the user, daily during sprint pushes — passes.
+Q2 proposes adding tracing spans only — passes.
+Q3 has a measurable threshold — passes.
+Q4 honestly says "nothing today, revisit at 20+ sessions" — passes.
+Q5 picks "Adjacent" — passes.
+
+```json idea-triager
+{
+  "report_version": 1,
+  "recommendation": "promote",
+  "checks": {
+    "whose_problem": { "verdict": "pass", "note": "named user, daily frequency" },
+    "smallest_proof": { "verdict": "pass", "note": "tracing spans, ≤1 day" },
+    "success_signal": { "verdict": "pass", "note": "p95 latency threshold" },
+    "cost_of_skipping": { "verdict": "pass", "note": "honest 'nothing today' with revisit" },
+    "vision_alignment": { "verdict": "pass", "note": "Adjacent" }
+  },
+  "score": { "pass": 5, "weak": 0, "fail": 0 },
+  "spike_proposal": {
+    "scope": "add tracing spans around Command::spawn and first-event-received; log to .maestro/metrics/",
+    "time_box_days": 1,
+    "exit_criteria": [
+      "spans visible in tracing output",
+      "metrics file written for ≥1 session",
+      "p50/p95 spawn latency reported"
+    ]
+  },
+  "remediation": {
+    "comment_body": "",
+    "labels_to_add": ["spike", "ready"],
+    "labels_to_remove": ["needs-triage"]
+  },
+  "reasons": [
+    "all 5 checks passed",
+    "spike scope fits within 1 day"
+  ]
+}
+```

--- a/.claude/hooks/parse_idea_triager_report.py
+++ b/.claude/hooks/parse_idea_triager_report.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Extract and validate idea-triager JSON reports from subagent responses.
+
+Usage:
+    python3 parse_idea_triager_report.py < input.txt
+    echo "<text>" | python3 parse_idea_triager_report.py
+
+Exit codes:
+    0 — valid report extracted, re-emitted as compact JSON on stdout
+    1 — parse error (no fence, malformed JSON, wrong version, schema violation)
+"""
+import json
+import re
+import sys
+
+FENCE_PATTERN = re.compile(
+    r"```json\s+idea-triager\s*\n(.*?)\n```",
+    re.DOTALL,
+)
+
+SUPPORTED_VERSION = 1
+RECOMMENDATIONS = {"promote", "park", "archive"}
+RECOMMENDATIONS_REQUIRING_REMEDIATION = frozenset({"park", "archive"})
+VERDICTS = {"pass", "weak", "fail"}
+CHECK_KEYS = (
+    "whose_problem",
+    "smallest_proof",
+    "success_signal",
+    "cost_of_skipping",
+    "vision_alignment",
+)
+
+
+class ParseError(Exception):
+    """Raised when the input cannot be parsed as a valid triager report."""
+
+
+def extract_report(text: str) -> dict:
+    match = FENCE_PATTERN.search(text)
+    if not match:
+        raise ParseError("no ```json idea-triager fenced block found in input")
+
+    try:
+        report = json.loads(match.group(1))
+    except json.JSONDecodeError as exc:
+        raise ParseError(f"malformed JSON in idea-triager fence: {exc}") from exc
+
+    if not isinstance(report, dict):
+        raise ParseError("idea-triager report must be a JSON object")
+
+    version = report.get("report_version")
+    if version != SUPPORTED_VERSION:
+        raise ParseError(
+            f"unsupported report_version: {version!r} "
+            f"(this parser supports {SUPPORTED_VERSION})"
+        )
+
+    recommendation = report.get("recommendation")
+    if recommendation not in RECOMMENDATIONS:
+        raise ParseError(
+            f"recommendation must be one of {sorted(RECOMMENDATIONS)}, "
+            f"got {recommendation!r}"
+        )
+
+    checks = report.get("checks")
+    if not isinstance(checks, dict):
+        raise ParseError("checks must be a JSON object")
+    for key in CHECK_KEYS:
+        check = checks.get(key)
+        if not isinstance(check, dict):
+            raise ParseError(f"checks.{key} missing or not an object")
+        verdict = check.get("verdict")
+        if verdict not in VERDICTS:
+            raise ParseError(
+                f"checks.{key}.verdict must be one of {sorted(VERDICTS)}, "
+                f"got {verdict!r}"
+            )
+
+    if recommendation == "promote" and "spike_proposal" not in report:
+        raise ParseError("recommendation 'promote' requires spike_proposal")
+
+    if recommendation in RECOMMENDATIONS_REQUIRING_REMEDIATION:
+        remediation = report.get("remediation") or {}
+        if not remediation.get("comment_body"):
+            raise ParseError(
+                f"recommendation '{recommendation}' requires "
+                "remediation.comment_body"
+            )
+
+    return report
+
+
+def main() -> int:
+    text = sys.stdin.read()
+    try:
+        report = extract_report(text)
+    except ParseError as exc:
+        print(f"parse-idea-triager-report: {exc}", file=sys.stderr)
+        return 1
+
+    json.dump(report, sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-26 00:00 (UTC)
+> Last updated: 2026-04-27 00:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -32,8 +32,16 @@ maestro/
 │   │   └── video-frames.md                # Slash command: extract video frames
 │   ├── hooks/
 │   │   ├── README.md                      # Hook usage documentation
+│   │   ├── fixtures/                      # Fixture inputs for smoke-testing parser hooks
+│   │   │   ├── idea_triager_fail_bad_enum.txt     # Negative fixture: valid JSON but unsupported recommendation enum value
+│   │   │   ├── idea_triager_fail_missing_fence.txt # Negative fixture: plain prose with no fenced block
+│   │   │   └── idea_triager_pass.txt              # Golden-path fixture: full valid idea-triager report
+│   │   ├── implement-gates.sh             # Pre-implementation gate: DOR / blocker / contract checks
 │   │   ├── notify.ps1                     # Windows notification hook
-│   │   └── notify.sh                      # Unix notification hook
+│   │   ├── notify.sh                      # Unix notification hook
+│   │   ├── parse_gatekeeper_report.py     # Validates and re-emits gatekeeper JSON reports (exit 1 on contract violation)
+│   │   ├── parse_idea_triager_report.py   # Validates and re-emits idea-triager JSON reports; enforces fence, version, enums (exit 1 on violation)  [Issue #484]
+│   │   └── preflight.sh                   # Preflight environment checks run before session launch
 │   ├── settings.json                      # Claude Code project settings
 │   ├── settings.local.json                # Local overrides (not committed)
 │   ├── worktrees/

--- a/docs/superpowers/plans/2026-04-25-idea-triage-foundation.md
+++ b/docs/superpowers/plans/2026-04-25-idea-triage-foundation.md
@@ -39,7 +39,7 @@ The parser is the only piece with real logic. Everything else is config/markdown
 - Create: `.claude/hooks/fixtures/idea_triager_pass.txt`
 - Test: invoked via shell — no Python test framework exists in this Rust project, so we use fixture-driven smoke tests (same pattern as the gatekeeper parser, which has no Python tests today).
 
-- [ ] **Step 1: Create the golden-path fixture**
+- [x] **Step 1: Create the golden-path fixture**
 
 Write `.claude/hooks/fixtures/idea_triager_pass.txt`:
 
@@ -86,7 +86,7 @@ Q5 picks "Adjacent" — passes.
 ```
 ````
 
-- [ ] **Step 2: Run the parser to verify it fails (RED)**
+- [x] **Step 2: Run the parser to verify it fails (RED)**
 
 Run:
 ```bash
@@ -100,7 +100,7 @@ Expected: `python3: can't open file '...parse_idea_triager_report.py': [Errno 2]
 **Files:**
 - Create: `.claude/hooks/parse_idea_triager_report.py`
 
-- [ ] **Step 1: Create the parser**
+- [x] **Step 1: Create the parser**
 
 Write `.claude/hooks/parse_idea_triager_report.py`:
 
@@ -213,13 +213,13 @@ if __name__ == "__main__":
     sys.exit(main())
 ```
 
-- [ ] **Step 2: Make it executable**
+- [x] **Step 2: Make it executable**
 
 ```bash
 chmod +x .claude/hooks/parse_idea_triager_report.py
 ```
 
-- [ ] **Step 3: Run the golden-path fixture and verify it passes (GREEN)**
+- [x] **Step 3: Run the golden-path fixture and verify it passes (GREEN)**
 
 ```bash
 cat .claude/hooks/fixtures/idea_triager_pass.txt | python3 .claude/hooks/parse_idea_triager_report.py; echo "exit=$?"
@@ -227,7 +227,7 @@ cat .claude/hooks/fixtures/idea_triager_pass.txt | python3 .claude/hooks/parse_i
 
 Expected: a single line of compact JSON on stdout (the report), then `exit=0`.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add .claude/hooks/parse_idea_triager_report.py .claude/hooks/fixtures/idea_triager_pass.txt
@@ -236,7 +236,7 @@ git commit -m "feat(hooks): add parse_idea_triager_report hook with golden fixtu
 
 ### Task 3: Negative-path fixtures (RED→GREEN)
 
-- [ ] **Step 1: Create missing-fence fixture**
+- [x] **Step 1: Create missing-fence fixture**
 
 Write `.claude/hooks/fixtures/idea_triager_fail_missing_fence.txt`:
 
@@ -245,7 +245,7 @@ The triager forgot to emit a fenced block.
 This is plain prose with no JSON anywhere.
 ```
 
-- [ ] **Step 2: Verify parser rejects it**
+- [x] **Step 2: Verify parser rejects it**
 
 ```bash
 cat .claude/hooks/fixtures/idea_triager_fail_missing_fence.txt | python3 .claude/hooks/parse_idea_triager_report.py 2>&1; echo "exit=$?"
@@ -253,7 +253,7 @@ cat .claude/hooks/fixtures/idea_triager_fail_missing_fence.txt | python3 .claude
 
 Expected: stderr line `parse-idea-triager-report: no \`\`\`json idea-triager fenced block found in input`, `exit=1`.
 
-- [ ] **Step 3: Create bad-enum fixture**
+- [x] **Step 3: Create bad-enum fixture**
 
 Write `.claude/hooks/fixtures/idea_triager_fail_bad_enum.txt`:
 
@@ -276,7 +276,7 @@ Write `.claude/hooks/fixtures/idea_triager_fail_bad_enum.txt`:
 ```
 ````
 
-- [ ] **Step 4: Verify parser rejects it**
+- [x] **Step 4: Verify parser rejects it**
 
 ```bash
 cat .claude/hooks/fixtures/idea_triager_fail_bad_enum.txt | python3 .claude/hooks/parse_idea_triager_report.py 2>&1; echo "exit=$?"
@@ -284,7 +284,7 @@ cat .claude/hooks/fixtures/idea_triager_fail_bad_enum.txt | python3 .claude/hook
 
 Expected: stderr line `parse-idea-triager-report: recommendation must be one of ['archive', 'park', 'promote'], got 'maybe'`, `exit=1`.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add .claude/hooks/fixtures/idea_triager_fail_missing_fence.txt .claude/hooks/fixtures/idea_triager_fail_bad_enum.txt
@@ -601,7 +601,7 @@ These are intentionally **not** in this plan. Each becomes its own plan after Fo
 
 ## Definition of Done
 
-- [ ] Parser hook exists, executable, all 3 fixtures behave per expectations.
+- [x] Parser hook exists, executable, all 3 fixtures behave per expectations.
 - [ ] Subagent moved from `drafts/` to `.claude/agents/`, history preserved via `git mv`.
 - [ ] `/triage-idea` slash command spec exists and references parser correctly.
 - [ ] CLAUDE.md registry and delegation tables updated.


### PR DESCRIPTION
## Summary
- Adds `parse_idea_triager_report.py` — stdlib-only Python parser that extracts the fenced ```json idea-triager``` block from a subagent response and validates the schema (report_version, recommendation enum, per-check verdicts, conditional `spike_proposal` / `remediation.comment_body` rules).
- Adds three smoke-test fixtures: golden path (`promote`), missing-fence negative, bad-enum negative.
- Mirrors the existing `parse_gatekeeper_report.py` shape; fail-loud on contract violations with `parse-idea-triager-report:` stderr prefix.

Closes #484

## Test plan
- [x] `cat .claude/hooks/fixtures/idea_triager_pass.txt | python3 .claude/hooks/parse_idea_triager_report.py` exits 0 and prints compact JSON to stdout.
- [x] `cat .claude/hooks/fixtures/idea_triager_fail_missing_fence.txt | ...` exits 1 with the issue-mandated stderr substring.
- [x] `cat .claude/hooks/fixtures/idea_triager_fail_bad_enum.txt | ...` exits 1 with the issue-mandated stderr substring.
- [x] Edge cases verified by hand: empty fence body, promote without `spike_proposal`, park with empty `comment_body`, archive with empty `comment_body`, bad verdict on a single check.
- [x] Direct shebang invocation works (`chmod +x` applied).
- [x] No new Python dependencies; stdlib only.
- [x] `cargo fmt --check`, `cargo clippy -- -D warnings -A dead_code`, and `scripts/check-file-size.sh` all clean.