### PR TITLE
fix(updater): atomic binary replace via BinaryReplacer trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ walkdir = "2"
 flate2 = "1"
 tar = "0.4"
 tempfile = "3"
-thiserror = "1"
+thiserror = "2"
 
 [build-dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ syn = { version = "2", features = ["full", "visit"] }
 walkdir = "2"
 flate2 = "1"
 tar = "0.4"
+tempfile = "3"
+thiserror = "1"
 
 [build-dependencies]
 clap = { version = "4", features = ["derive"] }
@@ -53,7 +55,6 @@ clap_mangen = "0.2"
 anyhow = "1"
 
 [dev-dependencies]
-tempfile = "3"
 insta = "1"
 criterion = { version = "0.5", features = ["html_reports"] }
 

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-27 20:00 (UTC)
+> Last updated: 2026-04-28 00:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -126,9 +126,13 @@ maestro/
 │   │   ├── prompts.rs                     # Claude prompt builders for analyzer, planner, and scaffold phases  [Issue #371]
 │   │   └── knowledge.rs                   # Knowledge-base compression (Phase 2.6): consumes AdaptReport + ProjectProfile; produces KnowledgeBase (six token-budgeted sections); write_knowledge_file() writes .maestro/knowledge.md; auto-loaded by SessionPool::try_promote as a system-prompt component; 1 MiB size cap, symlink rejection, TOCTOU-safe load, envelope-wrapped injection  [Issue #347]
 │   ├── updater/                           # Self-upgrade subsystem  [Issue #118]
-│   │   ├── mod.rs                         # UpgradeState state machine (Idle, Checking, UpdateAvailable, Downloading, Installing, Done, Failed); ReleaseInfo type (tag_name, download_url, body)
+│   │   ├── mod.rs                         # UpgradeState state machine (Idle, Checking, UpdateAvailable, Downloading, Installing, Done, Failed); ReleaseInfo type (tag_name, download_url, body); pub mod declarations for error/lock/replace  [Issue #499]
 │   │   ├── checker.rs                     # UpdateChecker trait; GitHubReleaseChecker (hits GitHub Releases API); version parsing via semver comparison; asset names use Rust target triples (e.g. aarch64-apple-darwin); checksum file resolves to sha256sums.txt; check_for_update() async entry point  [Issue #118, #233]
-│   │   ├── installer.rs                   # Binary replacement with pre-install backup; atomic swap via temp file; tar.gz archives extracted via flate2 + tar pipeline; restart_with_same_args() re-execs the process with original argv after upgrade completes  [Issue #118, #233]
+│   │   ├── error.rs                       # Typed UpdateError enum (thiserror); variants: Io, TempFile, Rename, CurrentExe, Download, NoAsset, Checksum, Lock  [Issue #499]
+│   │   ├── installer.rs                   # Installer holds Arc<dyn BinaryReplacer>; install_with_backup delegates replacement via spawn_blocking; download_and_install returns typed UpdateError; tar.gz extracted via flate2 + tar pipeline  [Issue #118, #233, #499]
+│   │   ├── installer_tests.rs             # Split test module loaded via #[path] from installer.rs; unit tests for Installer using MockBinaryReplacer  [Issue #499]
+│   │   ├── lock.rs                        # UpdateLock RAII guard; lock file acquired with O_NOFOLLOW + O_CLOEXEC flags to prevent symlink attacks and fd leaks  [Issue #499]
+│   │   ├── replace.rs                     # BinaryReplacer trait; AtomicBinaryReplacer impl using NamedTempFile + atomic rename for safe in-place binary replacement  [Issue #499]
 │   │   └── restart.rs                     # RestartBuilder and RestartCommand: pure, testable command construction for post-upgrade re-exec; no side effects until .execute() is called
 │   ├── gates/                             # Completion gates framework  [Phase 3, Issue #40]
 │   │   ├── mod.rs                         # Module exports
@@ -443,7 +447,7 @@ maestro/
 │   └── scripts/                           # Test script fixtures
 ├── .gitignore                             # Includes .maestro/worktrees/ and runtime artifacts; .maestro/knowledge.md (written by maestro adapt, auto-loaded as system-prompt component by SessionPool::try_promote) is also excluded
 ├── Cargo.lock                             # Dependency lock file
-├── Cargo.toml                             # Rust package manifest; tempfile and insta dev-dependencies; optimized release profile; [features] section with experimental-sanitizer = []; flate2 and tar dependencies added for tar.gz archive extraction in self-updater; strip-ansi-escapes = "0.2" added for ANSI stripping in clipboard copy  [Issue #142, #233, #482]
+├── Cargo.toml                             # Rust package manifest; tempfile promoted to runtime dependency; thiserror = "1" added; insta dev-dependency; optimized release profile; [features] section with experimental-sanitizer = []; flate2 and tar dependencies for tar.gz extraction in self-updater; strip-ansi-escapes = "0.2" for ANSI stripping in clipboard copy  [Issue #142, #233, #482, #499]
 ├── CHANGELOG.md                           # Release history following Keep a Changelog format
 ├── LICENSE
 ├── README.md                              # Project front door
@@ -506,9 +510,13 @@ maestro/
 | `src/adapt/knowledge.rs` | Knowledge-base compression (Phase 2.6 of `cmd_adapt`); `KnowledgeBase` struct (six `KnowledgeSection` fields); `write_knowledge_file()` writes `.maestro/knowledge.md`; auto-loaded by `SessionPool::try_promote` as a system-prompt component; 1 MiB size cap, symlink rejection, TOCTOU-safe load, envelope-wrapped injection (Issue #347) |
 | `src/gates/` | Completion gates: TestsPass, FileExists, FileContains, PrCreated, Command (Phase 3, Issue #40) |
 | `src/updater/` | Self-upgrade subsystem: version check, binary installation, and restart (Issue #118) |
-| `src/updater/mod.rs` | `UpgradeState` state machine (`Idle` → `Checking` → `UpdateAvailable` → `Downloading` → `Installing` → `Done` / `Failed`); `ReleaseInfo` type |
+| `src/updater/mod.rs` | `UpgradeState` state machine (`Idle` → `Checking` → `UpdateAvailable` → `Downloading` → `Installing` → `Done` / `Failed`); `ReleaseInfo` type; `pub mod` declarations for `error`, `lock`, `replace` (Issue #499) |
 | `src/updater/checker.rs` | `UpdateChecker` trait; `GitHubReleaseChecker` hits GitHub Releases API; semver version comparison; asset names use Rust target triples (e.g. `aarch64-apple-darwin`); checksum file resolves to `sha256sums.txt`; `check_for_update()` async entry point (Issues #118, #233) |
-| `src/updater/installer.rs` | Binary replacement with pre-install backup; atomic swap via temp file; `.tar.gz` archives extracted via `flate2` + `tar` pipeline; `restart_with_same_args()` re-execs the upgraded binary with original argv (Issues #118, #233) |
+| `src/updater/error.rs` | `UpdateError` enum (thiserror); variants: `Io`, `TempFile`, `Rename`, `CurrentExe`, `Download`, `NoAsset`, `Checksum`, `Lock` (Issue #499) |
+| `src/updater/installer.rs` | `Installer` holds `Arc<dyn BinaryReplacer>`; `install_with_backup` delegates via `spawn_blocking`; `download_and_install` returns typed `UpdateError`; `.tar.gz` archives extracted via `flate2` + `tar` pipeline (Issues #118, #233, #499) |
+| `src/updater/installer_tests.rs` | Split test module loaded via `#[path]` from `installer.rs`; unit tests for `Installer` using `MockBinaryReplacer` (Issue #499) |
+| `src/updater/lock.rs` | `UpdateLock` RAII guard; lock file acquired with `O_NOFOLLOW` + `O_CLOEXEC` to prevent symlink attacks and fd leaks (Issue #499) |
+| `src/updater/replace.rs` | `BinaryReplacer` trait; `AtomicBinaryReplacer` impl using `NamedTempFile` + atomic rename for safe in-place binary replacement (Issue #499) |
 | `src/updater/restart.rs` | `RestartBuilder` and `RestartCommand`: pure, testable post-upgrade re-exec command construction; no side effects until `.execute()` is called |
 | `src/provider/` | Multi-provider abstraction layer (Issue #29) |
 | `src/provider/mod.rs` | create_provider factory; detect_provider_from_remote |

--- a/src/integration_tests/upgrade.rs
+++ b/src/integration_tests/upgrade.rs
@@ -26,8 +26,11 @@ async fn upgrade_flow_check_to_trigger_full_pipeline() {
     let state = UpgradeState::Available(info);
     assert!(state.is_visible());
 
-    let new_bytes = b"new binary v0.6.0";
-    installer.install_with_backup(new_bytes).await.unwrap();
+    let new_bytes = b"new binary v0.6.0".to_vec();
+    installer
+        .install_with_backup(new_bytes.clone())
+        .await
+        .unwrap();
     let installed = fs::read(&dest).await.unwrap();
     assert_eq!(installed, new_bytes);
 

--- a/src/tui/app/data_handler.rs
+++ b/src/tui/app/data_handler.rs
@@ -186,13 +186,24 @@ impl App {
                 );
                 self.upgrade_state = crate::updater::UpgradeState::Available(info);
             }
-            TuiDataEvent::VersionCheckResult(None) => {}
+            TuiDataEvent::VersionCheckResult(None) => {
+                self.activity_log.push_simple(
+                    "UPDATE".into(),
+                    "Already on the latest version.".into(),
+                    LogLevel::Info,
+                );
+            }
             TuiDataEvent::UpgradeResult(Ok(backup_path)) => {
                 if let crate::updater::UpgradeState::Downloading { version } = &self.upgrade_state {
                     self.upgrade_state = crate::updater::UpgradeState::ReadyToRestart {
                         version: version.clone(),
                         backup_path,
                     };
+                    self.activity_log.push_simple(
+                        "UPDATE".into(),
+                        "Update successful — please restart maestro to apply changes.".into(),
+                        LogLevel::Info,
+                    );
                 }
             }
             TuiDataEvent::UpgradeResult(Err(msg)) => {

--- a/src/tui/background_tasks.rs
+++ b/src/tui/background_tasks.rs
@@ -47,12 +47,22 @@ pub(super) fn spawn_upgrade_download(
     tx: tokio::sync::mpsc::UnboundedSender<app::TuiDataEvent>,
     info: crate::updater::ReleaseInfo,
 ) {
-    let dest = std::env::current_exe().unwrap_or_default();
+    let dest = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(e) => {
+            let _ = tx.send(app::TuiDataEvent::UpgradeResult(Err(format!(
+                "cannot resolve current executable path: {e}"
+            ))));
+            return;
+        }
+    };
     tokio::spawn(async move {
         let installer = crate::updater::installer::Installer::new(dest);
         match installer.download_and_install(&info.download_url).await {
             Ok(backup) => {
-                let _ = tx.send(app::TuiDataEvent::UpgradeResult(Ok(backup)));
+                let _ = tx.send(app::TuiDataEvent::UpgradeResult(Ok(backup
+                    .to_string_lossy()
+                    .to_string())));
             }
             Err(e) => {
                 let _ = tx.send(app::TuiDataEvent::UpgradeResult(Err(e.to_string())));

--- a/src/updater/error.rs
+++ b/src/updater/error.rs
@@ -1,0 +1,101 @@
+use std::path::PathBuf;
+use thiserror::Error;
+
+/// Typed error seam for the updater module.
+///
+/// Each variant maps to one user-facing message in the TUI banner / activity log.
+/// The `Display` impl produces those strings verbatim.
+#[derive(Debug, Error)]
+pub enum UpdateError {
+    #[error(
+        "permission denied — re-run with elevated privileges or move maestro to a writable path"
+    )]
+    PermissionDenied {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[error("network error during download: {message}")]
+    NetworkInterrupted { message: String },
+
+    #[error("checksum mismatch: expected {expected}, got {actual}")]
+    ChecksumMismatch { expected: String, actual: String },
+
+    #[error("update failed — original version restored")]
+    ReplaceFailedRolledBack { source: std::io::Error },
+
+    #[error("update failed and rollback could not complete — please reinstall maestro manually")]
+    RollbackFailed {
+        replace_source: std::io::Error,
+        rollback_source: std::io::Error,
+    },
+
+    #[error("another maestro instance is currently updating; please wait and try again")]
+    ConcurrentUpdate { lock_path: PathBuf },
+
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+
+    #[test]
+    fn update_error_display_permission_denied() {
+        let err = UpdateError::PermissionDenied {
+            path: PathBuf::from("/usr/local/bin/maestro"),
+            source: io::Error::from(io::ErrorKind::PermissionDenied),
+        };
+        assert_eq!(
+            format!("{err}"),
+            "permission denied — re-run with elevated privileges or move maestro to a writable path"
+        );
+    }
+
+    #[test]
+    fn update_error_display_network_interrupted() {
+        let err = UpdateError::NetworkInterrupted {
+            message: "connection reset by peer".to_string(),
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("network error during download"), "got: {msg}");
+        assert!(msg.contains("connection reset by peer"), "got: {msg}");
+    }
+
+    #[test]
+    fn update_error_display_replace_failed_rolled_back() {
+        let err = UpdateError::ReplaceFailedRolledBack {
+            source: io::Error::from(io::ErrorKind::Other),
+        };
+        assert_eq!(
+            format!("{err}"),
+            "update failed — original version restored"
+        );
+    }
+
+    #[test]
+    fn update_error_display_rollback_failed() {
+        let err = UpdateError::RollbackFailed {
+            replace_source: io::Error::from(io::ErrorKind::Other),
+            rollback_source: io::Error::from(io::ErrorKind::BrokenPipe),
+        };
+        assert_eq!(
+            format!("{err}"),
+            "update failed and rollback could not complete — please reinstall maestro manually"
+        );
+    }
+
+    #[test]
+    fn update_error_display_concurrent_update() {
+        let err = UpdateError::ConcurrentUpdate {
+            lock_path: PathBuf::from("/tmp/maestro.update.lock"),
+        };
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("another maestro instance is currently updating"),
+            "got: {msg}"
+        );
+    }
+}

--- a/src/updater/installer.rs
+++ b/src/updater/installer.rs
@@ -1,6 +1,9 @@
+use crate::updater::error::UpdateError;
+use crate::updater::replace::{AtomicBinaryReplacer, BinaryReplacer};
 use anyhow::{Context, Result};
 use sha2::{Digest, Sha256};
 use std::path::PathBuf;
+use std::sync::Arc;
 use tokio::fs;
 
 /// Extract the maestro binary from a tar.gz archive.
@@ -27,25 +30,29 @@ pub(crate) fn extract_binary_from_tar_gz(archive_bytes: &[u8]) -> Result<Vec<u8>
 
 pub struct Installer {
     pub dest_path: PathBuf,
+    // Arc<dyn> so the replacer can move into spawn_blocking ('static + Send + Sync).
+    replacer: Arc<dyn BinaryReplacer>,
 }
 
 impl Installer {
     pub fn new(dest_path: PathBuf) -> Self {
-        Self { dest_path }
+        Self {
+            dest_path,
+            replacer: Arc::new(AtomicBinaryReplacer::new()),
+        }
     }
 
-    fn backup_path(&self) -> PathBuf {
-        let mut p = self.dest_path.clone();
-        let name = p
-            .file_name()
-            .map(|n| format!("{}.bak", n.to_string_lossy()))
-            .unwrap_or_else(|| "maestro.bak".to_string());
-        p.set_file_name(name);
-        p
+    /// Test-only constructor that injects a custom `BinaryReplacer`.
+    #[cfg(test)]
+    pub(crate) fn with_replacer(dest_path: PathBuf, replacer: Arc<dyn BinaryReplacer>) -> Self {
+        Self {
+            dest_path,
+            replacer,
+        }
     }
 
     /// Write bytes to a staging area (same dir, `.tmp` suffix).
-    #[allow(dead_code)] // Reason: staging step for two-phase install
+    #[allow(dead_code)] // Reason: staging step retained for two-phase callers.
     pub async fn write_to_staging(&self, bytes: &[u8]) -> Result<PathBuf> {
         let staging = self.dest_path.with_extension("tmp");
         fs::write(&staging, bytes)
@@ -54,58 +61,23 @@ impl Installer {
         Ok(staging)
     }
 
-    /// Backup the current binary and replace with new bytes. Rolls back on failure.
-    pub async fn install_with_backup(&self, new_bytes: &[u8]) -> Result<()> {
-        let backup = self.backup_path();
+    /// Replace the binary at `dest_path` with `new_bytes`, delegating to the
+    /// injected `BinaryReplacer`. Returns the path of the backup of the
+    /// original binary on success.
+    pub async fn install_with_backup(&self, new_bytes: Vec<u8>) -> Result<PathBuf, UpdateError> {
+        let target = self.dest_path.clone();
+        let replacer = self.replacer.clone();
 
-        // Read original for backup
-        let original = fs::read(&self.dest_path)
+        let outcome = tokio::task::spawn_blocking(move || replacer.replace(&target, &new_bytes))
             .await
-            .context("Failed to read current binary for backup")?;
-
-        // Write backup
-        fs::write(&backup, &original)
-            .await
-            .context("Failed to write backup")?;
-
-        // Attempt to write new binary
-        match fs::write(&self.dest_path, new_bytes).await {
-            Ok(_) => {
-                // Set executable permissions on Unix
-                #[cfg(unix)]
-                {
-                    use std::os::unix::fs::PermissionsExt;
-                    let perms = std::fs::Permissions::from_mode(0o755);
-                    fs::set_permissions(&self.dest_path, perms).await?;
-                }
-                Ok(())
-            }
-            Err(e) => {
-                // Rollback: restore original
-                if let Err(rollback_err) = fs::write(&self.dest_path, &original).await {
-                    tracing::error!(
-                        "CRITICAL: rollback also failed after write error: {}",
-                        rollback_err
-                    );
-                }
-                Err(e).context("Failed to replace binary; attempted rollback")
-            }
-        }
+            .map_err(|e| UpdateError::Internal(format!("replace task panicked: {e}")))??;
+        Ok(outcome.backup_path)
     }
 
-    /// Verify SHA-256 checksum of downloaded bytes against expected hex hash.
-    pub fn verify_checksum(bytes: &[u8], expected_hex: &str) -> Result<()> {
+    fn compute_sha256_hex(bytes: &[u8]) -> String {
         let mut hasher = Sha256::new();
         hasher.update(bytes);
-        let actual = format!("{:x}", hasher.finalize());
-        if actual != expected_hex.to_lowercase() {
-            anyhow::bail!(
-                "Checksum mismatch: expected {}, got {}",
-                expected_hex,
-                actual
-            );
-        }
-        Ok(())
+        format!("{:x}", hasher.finalize())
     }
 
     /// Fetch the SHA256SUMS file from the same release directory and extract
@@ -144,57 +116,83 @@ impl Installer {
     ///
     /// Validates the URL against trusted domains, enforces a size limit,
     /// verifies SHA-256 checksum, and uses a 120-second download timeout.
-    pub async fn download_and_install(&self, download_url: &str) -> Result<String> {
+    /// Returns the backup path on success.
+    pub async fn download_and_install(&self, download_url: &str) -> Result<PathBuf, UpdateError> {
         if !crate::updater::is_trusted_download_url(download_url) {
-            anyhow::bail!("Untrusted download URL: only HTTPS from github.com is allowed");
+            return Err(UpdateError::NetworkInterrupted {
+                message: "untrusted download URL: only HTTPS from github.com is allowed"
+                    .to_string(),
+            });
         }
 
         let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(120))
-            .build()?;
+            .build()
+            .map_err(|e| UpdateError::Internal(format!("building reqwest client: {e}")))?;
 
         let resp = client
             .get(download_url)
             .header("User-Agent", concat!("maestro/", env!("CARGO_PKG_VERSION")))
             .send()
-            .await?;
+            .await
+            .map_err(|e| UpdateError::NetworkInterrupted {
+                message: format!("HTTP request failed: {e}"),
+            })?;
 
         if !resp.status().is_success() {
-            anyhow::bail!("Download failed: HTTP {}", resp.status());
+            return Err(UpdateError::NetworkInterrupted {
+                message: format!("HTTP {}", resp.status()),
+            });
         }
 
         if let Some(len) = resp.content_length()
             && len > crate::updater::MAX_DOWNLOAD_SIZE
         {
-            anyhow::bail!(
-                "Binary too large: {} bytes (max {} bytes)",
-                len,
-                crate::updater::MAX_DOWNLOAD_SIZE
-            );
+            return Err(UpdateError::NetworkInterrupted {
+                message: format!(
+                    "binary too large: {} bytes (max {} bytes)",
+                    len,
+                    crate::updater::MAX_DOWNLOAD_SIZE
+                ),
+            });
         }
 
-        let bytes = resp.bytes().await?;
-
-        // Verify SHA-256 checksum before installing
         let asset_name = download_url
             .rsplit_once('/')
             .map(|(_, name)| name)
             .unwrap_or("maestro");
 
-        let expected_hash =
-            Self::fetch_expected_checksum(&client, download_url, asset_name).await?;
-        Self::verify_checksum(&bytes, &expected_hash)?;
+        let download_fut = async {
+            resp.bytes()
+                .await
+                .map_err(|e| UpdateError::NetworkInterrupted {
+                    message: format!("download interrupted: {e}"),
+                })
+        };
+        let checksum_fut = async {
+            Self::fetch_expected_checksum(&client, download_url, asset_name)
+                .await
+                .map_err(|e| UpdateError::NetworkInterrupted {
+                    message: format!("fetching SHA256SUMS: {e}"),
+                })
+        };
+        let (bytes, expected_hash) = tokio::try_join!(download_fut, checksum_fut)?;
 
-        // Extract binary from tar.gz if applicable
+        let actual = Self::compute_sha256_hex(&bytes);
+        if actual != expected_hash.to_lowercase() {
+            return Err(UpdateError::ChecksumMismatch {
+                expected: expected_hash,
+                actual,
+            });
+        }
+
         let binary_bytes = if asset_name.ends_with(".tar.gz") {
-            extract_binary_from_tar_gz(&bytes)?
+            extract_binary_from_tar_gz(&bytes).map_err(|e| UpdateError::Internal(e.to_string()))?
         } else {
             bytes.to_vec()
         };
 
-        self.install_with_backup(&binary_bytes).await?;
-
-        Ok(self.backup_path().to_string_lossy().to_string())
+        self.install_with_backup(binary_bytes).await
     }
 }
 
@@ -224,173 +222,5 @@ pub fn restart_with_same_args() -> Result<()> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::tempdir;
-
-    #[tokio::test]
-    async fn installer_writes_downloaded_bytes_to_staging() {
-        let dir = tempdir().unwrap();
-        let dest = dir.path().join("maestro");
-        fs::write(&dest, b"old binary").await.unwrap();
-
-        let installer = Installer::new(dest);
-        let fake_bytes = b"new binary content";
-        let staging = installer.write_to_staging(fake_bytes).await.unwrap();
-
-        assert!(staging.exists());
-        let written = fs::read(&staging).await.unwrap();
-        assert_eq!(written, fake_bytes);
-    }
-
-    #[tokio::test]
-    async fn installer_creates_backup_before_replacement() {
-        let dir = tempdir().unwrap();
-        let dest = dir.path().join("maestro");
-        let original_content = b"original binary";
-        fs::write(&dest, original_content).await.unwrap();
-
-        let installer = Installer::new(dest);
-        installer.install_with_backup(b"new binary").await.unwrap();
-
-        let backup_path = dir.path().join("maestro.bak");
-        assert!(backup_path.exists(), "backup file must exist");
-        let backup_content = fs::read(&backup_path).await.unwrap();
-        assert_eq!(backup_content, original_content);
-    }
-
-    #[tokio::test]
-    async fn installer_replaces_binary_with_new_content() {
-        let dir = tempdir().unwrap();
-        let dest = dir.path().join("maestro");
-        fs::write(&dest, b"old binary").await.unwrap();
-
-        let installer = Installer::new(dest.clone());
-        let new_bytes = b"upgraded binary content";
-        installer.install_with_backup(new_bytes).await.unwrap();
-
-        let written = fs::read(&dest).await.unwrap();
-        assert_eq!(written, new_bytes);
-    }
-
-    #[tokio::test]
-    async fn installer_returns_error_when_dest_does_not_exist() {
-        let dir = tempdir().unwrap();
-        let dest = dir.path().join("nonexistent_maestro");
-        let installer = Installer::new(dest);
-        let result = installer.install_with_backup(b"new bytes").await;
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn verify_checksum_matches() {
-        let data = b"hello world";
-        // SHA-256 of "hello world"
-        let expected = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
-        assert!(Installer::verify_checksum(data, expected).is_ok());
-    }
-
-    #[test]
-    fn verify_checksum_mismatch_fails() {
-        let data = b"hello world";
-        let wrong = "0000000000000000000000000000000000000000000000000000000000000000";
-        let err = Installer::verify_checksum(data, wrong).unwrap_err();
-        assert!(err.to_string().contains("Checksum mismatch"));
-    }
-
-    #[test]
-    fn verify_checksum_case_insensitive() {
-        let data = b"hello world";
-        let expected = "B94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9";
-        assert!(Installer::verify_checksum(data, expected).is_ok());
-    }
-
-    #[test]
-    fn checksum_url_uses_sha256sums_txt_filename() {
-        // The SHA256SUMS URL should use "sha256sums.txt", not "SHA256SUMS"
-        let download_url = "https://github.com/CarlosDanielDev/maestro/releases/download/v0.10.0/maestro-v0.10.0-aarch64-apple-darwin.tar.gz";
-        let expected_base = "https://github.com/CarlosDanielDev/maestro/releases/download/v0.10.0";
-        let sums_url = download_url
-            .rsplit_once('/')
-            .map(|(base, _)| format!("{}/sha256sums.txt", base))
-            .unwrap();
-        assert_eq!(sums_url, format!("{}/sha256sums.txt", expected_base));
-    }
-
-    #[test]
-    fn extract_binary_from_tar_gz_finds_maestro_binary() {
-        use flate2::Compression;
-        use flate2::write::GzEncoder;
-
-        // Create a tar.gz archive containing a "maestro" binary
-        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
-        {
-            let mut builder = tar::Builder::new(&mut encoder);
-            let binary_content = b"fake maestro binary";
-            let mut header = tar::Header::new_gnu();
-            header.set_size(binary_content.len() as u64);
-            header.set_mode(0o755);
-            header.set_cksum();
-            builder
-                .append_data(&mut header, "maestro", &binary_content[..])
-                .unwrap();
-            builder.finish().unwrap();
-        }
-        let archive_bytes = encoder.finish().unwrap();
-
-        let result = extract_binary_from_tar_gz(&archive_bytes);
-        assert!(result.is_ok(), "Should extract binary: {:?}", result.err());
-        assert_eq!(result.unwrap(), b"fake maestro binary");
-    }
-
-    #[test]
-    fn extract_binary_from_tar_gz_fails_when_no_maestro_binary() {
-        use flate2::Compression;
-        use flate2::write::GzEncoder;
-
-        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
-        {
-            let mut builder = tar::Builder::new(&mut encoder);
-            let content = b"some other file";
-            let mut header = tar::Header::new_gnu();
-            header.set_size(content.len() as u64);
-            header.set_mode(0o644);
-            header.set_cksum();
-            builder
-                .append_data(&mut header, "not-maestro", &content[..])
-                .unwrap();
-            builder.finish().unwrap();
-        }
-        let archive_bytes = encoder.finish().unwrap();
-
-        let result = extract_binary_from_tar_gz(&archive_bytes);
-        assert!(
-            result.is_err(),
-            "Should fail when no maestro binary in archive"
-        );
-    }
-
-    #[tokio::test]
-    async fn installer_only_writes_expected_files() {
-        let dir = tempdir().unwrap();
-        let dest = dir.path().join("maestro");
-        fs::write(&dest, b"original").await.unwrap();
-
-        let installer = Installer::new(dest);
-        installer.install_with_backup(b"new").await.unwrap();
-
-        let entries: Vec<_> = std::fs::read_dir(dir.path())
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .collect();
-        for entry in &entries {
-            let name = entry.file_name();
-            let name_str = name.to_string_lossy();
-            assert!(
-                name_str == "maestro" || name_str == "maestro.bak",
-                "Unexpected file: {}",
-                name_str
-            );
-        }
-    }
-}
+#[path = "installer_tests.rs"]
+mod tests;

--- a/src/updater/installer_tests.rs
+++ b/src/updater/installer_tests.rs
@@ -1,0 +1,208 @@
+use super::*;
+use crate::updater::error::UpdateError;
+use crate::updater::replace::{FakeReplacer, ReplacerBehavior};
+use std::io;
+use std::sync::Arc;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn installer_writes_downloaded_bytes_to_staging() {
+    let dir = tempdir().expect("tempdir");
+    let dest = dir.path().join("maestro");
+    fs::write(&dest, b"old binary").await.expect("write");
+
+    let installer = Installer::new(dest);
+    let fake_bytes = b"new binary content";
+    let staging = installer
+        .write_to_staging(fake_bytes)
+        .await
+        .expect("staging");
+
+    assert!(staging.exists());
+    let written = fs::read(&staging).await.expect("read");
+    assert_eq!(written, fake_bytes);
+}
+
+#[tokio::test]
+async fn installer_returns_error_when_dest_does_not_exist() {
+    let dir = tempdir().expect("tempdir");
+    let dest = dir.path().join("nonexistent_maestro");
+    let installer = Installer::new(dest);
+    let result = installer.install_with_backup(b"new bytes".to_vec()).await;
+    assert!(result.is_err(), "expected Err, got: {result:?}");
+}
+
+#[test]
+fn compute_sha256_hex_matches_known_vector() {
+    let data = b"hello world";
+    let expected = "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+    assert_eq!(Installer::compute_sha256_hex(data), expected);
+}
+
+#[test]
+fn checksum_url_uses_sha256sums_txt_filename() {
+    let download_url = "https://github.com/CarlosDanielDev/maestro/releases/download/v0.10.0/maestro-v0.10.0-aarch64-apple-darwin.tar.gz";
+    let expected_base = "https://github.com/CarlosDanielDev/maestro/releases/download/v0.10.0";
+    let sums_url = download_url
+        .rsplit_once('/')
+        .map(|(base, _)| format!("{}/sha256sums.txt", base))
+        .expect("rsplit");
+    assert_eq!(sums_url, format!("{}/sha256sums.txt", expected_base));
+}
+
+#[test]
+fn extract_binary_from_tar_gz_finds_maestro_binary() {
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    {
+        let mut builder = tar::Builder::new(&mut encoder);
+        let binary_content = b"fake maestro binary";
+        let mut header = tar::Header::new_gnu();
+        header.set_size(binary_content.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "maestro", &binary_content[..])
+            .expect("append");
+        builder.finish().expect("finish");
+    }
+    let archive_bytes = encoder.finish().expect("encoder");
+
+    let result = extract_binary_from_tar_gz(&archive_bytes);
+    assert!(result.is_ok(), "Should extract binary: {:?}", result.err());
+    assert_eq!(result.expect("ok"), b"fake maestro binary");
+}
+
+#[test]
+fn extract_binary_from_tar_gz_fails_when_no_maestro_binary() {
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    {
+        let mut builder = tar::Builder::new(&mut encoder);
+        let content = b"some other file";
+        let mut header = tar::Header::new_gnu();
+        header.set_size(content.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "not-maestro", &content[..])
+            .expect("append");
+        builder.finish().expect("finish");
+    }
+    let archive_bytes = encoder.finish().expect("encoder");
+
+    let result = extract_binary_from_tar_gz(&archive_bytes);
+    assert!(
+        result.is_err(),
+        "Should fail when no maestro binary in archive"
+    );
+}
+
+#[tokio::test]
+async fn installer_success_returns_backup_path() {
+    let dir = tempdir().expect("tempdir");
+    let dest = dir.path().join("maestro");
+    let backup = dir.path().join("maestro.bak");
+    let fake = Arc::new(FakeReplacer::new([ReplacerBehavior::Succeed {
+        backup_path: backup.clone(),
+    }]));
+    let installer = Installer::with_replacer(dest, fake.clone());
+
+    let result = installer.install_with_backup(b"new bytes".to_vec()).await;
+
+    assert!(result.is_ok(), "expected Ok, got: {result:?}");
+    assert_eq!(result.expect("ok"), backup);
+    assert_eq!(fake.call_count(), 1);
+}
+
+#[tokio::test]
+async fn installer_permission_denied_surfaces_typed_error() {
+    let dir = tempdir().expect("tempdir");
+    let dest = dir.path().join("maestro");
+    let fake = Arc::new(FakeReplacer::new([ReplacerBehavior::Fail(
+        UpdateError::PermissionDenied {
+            path: dest.clone(),
+            source: io::Error::from(io::ErrorKind::PermissionDenied),
+        },
+    )]));
+    let installer = Installer::with_replacer(dest, fake);
+
+    let result = installer.install_with_backup(b"bytes".to_vec()).await;
+
+    assert!(
+        matches!(result, Err(UpdateError::PermissionDenied { .. })),
+        "expected PermissionDenied, got: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn installer_replace_fails_rollback_ok_returns_rolled_back_error() {
+    let dir = tempdir().expect("tempdir");
+    let dest = dir.path().join("maestro");
+    let fake = Arc::new(FakeReplacer::new([ReplacerBehavior::Fail(
+        UpdateError::ReplaceFailedRolledBack {
+            source: io::Error::from(io::ErrorKind::Other),
+        },
+    )]));
+    let installer = Installer::with_replacer(dest, fake);
+
+    let result = installer.install_with_backup(b"bytes".to_vec()).await;
+
+    let err = result.expect_err("expected ReplaceFailedRolledBack");
+    assert!(
+        matches!(err, UpdateError::ReplaceFailedRolledBack { .. }),
+        "expected ReplaceFailedRolledBack, got: {err:?}"
+    );
+    assert_eq!(
+        format!("{err}"),
+        "update failed — original version restored"
+    );
+}
+
+#[tokio::test]
+async fn installer_rollback_failed_no_panic() {
+    let dir = tempdir().expect("tempdir");
+    let dest = dir.path().join("maestro");
+    let fake = Arc::new(FakeReplacer::new([ReplacerBehavior::Fail(
+        UpdateError::RollbackFailed {
+            replace_source: io::Error::from(io::ErrorKind::Other),
+            rollback_source: io::Error::from(io::ErrorKind::BrokenPipe),
+        },
+    )]));
+    let installer = Installer::with_replacer(dest, fake);
+
+    let result = installer.install_with_backup(b"bytes".to_vec()).await;
+
+    let err = result.expect_err("expected RollbackFailed");
+    assert!(
+        matches!(err, UpdateError::RollbackFailed { .. }),
+        "expected RollbackFailed, got: {err:?}"
+    );
+    assert_eq!(
+        format!("{err}"),
+        "update failed and rollback could not complete — please reinstall maestro manually"
+    );
+}
+
+#[tokio::test]
+async fn download_and_install_rejects_untrusted_url() {
+    let dir = tempdir().expect("tempdir");
+    let dest = dir.path().join("maestro");
+    let fake = Arc::new(FakeReplacer::new([]));
+    let installer = Installer::with_replacer(dest, fake.clone());
+
+    let result = installer
+        .download_and_install("http://evil.com/maestro")
+        .await;
+
+    assert!(result.is_err(), "expected Err for untrusted URL");
+    assert_eq!(
+        fake.call_count(),
+        0,
+        "replace() must not be called for untrusted URL"
+    );
+}

--- a/src/updater/lock.rs
+++ b/src/updater/lock.rs
@@ -1,0 +1,119 @@
+use crate::updater::error::UpdateError;
+use std::fs::{File, OpenOptions};
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+
+/// RAII guard for the binary update flow.
+///
+/// Holds an exclusive flock on a per-target sentinel file (`<target>.update.lock`).
+/// On drop, the kernel releases the flock when the underlying `File` closes; we
+/// also remove the sentinel file best-effort so a clean exit leaves no breadcrumb.
+#[derive(Debug)]
+pub(crate) struct UpdateLock {
+    path: PathBuf,
+    _file: File,
+}
+
+impl UpdateLock {
+    /// Try to acquire the lock at `path`.
+    ///
+    /// Returns `UpdateError::ConcurrentUpdate` if another holder has it,
+    /// `UpdateError::PermissionDenied` if the lock file cannot be opened
+    /// for permission reasons, and `UpdateError::Internal` for everything else.
+    pub fn acquire(path: &Path) -> Result<Self, UpdateError> {
+        // O_NOFOLLOW refuses a symlinked lock path so a co-located attacker
+        // cannot trick us into writing PID bytes into an attacker-chosen file.
+        let mut opts = OpenOptions::new();
+        opts.create(true).read(true).write(true).truncate(false);
+        #[cfg(unix)]
+        {
+            opts.custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+        }
+        let file = opts.open(path).map_err(|e| {
+            #[cfg(unix)]
+            if e.raw_os_error() == Some(libc::ELOOP) {
+                return UpdateError::Internal(format!(
+                    "refusing to open symlinked lock file at {}",
+                    path.display()
+                ));
+            }
+            match e.kind() {
+                std::io::ErrorKind::PermissionDenied => UpdateError::PermissionDenied {
+                    path: path.to_path_buf(),
+                    source: e,
+                },
+                _ => UpdateError::Internal(format!("opening lock {}: {e}", path.display())),
+            }
+        })?;
+
+        match file.try_lock() {
+            Ok(()) => {
+                use std::io::Write;
+                let _ = (&file).write_all(format!("{}\n", std::process::id()).as_bytes());
+                Ok(Self {
+                    path: path.to_path_buf(),
+                    _file: file,
+                })
+            }
+            Err(std::fs::TryLockError::WouldBlock) => Err(UpdateError::ConcurrentUpdate {
+                lock_path: path.to_path_buf(),
+            }),
+            Err(std::fs::TryLockError::Error(e)) => Err(UpdateError::Internal(format!(
+                "try_lock {}: {e}",
+                path.display()
+            ))),
+        }
+    }
+}
+
+impl Drop for UpdateLock {
+    fn drop(&mut self) {
+        if let Err(e) = std::fs::remove_file(&self.path) {
+            tracing::warn!(
+                path = %self.path.display(),
+                error = %e,
+                "failed to remove update lock file on drop"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn update_lock_acquire_succeeds_when_no_lock_exists() {
+        let dir = tempdir().expect("tempdir");
+        let lock_path = dir.path().join("maestro.update.lock");
+        let result = UpdateLock::acquire(&lock_path);
+        assert!(result.is_ok(), "expected Ok, got: {result:?}");
+        assert!(lock_path.exists(), "lock file should exist while held");
+    }
+
+    #[test]
+    fn update_lock_second_acquire_returns_concurrent_update_error() {
+        let dir = tempdir().expect("tempdir");
+        let lock_path = dir.path().join("maestro.update.lock");
+        let _lock1 = UpdateLock::acquire(&lock_path).expect("first acquire");
+        let result = UpdateLock::acquire(&lock_path);
+        assert!(
+            matches!(result, Err(UpdateError::ConcurrentUpdate { .. })),
+            "expected ConcurrentUpdate, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn update_lock_drop_releases_lock_and_allows_reacquire() {
+        let dir = tempdir().expect("tempdir");
+        let lock_path = dir.path().join("maestro.update.lock");
+        {
+            let _lock = UpdateLock::acquire(&lock_path).expect("first acquire");
+        }
+        let result = UpdateLock::acquire(&lock_path);
+        assert!(result.is_ok(), "expected Ok after drop, got: {result:?}");
+    }
+}

--- a/src/updater/mod.rs
+++ b/src/updater/mod.rs
@@ -1,5 +1,8 @@
 pub mod checker;
+pub mod error;
 pub mod installer;
+pub mod lock;
+pub mod replace;
 pub mod restart;
 
 /// GitHub repository for version checks and binary downloads.

--- a/src/updater/replace.rs
+++ b/src/updater/replace.rs
@@ -1,0 +1,341 @@
+use crate::updater::error::UpdateError;
+use crate::updater::lock::UpdateLock;
+use std::path::{Path, PathBuf};
+
+/// Atomically replace a binary at a target path with new bytes.
+///
+/// Implementations must:
+/// - acquire a single-writer lock at `<target>.update.lock` for the duration
+/// - write the new bytes to a sibling temp path on the same filesystem
+/// - back up the original (atomic rename of original to `<target>.bak`)
+/// - atomically rename the temp into the target's place
+/// - on any failure between backup and rename, restore from backup
+/// - leave no partial files on disk in any error path
+pub trait BinaryReplacer: Send + Sync {
+    fn replace(&self, target: &Path, new_bytes: &[u8]) -> Result<ReplaceOutcome, UpdateError>;
+}
+
+/// Outcome of a successful replace: where the original was backed up.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReplaceOutcome {
+    pub backup_path: PathBuf,
+}
+
+const BACKUP_SUFFIX: &str = ".bak";
+const LOCK_SUFFIX: &str = ".update.lock";
+const FALLBACK_NAME: &str = "maestro";
+
+fn sibling_with_suffix(target: &Path, suffix: &str) -> PathBuf {
+    let mut p = target.to_path_buf();
+    let name = p
+        .file_name()
+        .map(|n| format!("{}{}", n.to_string_lossy(), suffix))
+        .unwrap_or_else(|| format!("{FALLBACK_NAME}{suffix}"));
+    p.set_file_name(name);
+    p
+}
+
+/// Production implementation backed by `tempfile::NamedTempFile` + `fs::rename`.
+///
+/// Strategy: write new bytes to a sibling NamedTempFile (same FS for atomic
+/// rename), rename original to `<target>.bak`, promote the temp into place,
+/// then chmod 0o755 on Unix. On promotion failure, restore from `.bak`. A
+/// flock-based `UpdateLock` rejects concurrent attempts.
+pub struct AtomicBinaryReplacer;
+
+impl AtomicBinaryReplacer {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn write_temp(parent: &Path, new_bytes: &[u8]) -> Result<tempfile::NamedTempFile, UpdateError> {
+        use std::io::Write;
+
+        let tmp = tempfile::NamedTempFile::new_in(parent).map_err(|e| match e.kind() {
+            std::io::ErrorKind::PermissionDenied => UpdateError::PermissionDenied {
+                path: parent.to_path_buf(),
+                source: e,
+            },
+            _ => UpdateError::Internal(format!("creating temp file in {}: {e}", parent.display())),
+        })?;
+        let mut file = tmp.as_file();
+        file.write_all(new_bytes)
+            .map_err(|e| UpdateError::Internal(format!("writing temp file: {e}")))?;
+        file.sync_all()
+            .map_err(|e| UpdateError::Internal(format!("fsyncing temp file: {e}")))?;
+        // chmod is deferred until after `persist` so the world-exec bit is
+        // never set while the file still bears its random `.tmp…` name.
+        Ok(tmp)
+    }
+
+    fn map_rename_err(err: std::io::Error, path: &Path, ctx: &str) -> UpdateError {
+        match err.kind() {
+            std::io::ErrorKind::PermissionDenied => UpdateError::PermissionDenied {
+                path: path.to_path_buf(),
+                source: err,
+            },
+            _ => UpdateError::Internal(format!("{ctx}: {err}")),
+        }
+    }
+
+    fn finalize_target(_target: &Path) -> Result<(), UpdateError> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(_target, std::fs::Permissions::from_mode(0o755))
+                .map_err(|e| UpdateError::Internal(format!("chmod target after persist: {e}")))?;
+        }
+        Ok(())
+    }
+
+    fn rollback_after_persist_failure(
+        target: &Path,
+        backup: &Path,
+        tmp_path: &Path,
+        replace_io: std::io::Error,
+    ) -> UpdateError {
+        let rollback_result = std::fs::rename(backup, target);
+        let _ = std::fs::remove_file(tmp_path);
+        match rollback_result {
+            Ok(()) => UpdateError::ReplaceFailedRolledBack { source: replace_io },
+            Err(rollback_io) => {
+                tracing::error!(
+                    target = %target.display(),
+                    backup = %backup.display(),
+                    replace_error = %replace_io,
+                    rollback_error = %rollback_io,
+                    "rollback failed: original may be at .bak path"
+                );
+                UpdateError::RollbackFailed {
+                    replace_source: replace_io,
+                    rollback_source: rollback_io,
+                }
+            }
+        }
+    }
+}
+
+impl Default for AtomicBinaryReplacer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BinaryReplacer for AtomicBinaryReplacer {
+    fn replace(&self, target: &Path, new_bytes: &[u8]) -> Result<ReplaceOutcome, UpdateError> {
+        let _lock = UpdateLock::acquire(&sibling_with_suffix(target, LOCK_SUFFIX))?;
+
+        let parent = target
+            .parent()
+            .ok_or_else(|| UpdateError::Internal(format!("target has no parent: {target:?}")))?;
+        let backup = sibling_with_suffix(target, BACKUP_SUFFIX);
+
+        let tmp = Self::write_temp(parent, new_bytes)?;
+        let tmp_path = tmp.path().to_path_buf();
+
+        std::fs::rename(target, &backup)
+            .map_err(|e| Self::map_rename_err(e, target, "backing up original"))?;
+
+        let persist_err = match tmp.persist(target) {
+            Ok(_persisted) => {
+                Self::finalize_target(target)?;
+                return Ok(ReplaceOutcome {
+                    backup_path: backup,
+                });
+            }
+            Err(e) => e,
+        };
+        Err(Self::rollback_after_persist_failure(
+            target,
+            &backup,
+            &tmp_path,
+            persist_err.error,
+        ))
+    }
+}
+
+// ----------------------------------------------------------------------------
+// FakeReplacer — module-scope under #[cfg(test)] so installer.rs tests can use it.
+// ----------------------------------------------------------------------------
+
+#[cfg(test)]
+pub(crate) enum ReplacerBehavior {
+    Succeed { backup_path: PathBuf },
+    Fail(UpdateError),
+}
+
+#[cfg(test)]
+impl ReplacerBehavior {
+    fn into_outcome(self) -> Result<ReplaceOutcome, UpdateError> {
+        match self {
+            Self::Succeed { backup_path } => Ok(ReplaceOutcome { backup_path }),
+            Self::Fail(err) => Err(err),
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) struct ReplacerCall {
+    pub target: PathBuf,
+    pub bytes_len: usize,
+}
+
+#[cfg(test)]
+pub(crate) struct FakeReplacer {
+    queue: std::sync::Arc<std::sync::Mutex<std::collections::VecDeque<ReplacerBehavior>>>,
+    pub calls: std::sync::Arc<std::sync::Mutex<Vec<ReplacerCall>>>,
+}
+
+#[cfg(test)]
+impl FakeReplacer {
+    pub(crate) fn new(behaviors: impl IntoIterator<Item = ReplacerBehavior>) -> Self {
+        Self {
+            queue: std::sync::Arc::new(std::sync::Mutex::new(behaviors.into_iter().collect())),
+            calls: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+        }
+    }
+
+    pub(crate) fn call_count(&self) -> usize {
+        self.calls.lock().expect("calls mutex").len()
+    }
+}
+
+#[cfg(test)]
+impl BinaryReplacer for FakeReplacer {
+    fn replace(&self, target: &Path, new_bytes: &[u8]) -> Result<ReplaceOutcome, UpdateError> {
+        self.calls.lock().expect("calls mutex").push(ReplacerCall {
+            target: target.to_path_buf(),
+            bytes_len: new_bytes.len(),
+        });
+        let next = self
+            .queue
+            .lock()
+            .expect("queue mutex")
+            .pop_front()
+            .unwrap_or_else(|| {
+                panic!("FakeReplacer: no behaviors remaining — test over-called replace()")
+            });
+        next.into_outcome()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn atomic_replacer_round_trip_writes_bytes_and_sets_exec_permission() {
+        let dir = tempdir().expect("tempdir");
+        let dest = dir.path().join("maestro");
+        std::fs::write(&dest, b"old binary").expect("write original");
+
+        let replacer = AtomicBinaryReplacer::new();
+        let result = replacer.replace(&dest, b"new binary content");
+
+        assert!(result.is_ok(), "expected Ok, got: {result:?}");
+        let outcome = result.expect("outcome");
+
+        let on_disk = std::fs::read(&dest).expect("read dest");
+        assert_eq!(on_disk, b"new binary content");
+
+        let backup = std::fs::read(&outcome.backup_path).expect("read backup");
+        assert_eq!(backup, b"old binary");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&dest)
+                .expect("metadata")
+                .permissions()
+                .mode();
+            assert_eq!(
+                mode & 0o777,
+                0o755,
+                "expected 0o755, got {:o}",
+                mode & 0o777
+            );
+        }
+    }
+
+    #[test]
+    fn atomic_replacer_leaves_no_tmp_file_on_success() {
+        let dir = tempdir().expect("tempdir");
+        let dest = dir.path().join("maestro");
+        std::fs::write(&dest, b"original").expect("write original");
+
+        let replacer = AtomicBinaryReplacer::new();
+        replacer.replace(&dest, b"new bytes").expect("replace ok");
+
+        let stray: Vec<_> = std::fs::read_dir(dir.path())
+            .expect("readdir")
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                let name = e.file_name();
+                let s = name.to_string_lossy();
+                s.contains(".tmp")
+            })
+            .collect();
+        assert!(
+            stray.is_empty(),
+            "stray tmp files found: {:?}",
+            stray.iter().map(|e| e.file_name()).collect::<Vec<_>>()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_replacer_permission_denied_returns_typed_error() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().expect("tempdir");
+        let dest = dir.path().join("maestro");
+        std::fs::write(&dest, b"old").expect("write original");
+
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o555))
+            .expect("chmod 0o555");
+
+        let replacer = AtomicBinaryReplacer::new();
+        let result = replacer.replace(&dest, b"new bytes");
+
+        let _ = std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755));
+
+        assert!(
+            matches!(result, Err(UpdateError::PermissionDenied { .. })),
+            "expected PermissionDenied, got: {result:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_replacer_leaves_no_partial_file_on_permission_failure() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().expect("tempdir");
+        let dest = dir.path().join("maestro");
+        std::fs::write(&dest, b"old").expect("write original");
+
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o555))
+            .expect("chmod 0o555");
+
+        let replacer = AtomicBinaryReplacer::new();
+        let _ = replacer.replace(&dest, b"new bytes");
+
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755))
+            .expect("chmod restore");
+
+        let entries: Vec<_> = std::fs::read_dir(dir.path())
+            .expect("readdir")
+            .filter_map(|e| e.ok())
+            .collect();
+
+        for entry in &entries {
+            let name = entry.file_name();
+            let s = name.to_string_lossy();
+            assert!(
+                s == "maestro" || s == "maestro.bak",
+                "unexpected file after permission failure: {s}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Root cause of `[u][u]` failing with *"failed to replace binary; attempted rollback"* was `fs::write` truncate-and-rewrite against the running executable, which POSIX rejects (ETXTBSY/EBUSY).
- Replace flow now: `tempfile::NamedTempFile::new_in(parent)` → fsync → `rename(target, .bak)` → `tmp.persist(target)` → chmod 0o755 → on persist failure, `rename(.bak, target)` to roll back.
- New `BinaryReplacer` trait makes the FS step injectable (real fake `FakeReplacer` for unit tests). `Installer` holds `Arc<dyn BinaryReplacer>`; `install_with_backup` runs in `tokio::task::spawn_blocking`.
- New typed `UpdateError` enum (thiserror) with verbatim user-facing strings for permission denied, network interrupted, rollback OK, rollback failed, concurrent update. TUI banner forwards `Display`.
- `UpdateLock` flock guard at `<target>.update.lock` with `O_NOFOLLOW`+`O_CLOEXEC` rejects concurrent attempts and symlinked lock paths.
- `download_and_install` parallelizes the binary fetch and SHA256SUMS fetch via `tokio::try_join!`.
- TUI activity log surfaces *"Already on the latest version."* (no-update) and *"Update successful — please restart maestro to apply changes."* (success).

Closes #499

## Test plan
- [x] `cargo test` — 3530 unit + 275 integration + 13 doc all green
- [x] `cargo clippy -- -D warnings -A dead_code` clean
- [x] `cargo fmt --check` clean
- [x] `scripts/check-file-size.sh` clean (all files ≤ 400 LOC)
- [ ] Manual: replace running binary at writable path → success message
- [ ] Manual: read-only parent dir → permission-denied message, no partial files
- [ ] Manual: two concurrent maestro instances → second sees concurrent-update message

## Security review notes (deferred to follow-up)

The pre-merge security review applied **M2** (`O_NOFOLLOW` + `O_CLOEXEC` on lock open) and **M3** (defer chmod 0o755 to post-persist target). Deferred items, all "next PR" priority:

- **M1** Post-persist `dev/ino` verification on Unix to detect tamper between `rename` and `persist`. POSIX `rename(2)` does not follow symlinks at destination, so no symlink-write escalation today.
- **L1** ANSI/control-char sanitation on error strings before storing in `UpgradeState::Failed`.
- **L2** URL canonicalization (case-insensitive host) in `is_trusted_download_url`.
- **I1** Truncate or drop the PID write in `UpdateLock` (cosmetic).
- **I4** `canonicalize` `current_exe()` for cross-OS consistency (Linux resolves symlinks, macOS does not).

## Known gaps

- AC #4 (mid-download interrupt → no partial file) covered at the typed-error level (`UpdateError::NetworkInterrupted`) and untrusted-URL level, but no end-to-end test exercises an interrupted download — would need a mock HTTP server.