### PR TITLE
feat(commands): add /triage-idea slash command + register subagent

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -306,6 +306,7 @@ Immediately after language selection, ask:
 | Security review, OWASP | `subagent-security-analyst` |
 | Documentation (CAN WRITE .md) | `subagent-docs-analyst` |
 | Complex architecture & design planning | `subagent-master-planner` |
+| Idea triage (pre-DOR funnel) | `subagent-idea-triager` |
 
 ### Subagent Registry
 
@@ -317,6 +318,7 @@ Immediately after language selection, ask:
 | `subagent-security-analyst` | Security review, OWASP, vulnerability analysis | **Ready** |
 | `subagent-docs-analyst` | Documentation management (CAN WRITE .md) | **Ready** |
 | `subagent-master-planner` | System architecture planning, ADRs | **Ready** |
+| `subagent-idea-triager` | Idea-inbox triage gate (5-question honesty check, promote/park/archive) | **Ready** |
 
 ---
 

--- a/.claude/commands/triage-idea.md
+++ b/.claude/commands/triage-idea.md
@@ -1,0 +1,239 @@
+# Triage Idea
+
+Run the upstream idea-inbox triage loop on a GitHub issue created from
+`.github/ISSUE_TEMPLATE/idea.yml`. Dispatches `subagent-idea-triager`,
+validates the structured report through `.claude/hooks/parse_idea_triager_report.py`,
+and prints a digest. **Does not mutate GitHub state without explicit user
+confirmation** — every comment posting and label change is gated on a
+`yes/no` prompt. v0.16.1 is the foundation milestone; auto-mutation flows
+ship later (see Consultive Boundaries below).
+
+**Usage:** `/triage-idea #123` or `/triage-idea 123`
+
+---
+
+## Arguments
+
+`$ARGUMENTS` contains the idea issue number with an optional `#` prefix.
+Extract the first `\d+` and reject if no number is present.
+
+---
+
+## Instructions
+
+### Step 0: Parse arguments
+
+Extract the first run of digits from `$ARGUMENTS` and re-validate the
+result is digits-only before exporting. Never pass `$ARGUMENTS` directly
+to `gh`.
+
+```bash
+IDEA_NUMBER=$(printf '%s' "$ARGUMENTS" | grep -oE '[0-9]+' | head -n1)
+[[ "$IDEA_NUMBER" =~ ^[0-9]+$ ]] || {
+  echo "no issue number in arguments" >&2
+  exit 1
+}
+export IDEA_NUMBER
+```
+
+If no number is found, ask: "Which idea issue should I triage?" and stop.
+
+### Step 1: Confirm the issue exists and surface its labels
+
+```bash
+gh issue view "$IDEA_NUMBER" \
+  --json number,title,labels,state,body \
+  --jq '{number, title, state, labels: [.labels[].name], body}'
+```
+
+- If `gh` is not installed or not authenticated → exit 1 with the standard
+  hint (`brew install gh` / `gh auth login`).
+- If the issue does not exist → exit 1.
+- If the issue is `CLOSED` → exit 1. Re-open or pick a different issue.
+- If the labels do **not** include `idea`, print a warning and ask the
+  user whether to proceed anyway. Some users may file ideas without the
+  template; the triager can still score the body.
+
+### Step 2: Dispatch `subagent-idea-triager`
+
+Invoke `subagent-idea-triager` via the `Agent` tool. Pass:
+
+- The full issue JSON from Step 1 (including title and body).
+- The repo name: `gh repo view --json nameWithOwner --jq .nameWithOwner`.
+
+The subagent's spec lives at `.claude/agents/subagent-idea-triager.md`.
+It must return a fenced ```` ```json idea-triager ```` block per its
+output contract.
+
+### Step 3: Validate the report
+
+Pipe the subagent's response through the parser hook into a single
+`PARSED_JSON` buffer — Step 4 and Step 5 both read from this buffer with
+no re-parsing in between.
+
+```bash
+PARSED_JSON=$(echo "$SUBAGENT_RESPONSE" | python3 .claude/hooks/parse_idea_triager_report.py)
+```
+
+If the parser exits non-zero:
+- Print the parser's stderr verbatim.
+- Stop. Do **NOT** post comments or change labels.
+- Suggest the user re-run `/triage-idea` or inspect the subagent's raw output.
+- Exit 2.
+
+### Step 4: Render the digest to the user
+
+Materialize the buffers Step 5 will need from `$PARSED_JSON` once, here.
+Step 5 must use these exact variables — not re-parse the JSON. Derive
+the pass/weak/fail counts from the `checks` block (do **not** trust
+`score.*` blindly — derive at render time).
+
+```bash
+RECOMMENDATION=$(jq -r '.recommendation' <<<"$PARSED_JSON")
+COMMENT_BODY=$(jq -r '.remediation.comment_body // ""' <<<"$PARSED_JSON")
+mapfile -t LABELS_TO_ADD    < <(jq -r '.remediation.labels_to_add[]?    // empty' <<<"$PARSED_JSON")
+mapfile -t LABELS_TO_REMOVE < <(jq -r '.remediation.labels_to_remove[]? // empty' <<<"$PARSED_JSON")
+```
+
+**Sanitize before printing.** Strip ASCII control characters
+(`\x00-\x08\x0b-\x1f\x7f`) from every `note`, `comment_body`, and
+`scope` string before they hit the user's terminal. The y/n prompt in
+Step 5 must show the user the same bytes that will land on GitHub —
+hidden escape sequences would let a hostile subagent response deceive
+the operator.
+
+Then print:
+
+```
+Triage result: <recommendation>
+
+Checks:
+  whose_problem    : <verdict>  — <note>
+  smallest_proof   : <verdict>  — <note>
+  success_signal   : <verdict>  — <note>
+  cost_of_skipping : <verdict>  — <note>
+  vision_alignment : <verdict>  — <note>
+
+Score: <pass> pass / <weak> weak / <fail> fail
+```
+
+If `recommendation == "promote"`, also print:
+
+```
+Spike proposal:
+  Scope: <scope>
+  Time-box: <time_box_days> day(s)
+  Exit criteria:
+    - <each criterion>
+
+Suggested labels (NOT applied — Plan 3 territory):
+  add:    <labels_to_add>
+  remove: <labels_to_remove>
+```
+
+If `recommendation == "park"` or `recommendation == "archive"`, also print:
+
+```
+Draft remediation comment:
+---
+<comment_body>
+---
+
+Suggested label changes:
+  add:    <labels_to_add>
+  remove: <labels_to_remove>
+```
+
+### Step 5: Confirm before any GitHub mutation
+
+**This command never auto-mutates GitHub state.** Always prompt; act only
+on an explicit `yes`.
+
+- For `promote`:
+  > "Spike-issue creation lands in Plan 3 (Spike pipeline). For now, no
+  > GitHub mutation is performed. Approve? (y/n)"
+  - `y` — print `noted — Spike pipeline lands in Plan 3` and exit 0.
+  - `n` — print `no changes made` and exit 3.
+
+- For `park`:
+  > "Post the draft comment and apply the label changes? (y/n)"
+  - `y` — execute against the **same buffers materialized in Step 4**
+    (no re-parsing of the JSON between confirm and act). Marshal the
+    JSON arrays into repeated CLI flags rather than passing them as
+    single comma-joined strings:
+    ```bash
+    gh issue comment "$IDEA_NUMBER" --body "$COMMENT_BODY"
+
+    edit_args=()
+    for lbl in "${LABELS_TO_ADD[@]}";    do edit_args+=(--add-label    "$lbl"); done
+    for lbl in "${LABELS_TO_REMOVE[@]}"; do edit_args+=(--remove-label "$lbl"); done
+    gh issue edit "$IDEA_NUMBER" "${edit_args[@]}"
+    ```
+    Then exit 0. The user-confirmation loop also covers brainstorming for
+    `park` outcomes — that lands in Plan 2 (Park-lift).
+  - `n` — print `no changes made` and exit 3.
+
+- For `archive`: same prompt and flow as `park`, but the label set
+  reflects archival. Auto-archive of stale ideas (>28 days) lands in
+  Plan 5; this command never closes the issue, even on `archive`.
+
+---
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success — digest printed; mutations either declined or completed after explicit user confirmation. |
+| 1 | Generic failure (`gh` missing or unauthenticated, issue not found, issue closed). |
+| 2 | Parser contract violation — subagent response did not validate. No mutation performed. |
+| 3 | User declined the post-digest confirmation; no mutation performed. Informational, not an error. |
+
+---
+
+## Error Handling
+
+- `gh` not installed → exit 1 with the install hint.
+- `gh` not authenticated → exit 1 with `gh auth login` hint.
+- Issue does not exist or is closed → exit 1.
+- Subagent fails to return a fenced ```` ```json idea-triager ```` block →
+  the parser produces the canonical "no fence" error; orchestrator exits 2.
+- Parser rejects the report (bad enum, missing required field) → print
+  parser stderr verbatim, exit 2. Never act on raw subagent output.
+- User answers `n` at the Step 5 prompt → exit 3 cleanly with
+  `no changes made`.
+
+---
+
+## Consultive Boundaries (v0.16.1 scope)
+
+- This command **never auto-mutates** GitHub state. Comments and label
+  changes always require an explicit `yes` at the Step 5 prompt.
+- Spike-issue creation from `recommendation == "promote"` is deferred to
+  **Plan 3** (Spike pipeline). The `labels_to_add` for `promote` are
+  surfaced in the digest but **not applied** by this command.
+- `superpowers:brainstorming` for `park` results is deferred to
+  **Plan 2** (Park-lift).
+- `superpowers:writing-plans` handoff for promoted spikes is deferred to
+  **Plan 4** (Spike→DOR handoff).
+- Auto-archive of stale ideas (>28 days) is deferred to
+  **Plan 5** (Auto-archive Action).
+
+---
+
+## Do Not
+
+- Run mutating `gh` commands (`gh issue comment`, `gh issue edit`,
+  `gh issue close`) without an explicit `yes` from the Step 5 prompt.
+- Act on the subagent's raw response — always pipe through
+  `.claude/hooks/parse_idea_triager_report.py` first.
+- Create spike issues from this command (Plan 3 territory).
+- Invoke `superpowers:brainstorming` from this command (Plan 2 territory).
+- Close the idea issue from this command, even on `archive`
+  (Plan 5 territory).
+- Apply the `promote` recommendation's `labels_to_add` — they are
+  surfaced for the user but applied by Plan 3, not here.
+- Pass `$ARGUMENTS` directly into any `gh` invocation; route through the
+  validated `$IDEA_NUMBER` from Step 0.
+- Pass JSON-array label fields as a single comma-joined string to
+  `gh issue edit`; always expand into repeated `--add-label` /
+  `--remove-label` flags as shown in Step 5.

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-27 00:00 (UTC)
+> Last updated: 2026-04-27 12:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -27,6 +27,7 @@ maestro/
 │   │   ├── pushup.md                      # Slash command: git push workflow
 │   │   ├── setup-notifications.md         # Slash command: configure hook notifications
 │   │   ├── setup-project.md               # Slash command: initialize project config
