### PR TITLE
fix(notifications): wire desktop notify dispatch on session terminal events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(notifications): desktop notifications now fire when a session completes or errors (#487)
+
 ## [0.16.0] - 2026-04-25
 
 Milestone "PR Review Automation & Interactive PRD" — automated PR review flow with slash command integration, dangerously-skip-permissions bypass mode for power users, interactive PRD management, milestone roadmap visualization, and the opt-in caveman compressed-prose skill. Closes #321, #322, #327, #328, #329, #481, #490 across PRs #488, #489, #491.

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-27 18:00 (UTC)
+> Last updated: 2026-04-27 19:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -164,9 +164,10 @@ maestro/
 │   ├── modes/                             # Session mode definitions and resolution  [Phase 3]
 │   │   └── mod.rs                         # builtin_modes, resolve_mode, mode_from_labels
 │   ├── notifications/                     # Interruption and notification system  [Phase 3]
-│   │   ├── mod.rs                         # Module exports
+│   │   ├── mod.rs                         # Module exports; pub mod desktop added  [Issue #487]
 │   │   ├── types.rs                       # Notification levels: Info, Warning, Critical, Blocker
 │   │   ├── dispatcher.rs                  # Notification dispatcher
+│   │   ├── desktop.rs                     # DesktopNotifier trait; NotifyError enum; OsascriptNotifier (macOS, /usr/bin/osascript via spawn_blocking); sanitize_applescript() (escapes \, ", \n, \r, \t; drops C0 controls); truncate() (title ≤128, body ≤256 chars); FakeNotifier (#[cfg(test)])  [Issue #487]
 │   │   └── slack.rs                       # Slack webhook notification sender
 │   ├── plugins/                           # Plugin and hook execution system  [Phase 3]
 │   │   ├── mod.rs                         # Module exports
@@ -210,7 +211,7 @@ maestro/
 │   ├── tui/
 │   │   ├── mod.rs                         # Event loop; keybindings; handle_screen_action() rewritten; command processing loop; launch_session_from_config(); FetchSuggestionData async handler spawns background GitHub fetch for ready/failed counts and milestone progress; spawns async version check on startup via check_for_update() — result delivered as VersionCheckResult data event; key handlers for upgrade flow (confirm/decline banner); CompletionSummary key-intercept branch: [f] collects NeedsReview sessions and calls spawn_gate_fix_session() for each then transitions to Overview, [i] opens issue browser, [r] opens prompt input, [l] switches to Overview (activity log view), [Enter]/[Esc] returns to dashboard via transition_to_dashboard(), [q] quits; ContinuousPause key-intercept overlay: [s] skip, [r] retry, [q] quit continuous loop; RefreshSuggestions branch sets loading_suggestions=true and queues FetchSuggestionData; exit path checks once_mode — exits immediately when true, otherwise shows CompletionSummary overlay; "All Issues" navigation always creates a fresh IssueBrowserScreen to prevent stale milestone filters leaking across navigation contexts; PromptInputScreen always created with injected history so Up/Down arrow recall works correctly; F-key bar actions wired (F1–F10, Alt-X); per-tick flash_counter decrement dispatched to session pool; pub mod theme; pub mod widgets; RunAdaptScaffold command dispatch  [Phase 3, Issue #31-33, #46-48, #35, #38, #83, #84, #85, #86, #104, #117, #118, #124, #202, #218, #232, #371]
 │   │   ├── app/                           # App state module (split across multiple files)
-│   │   │   ├── mod.rs                     # App struct; nav_stack: NavigationStack field (replaces confirm_exit_return_mode); navigate_to(), navigate_back(), navigate_back_or_dashboard(), navigate_to_root() navigation methods; gh_auth_ok: bool; theme: Theme; pending_prs: Vec<PendingPr>; config_path: Option<PathBuf> field carries the resolved maestro.toml path for settings save; set_config_path() setter; process_pending_pr_retries(); trigger_manual_pr_retry(); mascot_style: MascotStyle field hydrated in apply_config()  [Issue #12, #31-33, #35, #38, #40, #41, #43, #46-48, #52, #83, #84, #85, #86, #102, #104, #118, #123, #158, #159, #342, #437, #473]
+│   │   │   ├── mod.rs                     # App struct; nav_stack: NavigationStack field (replaces confirm_exit_return_mode); navigate_to(), navigate_back(), navigate_back_or_dashboard(), navigate_to_root() navigation methods; gh_auth_ok: bool; theme: Theme; pending_prs: Vec<PendingPr>; config_path: Option<PathBuf> field carries the resolved maestro.toml path for settings save; set_config_path() setter; process_pending_pr_retries(); trigger_manual_pr_retry(); mascot_style: MascotStyle field hydrated in apply_config(); desktop_notifier: Arc<dyn DesktopNotifier>; notify_error_flash: Option<(String, Instant)>; with_desktop_notifier() test builder; tick_notify_error() drains take_last_error() and surfaces status-bar flash + LogLevel::Warn activity-log entry; OsascriptNotifier::new() wired in App::configure()  [Issue #12, #31-33, #35, #38, #40, #41, #43, #46-48, #52, #83, #84, #85, #86, #102, #104, #118, #123, #158, #159, #342, #437, #473, #487]
 │   │   │   ├── types.rs                   # TuiMode enum (+ CompletionSummary, ContinuousPause variants) with breadcrumb_label() method; NavigationStack struct (push/pop/peek/clear/breadcrumbs, cap 32); TuiCommand enum (+ RunAdaptScaffold); TuiDataEvent enum (+ AdaptScaffoldResult); SuggestionDataPayload; CompletionSummaryData; CompletionSessionLine; GateFailureInfo  [Issue #342, #371]
 │   │   │   ├── budget.rs                  # Budget enforcement helpers within App
 │   │   │   ├── ci_polling.rs              # poll_ci_status() CI auto-fix loop using CiCheck trait; decide_ci_action(); spawn_ci_fix_session()  [Issue #41, #123]
@@ -219,7 +220,8 @@ maestro/
 │   │   │   ├── completion_summary.rs      # build_completion_summary(); transition_to_dashboard() calls navigate_to_root() to clear nav stack  [Issue #342]
 │   │   │   ├── context_overflow.rs        # Context overflow detection and fork triggering
 │   │   │   ├── data_handler.rs            # handle_data_event(); data_tx/data_rx channel; SuggestionData, VersionCheckResult, UpgradeResult, AdaptScaffoldResult handlers  [Issue #371]
-│   │   │   ├── event_handler.rs           # Top-level event dispatch and tick handling
+│   │   │   ├── event_handler.rs           # Top-level event dispatch and tick handling; dispatches desktop notification on StreamEvent::Completed (title: "Session complete: #N <label>", body: "Cost $X.XX — N files changed") and StreamEvent::Error (title/body from error message)  [Issue #487]
+│   │   │   ├── event_handler_tests.rs     # 4 integration tests for desktop notification dispatch using FakeNotifier  [Issue #487]
 │   │   │   ├── helpers.rs                 # Shared App helper utilities
 │   │   │   ├── issue_completion.rs        # on_issue_session_completed(); skips PR creation for CI-fix sessions
 │   │   │   ├── plugins.rs                 # Hook point invocation via PluginRunner
@@ -491,7 +493,7 @@ maestro/
 | `src/github/merge.rs` | `PrMergeCheck` trait (mockable); `PrMergeChecker` impl (`gh pr view` + `git diff`); `MergeState` enum; `PrConflictStatus` struct; `parse_merge_json()`; `parse_conflicting_files()`; `build_conflict_fix_prompt()` |
 | `src/github/pr.rs` | Automated PR creation |
 | `src/modes/` | Session mode definitions: orchestrator, vibe, review (Phase 3) |
-| `src/notifications/` | Interruption system with Info/Warning/Critical/Blocker levels (Phase 3) |
+| `src/notifications/` | Interruption system with Info/Warning/Critical/Blocker levels (Phase 3); `desktop.rs` adds `DesktopNotifier` trait + macOS `OsascriptNotifier` that fires on session Completed/Error events (Issue #487) |
 | `src/plugins/` | Plugin and hook execution system (Phase 3) |
 | `src/plugins/hooks.rs` | HookPoint enum for plugin attachment points |
 | `src/plugins/runner.rs` | External plugin command execution per hook point |
@@ -512,7 +514,7 @@ maestro/
 | `src/state/progress.rs` | Session phase tracking (Phase 3) |
 | `src/tui/` | Terminal UI (ratatui) |
 | `src/tui/mod.rs` | Event loop; `handle_screen_action()`; command processing; `launch_session_from_config()`; `FetchSuggestionData` async handler for GitHub ready/failed counts and milestone progress; spawns async version check on startup via `check_for_update()` — result delivered as `VersionCheckResult` data event; key handlers for upgrade confirmation banner (`[y]` confirm / `[n]` decline); `CompletionSummary` key-intercept branch with `[i]` issue browser, `[r]` new prompt, `[l]` activity log view, `[Enter]`/`[Esc]` dashboard; `ContinuousPause` key-intercept overlay: `[s]` skip, `[r]` retry, `[q]` quit continuous loop; exit path respects `once_mode`; `PromptInputScreen` always constructed with injected history for correct Up/Down recall; `pub mod theme`; `RunAdaptScaffold` command dispatch (Issues #31-33, #35, #38, #46-48, #83, #84, #85, #118, #232, #371) |
-| `src/tui/app/` | App state module split into focused sub-files; `App` struct with `nav_stack: NavigationStack` field (replaces `confirm_exit_return_mode`); `navigate_to()`, `navigate_back()`, `navigate_back_or_dashboard()`, `navigate_to_root()` navigation methods; `theme: Theme`; `gh_auth_ok: bool`; `upgrade_state: UpgradeState`; `pending_prs: Vec<PendingPr>`; `config_path: Option<PathBuf>` propagated from `LoadedConfig` for settings save (Issues #12, #31-33, #35, #38, #40, #41, #43, #46-48, #52, #83, #84, #85, #118, #158, #342, #437) |
+| `src/tui/app/` | App state module split into focused sub-files; `App` struct with `nav_stack: NavigationStack` field (replaces `confirm_exit_return_mode`); `navigate_to()`, `navigate_back()`, `navigate_back_or_dashboard()`, `navigate_to_root()` navigation methods; `theme: Theme`; `gh_auth_ok: bool`; `upgrade_state: UpgradeState`; `pending_prs: Vec<PendingPr>`; `config_path: Option<PathBuf>` propagated from `LoadedConfig` for settings save; `desktop_notifier: Arc<dyn DesktopNotifier>`; `notify_error_flash: Option<(String, Instant)>`; `tick_notify_error()` per-frame error drain (Issues #12, #31-33, #35, #38, #40, #41, #43, #46-48, #52, #83, #84, #85, #118, #158, #342, #437, #487) |
 | `src/tui/app/types.rs` | `TuiMode` enum with `breadcrumb_label()` for human-readable mode names; `NavigationStack` struct — push/pop/peek/clear/breadcrumbs with a cap of 32 entries; `TuiCommand` (+ `RunAdaptScaffold`), `TuiDataEvent` (+ `AdaptScaffoldResult`), `SuggestionDataPayload`, `CompletionSummaryData`, `CompletionSessionLine`, `GateFailureInfo` (Issues #342, #371) |
 | `src/tui/app/completion_summary.rs` | `build_completion_summary()`; `transition_to_dashboard()` now calls `navigate_to_root()` to fully clear the nav stack on dashboard return (Issue #342) |
 | `src/tui/app/clipboard_action.rs` | `App::copy_focused_response()` + `App::copy_focused_response_enabled()` predicate; `CopyOutcome` enum (`Success`, `NoContent`, `NotEnded`, `Failed`); `set_copy_toast()` / `tick_copy_toast()` with `COPY_TOAST_TTL_MS = 2_000` (Issue #482) |

--- a/src/config.rs
+++ b/src/config.rs
@@ -2032,4 +2032,28 @@ max_cost_total = 10.0
             "error should reference the unknown value, got: {msg}"
         );
     }
+
+    #[test]
+    fn notifications_config_desktop_false_survives_toml_round_trip() {
+        let original = NotificationsConfig {
+            desktop: false,
+            slack: false,
+            slack_webhook_url: None,
+            slack_rate_limit_per_min: 10,
+        };
+
+        let serialized = toml::to_string(&original).expect("serialize");
+        let deserialized: NotificationsConfig = toml::from_str(&serialized).expect("deserialize");
+
+        assert!(!deserialized.desktop);
+    }
+
+    #[test]
+    fn notifications_config_missing_desktop_field_defaults_to_true() {
+        let toml_str = r#"slack = false"#;
+
+        let cfg: NotificationsConfig = toml::from_str(toml_str).expect("deserialize");
+
+        assert!(cfg.desktop, "missing `desktop` key must default to true");
+    }
 }

--- a/src/notifications/desktop.rs
+++ b/src/notifications/desktop.rs
@@ -1,0 +1,312 @@
+//! Desktop notification dispatch seam.
+//!
+//! Production code holds an `Arc<dyn DesktopNotifier>`; tests inject
+//! `FakeNotifier`. Real macOS dispatch goes through `OsascriptNotifier`,
+//! which spawns a fire-and-forget `osascript` subprocess so the tokio
+//! reactor never blocks. Errors are buffered and drained per render tick
+//! by the TUI so permission failures land in the activity log instead of
+//! disappearing silently.
+
+use crate::util::formatting::truncate_with_ellipsis;
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Clone)]
+pub(crate) enum NotifyError {
+    /// macOS user has not granted notification permission to the launcher
+    /// (Terminal.app / iTerm.app / etc.).
+    PermissionDenied,
+    DispatchFailed(String),
+    Internal(String),
+}
+
+impl fmt::Display for NotifyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            NotifyError::PermissionDenied => {
+                f.write_str("permission denied — grant Notifications in System Settings")
+            }
+            NotifyError::DispatchFailed(msg) => write!(f, "dispatch failed: {}", msg),
+            NotifyError::Internal(msg) => write!(f, "internal error: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for NotifyError {}
+
+/// Sends OS-level desktop notifications. Implementations MUST NOT block
+/// the tokio reactor; if a backend is sync, it should `spawn_blocking`
+/// internally. The `notify` method is fire-and-forget — errors are
+/// buffered and drained via `take_last_error`.
+pub(crate) trait DesktopNotifier: Send + Sync {
+    /// Fire a notification. Disabled-toggle short-circuit lives inside
+    /// the impl — callers do not branch on enablement.
+    fn notify(&self, title: &str, body: &str);
+
+    /// Returns and clears the most recent error, if any. Polled by the
+    /// TUI render tick to surface permission failures.
+    fn take_last_error(&self) -> Option<NotifyError>;
+}
+
+const NOTIFICATION_TITLE_MAX_BYTES: usize = 128;
+const NOTIFICATION_BODY_MAX_BYTES: usize = 256;
+/// Pinned to defeat PATH hijacking (CWE-426).
+const OSASCRIPT_PATH: &str = "/usr/bin/osascript";
+
+/// Escape control characters and string-literal delimiters for safe
+/// interpolation into an AppleScript double-quoted string literal.
+///
+/// AppleScript terminates a `"..."` literal at a raw `\n` or `\r`, so
+/// passing those through would let attacker-influenceable input (CLI
+/// error messages, session labels) escape the string and execute as
+/// arbitrary script.
+pub(crate) fn sanitize_applescript(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for c in input.chars() {
+        match c {
+            '\\' => out.push_str(r"\\"),
+            '"' => out.push_str(r#"\""#),
+            '\n' => out.push_str(r"\n"),
+            '\r' => out.push_str(r"\r"),
+            '\t' => out.push_str(r"\t"),
+            c if (c as u32) < 0x20 => {}
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+pub(crate) struct OsascriptNotifier {
+    enabled: bool,
+    last_error: Arc<Mutex<Option<NotifyError>>>,
+}
+
+impl OsascriptNotifier {
+    pub(crate) fn new(enabled: bool) -> Self {
+        Self {
+            enabled,
+            last_error: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+impl DesktopNotifier for OsascriptNotifier {
+    fn notify(&self, title: &str, body: &str) {
+        if !self.enabled {
+            return;
+        }
+
+        let safe_title =
+            sanitize_applescript(&truncate_with_ellipsis(title, NOTIFICATION_TITLE_MAX_BYTES));
+        let safe_body =
+            sanitize_applescript(&truncate_with_ellipsis(body, NOTIFICATION_BODY_MAX_BYTES));
+        let script = format!(
+            r#"display notification "{body}" with title "Maestro" subtitle "{title}""#,
+            body = safe_body,
+            title = safe_title,
+        );
+        let last_error = Arc::clone(&self.last_error);
+
+        tokio::spawn(async move {
+            let result = tokio::task::spawn_blocking(move || {
+                std::process::Command::new(OSASCRIPT_PATH)
+                    .args(["-e", &script])
+                    .output()
+            })
+            .await;
+
+            let err = match result {
+                Ok(Ok(out)) if out.status.success() => return,
+                Ok(Ok(out)) => {
+                    let stderr = String::from_utf8_lossy(&out.stderr);
+                    if stderr.contains("not authorized") || stderr.contains("-1743") {
+                        NotifyError::PermissionDenied
+                    } else {
+                        NotifyError::DispatchFailed(stderr.into_owned())
+                    }
+                }
+                Ok(Err(io)) => NotifyError::Internal(format!("spawn failed: {}", io)),
+                Err(join) => NotifyError::Internal(format!("join failed: {}", join)),
+            };
+
+            tracing::warn!(error = %err, "desktop notify failed");
+            let mut slot = last_error.lock().unwrap_or_else(|e| e.into_inner());
+            *slot = Some(err);
+        });
+    }
+
+    fn take_last_error(&self) -> Option<NotifyError> {
+        self.last_error
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take()
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct NotificationCall {
+    pub title: String,
+    pub body: String,
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+struct FakeNotifierInner {
+    enabled: bool,
+    calls: Mutex<Vec<NotificationCall>>,
+    last_error: Mutex<Option<NotifyError>>,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone)]
+pub(crate) struct FakeNotifier {
+    inner: Arc<FakeNotifierInner>,
+}
+
+#[cfg(test)]
+impl FakeNotifier {
+    pub(crate) fn new(enabled: bool) -> Self {
+        Self {
+            inner: Arc::new(FakeNotifierInner {
+                enabled,
+                calls: Mutex::new(Vec::new()),
+                last_error: Mutex::new(None),
+            }),
+        }
+    }
+
+    pub(crate) fn inject_error(&self, err: NotifyError) {
+        let mut slot = self
+            .inner
+            .last_error
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        *slot = Some(err);
+    }
+
+    pub(crate) fn calls(&self) -> Vec<NotificationCall> {
+        self.inner
+            .calls
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
+    pub(crate) fn call_count(&self) -> usize {
+        self.inner
+            .calls
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .len()
+    }
+}
+
+#[cfg(test)]
+impl DesktopNotifier for FakeNotifier {
+    fn notify(&self, title: &str, body: &str) {
+        if !self.inner.enabled {
+            return;
+        }
+        let mut guard = self.inner.calls.lock().unwrap_or_else(|e| e.into_inner());
+        guard.push(NotificationCall {
+            title: title.to_owned(),
+            body: body.to_owned(),
+        });
+    }
+
+    fn take_last_error(&self) -> Option<NotifyError> {
+        self.inner
+            .last_error
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fake_notifier_records_call_when_enabled() {
+        let fake = FakeNotifier::new(true);
+
+        fake.notify("Session complete: #42", "Finished in 3.2s");
+
+        let calls = fake.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].title, "Session complete: #42");
+        assert_eq!(calls[0].body, "Finished in 3.2s");
+    }
+
+    #[test]
+    fn fake_notifier_is_noop_when_disabled() {
+        let fake = FakeNotifier::new(false);
+
+        fake.notify("Session complete: #7", "done");
+        fake.notify("Session complete: #7", "done again");
+
+        assert_eq!(fake.call_count(), 0);
+    }
+
+    #[test]
+    fn osascript_notifier_is_noop_when_disabled() {
+        let notifier = OsascriptNotifier::new(false);
+
+        notifier.notify("should-not-fire", "body");
+
+        assert!(notifier.take_last_error().is_none());
+    }
+
+    #[test]
+    fn sanitize_applescript_escapes_double_quote_and_backslash() {
+        let input = r#"a"b\c"#;
+
+        let out = sanitize_applescript(input);
+
+        assert_eq!(out, r#"a\"b\\c"#);
+    }
+
+    #[test]
+    fn sanitize_applescript_escapes_newlines_and_carriage_returns() {
+        // Without escaping, a raw newline terminates the AppleScript
+        // string literal and lets the rest of the input parse as code.
+        let input = "ok\nmalicious\rstuff";
+
+        let out = sanitize_applescript(input);
+
+        assert!(!out.contains('\n'), "raw LF must be escaped: {:?}", out);
+        assert!(!out.contains('\r'), "raw CR must be escaped: {:?}", out);
+        assert_eq!(out, r"ok\nmalicious\rstuff");
+    }
+
+    #[test]
+    fn sanitize_applescript_drops_control_characters_and_nul() {
+        let input = "a\u{0000}b\u{0007}c\u{001b}d";
+
+        let out = sanitize_applescript(input);
+
+        assert_eq!(out, "abcd");
+    }
+
+    #[test]
+    fn take_last_error_returns_some_then_drain_returns_none() {
+        let fake = FakeNotifier::new(true);
+        fake.inject_error(NotifyError::PermissionDenied);
+
+        let first = fake.take_last_error();
+        assert!(
+            matches!(first, Some(NotifyError::PermissionDenied)),
+            "expected PermissionDenied, got {:?}",
+            first
+        );
+
+        let second = fake.take_last_error();
+        assert!(
+            second.is_none(),
+            "expected None after drain, got {:?}",
+            second
+        );
+    }
+}

--- a/src/notifications/mod.rs
+++ b/src/notifications/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod desktop;
 pub mod dispatcher;
 pub mod slack;
 pub mod types;

--- a/src/tui/app/event_handler.rs
+++ b/src/tui/app/event_handler.rs
@@ -10,6 +10,13 @@ use crate::session::types::{SessionStatus, StreamEvent};
 use crate::state::file_claims::{ClaimResult, FILE_CONFLICT_SENTINEL};
 use crate::tui::activity_log::LogLevel;
 
+fn format_session_notify_title(prefix: &str, issue: Option<u64>, label: &str) -> String {
+    match issue {
+        Some(n) => format!("{}: #{} {}", prefix, n, label),
+        None => format!("{}: {}", prefix, label),
+    }
+}
+
 impl App {
     /// Process a stream event from a session.
     pub fn handle_session_event(&mut self, evt: SessionEvent) {
@@ -195,6 +202,7 @@ impl App {
                 StreamEvent::Thinking { .. } => {}
                 StreamEvent::TokenUpdate { .. } => {}
                 StreamEvent::Completed { cost_usd } => {
+                    let desktop_label = label.clone();
                     self.activity_log.push_simple(
                         label.clone(),
                         format!("Completed (${:.2})", cost_usd),
@@ -208,6 +216,17 @@ impl App {
                             LogLevel::Warn,
                         );
                     }
+                    let title = format_session_notify_title(
+                        "Session complete",
+                        managed.session.issue_number,
+                        &desktop_label,
+                    );
+                    let body = format!(
+                        "Cost ${:.2} — {} files changed",
+                        cost_usd,
+                        managed.session.files_touched.len()
+                    );
+                    self.desktop_notifier.notify(&title, &body);
                     self.notifications
                         .notify_slack(SlackEvent::SessionCompleted {
                             session_id: managed.session.id.to_string(),
@@ -248,6 +267,7 @@ impl App {
                     }
                 }
                 StreamEvent::Error { message } => {
+                    let desktop_label = label.clone();
                     self.activity_log.push_simple(
                         label,
                         format!("ERROR: {}", message),
@@ -257,6 +277,12 @@ impl App {
                         managed.session.id,
                         crate::state::prompt_history::PromptOutcome::Errored,
                     );
+                    let title = format_session_notify_title(
+                        "Session errored",
+                        managed.session.issue_number,
+                        &desktop_label,
+                    );
+                    self.desktop_notifier.notify(&title, message);
                     self.notifications.notify_slack(SlackEvent::SessionErrored {
                         session_id: managed.session.id.to_string(),
                         issue_number: managed.session.issue_number,
@@ -302,3 +328,7 @@ impl App {
         crate::tui::screen_dispatch::dispatch_paste_to_active_screen(self, text);
     }
 }
+
+#[cfg(test)]
+#[path = "event_handler_tests.rs"]
+mod tests;

--- a/src/tui/app/event_handler_tests.rs
+++ b/src/tui/app/event_handler_tests.rs
@@ -1,0 +1,125 @@
+//! Tests for `App::handle_session_event` desktop-notification dispatch.
+//! Extracted to keep `event_handler.rs` under the 400-LOC budget.
+
+#![cfg(test)]
+
+use super::App;
+use crate::notifications::desktop::{FakeNotifier, NotifyError};
+use crate::session::manager::SessionEvent;
+use crate::session::types::{Session, StreamEvent};
+use crate::tui::make_test_app;
+use std::sync::Arc;
+
+fn session_with_issue(issue: u64) -> Session {
+    let mut s = Session::new(
+        "fix bug".to_string(),
+        "claude-opus-4-5".to_string(),
+        "orchestrator".to_string(),
+        Some(issue),
+    );
+    s.issue_title = Some(format!("Issue #{}", issue));
+    s
+}
+
+fn promote_session(app: &mut App, session: Session) -> uuid::Uuid {
+    let id = session.id;
+    app.pool.enqueue(session);
+    app.pool.try_promote();
+    id
+}
+
+#[test]
+fn app_dispatches_desktop_notification_on_session_completed() {
+    let fake = FakeNotifier::new(true);
+    let arc_fake: Arc<dyn crate::notifications::desktop::DesktopNotifier> = Arc::new(fake.clone());
+    let mut app = make_test_app("notif-test-completed").with_desktop_notifier(arc_fake);
+
+    let session_id = promote_session(&mut app, session_with_issue(42));
+    let evt = SessionEvent {
+        session_id,
+        event: StreamEvent::Completed { cost_usd: 1.50 },
+    };
+
+    app.handle_session_event(evt);
+
+    assert_eq!(fake.call_count(), 1);
+    let calls = fake.calls();
+    assert!(
+        calls[0].title.contains("Session complete"),
+        "title was: {}",
+        calls[0].title
+    );
+    assert!(
+        calls[0].title.contains("42"),
+        "title should reference issue #42, got: {}",
+        calls[0].title
+    );
+}
+
+#[test]
+fn app_skips_desktop_notification_when_notifier_disabled() {
+    let fake = FakeNotifier::new(false);
+    let arc_fake: Arc<dyn crate::notifications::desktop::DesktopNotifier> = Arc::new(fake.clone());
+    let mut app = make_test_app("notif-test-disabled").with_desktop_notifier(arc_fake);
+
+    let session_id = promote_session(&mut app, session_with_issue(99));
+    let evt = SessionEvent {
+        session_id,
+        event: StreamEvent::Completed { cost_usd: 0.0 },
+    };
+
+    app.handle_session_event(evt);
+
+    assert_eq!(fake.call_count(), 0);
+}
+
+#[test]
+fn app_dispatches_desktop_notification_on_session_error() {
+    let fake = FakeNotifier::new(true);
+    let arc_fake: Arc<dyn crate::notifications::desktop::DesktopNotifier> = Arc::new(fake.clone());
+    let mut app = make_test_app("notif-test-error").with_desktop_notifier(arc_fake);
+
+    let session_id = promote_session(&mut app, session_with_issue(11));
+    let evt = SessionEvent {
+        session_id,
+        event: StreamEvent::Error {
+            message: "process exited with code 1".to_string(),
+        },
+    };
+
+    app.handle_session_event(evt);
+
+    assert_eq!(fake.call_count(), 1);
+    let calls = fake.calls();
+    assert!(
+        calls[0].title.contains("Session errored"),
+        "title was: {}",
+        calls[0].title
+    );
+}
+
+#[test]
+fn tick_notify_error_logs_permission_denied_warning_then_drains() {
+    let fake = FakeNotifier::new(true);
+    fake.inject_error(NotifyError::PermissionDenied);
+    let arc_fake: Arc<dyn crate::notifications::desktop::DesktopNotifier> = Arc::new(fake);
+    let mut app = make_test_app("notif-test-perm-denied").with_desktop_notifier(arc_fake);
+
+    let log_count_before = app.activity_log.entries().len();
+
+    app.tick_notify_error();
+
+    let log_count_after_first = app.activity_log.entries().len();
+    assert_eq!(
+        log_count_after_first,
+        log_count_before + 1,
+        "first tick must push exactly one log entry"
+    );
+
+    app.tick_notify_error();
+    assert_eq!(
+        app.activity_log.entries().len(),
+        log_count_after_first,
+        "second tick must not push another log entry"
+    );
+}

--- a/src/tui/app/mod.rs
+++ b/src/tui/app/mod.rs
@@ -26,6 +26,7 @@ use crate::continuous::ContinuousModeState;
 use crate::mascot::MascotAnimator;
 use crate::mascot::animator::SystemClock;
 use crate::models::ModelRouter;
+use crate::notifications::desktop::{DesktopNotifier, OsascriptNotifier};
 use crate::notifications::dispatcher::NotificationDispatcher;
 use crate::plugins::runner::PluginRunner;
 use crate::provider::github::client::GitHubClient;
@@ -172,6 +173,9 @@ pub struct App {
     pub(crate) clipboard: Box<dyn crate::tui::clipboard::Clipboard>,
     /// Transient (~2 s) banner shown after a copy action.
     pub(crate) copy_toast: Option<crate::tui::app::clipboard_action::CopyToast>,
+    /// Desktop notification dispatcher. Production wires `OsascriptNotifier`;
+    /// tests inject `FakeNotifier` via `with_desktop_notifier`.
+    pub(crate) desktop_notifier: std::sync::Arc<dyn DesktopNotifier>,
 }
 
 impl App {
@@ -287,6 +291,7 @@ impl App {
             settings_store: None,
             clipboard: Box::new(crate::tui::clipboard::SystemClipboard),
             copy_toast: None,
+            desktop_notifier: std::sync::Arc::new(OsascriptNotifier::new(false)),
         }
     }
 
@@ -298,6 +303,38 @@ impl App {
     ) -> Self {
         self.clipboard = clipboard;
         self
+    }
+
+    /// Builder for tests: swap the desktop notifier for a fake.
+    #[cfg(test)]
+    pub(crate) fn with_desktop_notifier(
+        mut self,
+        notifier: std::sync::Arc<dyn DesktopNotifier>,
+    ) -> Self {
+        self.desktop_notifier = notifier;
+        self
+    }
+
+    /// Drain any pending desktop-notifier error into the activity log.
+    /// Called once per render frame from `tui::ui::draw`.
+    pub fn tick_notify_error(&mut self) {
+        let Some(err) = self.desktop_notifier.take_last_error() else {
+            return;
+        };
+        let msg = match err {
+            crate::notifications::desktop::NotifyError::PermissionDenied => {
+                "Desktop notifications blocked. Grant access in System Settings → Notifications."
+                    .to_string()
+            }
+            crate::notifications::desktop::NotifyError::DispatchFailed(m) => {
+                format!("Desktop notification failed: {}", m)
+            }
+            crate::notifications::desktop::NotifyError::Internal(m) => {
+                format!("Desktop notification internal error: {}", m)
+            }
+        };
+        self.activity_log
+            .push_simple("NOTIFICATIONS".into(), msg, LogLevel::Warn);
     }
 
     pub fn configure(&mut self, config: Config) {
@@ -349,6 +386,8 @@ impl App {
         crate::icon_mode::init_from_config(config.tui.ascii_icons);
         self.show_mascot = config.tui.show_mascot;
         self.mascot_style = config.tui.mascot_style;
+        self.desktop_notifier =
+            std::sync::Arc::new(OsascriptNotifier::new(config.notifications.desktop));
         // Sync TurboQuant flag from [turboquant] config section
         if config.turboquant.enabled {
             self.flags.set_enabled(crate::flags::Flag::TurboQuant, true);

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -90,6 +90,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
 
     // Aged out before render so the empty-toast frame draws cleanly.
     app.tick_copy_toast(std::time::Instant::now());
+    app.tick_notify_error();
     if let Some(toast) = app.copy_toast.as_ref() {
         let banner_area = Rect::new(chunks[0].x, chunks[0].y, chunks[0].width, 1);
         crate::tui::clipboard_toast::draw_copy_toast(


### PR DESCRIPTION
## Summary

- Adds a `DesktopNotifier` trait + `OsascriptNotifier` macOS impl at `src/notifications/desktop.rs`; wires dispatch into the `Completed` and `Error` arms of `handle_session_event` so a system notification fires when a managed Claude session ends.
- Toggle (`config.notifications.desktop`) short-circuits inside the notifier so call sites stay flag-free; permission/dispatch errors drain into the activity log per render tick.
- Hardened against AppleScript injection (escape `\` `"` `\n` `\r` `\t`, drop NUL/C0 controls, cap title at 128 / body at 256 bytes) and PATH hijacking (pinned `/usr/bin/osascript`).

Closes #487

## Test plan

- [x] `cargo test` (3416 unit + 13 integration tests pass)
- [x] `cargo clippy -- -D warnings -A dead_code` clean
- [x] `cargo fmt --check` clean
- [x] `scripts/check-file-size.sh` clean (new files under 400 LOC; existing allowlisted files unchanged)
- [x] New unit tests cover sanitizer escaping (quote, backslash, newline, carriage return, control chars), `FakeNotifier` enabled/disabled paths, and `take_last_error` drain semantics
- [x] New integration tests in `event_handler_tests.rs` cover `Completed`/`Error` dispatch with `FakeNotifier` and `tick_notify_error` activity-log surfacing
- [x] Manual smoke (macOS): enable Notifications toggle in [S], run a session to completion with terminal unfocused, confirm system notification appears
- [x] Manual smoke (macOS): revoke Terminal notification permission in System Settings → Notifications, run a session, confirm activity log Warn entry instead of silent failure