### PR TITLE
chore(docs): smoke-test idea-triage foundation + sync directory-tree

### DIFF
--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-27 12:00 (UTC)
+> Last updated: 2026-04-27 15:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -25,6 +25,7 @@ maestro/
 │   │   ├── implement.md                   # Slash command: run full TDD implementation flow
 │   │   ├── plan-feature.md                # Slash command: invoke master planner
 │   │   ├── pushup.md                      # Slash command: git push workflow
+│   │   ├── release.md                     # Slash command: semantic version release — bump version, update changelog, tag, push, and create GitHub Release
 │   │   ├── setup-notifications.md         # Slash command: configure hook notifications
 │   │   ├── setup-project.md               # Slash command: initialize project config
 │   │   ├── triage-idea.md                 # Slash command: non-mutating idea triage loop (fetch idea issue → dispatch subagent-idea-triager → validate report → render digest)  [Issue #485]


### PR DESCRIPTION
## Summary

- Validates the v0.16.1 idea-triage foundation seam end-to-end (parser → subagent → slash command) against throwaway idea issue #497.
- Reconciles `directory-tree.md` with HEAD: timestamp bump + restores the missing `.claude/commands/release.md` entry.
- Surfaces and resolves a foundation finding: `subagent-idea-triager` was not loaded into the Agent registry on the first /implement run; a fresh Claude Code session picked it up. No code change required — the smoke test caught exactly the integration defect it was designed to catch.

Closes #486

## Smoke-test evidence (#497)

- **Parser:** `.claude/hooks/parse_idea_triager_report.py` exited `0` on the triager response (recommendation: `promote`, score 5p/0w/0f).
- **Step-5 prompt:** declined per smoke-test policy → no GitHub mutation by the slash command.
- **Label snapshot diff:** byte-identical before/after (`idea`, `needs-triage`).
- **Timeline audit:** 5 events on #497 — `labeled` x2 (template auto-apply at creation), `commented` x2 (paused-session note + closing summary), `closed`. No assignee, milestone, project, lock, or post-creation label changes.
- Closed with `--reason "not planned"`.

## Acceptance criteria

- [x] Throwaway smoke-test issue filed via `idea.yml` (#497)
- [x] `/triage-idea` runs end-to-end: parser exits 0, digest printed
- [x] `gh issue view --json labels` confirms no unauthorized label changes
- [x] Test issue closed cleanly
- [x] `directory-tree.md` includes all 7 v0.16.1 foundation paths

## Test plan

- [x] CI green (preflight: cargo fmt + clippy -D warnings + 400-line cap)
- [ ] `grep` the 7 foundation file basenames in `directory-tree.md` — all return ≥1
- [x] `git diff main...HEAD -- directory-tree.md` shows only the timestamp bump and the `release.md` line addition
- [ ] No source-code files modified (`git diff main...HEAD --stat | grep -v '\.md$'` is empty)

## Follow-ups (out of scope, tracked for Plan 2/3)

Security review (forward-looking, non-blocking for #486):
- Broaden the smoke-test snapshot to cover `assignees`, `milestone`, `projectItems`, `locked`, `reactionGroups` — current proof covers labels + comments + close only.
- Add a paired y-branch smoke test once `park`/`archive` mutation paths land (Plan 2), so the `y` half of the contract is exercised.
- Move the `comment_body` / `note` / `scope` control-character strip from the orchestrator's Step 4 prose into `parse_idea_triager_report.py` so the trust boundary enforces sanitization instead of trusting the caller.