+│   │   ├── triage-idea.md                 # Slash command: non-mutating idea triage loop (fetch idea issue → dispatch subagent-idea-triager → validate report → render digest)  [Issue #485]
 │   │   ├── update-from-template.md        # Slash command: sync from template directory
 │   │   ├── validate-contracts.md          # Slash command: validate API contracts
 │   │   └── video-frames.md                # Slash command: extract video frames
@@ -388,6 +389,14 @@ maestro/
 │           ├── api-contract-validation/
 │           ├── project-patterns/
 │           └── security-patterns/
+├── scripts/                               # Project-level shell scripts for architecture checks, coverage, and verification gates
+│   ├── allowlist-large-files.txt          # Allowlist for large files exempted from size checks
+│   ├── architecture-layers.yml            # Layer dependency rules for check-layers.sh
+│   ├── check-coverage-tiers.sh            # Validate test-coverage tier thresholds
+│   ├── check-file-size.sh                 # Enforce per-file LOC limits (500-line rule)
+│   ├── check-layers.sh                    # Enforce architecture layer boundaries
+│   ├── coverage-tiers.yml                 # Coverage tier definitions
+│   └── verify-issue-485.sh                # TDD verification harness: 27 grep/awk assertions for /triage-idea command + CLAUDE.md registry entries  [Issue #485]
 ├── tests/                                 # Cargo integration tests (run as a separate binary, full crate access)
 │   ├── settings_caveman.rs                # Integration tests for FsSettingsStore against real tempfiles: read/write/toggle round-trips for caveman mode, missing-key defaults, malformed JSON handling  [Issue #490]
 │   ├── gatekeeper/                        # Gatekeeper harness fixtures and tests

