### PR TITLE
feat(tui): copy focused agent-tab response to clipboard with c key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ async-trait = "0.1"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 sha2 = "0.10"
 arboard = "3.6.1"
+strip-ansi-escapes = "0.2"
 image = { version = "0.25.10", features = ["png"], default-features = false }
 pulldown-cmark = { version = "0.12", default-features = false }
 tui-textarea = { version = "0.7", features = ["crossterm"] }

--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ Dependencies can also be declared in the issue body as `blocked-by: #N` (case-in
 | `p` | Pause all running sessions (SIGSTOP) |
 | `r` | Resume all paused sessions (SIGCONT) |
 | `k` | Kill all sessions |
+| `c` | Copy focused agent's last response to clipboard (dimmed when no response or session is streaming) |
 
 ### Home Screen
 

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-27 15:00 (UTC)
+> Last updated: 2026-04-27 18:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -214,6 +214,7 @@ maestro/
 │   │   │   ├── types.rs                   # TuiMode enum (+ CompletionSummary, ContinuousPause variants) with breadcrumb_label() method; NavigationStack struct (push/pop/peek/clear/breadcrumbs, cap 32); TuiCommand enum (+ RunAdaptScaffold); TuiDataEvent enum (+ AdaptScaffoldResult); SuggestionDataPayload; CompletionSummaryData; CompletionSessionLine; GateFailureInfo  [Issue #342, #371]
 │   │   │   ├── budget.rs                  # Budget enforcement helpers within App
 │   │   │   ├── ci_polling.rs              # poll_ci_status() CI auto-fix loop using CiCheck trait; decide_ci_action(); spawn_ci_fix_session()  [Issue #41, #123]
+│   │   │   ├── clipboard_action.rs        # App::copy_focused_response() + App::copy_focused_response_enabled() predicate; CopyOutcome enum (Success, NoContent, NotEnded, Failed); set_copy_toast() / tick_copy_toast() with COPY_TOAST_TTL_MS = 2_000  [Issue #482]
 │   │   │   ├── completion_pipeline.rs     # check_completions() config-driven gate evaluation with per-gate logging  [Issue #40, #104]
 │   │   │   ├── completion_summary.rs      # build_completion_summary(); transition_to_dashboard() calls navigate_to_root() to clear nav stack  [Issue #342]
 │   │   │   ├── context_overflow.rs        # Context overflow detection and fork triggering
@@ -226,17 +227,21 @@ maestro/
 │   │   │   ├── review.rs                  # ReviewCouncil integration and gate-fix session spawning
 │   │   │   ├── session_lifecycle.rs       # Session promotion, state transitions, activity log forwarding
 │   │   │   ├── session_spawners.rs        # spawn_gate_fix_session(); build_gate_fix_prompt(); launch_session_from_config()
+│   │   │   ├── settings_actions.rs        # SettingsStore-backed App methods extracted from app/mod.rs to keep it under the file-size cap: with_settings_store(), caveman_mode(), process_pending_caveman_toggle()  [Issue #482]
 │   │   │   ├── tests.rs                   # App-level unit tests
 │   │   │   └── work_assigner.rs           # WorkAssigner integration: topo-sort, issue queueing
 │   │   ├── theme.rs                       # Theme module: Theme struct (resolved color fields), ThemeConfig (preset + overrides), ThemePreset (Dark, Light), ThemeOverrides (per-field optional color overrides), SerializableColor (named/hex/indexed), ColorCapability; fkey_badge_bg and fkey_badge_fg optional override fields for F-key bar badge styling; milestone_gauge_color() derives a completion-aware color (green=high, yellow=mid, red=low) with inverted semantics relative to budget gauges; builds ratatui Color values from maestro.toml [tui.theme] block  [Issue #38, #218, #299]
 │   │   ├── activity_log.rs                # Scrollable activity log widget with LogLevel color coding; LogLevel::Thinking variant (green / accent_success color, distinct from Error)  [Phase 1, Issue #102]
+│   │   ├── clipboard.rs                   # Clipboard trait + SystemClipboard impl (arboard); strip_ansi() helper strips ANSI escape sequences from response text before copy  [Issue #482]
+│   │   ├── clipboard_toast.rs             # Toast renderer: 2-second status-bar overlay confirming clipboard copy success or failure  [Issue #482]
 │   │   ├── cost_dashboard.rs              # Cost dashboard widget: per-session and aggregate cost display  [Phase 3]
 │   │   ├── dep_graph.rs                   # ASCII dependency graph visualization  [Phase 3]
 │   │   ├── detail.rs                      # Session detail view  [Phase 3]
 │   │   ├── fullscreen.rs                  # Fullscreen session view with phase progress overlay  [Phase 3]
 │   │   ├── help.rs                        # Help overlay widget with keybinding reference  [Phase 3]
 │   │   ├── icons.rs                       # Thin re-export shim: re-exports IconId, IconPair, icon_pair(), get(), get_for_mode() from src/icons.rs and init_from_config(), use_nerd_font() from src/icon_mode.rs so existing tui:: import paths remain valid after the registry was extracted  [Issue #307, #308]
-│   │   ├── input_handler.rs               # Top-level key event dispatcher extracted from mod.rs; KeyAction enum (Consumed, Quit); handle_key() dispatches to overlay handlers, mode-specific input, global shortcuts, and screen dispatch in priority order; all Esc handlers use navigate_back_or_dashboard() via NavigationStack  [Issue #342]
+│   │   ├── input_handler.rs               # Top-level key event dispatcher extracted from mod.rs; KeyAction enum (Consumed, Quit); handle_key() dispatches to overlay handlers, mode-specific input, global shortcuts, and screen dispatch in priority order; all Esc handlers use navigate_back_or_dashboard() via NavigationStack; 'c' key arm in handle_overview_keys() triggers copy_focused_response()  [Issue #342, #482]
+│   │   ├── keybinding_hints.rs            # Dim-aware hint bar span builder; keybinding_hints_spans() emits '[c] Copy' dimmed when no response is available or session is still streaming  [Issue #482]
 │   │   ├── log_viewer.rs                  # Full-screen scrollable log viewer widget
 │   │   ├── markdown.rs                    # markdown-to-ratatui rendering module; convert Markdown content to terminal-friendly widgets; wrap_and_push_text() performs width-aware word wrapping when appending text spans to a line buffer
 │   │   ├── marquee.rs                     # Horizontally scrolling marquee text widget
@@ -246,7 +251,7 @@ maestro/
 │   │   │   ├── mod.rs                     # Module exports for navigation subsystem
 │   │   │   ├── focus.rs                   # Focus management: FocusManager, focus ring, widget focus state
 │   │   │   ├── keymap.rs                  # Keymap definitions: action-to-key bindings, context-sensitive keymaps; F-key bar actions registered (F1 Help, F2 Summary, F3 Full, F4 Costs, F5 Tokens, F6 Deps, F9 Pause, F10 Kill, Alt-X Exit); KeyBindingGroup, InlineHint, FKeyRelevance, ModeKeyMap, global_keybindings() LazyLock  [Issue #218]
-│   │   │   └── mode_hints.rs              # mode_keymap() builds ModeKeyMap for a given TuiMode + optional session status; maps TuiMode variants to mode labels, F-key visibility rules, and context-sensitive inline hints; consumes screen_bindings from KeymapProvider::keybindings()
+│   │   │   └── mode_hints.rs              # mode_keymap() builds ModeKeyMap for a given TuiMode + optional session status; maps TuiMode variants to mode labels, F-key visibility rules, and context-sensitive inline hints; consumes screen_bindings from KeymapProvider::keybindings(); 'c Copy' hint added to Overview mode  [Issue #482]
 │   │   ├── session_summary.rs             # Session summary widget rendered in the completion overlay and detail pane
 │   │   ├── session_switcher.rs            # Session switcher overlay for jumping between active sessions
 │   │   ├── splash.rs                      # Startup splash screen rendered before the TUI loop begins
@@ -265,7 +270,8 @@ maestro/
 │   │   │   ├── cost_dashboard.rs          # 5 snapshot tests for CostDashboard (no budget, under threshold, over 90%, empty, sorted)
 │   │   │   ├── turboquant_dashboard.rs    # 3 snapshot tests for TurboQuantDashboard (projections-only, mixed actual+projections, empty sessions)  [Issue #346]
 │   │   │   ├── caveman_row.rs             # 5 snapshot tests for caveman_row in SettingsScreen (explicit_true, explicit_false, default, error, focused_explicit_true)  [Issue #490]
-│   │   │   └── snapshots/                 # Committed insta snapshot files (.snap files); includes caveman_row renders (default, error, explicit_false, explicit_true, focused_explicit_true)  [Issue #490]
+│   │   │   ├── copy_keybinding_hint.rs    # Insta snapshot tests for keybinding hint bar: copy_keybinding_hint_enabled and copy_keybinding_hint_disabled  [Issue #482]
+│   │   │   └── snapshots/                 # Committed insta snapshot files (.snap files); includes caveman_row renders (default, error, explicit_false, explicit_true, focused_explicit_true); copy_keybinding_hint_enabled and copy_keybinding_hint_disabled  [Issue #490, #482]
 │   │   ├── screen_dispatch.rs             # ScreenDispatch: routes key events and render calls to the active screen; constructor receives FeatureFlags for settings screen injection; always injects prompt history when constructing PromptInputScreen; ScreenAction::Push delegates to navigate_to(), ScreenAction::Pop delegates to navigate_back(); Scaffolding case in StartAdaptPipeline dispatch; reads app.config_path directly for settings save (removed relative-path probe at TuiMode::Settings); tracing::warn! when config_path is absent  [Issue #146, #232, #342, #371, #437]
 │   │   └── screens/                       # Interactive screen components  [Issue #31-33]
 │   │       ├── mod.rs                     # Screen types: ScreenAction enum (+ RefreshSuggestions variant), SessionConfig; re-exports HomeScreen, IssueBrowserScreen, MilestoneScreen; pub mod wizard_fields (added #447); wizard_paste removed  [Issue #31-33, #86, #447]
@@ -406,7 +412,7 @@ maestro/
 │   └── scripts/                           # Test script fixtures
 ├── .gitignore                             # Includes .maestro/worktrees/ and runtime artifacts; .maestro/knowledge.md (written by maestro adapt, auto-loaded as system-prompt component by SessionPool::try_promote) is also excluded
 ├── Cargo.lock                             # Dependency lock file
-├── Cargo.toml                             # Rust package manifest; tempfile and insta dev-dependencies; optimized release profile; [features] section with experimental-sanitizer = []; flate2 and tar dependencies added for tar.gz archive extraction in self-updater  [Issue #142, #233]
+├── Cargo.toml                             # Rust package manifest; tempfile and insta dev-dependencies; optimized release profile; [features] section with experimental-sanitizer = []; flate2 and tar dependencies added for tar.gz archive extraction in self-updater; strip-ansi-escapes = "0.2" added for ANSI stripping in clipboard copy  [Issue #142, #233, #482]
 ├── CHANGELOG.md                           # Release history following Keep a Changelog format
 ├── LICENSE
 ├── README.md                              # Project front door
@@ -509,8 +515,13 @@ maestro/
 | `src/tui/app/` | App state module split into focused sub-files; `App` struct with `nav_stack: NavigationStack` field (replaces `confirm_exit_return_mode`); `navigate_to()`, `navigate_back()`, `navigate_back_or_dashboard()`, `navigate_to_root()` navigation methods; `theme: Theme`; `gh_auth_ok: bool`; `upgrade_state: UpgradeState`; `pending_prs: Vec<PendingPr>`; `config_path: Option<PathBuf>` propagated from `LoadedConfig` for settings save (Issues #12, #31-33, #35, #38, #40, #41, #43, #46-48, #52, #83, #84, #85, #118, #158, #342, #437) |
 | `src/tui/app/types.rs` | `TuiMode` enum with `breadcrumb_label()` for human-readable mode names; `NavigationStack` struct — push/pop/peek/clear/breadcrumbs with a cap of 32 entries; `TuiCommand` (+ `RunAdaptScaffold`), `TuiDataEvent` (+ `AdaptScaffoldResult`), `SuggestionDataPayload`, `CompletionSummaryData`, `CompletionSessionLine`, `GateFailureInfo` (Issues #342, #371) |
 | `src/tui/app/completion_summary.rs` | `build_completion_summary()`; `transition_to_dashboard()` now calls `navigate_to_root()` to fully clear the nav stack on dashboard return (Issue #342) |
+| `src/tui/app/clipboard_action.rs` | `App::copy_focused_response()` + `App::copy_focused_response_enabled()` predicate; `CopyOutcome` enum (`Success`, `NoContent`, `NotEnded`, `Failed`); `set_copy_toast()` / `tick_copy_toast()` with `COPY_TOAST_TTL_MS = 2_000` (Issue #482) |
+| `src/tui/app/settings_actions.rs` | `SettingsStore`-backed `App` methods extracted from `app/mod.rs` to keep it under the file-size cap: `with_settings_store()`, `caveman_mode()`, `process_pending_caveman_toggle()` (Issue #482) |
 | `src/tui/theme.rs` | `Theme` (resolved ratatui `Color` fields); `ThemeConfig` (`preset` + `overrides`); `ThemePreset` (`Dark`, `Light`); `ThemeOverrides` (per-field optional overrides); `SerializableColor` (named string / `#rrggbb` hex / 256-color index); `ColorCapability`; all 14 TUI rendering files consume theme fields instead of hardcoded `Color::` constants (Issue #38) |
 | `src/tui/activity_log.rs` | Scrollable log widget |
+| `src/tui/clipboard.rs` | `Clipboard` trait + `SystemClipboard` impl (arboard); `strip_ansi()` helper strips ANSI escape sequences before clipboard write (Issue #482) |
+| `src/tui/clipboard_toast.rs` | Toast renderer: 2-second status-bar overlay confirming clipboard copy success or failure (Issue #482) |
+| `src/tui/keybinding_hints.rs` | Dim-aware hint bar span builder; `keybinding_hints_spans()` emits `[c] Copy` dimmed when no response or session is streaming (Issue #482) |
 | `src/tui/cost_dashboard.rs` | Per-session and aggregate cost display (Phase 3) |
 | `src/tui/turboquant_dashboard.rs` | TurboQuant savings dashboard; `draw_turboquant_dashboard()`; `classify_savings()` → `(Vec<SessionSavings>, bool)`; `aggregate_savings()` → `AggregateSavings`; renders "Estimated Savings (projection)" (italic, rounded border) when no fork-handoff data, "Actual Savings" (bold, plain border) when real handoff metrics exist; per-session rows show `ACTUAL` or `proj.` kind markers (Issue #346) |
 | `src/tui/dep_graph.rs` | ASCII dependency graph visualization (Phase 3) |
@@ -523,7 +534,7 @@ maestro/
 | `src/tui/navigation/focus.rs` | `FocusManager`: focus ring, widget focus state tracking |
 | `src/tui/navigation/keymap.rs` | Keymap definitions: action-to-key bindings, context-sensitive keymaps |
 | `src/tui/panels.rs` | Split-pane multi-session view; `panel_border_type()` returns thick borders for the focused grid panel; `▸` indicator on the selected panel title; `GatesRunning` (Cyan), `NeedsReview` (LightYellow), and `CiFix` (LightMagenta) status colors (Issues #40, #41) |
-| `src/tui/ui.rs` | `draw_upgrade_banner()`: top-of-screen banner that renders all `UpgradeState` variants; `draw_gh_auth_warning()`: persistent top-of-screen banner shown when gh CLI is not authenticated, blocks gh-dependent actions until resolved; `draw_completion_overlay()`: centred overlay rendering PR links (underlined, full GitHub URL or `#N`), per-session error summaries in error color, and a keybindings bar with `[i]` Browse issues, `[r]` New prompt, `[l]` View logs, `[q]` Quit, `[Esc]` Dashboard; `ContinuousPause` render branch with pause overlay and status bar indicator; `HelpBarContext` struct drives context-aware keybinding dimming in the help bar; breadcrumb trail rendered in status bar from `nav_stack.breadcrumbs()` using `TuiMode::breadcrumb_label()`; `should_show_dashboard_mascot_panel()` / `dashboard_mascot_panel_width()` style-aware panel gate; passes `MascotStyle` through `draw_mascot_block()`, `HomeScreen::set_mascot()`, `LandingScreen::set_mascot()` (Issues #83, #84, #85, #118, #158, #342, #473) |
+| `src/tui/ui.rs` | `draw_upgrade_banner()`: top-of-screen banner that renders all `UpgradeState` variants; `draw_gh_auth_warning()`: persistent top-of-screen banner shown when gh CLI is not authenticated, blocks gh-dependent actions until resolved; `draw_completion_overlay()`: centred overlay rendering PR links (underlined, full GitHub URL or `#N`), per-session error summaries in error color, and a keybindings bar with `[i]` Browse issues, `[r]` New prompt, `[l]` View logs, `[q]` Quit, `[Esc]` Dashboard; `ContinuousPause` render branch with pause overlay and status bar indicator; `HelpBarContext` struct drives context-aware keybinding dimming in the help bar; breadcrumb trail rendered in status bar from `nav_stack.breadcrumbs()` using `TuiMode::breadcrumb_label()`; `should_show_dashboard_mascot_panel()` / `dashboard_mascot_panel_width()` style-aware panel gate; passes `MascotStyle` through `draw_mascot_block()`, `HomeScreen::set_mascot()`, `LandingScreen::set_mascot()`; uses `keybinding_hints_spans()` for hint bar; ticks and renders clipboard toast overlay (Issues #83, #84, #85, #118, #158, #218, #342, #473, #482) |
 | `src/tui/screens/` | Interactive TUI screen components (Issues #31-33) |
 | `src/tui/screens/mod.rs` | `ScreenAction` enum, `SessionConfig`; re-exports all screen types including `PromptInputScreen`; adds `pub mod wizard_fields`; removes `wizard_paste` (sanitizer moved into `TextAreaField::insert_sanitized`) (Issues #31-33, #86, #447) |
 | `src/tui/screens/adapt_follow_up.rs` | `AdaptFollowUp`: post-scaffold follow-up prompt screen |
@@ -577,6 +588,7 @@ maestro/
 | `src/settings/claude_settings.rs` | `CavemanModeState` (ExplicitTrue/ExplicitFalse/Default/Error); `SettingsStore` trait; `FsSettingsStore` atomic writer; `toggle_caveman_mode()` (Issue #490) |
 | `src/tui/screens/settings/caveman_row.rs` | Render helper for the caveman-mode row in SettingsScreen; four visual states driven by `CavemanModeState` (Issue #490) |
 | `src/tui/snapshot_tests/caveman_row.rs` | 5 insta snapshot tests for caveman row rendering (Issue #490) |
+| `src/tui/snapshot_tests/copy_keybinding_hint.rs` | Insta snapshot tests for hint bar: `copy_keybinding_hint_enabled` and `copy_keybinding_hint_disabled` (Issue #482) |
 | `src/tui/snapshot_tests/` | TUI snapshot test suite; 41 tests across 9 views using `insta`; run with `cargo test tui::snapshot_tests`; update with `INSTA_UPDATE=always cargo test` or `cargo insta review` (Issues #16, #490) |
 | `src/tui/snapshot_tests/overview.rs` | 6 snapshot tests for `PanelView`: empty, single running, multiple, selected, context overflow, forked |
 | `src/tui/snapshot_tests/detail.rs` | 6 snapshot tests for `DetailView`: basic, progress, activity log, no files touched, files + retries, markdown content |

--- a/src/session/pool.rs
+++ b/src/session/pool.rs
@@ -216,7 +216,19 @@ impl SessionPool {
 
     /// Get session UUID at a given display index (from all_sessions ordering).
     pub fn session_id_at_index(&self, index: usize) -> Option<Uuid> {
-        self.all_sessions().get(index).map(|s| s.id)
+        self.session_at_index(index).map(|s| s.id)
+    }
+
+    /// Borrow the session at a given display index without allocating —
+    /// mirrors `all_statuses` for the on-render hot path. Active → finished
+    /// → queue ordering matches `all_sessions`.
+    pub fn session_at_index(&self, index: usize) -> Option<&Session> {
+        self.active
+            .iter()
+            .map(|m| &m.session)
+            .chain(self.finished.iter().map(|m| &m.session))
+            .chain(self.queue.iter())
+            .nth(index)
     }
 
     /// Find a session by UUID from any bucket.

--- a/src/tui/app/clipboard_action.rs
+++ b/src/tui/app/clipboard_action.rs
@@ -1,0 +1,370 @@
+#![deny(clippy::unwrap_used)]
+
+//! Copy-focused-response action: routes a `c` keypress on the Overview
+//! into a clipboard write of the focused session's `last_message`, with
+//! ANSI escapes stripped.
+//!
+//! All clipboard I/O goes through [`crate::tui::clipboard::Clipboard`] so
+//! tests can swap in a `MockClipboard` (see `clipboard::testing`).
+
+use crate::session::types::Session;
+use crate::tui::app::App;
+use crate::tui::clipboard::strip_ansi;
+use crate::tui::clipboard_toast::CopyToastKind;
+use std::time::{Duration, Instant};
+use tracing::{debug, warn};
+
+/// Toast TTL.
+pub(crate) const COPY_TOAST_TTL_MS: u64 = 2_000;
+
+#[derive(Debug, Clone)]
+pub(crate) struct CopyToast {
+    pub(crate) kind: CopyToastKind,
+    pub(crate) message: String,
+    set_at: Instant,
+}
+
+#[derive(Debug)]
+pub(crate) enum CopyOutcome {
+    Success,
+    NoContent,
+    NotEnded,
+    Failed(String),
+}
+
+impl CopyOutcome {
+    /// Map outcome → toast (kind + message). `None` for the silent paths;
+    /// the dimmed hint already communicates the disabled state.
+    pub(crate) fn toast(&self) -> Option<(CopyToastKind, String)> {
+        match self {
+            Self::Success => Some((
+                CopyToastKind::Success,
+                "Response copied to clipboard".to_string(),
+            )),
+            Self::Failed(msg) => Some((CopyToastKind::Error, format!("Copy failed: {msg}"))),
+            Self::NoContent | Self::NotEnded => None,
+        }
+    }
+}
+
+impl App {
+    /// True when the focused session has terminal status and non-empty
+    /// `last_message`. Drives both the `c` key arm in the input handler
+    /// and the dimmed-hint styling in the status bar.
+    pub(crate) fn copy_focused_response_enabled(&self) -> bool {
+        self.focused_session_for_copy()
+            .map(|s| s.status.is_terminal() && !s.last_message.is_empty())
+            .unwrap_or(false)
+    }
+
+    pub(crate) fn focused_session_for_copy(&self) -> Option<&Session> {
+        self.pool.session_at_index(self.panel_view.selected_index())
+    }
+
+    /// Try to copy the focused session's `last_message` (ANSI-stripped) to
+    /// the system clipboard via `self.clipboard`. Pure routing — toast
+    /// state is set by the caller from `CopyOutcome::toast`.
+    pub(crate) fn copy_focused_response(&self) -> CopyOutcome {
+        let (id_for_log, payload) = {
+            let Some(session) = self.focused_session_for_copy() else {
+                return CopyOutcome::NoContent;
+            };
+            if !session.status.is_terminal() {
+                return CopyOutcome::NotEnded;
+            }
+            if session.last_message.is_empty() {
+                return CopyOutcome::NoContent;
+            }
+            (session.id, strip_ansi(&session.last_message))
+        };
+        match self.clipboard.write(&payload) {
+            Ok(()) => {
+                debug!(session_id = %id_for_log, "copied response to clipboard");
+                CopyOutcome::Success
+            }
+            Err(e) => {
+                // Verbose error stays in the trace log; the toast surfaces a
+                // fixed message so it doesn't leak arboard internals (e.g.
+                // Wayland socket paths) to screen-shares.
+                warn!(error = %e, "clipboard write failed");
+                CopyOutcome::Failed("clipboard unavailable".to_string())
+            }
+        }
+    }
+
+    pub(crate) fn set_copy_toast(&mut self, kind: CopyToastKind, message: String) {
+        self.copy_toast = Some(CopyToast {
+            kind,
+            message,
+            set_at: Instant::now(),
+        });
+    }
+
+    /// Drop the toast if `now - set_at >= TTL`. The `now` arg is injected
+    /// for deterministic testing; the production caller passes
+    /// `Instant::now()`.
+    pub(crate) fn tick_copy_toast(&mut self, now: Instant) {
+        if let Some(t) = &self.copy_toast
+            && now.duration_since(t.set_at) >= Duration::from_millis(COPY_TOAST_TTL_MS)
+        {
+            self.copy_toast = None;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::types::{Session, SessionStatus};
+    use crate::tui::app::App;
+    use crate::tui::clipboard::testing::MockClipboard;
+    use crate::tui::make_test_app as make_app;
+
+    fn make_clipboard_app(mock: MockClipboard) -> App {
+        make_app("maestro-clipboard-action-test").with_clipboard(Box::new(mock))
+    }
+
+    fn empty_app() -> App {
+        make_clipboard_app(MockClipboard::new())
+    }
+
+    fn session_with(status: SessionStatus, last_message: &str) -> Session {
+        let mut s = Session::new(
+            "Test task".to_string(),
+            "claude-opus-4-5".to_string(),
+            "orchestrator".to_string(),
+            None,
+        );
+        s.status = status;
+        s.last_message = last_message.to_string();
+        s
+    }
+
+    // ── CopyOutcome::toast ────────────────────────────────────────────
+
+    #[test]
+    fn copy_outcome_success_toast_is_some_with_confirmation_message() {
+        match CopyOutcome::Success.toast() {
+            Some((CopyToastKind::Success, msg)) => {
+                assert_eq!(msg, "Response copied to clipboard")
+            }
+            other => panic!("unexpected toast: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn copy_outcome_failed_toast_carries_error_kind_and_message() {
+        match CopyOutcome::Failed("disk full".to_string()).toast() {
+            Some((CopyToastKind::Error, msg)) => assert_eq!(msg, "Copy failed: disk full"),
+            other => panic!("unexpected toast: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn copy_outcome_no_content_toast_is_none() {
+        assert!(CopyOutcome::NoContent.toast().is_none());
+    }
+
+    #[test]
+    fn copy_outcome_not_ended_toast_is_none() {
+        assert!(CopyOutcome::NotEnded.toast().is_none());
+    }
+
+    // ── copy_focused_response_enabled ─────────────────────────────────
+
+    #[test]
+    fn enabled_when_completed_and_has_content() {
+        let mut app = empty_app();
+        app.pool
+            .enqueue(session_with(SessionStatus::Completed, "Some response"));
+        app.panel_view.selected = Some(0);
+        assert!(app.copy_focused_response_enabled());
+    }
+
+    #[test]
+    fn disabled_when_completed_but_empty_last_message() {
+        let mut app = empty_app();
+        app.pool.enqueue(session_with(SessionStatus::Completed, ""));
+        app.panel_view.selected = Some(0);
+        assert!(!app.copy_focused_response_enabled());
+    }
+
+    #[test]
+    fn disabled_when_running_regardless_of_content() {
+        let mut app = empty_app();
+        app.pool.enqueue(session_with(
+            SessionStatus::Running,
+            "Partial output so far",
+        ));
+        app.panel_view.selected = Some(0);
+        assert!(!app.copy_focused_response_enabled());
+    }
+
+    #[test]
+    fn enabled_when_needs_review_and_has_content() {
+        let mut app = empty_app();
+        app.pool
+            .enqueue(session_with(SessionStatus::NeedsReview, "Review required"));
+        app.panel_view.selected = Some(0);
+        assert!(app.copy_focused_response_enabled());
+    }
+
+    #[test]
+    fn enabled_when_killed_and_has_content() {
+        let mut app = empty_app();
+        app.pool
+            .enqueue(session_with(SessionStatus::Killed, "Work done before kill"));
+        app.panel_view.selected = Some(0);
+        assert!(app.copy_focused_response_enabled());
+    }
+
+    #[test]
+    fn disabled_when_no_focused_session() {
+        let app = empty_app();
+        assert!(!app.copy_focused_response_enabled());
+    }
+
+    #[test]
+    fn disabled_when_errored_status() {
+        let mut app = empty_app();
+        app.pool
+            .enqueue(session_with(SessionStatus::Errored, "Something went wrong"));
+        app.panel_view.selected = Some(0);
+        assert!(!app.copy_focused_response_enabled());
+    }
+
+    // ── copy_focused_response — outcomes ──────────────────────────────
+
+    #[test]
+    fn copy_success_writes_last_message_to_clipboard() {
+        let mock = MockClipboard::new();
+        let mut app = make_clipboard_app(mock.clone());
+        app.pool
+            .enqueue(session_with(SessionStatus::Completed, "hello"));
+        app.panel_view.selected = Some(0);
+
+        let outcome = app.copy_focused_response();
+
+        assert!(matches!(outcome, CopyOutcome::Success));
+        assert_eq!(mock.recorded_writes(), vec!["hello"]);
+    }
+
+    #[test]
+    fn copy_no_content_does_not_write_to_clipboard() {
+        let mock = MockClipboard::new();
+        let mut app = make_clipboard_app(mock.clone());
+        app.pool.enqueue(session_with(SessionStatus::Completed, ""));
+        app.panel_view.selected = Some(0);
+
+        let outcome = app.copy_focused_response();
+
+        assert!(matches!(outcome, CopyOutcome::NoContent));
+        assert_eq!(mock.write_count(), 0);
+    }
+
+    #[test]
+    fn copy_not_ended_does_not_write_to_clipboard() {
+        let mock = MockClipboard::new();
+        let mut app = make_clipboard_app(mock.clone());
+        app.pool
+            .enqueue(session_with(SessionStatus::Running, "Streaming..."));
+        app.panel_view.selected = Some(0);
+
+        let outcome = app.copy_focused_response();
+
+        assert!(matches!(outcome, CopyOutcome::NotEnded));
+        assert_eq!(mock.write_count(), 0);
+    }
+
+    #[test]
+    fn copy_failed_returns_error_outcome_and_does_not_panic() {
+        // Failure must surface a fixed user-visible string and never leak
+        // the inner error chain.
+        let mock = MockClipboard::will_fail("internal: $XDG_RUNTIME_DIR/wayland-0");
+        let mut app = make_clipboard_app(mock.clone());
+        app.pool
+            .enqueue(session_with(SessionStatus::Completed, "content"));
+        app.panel_view.selected = Some(0);
+
+        let outcome = app.copy_focused_response();
+
+        match outcome {
+            CopyOutcome::Failed(msg) => assert_eq!(msg, "clipboard unavailable"),
+            other => panic!("expected Failed, got {other:?}"),
+        }
+        assert_eq!(mock.write_count(), 0);
+    }
+
+    #[test]
+    fn copy_strips_ansi_before_writing_to_clipboard() {
+        let mock = MockClipboard::new();
+        let mut app = make_clipboard_app(mock.clone());
+        let ansi = "\x1b[32mSuccess\x1b[0m: all tests pass";
+        app.pool
+            .enqueue(session_with(SessionStatus::Completed, ansi));
+        app.panel_view.selected = Some(0);
+
+        let outcome = app.copy_focused_response();
+
+        assert!(matches!(outcome, CopyOutcome::Success));
+        let writes = mock.recorded_writes();
+        assert_eq!(writes, vec!["Success: all tests pass"]);
+        assert!(!writes[0].contains('\x1b'));
+    }
+
+    #[test]
+    fn copy_writes_only_focused_tab_content() {
+        let mock = MockClipboard::new();
+        let mut app = make_clipboard_app(mock.clone());
+        app.pool.enqueue(session_with(
+            SessionStatus::Completed,
+            "Content of session A",
+        ));
+        app.pool.enqueue(session_with(
+            SessionStatus::Completed,
+            "Content of session B",
+        ));
+        app.panel_view.selected = Some(1);
+
+        let outcome = app.copy_focused_response();
+
+        assert!(matches!(outcome, CopyOutcome::Success));
+        assert_eq!(mock.recorded_writes(), vec!["Content of session B"]);
+    }
+
+    // ── Toast TTL ─────────────────────────────────────────────────────
+
+    #[test]
+    fn toast_cleared_when_ttl_expires() {
+        let mut app = empty_app();
+        app.set_copy_toast(CopyToastKind::Success, "Copied!".to_string());
+        assert!(app.copy_toast.is_some());
+
+        let past_ttl = Instant::now() + Duration::from_millis(COPY_TOAST_TTL_MS + 1);
+        app.tick_copy_toast(past_ttl);
+
+        assert!(app.copy_toast.is_none());
+    }
+
+    #[test]
+    fn toast_preserved_within_ttl() {
+        let mut app = empty_app();
+        app.set_copy_toast(CopyToastKind::Success, "Copied!".to_string());
+
+        let within = Instant::now() + Duration::from_millis(500);
+        app.tick_copy_toast(within);
+
+        assert!(app.copy_toast.is_some());
+    }
+
+    #[test]
+    fn toast_cleared_at_ttl_boundary() {
+        let mut app = empty_app();
+        app.set_copy_toast(CopyToastKind::Success, "x".to_string());
+
+        let at_ttl = Instant::now() + Duration::from_millis(COPY_TOAST_TTL_MS);
+        app.tick_copy_toast(at_ttl);
+
+        assert!(app.copy_toast.is_none());
+    }
+}

--- a/src/tui/app/mod.rs
+++ b/src/tui/app/mod.rs
@@ -1,6 +1,7 @@
 mod budget;
 mod bypass;
 mod ci_polling;
+pub(crate) mod clipboard_action;
 mod completion_pipeline;
 mod completion_summary;
 mod context_overflow;
@@ -13,6 +14,7 @@ mod pr_retry;
 mod review;
 mod session_lifecycle;
 mod session_spawners;
+mod settings_actions;
 pub mod types;
 pub mod work_assigner;
 
@@ -165,6 +167,11 @@ pub struct App {
     /// Reads/writes `.claude/settings.json` for the caveman_mode toggle (#490).
     /// `None` when not yet wired (pre-`with_settings_store` or in tests).
     pub settings_store: Option<Box<dyn crate::settings::SettingsStore + Send>>,
+    /// System clipboard adapter for the `c` Copy keybinding. Tests
+    /// inject a `MockClipboard` via `with_clipboard`.
+    pub(crate) clipboard: Box<dyn crate::tui::clipboard::Clipboard>,
+    /// Transient (~2 s) banner shown after a copy action.
+    pub(crate) copy_toast: Option<crate::tui::app::clipboard_action::CopyToast>,
 }
 
 impl App {
@@ -278,59 +285,19 @@ impl App {
             prd_show_explore: false,
             prd_explore_cursor: 0,
             settings_store: None,
+            clipboard: Box::new(crate::tui::clipboard::SystemClipboard),
+            copy_toast: None,
         }
     }
 
-    pub fn with_settings_store(
+    /// Builder for tests: swap the system clipboard for a fake.
+    #[cfg(test)]
+    pub(crate) fn with_clipboard(
         mut self,
-        store: Box<dyn crate::settings::SettingsStore + Send>,
+        clipboard: Box<dyn crate::tui::clipboard::Clipboard>,
     ) -> Self {
-        self.settings_store = Some(store);
+        self.clipboard = clipboard;
         self
-    }
-
-    /// Read the current `behavior.caveman_mode` from `.claude/settings.json`.
-    /// Returns `Default` when no store is wired.
-    pub fn caveman_mode(&self) -> crate::settings::CavemanModeState {
-        match self.settings_store.as_ref() {
-            Some(store) => store.load_caveman_mode(),
-            None => crate::settings::CavemanModeState::Default,
-        }
-    }
-
-    /// Drain the settings screen's pending caveman toggle and persist it.
-    /// Surfaces a status flash on the screen, and reverts the in-screen
-    /// widget on write failure.
-    pub fn process_pending_caveman_toggle(&mut self) {
-        let Some(screen) = self.settings_screen.as_mut() else {
-            return;
-        };
-        let Some(new_value) = screen.take_pending_caveman_toggle() else {
-            return;
-        };
-        let Some(store) = self.settings_store.as_ref() else {
-            screen.show_caveman_status("settings store unavailable; toggle ignored.".to_string());
-            return;
-        };
-        match store.save_caveman_mode(new_value) {
-            Ok(()) => {
-                let new_state = if new_value {
-                    crate::settings::CavemanModeState::ExplicitTrue
-                } else {
-                    crate::settings::CavemanModeState::ExplicitFalse
-                };
-                screen.set_caveman_state(new_state);
-                screen.show_caveman_status(format!(
-                    "caveman_mode → {}  (effective on next Claude session)",
-                    new_value
-                ));
-            }
-            Err(err) => {
-                let prior = store.load_caveman_mode();
-                screen.set_caveman_state(prior);
-                screen.show_caveman_status(format!("caveman_mode write error: {}", err));
-            }
-        }
     }
 
     pub fn configure(&mut self, config: Config) {

--- a/src/tui/app/settings_actions.rs
+++ b/src/tui/app/settings_actions.rs
@@ -1,0 +1,55 @@
+use crate::tui::app::App;
+
+impl App {
+    pub fn with_settings_store(
+        mut self,
+        store: Box<dyn crate::settings::SettingsStore + Send>,
+    ) -> Self {
+        self.settings_store = Some(store);
+        self
+    }
+
+    /// Read the current `behavior.caveman_mode` from `.claude/settings.json`.
+    /// Returns `Default` when no store is wired.
+    pub fn caveman_mode(&self) -> crate::settings::CavemanModeState {
+        match self.settings_store.as_ref() {
+            Some(store) => store.load_caveman_mode(),
+            None => crate::settings::CavemanModeState::Default,
+        }
+    }
+
+    /// Drain the settings screen's pending caveman toggle and persist it.
+    /// Surfaces a status flash on the screen, and reverts the in-screen
+    /// widget on write failure.
+    pub fn process_pending_caveman_toggle(&mut self) {
+        let Some(screen) = self.settings_screen.as_mut() else {
+            return;
+        };
+        let Some(new_value) = screen.take_pending_caveman_toggle() else {
+            return;
+        };
+        let Some(store) = self.settings_store.as_ref() else {
+            screen.show_caveman_status("settings store unavailable; toggle ignored.".to_string());
+            return;
+        };
+        match store.save_caveman_mode(new_value) {
+            Ok(()) => {
+                let new_state = if new_value {
+                    crate::settings::CavemanModeState::ExplicitTrue
+                } else {
+                    crate::settings::CavemanModeState::ExplicitFalse
+                };
+                screen.set_caveman_state(new_state);
+                screen.show_caveman_status(format!(
+                    "caveman_mode → {}  (effective on next Claude session)",
+                    new_value
+                ));
+            }
+            Err(err) => {
+                let prior = store.load_caveman_mode();
+                screen.set_caveman_state(prior);
+                screen.show_caveman_status(format!("caveman_mode write error: {}", err));
+            }
+        }
+    }
+}

--- a/src/tui/app/tests.rs
+++ b/src/tui/app/tests.rs
@@ -2,23 +2,10 @@ use super::helpers::{build_gate_fix_prompt, session_label};
 use super::*;
 use crate::flags::Flag;
 use crate::session::types::GateResultEntry;
-use crate::session::worktree::MockWorktreeManager;
-use crate::state::store::StateStore;
 use std::time::Duration;
 
 fn make_app() -> App {
-    let tmp = std::env::temp_dir().join(format!(
-        "maestro-tui-app-test-{}.json",
-        uuid::Uuid::new_v4()
-    ));
-    let store = StateStore::new(tmp);
-    App::new(
-        store,
-        3,
-        Box::new(MockWorktreeManager::new()),
-        "bypassPermissions".into(),
-        vec![],
-    )
+    crate::tui::make_test_app("maestro-tui-app-test")
 }
 
 #[test]

--- a/src/tui/clipboard.rs
+++ b/src/tui/clipboard.rs
@@ -1,0 +1,186 @@
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
+
+//! Write side of the system clipboard for the TUI.
+//!
+//! The read side (text + image fallback for paste) lives in
+//! `screens::prompt_input::ClipboardProvider` and predates this module.
+//! Both adapters wrap `arboard`. They are intentionally kept separate
+//! for now; a follow-up may unify them under a single trait.
+
+use anyhow::{Context, Result};
+use std::sync::OnceLock;
+
+/// Place plain UTF-8 text on the system clipboard.
+pub trait Clipboard: Send + Sync {
+    fn write(&self, text: &str) -> Result<()>;
+}
+
+static CLIPBOARD_AVAILABLE: OnceLock<bool> = OnceLock::new();
+
+/// Returns true if `arboard::Clipboard::new()` produced a usable handle
+/// on first call. Cached for the process lifetime so headless / WSL
+/// environments fail fast on subsequent attempts without re-paying the
+/// init cost or risking another panic. Shared between this module's
+/// `SystemClipboard::write` and `screens::prompt_input::SystemClipboard::read`.
+pub fn backend_available() -> bool {
+    *CLIPBOARD_AVAILABLE.get_or_init(|| {
+        std::panic::catch_unwind(arboard::Clipboard::new)
+            .ok()
+            .and_then(|r| r.ok())
+            .is_some()
+    })
+}
+
+pub struct SystemClipboard;
+
+impl Clipboard for SystemClipboard {
+    fn write(&self, text: &str) -> Result<()> {
+        if !backend_available() {
+            anyhow::bail!("clipboard unavailable");
+        }
+        // arboard can panic on Wayland/X11 connection loss even after the
+        // initial probe succeeded; a panic on the input thread would
+        // crash the TUI without restoring raw mode.
+        let cb_result = std::panic::catch_unwind(arboard::Clipboard::new)
+            .map_err(|_| anyhow::anyhow!("clipboard unavailable"))?;
+        let mut cb = cb_result.context("clipboard unavailable")?;
+        cb.set_text(text.to_owned())
+            .context("clipboard unavailable")?;
+        Ok(())
+    }
+}
+
+/// Strip ANSI escape sequences (CSI, SGR, OSC, …) from `input` and any
+/// residual C0 control bytes (NUL, BEL, BS, DEL, …) that the underlying
+/// parser may pass through. LF (`\n`) is preserved; the underlying
+/// `strip-ansi-escapes` (vte) also drops TAB and CR as part of its
+/// terminal-state-machine handling. The post-filter is defence in
+/// depth: if the parser ever leaves a control byte through, it doesn't
+/// reach the OS clipboard (some platforms truncate at NUL).
+pub fn strip_ansi(input: &str) -> String {
+    strip_ansi_escapes::strip_str(input)
+        .chars()
+        .filter(|c| {
+            let code = *c as u32;
+            // Drop C0 (0x00..=0x1F) and DEL (0x7F), except 0x0A LF.
+            !matches!(code, 0x00..=0x09 | 0x0B..=0x1F | 0x7F)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+pub(crate) mod testing {
+    //! Test fakes shared across `clipboard` and `app::clipboard_action` tests.
+    use super::Clipboard;
+    use std::sync::{Arc, Mutex, MutexGuard};
+
+    fn guard<T>(m: &Mutex<T>) -> MutexGuard<'_, T> {
+        m.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    struct MockState {
+        writes: Mutex<Vec<String>>,
+        fail_with: Mutex<Option<String>>,
+    }
+
+    /// Cloneable fake clipboard. The handle held by the test and the one
+    /// passed to `App::with_clipboard(Box::new(...))` share the same
+    /// inner state via `Arc`, so the test can read `recorded_writes()`
+    /// after the production code wrote to it.
+    #[derive(Clone)]
+    pub(crate) struct MockClipboard {
+        inner: Arc<MockState>,
+    }
+
+    impl MockClipboard {
+        pub(crate) fn new() -> Self {
+            Self {
+                inner: Arc::new(MockState {
+                    writes: Mutex::new(Vec::new()),
+                    fail_with: Mutex::new(None),
+                }),
+            }
+        }
+
+        pub(crate) fn will_fail(msg: impl Into<String>) -> Self {
+            Self {
+                inner: Arc::new(MockState {
+                    writes: Mutex::new(Vec::new()),
+                    fail_with: Mutex::new(Some(msg.into())),
+                }),
+            }
+        }
+
+        pub(crate) fn recorded_writes(&self) -> Vec<String> {
+            guard(&self.inner.writes).clone()
+        }
+
+        pub(crate) fn write_count(&self) -> usize {
+            guard(&self.inner.writes).len()
+        }
+    }
+
+    impl Clipboard for MockClipboard {
+        fn write(&self, text: &str) -> anyhow::Result<()> {
+            let fail = guard(&self.inner.fail_with).clone();
+            if let Some(msg) = fail {
+                return Err(anyhow::anyhow!("{}", msg));
+            }
+            guard(&self.inner.writes).push(text.to_owned());
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_ansi_removes_sgr_color_sequence() {
+        assert_eq!(strip_ansi("\x1b[32mhello\x1b[0m"), "hello");
+    }
+
+    #[test]
+    fn strip_ansi_plain_text_unchanged() {
+        assert_eq!(strip_ansi("plain"), "plain");
+    }
+
+    #[test]
+    fn strip_ansi_empty_string_returns_empty() {
+        assert_eq!(strip_ansi(""), "");
+    }
+
+    #[test]
+    fn strip_ansi_multiple_sequences_all_removed() {
+        let input = "\x1b[1;34mBold Blue\x1b[0m \x1b[41mRed BG\x1b[0m";
+        assert_eq!(strip_ansi(input), "Bold Blue Red BG");
+    }
+
+    #[test]
+    fn strip_ansi_cursor_movement_csi_removed() {
+        let input = "\x1b[3Atext";
+        assert_eq!(strip_ansi(input), "text");
+    }
+
+    #[test]
+    fn strip_ansi_does_not_panic_on_partial_escape() {
+        // The exact handling of an ESC byte that is not followed by a
+        // recognized terminator depends on the parser's state machine;
+        // the crate may consume trailing bytes. The contract we require
+        // is purely "does not panic and returns valid UTF-8".
+        let _ = strip_ansi("\x1babc");
+    }
+
+    #[test]
+    fn strip_ansi_drops_c0_controls_but_keeps_lf() {
+        let stripped = strip_ansi("a\x00b\x07c\x08d\x7fe\tf\ng\rh");
+        assert!(!stripped.contains('\x00'), "NUL must be stripped");
+        assert!(!stripped.contains('\x07'), "BEL must be stripped");
+        assert!(!stripped.contains('\x08'), "BS must be stripped");
+        assert!(!stripped.contains('\x7f'), "DEL must be stripped");
+        assert!(stripped.contains('\n'), "LF must survive");
+        assert!(stripped.contains("abc"));
+    }
+}

--- a/src/tui/clipboard_toast.rs
+++ b/src/tui/clipboard_toast.rs
@@ -1,0 +1,48 @@
+//! Transient banner shown after a Copy action — overlays the status bar
+//! row for ~2 s with a success or error message. See
+//! [`crate::tui::app::clipboard_action::COPY_TOAST_TTL_MS`].
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Clear, Paragraph},
+};
+
+use crate::tui::theme::Theme;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum CopyToastKind {
+    Success,
+    Error,
+}
+
+pub fn draw_copy_toast(
+    f: &mut Frame,
+    area: Rect,
+    kind: CopyToastKind,
+    message: &str,
+    theme: &Theme,
+) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let banner = Rect {
+        x: area.x,
+        y: area.y,
+        width: area.width,
+        height: 1,
+    };
+    let bg = match kind {
+        CopyToastKind::Success => theme.accent_success,
+        CopyToastKind::Error => theme.accent_error,
+    };
+    let style = Style::default()
+        .fg(theme.branding_fg)
+        .bg(bg)
+        .add_modifier(Modifier::BOLD);
+    f.render_widget(Clear, banner);
+    let p = Paragraph::new(Line::from(Span::styled(format!(" {} ", message), style)));
+    f.render_widget(p, banner);
+}

--- a/src/tui/input_handler.rs
+++ b/src/tui/input_handler.rs
@@ -748,14 +748,14 @@ fn handle_overview_keys(app: &mut App, key: &KeyEvent) {
             app.session_switcher = Some(crate::tui::session_switcher::SessionSwitcher::default());
             app.navigate_to(app::TuiMode::SessionSwitcher);
         }
-        (KeyCode::Char('c'), KeyModifiers::NONE) => {
-            // Ctrl+C is short-circuited at the top of handle_key, so
-            // reaching this arm always means plain `c`.
-            if app.copy_focused_response_enabled() {
-                let outcome = app.copy_focused_response();
-                if let Some((kind, msg)) = outcome.toast() {
-                    app.set_copy_toast(kind, msg);
-                }
+        // Ctrl+C is short-circuited at the top of handle_key, so reaching
+        // this arm always means plain `c`. A disabled `c` falls through to
+        // the trailing `_ => {}` and becomes a no-op — the dimmed hint
+        // already advertises the disabled state.
+        (KeyCode::Char('c'), KeyModifiers::NONE) if app.copy_focused_response_enabled() => {
+            let outcome = app.copy_focused_response();
+            if let Some((kind, msg)) = outcome.toast() {
+                app.set_copy_toast(kind, msg);
             }
         }
         (KeyCode::Char('d'), _) => {

--- a/src/tui/input_handler.rs
+++ b/src/tui/input_handler.rs
@@ -748,6 +748,16 @@ fn handle_overview_keys(app: &mut App, key: &KeyEvent) {
             app.session_switcher = Some(crate::tui::session_switcher::SessionSwitcher::default());
             app.navigate_to(app::TuiMode::SessionSwitcher);
         }
+        (KeyCode::Char('c'), KeyModifiers::NONE) => {
+            // Ctrl+C is short-circuited at the top of handle_key, so
+            // reaching this arm always means plain `c`.
+            if app.copy_focused_response_enabled() {
+                let outcome = app.copy_focused_response();
+                if let Some((kind, msg)) = outcome.toast() {
+                    app.set_copy_toast(kind, msg);
+                }
+            }
+        }
         (KeyCode::Char('d'), _) => {
             app.show_activity_log = !app.show_activity_log;
         }
@@ -812,8 +822,6 @@ fn handle_grid_navigation(app: &mut App, key: &KeyEvent) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::session::worktree::MockWorktreeManager;
-    use crate::state::store::StateStore;
     use crate::tui::app::{App, TuiMode};
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
@@ -830,18 +838,7 @@ mod tests {
     }
 
     fn make_app() -> App {
-        let tmp = std::env::temp_dir().join(format!(
-            "maestro-input-handler-test-{}.json",
-            uuid::Uuid::new_v4()
-        ));
-        let store = StateStore::new(tmp);
-        App::new(
-            store,
-            3,
-            Box::new(MockWorktreeManager::new()),
-            "bypassPermissions".into(),
-            vec![],
-        )
+        crate::tui::make_test_app("maestro-input-handler-test")
     }
 
     // ── Group 1: TuiMode variant and field defaults ───────────────────
@@ -1300,5 +1297,96 @@ mod tests {
             "expected F4/F5/F6 to be verified, got {}",
             checked
         );
+    }
+
+    // ── copy-focused-response keybinding ─────────────────────────────────
+
+    use crate::session::types::{Session, SessionStatus};
+    use crate::tui::clipboard::testing::MockClipboard;
+    use crate::tui::clipboard_toast::CopyToastKind;
+
+    fn make_clipboard_app(mock: MockClipboard) -> App {
+        crate::tui::make_test_app("maestro-copy-key-test").with_clipboard(Box::new(mock))
+    }
+
+    fn completed_session(last_message: &str) -> Session {
+        let mut s = Session::new(
+            "task".into(),
+            "claude-opus-4-5".into(),
+            "orchestrator".into(),
+            None,
+        );
+        s.status = SessionStatus::Completed;
+        s.last_message = last_message.to_string();
+        s
+    }
+
+    #[tokio::test]
+    async fn c_key_with_enabled_state_writes_clipboard_and_sets_toast() {
+        let mock = MockClipboard::new();
+        let mut app = make_clipboard_app(mock.clone());
+        app.pool.enqueue(completed_session("result text"));
+        app.panel_view.selected = Some(0);
+        app.tui_mode = TuiMode::Overview;
+
+        let _ = handle_key(&mut app, key('c')).await;
+
+        assert_eq!(mock.recorded_writes(), vec!["result text"]);
+        let toast = app.copy_toast.as_ref().expect("toast must be set");
+        assert!(matches!(toast.kind, CopyToastKind::Success));
+        assert_eq!(toast.message, "Response copied to clipboard");
+    }
+
+    #[tokio::test]
+    async fn c_key_with_disabled_state_does_not_write_clipboard() {
+        let mock = MockClipboard::new();
+        let mut app = make_clipboard_app(mock.clone());
+        let mut s = Session::new(
+            "task".into(),
+            "claude-opus-4-5".into(),
+            "orchestrator".into(),
+            None,
+        );
+        s.status = SessionStatus::Running;
+        s.last_message = "in progress".to_string();
+        app.pool.enqueue(s);
+        app.panel_view.selected = Some(0);
+        app.tui_mode = TuiMode::Overview;
+
+        let _ = handle_key(&mut app, key('c')).await;
+
+        assert_eq!(mock.write_count(), 0);
+        assert!(app.copy_toast.is_none());
+    }
+
+    #[tokio::test]
+    async fn c_key_with_clipboard_failure_sets_error_toast_without_panic() {
+        let mock = MockClipboard::will_fail("backend exposed: /run/user/1000/wayland-0");
+        let mut app = make_clipboard_app(mock.clone());
+        app.pool.enqueue(completed_session("payload"));
+        app.panel_view.selected = Some(0);
+        app.tui_mode = TuiMode::Overview;
+
+        let _ = handle_key(&mut app, key('c')).await;
+
+        assert_eq!(mock.write_count(), 0);
+        let toast = app.copy_toast.as_ref().expect("toast must be set");
+        assert!(matches!(toast.kind, CopyToastKind::Error));
+        assert_eq!(toast.message, "Copy failed: clipboard unavailable");
+    }
+
+    #[tokio::test]
+    async fn ctrl_c_does_not_trigger_copy_path() {
+        let mock = MockClipboard::new();
+        let mut app = make_clipboard_app(mock.clone());
+        app.pool.enqueue(completed_session("done"));
+        app.panel_view.selected = Some(0);
+        app.tui_mode = TuiMode::Overview;
+
+        let _ = handle_key(&mut app, ctrl_c_event()).await;
+
+        assert!(!app.running);
+        assert_eq!(mock.write_count(), 0);
+        assert!(app.copy_toast.is_none());
     }
 }

--- a/src/tui/keybinding_hints.rs
+++ b/src/tui/keybinding_hints.rs
@@ -1,0 +1,47 @@
+//! Render the inline keybinding-hint bar with optional per-key dimming.
+//!
+//! The Overview status bar advertises hints like `[Enter] Detail
+//! [c] Copy [d] Log`. When the focused tab can't be copied (no content
+//! or session still streaming), the `c` hint is rendered in a muted
+//! style so the user sees the option exists but is currently inactive.
+//!
+//! Pre-fit the hints with [`crate::tui::navigation::keymap::fit_hints_to_width`]
+//! and pass the result in.
+
+use ratatui::{
+    style::{Modifier, Style},
+    text::Span,
+};
+
+use crate::tui::theme::Theme;
+
+pub const COPY_HINT_KEY: &str = "c";
+
+pub fn keybinding_hints_spans(
+    fitted: &[(&str, &str)],
+    copy_enabled: bool,
+    theme: &Theme,
+) -> Vec<Span<'static>> {
+    let dim_style = Style::default()
+        .fg(theme.text_muted)
+        .add_modifier(Modifier::DIM);
+    let key_style = Style::default().fg(theme.accent_success);
+    let action_style = Style::default().fg(theme.text_secondary);
+
+    let mut spans: Vec<Span<'static>> = Vec::with_capacity(fitted.len() * 3);
+    for (i, (key, action)) in fitted.iter().enumerate() {
+        let dim = !copy_enabled && *key == COPY_HINT_KEY;
+        if i > 0 {
+            spans.push(Span::raw("  "));
+        }
+        spans.push(Span::styled(
+            format!("[{}]", key),
+            if dim { dim_style } else { key_style },
+        ));
+        spans.push(Span::styled(
+            format!(" {}", action),
+            if dim { dim_style } else { action_style },
+        ));
+    }
+    spans
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,6 +1,8 @@
 pub mod activity_log;
 pub mod app;
 mod background_tasks;
+pub mod clipboard;
+pub mod clipboard_toast;
 pub mod cost_dashboard;
 pub mod dep_graph;
 pub mod detail;
@@ -9,6 +11,7 @@ pub mod help;
 pub mod icons;
 mod input_handler;
 pub mod issue_refs;
+pub mod keybinding_hints;
 pub mod log_viewer;
 pub mod markdown;
 pub mod marquee;
@@ -676,7 +679,7 @@ async fn event_loop(
 }
 
 #[cfg(test)]
-fn make_test_app(name: &str) -> app::App {
+pub(crate) fn make_test_app(name: &str) -> app::App {
     use crate::session::worktree::MockWorktreeManager;
     use crate::state::store::StateStore;
 

--- a/src/tui/navigation/mode_hints.rs
+++ b/src/tui/navigation/mode_hints.rs
@@ -28,25 +28,33 @@ pub fn mode_keymap(
                     action: "Detail",
                     priority: 0,
                 },
+                // `c` is given priority 1 so it survives narrow widths —
+                // the dimmed-when-disabled state means the hint is the
+                // user's only signal that copy exists.
+                InlineHint {
+                    key: "c",
+                    action: "Copy",
+                    priority: 1,
+                },
                 InlineHint {
                     key: "d",
                     action: "Log",
-                    priority: 1,
+                    priority: 2,
                 },
                 InlineHint {
                     key: "f",
                     action: "Full",
-                    priority: 2,
+                    priority: 3,
                 },
                 InlineHint {
                     key: "w",
                     action: "Switcher",
-                    priority: 3,
+                    priority: 4,
                 },
                 InlineHint {
                     key: "Tab",
                     action: "Cycle Views",
-                    priority: 4,
+                    priority: 5,
                 },
             ],
         ),

--- a/src/tui/screens/prompt_input.rs
+++ b/src/tui/screens/prompt_input.rs
@@ -14,7 +14,6 @@ use ratatui::{
     widgets::Paragraph,
 };
 use std::path::PathBuf;
-use std::sync::OnceLock;
 use tui_textarea::TextArea;
 
 /// Result of reading the system clipboard.
@@ -34,10 +33,6 @@ pub trait ClipboardProvider: Send {
     fn read(&self) -> ClipboardContent;
 }
 
-/// Caches whether the clipboard backend is available. Once a failure is
-/// recorded, subsequent paste attempts skip `arboard::Clipboard::new()`.
-static CLIPBOARD_AVAILABLE: OnceLock<bool> = OnceLock::new();
-
 /// Production clipboard using arboard.
 ///
 /// Wraps clipboard access in `catch_unwind` because `arboard::Clipboard::new()`
@@ -46,14 +41,7 @@ pub struct SystemClipboard;
 
 impl ClipboardProvider for SystemClipboard {
     fn read(&self) -> ClipboardContent {
-        let available = CLIPBOARD_AVAILABLE.get_or_init(|| {
-            std::panic::catch_unwind(arboard::Clipboard::new)
-                .ok()
-                .and_then(|r| r.ok())
-                .is_some()
-        });
-
-        if !available {
+        if !crate::tui::clipboard::backend_available() {
             return ClipboardContent::Unavailable;
         }
 

--- a/src/tui/snapshot_tests/copy_keybinding_hint.rs
+++ b/src/tui/snapshot_tests/copy_keybinding_hint.rs
@@ -1,0 +1,24 @@
+use crate::session::types::SessionStatus;
+use crate::tui::app::TuiMode;
+use crate::tui::keybinding_hints::keybinding_hints_spans;
+use crate::tui::navigation::keymap::{fit_hints_to_width, mode_keymap};
+use crate::tui::theme::Theme;
+use insta::assert_debug_snapshot;
+use ratatui::text::Span;
+
+fn render_spans(copy_enabled: bool) -> Vec<Span<'static>> {
+    let km = mode_keymap(TuiMode::Overview, Some(SessionStatus::Completed), &[]);
+    let theme = Theme::dark();
+    let fitted = fit_hints_to_width(km.hints, 120);
+    keybinding_hints_spans(&fitted, copy_enabled, &theme)
+}
+
+#[test]
+fn copy_keybinding_hint_enabled() {
+    assert_debug_snapshot!(render_spans(true));
+}
+
+#[test]
+fn copy_keybinding_hint_disabled() {
+    assert_debug_snapshot!(render_spans(false));
+}

--- a/src/tui/snapshot_tests/mod.rs
+++ b/src/tui/snapshot_tests/mod.rs
@@ -1,4 +1,5 @@
 mod caveman_row;
+mod copy_keybinding_hint;
 mod cost_dashboard;
 mod dashboard;
 mod detail;

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__copy_keybinding_hint__copy_keybinding_hint_disabled.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__copy_keybinding_hint__copy_keybinding_hint_disabled.snap
@@ -1,0 +1,24 @@
+---
+source: src/tui/snapshot_tests/copy_keybinding_hint.rs
+assertion_line: 24
+expression: render_spans(false)
+---
+[
+    Span::from("[Enter]").green(),
+    Span::from(" Detail").dark_gray(),
+    Span::from("  "),
+    Span::from("[c]").dark_gray().dim(),
+    Span::from(" Copy").dark_gray().dim(),
+    Span::from("  "),
+    Span::from("[d]").green(),
+    Span::from(" Log").dark_gray(),
+    Span::from("  "),
+    Span::from("[f]").green(),
+    Span::from(" Full").dark_gray(),
+    Span::from("  "),
+    Span::from("[w]").green(),
+    Span::from(" Switcher").dark_gray(),
+    Span::from("  "),
+    Span::from("[Tab]").green(),
+    Span::from(" Cycle Views").dark_gray(),
+]

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__copy_keybinding_hint__copy_keybinding_hint_enabled.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__copy_keybinding_hint__copy_keybinding_hint_enabled.snap
@@ -1,0 +1,24 @@
+---
+source: src/tui/snapshot_tests/copy_keybinding_hint.rs
+assertion_line: 19
+expression: render_spans(true)
+---
+[
+    Span::from("[Enter]").green(),
+    Span::from(" Detail").dark_gray(),
+    Span::from("  "),
+    Span::from("[c]").green(),
+    Span::from(" Copy").dark_gray(),
+    Span::from("  "),
+    Span::from("[d]").green(),
+    Span::from(" Log").dark_gray(),
+    Span::from("  "),
+    Span::from("[f]").green(),
+    Span::from(" Full").dark_gray(),
+    Span::from("  "),
+    Span::from("[w]").green(),
+    Span::from(" Switcher").dark_gray(),
+    Span::from("  "),
+    Span::from("[Tab]").green(),
+    Span::from(" Cycle Views").dark_gray(),
+]

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -60,11 +60,10 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     // Use preview theme if active, otherwise base theme
     let theme = app.active_theme().clone();
 
-    let selected_status = {
-        let sessions = app.pool.all_sessions();
-        let idx = app.panel_view.selected_index();
-        sessions.get(idx).map(|s| s.status)
-    };
+    let selected_status = app
+        .pool
+        .session_at_index(app.panel_view.selected_index())
+        .map(|s| s.status);
     let cache_key = (app.tui_mode, selected_status);
     if app.cached_mode_km.is_none() || app.cached_mode_km_key != cache_key {
         let screen_bindings = active_screen_bindings(app);
@@ -86,6 +85,19 @@ pub fn draw(f: &mut Frame, app: &mut App) {
             f,
             banner_area,
             crate::tui::widgets::bypass_indicator::BypassIndicatorState::Active,
+        );
+    }
+
+    // Aged out before render so the empty-toast frame draws cleanly.
+    app.tick_copy_toast(std::time::Instant::now());
+    if let Some(toast) = app.copy_toast.as_ref() {
+        let banner_area = Rect::new(chunks[0].x, chunks[0].y, chunks[0].width, 1);
+        crate::tui::clipboard_toast::draw_copy_toast(
+            f,
+            banner_area,
+            toast.kind,
+            &toast.message,
+            &app.theme,
         );
     }
 
@@ -899,22 +911,11 @@ fn draw_status_bar_inner(
     if remaining > 10 && !mode_km.hints.is_empty() {
         let fitted = keymap::fit_hints_to_width(mode_km.hints, remaining.saturating_sub(4));
         if !fitted.is_empty() {
+            let copy_enabled = app.copy_focused_response_enabled();
+            let hint_spans =
+                crate::tui::keybinding_hints::keybinding_hints_spans(&fitted, copy_enabled, theme);
             spans.push(sep.clone());
-            for (i, (key, action)) in fitted.iter().enumerate() {
-                if i > 0 {
-                    spans.push(Span::raw("  "));
-                }
-                spans.push(Span::styled(
-                    format!("[{}]", key),
-                    Style::default().fg(theme.accent_success),
-                ));
-                spans.push(Span::styled(
-                    format!(" {}", action),
-                    Style::default().fg(theme.text_secondary),
-                ));
-                // Account for the appended hint width incrementally so we
-                // don't re-walk the whole vec for the marquee check.
-            }
+            spans.extend(hint_spans);
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds a `c` keybinding in the Overview that copies the focused agent panel's `last_message` to the system clipboard, ANSI-stripped, with a 2-second status-bar toast banner confirming success or failure.
- Introduces `Clipboard` trait with `SystemClipboard` (arboard, panic-safe via `catch_unwind`, headless-aware via shared `backend_available()` cache) and a thread-safe `MockClipboard` for unit tests.
- Renders `[c] Copy` right after `[Enter] Detail` in the inline-hint bar, dimmed (`text_muted` + `DIM` modifier) when no copyable response is available or the session is still streaming.

Closes #482

## Test plan

- [x] Open a session, wait for completion, focus the panel, press `c` — clipboard receives the response with ANSI stripped, green toast appears for ~2 s.
- [x] Press `c` while a session is still running — no clipboard write, no toast, hint renders dimmed.
- [x] Focus a completed session whose `last_message` is empty — `c` is a no-op, hint dimmed.
- [ ] On a headless / WSL host without a clipboard backend — pressing `c` shows a red `Copy failed: clipboard unavailable` toast, no panic, terminal stays in raw mode.
- [x] With multiple agent panels, focus session B and press `c` — only B's content is on the clipboard, not A's.
- [x] Snapshot tests `copy_keybinding_hint_enabled` / `copy_keybinding_hint_disabled` capture the dim styling difference.
- [x] `cargo fmt --check && cargo clippy -- -D warnings -A dead_code && cargo test` all clean (3402 main tests).