--- a/scripts/verify-issue-485.sh
+++ b/scripts/verify-issue-485.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Verify the .md deliverables for issue #485:
+#   - .claude/commands/triage-idea.md exists with required structure
+#   - .claude/CLAUDE.md registers subagent-idea-triager in two tables
+#
+# Runs as the TDD RED/GREEN gate for a docs-only task. Exits non-zero on
+# the first failed assertion with a description on stderr.
+
+set -euo pipefail
+
+# Pin to repo root so relative paths work from any cwd.
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+CMD=".claude/commands/triage-idea.md"
+CLAUDE_MD=".claude/CLAUDE.md"
+AGENT=".claude/agents/subagent-idea-triager.md"
+PARSER=".claude/hooks/parse_idea_triager_report.py"
+
+fail() {
+  echo "verify-issue-485: FAIL — $1" >&2
+  exit 1
+}
+
+# Extract the body of a `### Heading` block from CLAUDE.md, stopping at
+# the first line matching the stop pattern. Returns lines AFTER the
+# start heading (not the heading itself).
+claude_md_section() {
+  local start="$1" stop="$2"
+  awk -v start="$start" -v stop="$stop" '
+    $0 ~ stop && in_block { exit }
+    in_block { print }
+    $0 ~ start { in_block = 1 }
+  ' "$CLAUDE_MD"
+}
+
+[ -f "$CMD" ] || fail "F1: $CMD does not exist"
+[ -s "$CMD" ] || fail "F2: $CMD is empty"
+
+grep -qE '^# Triage Idea[[:space:]]*$' "$CMD" \
+  || fail "F3: H1 '# Triage Idea' missing in $CMD"
+grep -q '^## Arguments$' "$CMD" \
+  || fail "F4: '## Arguments' section missing in $CMD"
+grep -q '^## Instructions$' "$CMD" \
+  || fail "F5: '## Instructions' section missing in $CMD"
+grep -q '^## Exit Codes$' "$CMD" \
+  || fail "F6: '## Exit Codes' section missing in $CMD"
+grep -q '^## Do Not$' "$CMD" \
+  || fail "F7: '## Do Not' section missing in $CMD"
+
+# F8-F13. Step 0 through Step 5 sub-sections.
+for n in 0 1 2 3 4 5; do
+  grep -q "### Step ${n}:" "$CMD" \
+    || fail "F$((8 + n)): '### Step ${n}:' missing in $CMD"
+done
+
+# `set -e` would abort on grep -c returning 1 (zero matches), so guard with `|| true`.
+hits=$(grep -c 'subagent-idea-triager' "$CMD" || true)
+[ "$hits" -ge 2 ] \
+  || fail "F14: 'subagent-idea-triager' appears $hits time(s) in $CMD (need >= 2)"
+
+grep -q '\.claude/hooks/parse_idea_triager_report\.py' "$CMD" \
+  || fail "F15: parser path '.claude/hooks/parse_idea_triager_report.py' missing in $CMD"
+grep -Eiq '(does not mutate|never auto-mutate|non-mutation|do not mutate)' "$CMD" \
+  || fail "F16: non-mutation guarantee phrasing missing in $CMD"
+grep -qiE '(confirm|yes.*no|proceed\?|approve|y/n)' "$CMD" \
+  || fail "F17: confirmation prompt phrasing missing in $CMD"
+
+# F18-F21. Plans 2-5 explicitly deferred.
+for n in 2 3 4 5; do
+  grep -q "Plan $n" "$CMD" \
+    || fail "F$((16 + n)): 'Plan $n' deferral missing in $CMD"
+done
+
+# F22-F23. Delegation Rules table contains the row + description.
+delegation_block=$(claude_md_section \
+  '^### Subagent Reference [(]Orchestrator Mode[)]' \
+  '^### Subagent Registry')
+[ -n "$delegation_block" ] \
+  || fail "F22: Delegation Rules section heading not found — table layout in $CLAUDE_MD may have drifted"
+echo "$delegation_block" | grep -q 'subagent-idea-triager' \
+  || fail "F22: 'subagent-idea-triager' missing from Delegation Rules table in $CLAUDE_MD"
+echo "$delegation_block" | grep -q 'Idea triage (pre-DOR funnel)' \
+  || fail "F23: 'Idea triage (pre-DOR funnel)' description missing from Delegation Rules table"
+
+# F24-F25. Subagent Registry table contains the row with a Ready/Draft status.
+registry_block=$(claude_md_section \
+  '^### Subagent Registry' \
+  '^(---|## )')
+[ -n "$registry_block" ] \
+  || fail "F24: Subagent Registry section heading not found — table layout in $CLAUDE_MD may have drifted"
+echo "$registry_block" | grep -q 'subagent-idea-triager' \
+  || fail "F24: 'subagent-idea-triager' missing from Subagent Registry table in $CLAUDE_MD"
+echo "$registry_block" \
+  | grep 'subagent-idea-triager' \
+  | grep -qE '\*\*(Ready|Draft)\*\*' \
+  || fail "F25: registry row for 'subagent-idea-triager' missing **Ready** or **Draft** status"
+
+[ -f "$AGENT" ] || fail "F26: $AGENT missing (blocker #483 should have shipped this)"
+[ -x "$PARSER" ] || fail "F27: $PARSER missing or not executable (blocker #484)"
+
+echo "verify-issue-485: PASS — all 27 assertions ok"


### PR DESCRIPTION
## Summary

- Adds `.claude/commands/triage-idea.md` — non-mutating slash command spec that fetches an idea issue, dispatches `subagent-idea-triager`, validates the report through `parse_idea_triager_report.py`, renders a digest, and gates every GitHub mutation on an explicit `y/n` prompt.
- Registers `subagent-idea-triager` in `.claude/CLAUDE.md` (Delegation Rules + Subagent Registry).
- Adds `scripts/verify-issue-485.sh` — 27 grep/awk assertions used as the TDD RED/GREEN gate for this docs-only deliverable.

Implements Plan 1 (Foundation) of `docs/superpowers/plans/2026-04-25-idea-triage-foundation.md`. Plans 2–5 (Park-lift, Spike pipeline, Spike→DOR handoff, Auto-archive) are explicitly deferred and called out in the spec's Consultive Boundaries section.

Closes #485

## Security hardening (post-review)

- Step 0 strictly re-validates `IDEA_NUMBER` is digits-only after extraction; never passes raw `$ARGUMENTS` to `gh`.
- Step 4 strips ASCII control characters from `comment_body` / `note` / `scope` before rendering, so the y/n confirmation reflects what will actually post.
- Step 5 marshals JSON-array labels into repeated `--add-label` / `--remove-label` flags rather than a comma-joined string, and pins variable buffers across the confirm→act boundary.

## Test plan

- [x] `bash scripts/verify-issue-485.sh` exits 0 (27/27 assertions pass) from repo root and from `/tmp` (cwd-pinning works)
- [x] `bash .claude/hooks/implement-gates.sh 485` passes (cargo fmt, clippy -D warnings, file-size, preflight)
- [x] `grep -c subagent-idea-triager .claude/CLAUDE.md` returns `2` (one row per table)
- [ ] Smoke test the command end-to-end against a throwaway issue — covered by follow-up issue #486