### PR TITLE
feat(ci): send Discord release notification on new version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,18 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Print the Discord payload to the log instead of POSTing"
+        type: boolean
+        required: false
+        default: true
+      target_tag:
+        description: "Tag to simulate (workflow_dispatch only; default v0.0.0-test is a smoke-test placeholder)"
+        type: string
+        required: true
+        default: "v0.0.0-test"
 
 concurrency:
   group: release-${{ github.ref }}
@@ -80,7 +92,7 @@ jobs:
         id: checksums
         run: |
           cd artifacts
-          sha256sum *.tar.gz > sha256sums.txt
+          sha256sum ./*.tar.gz > sha256sums.txt
           cat sha256sums.txt
 
       - name: Create GitHub Release
@@ -190,3 +202,88 @@ jobs:
           git diff --cached --quiet && echo "No changes to formula" && exit 0
           git commit -m "feat: update maestro to ${VERSION}"
           git push
+
+  notify-discord:
+    name: Notify Discord
+    needs: release
+    runs-on: ubuntu-latest
+    permissions: {}
+    # Pre-release suffix blocklist: alpha, beta, rc, pre, dev, canary, smoketest.
+    # contains() is case-sensitive — project tag convention is lowercase semver
+    # (v1.2.3, v1.2.3-rc.1). Extend this list if uppercase suffixes (-RC, -BETA)
+    # ever ship.
+    # Idempotency: manual re-runs WILL post a duplicate message. Accepted per #507
+    # to keep the workflow simple.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (startsWith(github.ref, 'refs/tags/v') &&
+       !contains(github.ref, '-alpha') &&
+       !contains(github.ref, '-beta') &&
+       !contains(github.ref, '-rc') &&
+       !contains(github.ref, '-pre') &&
+       !contains(github.ref, '-dev') &&
+       !contains(github.ref, '-canary') &&
+       !contains(github.ref, '-smoketest'))
+    steps:
+      - name: Resolve tag
+        id: resolve
+        env:
+          DISPATCH_TAG: ${{ inputs.target_tag }}
+          PUSH_REF: ${{ github.ref }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            TAG="${DISPATCH_TAG}"
+          else
+            TAG="${PUSH_REF#refs/tags/}"
+          fi
+          # Defense in depth: env: indirection already neutralizes shell injection,
+          # but rejecting non-semver shapes early gives a clearer error than letting
+          # a malformed tag flow into the URL and payload.
+          if ! [[ "${TAG}" =~ ^v[0-9A-Za-z._+-]+$ ]]; then
+            echo "::error::Invalid tag format: '${TAG}' (expected v<semver>)" >&2
+            exit 1
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Build payload
+        id: payload
+        env:
+          TAG: ${{ steps.resolve.outputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          RELEASE_URL="https://github.com/${REPO}/releases/tag/${TAG}"
+          MESSAGE="**maestro ${TAG}** released. Upgrade: \`cargo install --force maestro\` or \`brew upgrade carlosdanieldev/tap/maestro\`. Release notes: ${RELEASE_URL} — see the release page for the full changelog."
+          PAYLOAD=$(jq -n --arg content "${MESSAGE}" '{content: $content}')
+          {
+            echo "payload<<EOF"
+            echo "${PAYLOAD}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Dry run — print payload
+        if: ${{ inputs.dry_run == true }}
+        env:
+          PAYLOAD: ${{ steps.payload.outputs.payload }}
+        run: |
+          echo "[DRY RUN] Would POST the following payload to Discord:"
+          # Re-parse via jq to close the log-injection surface (control chars /
+          # ANSI / GitHub workflow commands embedded in any field).
+          printf '%s\n' "${PAYLOAD}" | jq .
+
+      - name: Post to Discord
+        if: ${{ inputs.dry_run != true }}
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          PAYLOAD: ${{ steps.payload.outputs.payload }}
+        run: |
+          [ -n "${DISCORD_WEBHOOK_URL}" ] || {
+            echo "::error::DISCORD_WEBHOOK_URL secret is empty — set it in repo Settings → Secrets" >&2
+            exit 1
+          }
+          # Discord webhooks do not redirect; default curl retry covers transient
+          # network errors, 5xx, 408, 429.
+          curl -fsS --retry 3 --retry-delay 5 \
+               -H 'Content-Type: application/json' \
+               --data "${PAYLOAD}" \
+               "${DISCORD_WEBHOOK_URL}"

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ __pycache__/
 
 # Claude Code local state
 .claude/scheduled_tasks.lock
+
+# Environment files (may contain secrets)
+.env
+.env.*
+!.env.example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `src/integration_tests/milestone_health_wizard.rs` — 9 end-to-end tests against `MockGitHubClient`
   - `GitHubClient` trait extended with `patch_milestone_description`; `GhCliClient` impl uses `gh api ... --method PATCH`; Azure DevOps stub returns `bail!`
 
+- feat(ci): Discord `#releases` notification on new version tag (#507)
+  - `.github/workflows/release.yml` gains a `notify-discord` job that POSTs a message to the channel webhook after a successful release build
+  - Pre-release tags (alpha, beta, rc, pre, dev, canary, smoketest) are suppressed and do not trigger a notification
+  - `workflow_dispatch` dry-run mode (`dry_run: true`) prints the payload to the Actions log instead of POSTing; use `target_tag` to simulate any tag
+  - Requires `DISCORD_WEBHOOK_URL` repo secret; optional `DISCORD_WEBHOOK_URL_TEST` for staging smoke tests
+
 ### Fixed
 
 - fix(notifications): desktop notifications now fire when a session completes or errors (#487)

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-28 12:00 (UTC)
+> Last updated: 2026-04-28 18:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -445,7 +445,8 @@ maestro/
 │   ├── check-file-size.sh                 # Enforce per-file LOC limits (500-line rule)
 │   ├── check-layers.sh                    # Enforce architecture layer boundaries
 │   ├── coverage-tiers.yml                 # Coverage tier definitions
-│   └── verify-issue-485.sh                # TDD verification harness: 27 grep/awk assertions for /triage-idea command + CLAUDE.md registry entries  [Issue #485]
+│   ├── verify-issue-485.sh                # TDD verification harness: 27 grep/awk assertions for /triage-idea command + CLAUDE.md registry entries  [Issue #485]
+│   └── verify-issue-507.sh                # TDD verification harness: 17 assertions for Discord release-notification job in release.yml (notify-discord job, workflow_dispatch inputs, pre-release tag suppression)  [Issue #507]
 ├── tests/                                 # Cargo integration tests (run as a separate binary, full crate access)
 │   ├── settings_caveman.rs                # Integration tests for FsSettingsStore against real tempfiles: read/write/toggle round-trips for caveman mode, missing-key defaults, malformed JSON handling  [Issue #490]
 │   ├── gatekeeper/                        # Gatekeeper harness fixtures and tests
@@ -474,7 +475,7 @@ maestro/
 | `.github/ISSUE_TEMPLATE/feature.yml` | Feature request issue form with DOR fields; `Blocked By` required; `Dependency Graph` textarea for epic/multi-issue ordering |
 | `.github/ISSUE_TEMPLATE/idea.yml` | Idea inbox issue form — 5 required textareas (the itch + Q1-Q4 honesty checks) + Q5 vision-alignment dropdown; auto-applies labels `idea` and `needs-triage` |
 | `.github/workflows/ci.yml` | GitHub Actions CI pipeline |
-| `.github/workflows/release.yml` | Release automation: cross-platform builds, GitHub Release with SHA256 checksums, Homebrew tap update |
+| `.github/workflows/release.yml` | Release automation: cross-platform builds, GitHub Release with SHA256 checksums, Homebrew tap update, Discord `#releases` notification (`notify-discord` job; requires `DISCORD_WEBHOOK_URL` secret) |
 | `.claude/` | Claude Code agent configuration |
 | `.claude/agents/` | Subagent definitions |
 | `.claude/commands/` | Slash command definitions |

--- a/scripts/verify-issue-507.sh
+++ b/scripts/verify-issue-507.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Verify the .github/workflows/release.yml deliverables for issue #507:
+#   - SC2035 fix on the existing checksums step (sha256sum ./*.tar.gz)
+#   - notify-discord job exists with the required structure
+#   - Pre-release filter blocks alpha/beta/rc/pre/dev/canary/smoketest
+#   - startsWith(github.ref, 'refs/tags/v') guard present (rejects branch refs)
+#   - permissions: {} per-job lockdown (defense in depth)
+#   - DISCORD_WEBHOOK_URL referenced via secrets context only, never inlined
+#     in run: blocks (CWE-78 / shell injection)
+#   - No hardcoded discord.com/api/webhooks URL anywhere
+#   - dry_run boolean input defaults to true (fail-safe)
+#   - curl uses --fail / -f (non-2xx -> non-zero exit, AC #5)
+#   - jq used to build payload (no naive JSON interpolation)
+#   - Empty-secret guard before curl (clear error vs curl exit 7)
+#   - actionlint reports zero findings on the file (AC #7)
+#
+# Runs as the TDD RED/GREEN gate for a CI-only task. Exits non-zero on
+# the first failed assertion with a description on stderr.
+
+set -euo pipefail
+
+# Pin to repo root so relative paths work from any cwd.
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+WORKFLOW=".github/workflows/release.yml"
+
+fail() {
+  echo "verify-issue-507: FAIL — $1" >&2
+  exit 1
+}
+
+# Extract the body of a named top-level job block. Starts after the job
+# header line; stops at the next top-level job (line at 2-space indent
+# ending in ':') or EOF.
+job_block() {
+  local job="$1"
+  awk -v job="$job" '
+    in_block && /^  [a-z][a-z-]*:[[:space:]]*$/ { exit }
+    in_block { print }
+    $0 ~ "^  " job ":[[:space:]]*$" { in_block = 1 }
+  ' "$WORKFLOW"
+}
+
+[ -f "$WORKFLOW" ] || fail "F1: $WORKFLOW does not exist"
+[ -s "$WORKFLOW" ] || fail "F2: $WORKFLOW is empty"
+
+# F3. SC2035 fix: sha256sum must use ./* glob (AC #7 demands actionlint clean).
+grep -q 'sha256sum \./\*\.tar\.gz' "$WORKFLOW" \
+  || fail "F3: SC2035 not fixed — 'sha256sum ./*.tar.gz' missing (got bare glob)"
+
+# F4. notify-discord job exists.
+grep -qE '^  notify-discord:[[:space:]]*$' "$WORKFLOW" \
+  || fail "F4: 'notify-discord:' job missing in $WORKFLOW"
+
+# Extract the notify-discord block once for reuse.
+ND_BLOCK=$(job_block "notify-discord")
+[ -n "$ND_BLOCK" ] \
+  || fail "F4a: notify-discord job block could not be extracted"
+
+# F5. needs: release for upstream success gating (AC #4).
+echo "$ND_BLOCK" | grep -q 'needs: release' \
+  || fail "F5: 'needs: release' missing in notify-discord block"
+
+# F6. Pre-release filter blocks each required prefix (AC #3).
+for prefix in alpha beta rc pre dev canary smoketest; do
+  echo "$ND_BLOCK" | grep -qE "contains\(github\.ref, '-${prefix}'\)" \
+    || fail "F6.${prefix}: !contains(github.ref, '-${prefix}') missing in notify-discord if:"
+done
+
+# F7. startsWith(github.ref, 'refs/tags/v') guard — rejects branch refs from
+# workflow_dispatch reaching the curl path with a non-tag context.
+echo "$ND_BLOCK" | grep -qE "startsWith\(github\.ref, 'refs/tags/v'\)" \
+  || fail "F7: startsWith(github.ref, 'refs/tags/v') guard missing in notify-discord if:"
+
+# F8. permissions: {} per-job lockdown.
+echo "$ND_BLOCK" | grep -qE 'permissions:[[:space:]]*\{\}' \
+  || fail "F8: 'permissions: {}' missing in notify-discord block"
+
+# F9. DISCORD_WEBHOOK_URL referenced via secrets context (AC #6).
+grep -q 'secrets\.DISCORD_WEBHOOK_URL' "$WORKFLOW" \
+  || fail "F9: 'secrets.DISCORD_WEBHOOK_URL' reference missing"
+
+# F10. Secret never interpolated into run: shell — only via env: indirection.
+# Every ${{ secrets.DISCORD_WEBHOOK_URL }} expression must appear on an
+# env-key assignment line (e.g.  '  DISCORD_WEBHOOK_URL: ${{ secrets... }}').
+bad_inlines=$(grep -n '\${{[[:space:]]*secrets\.DISCORD_WEBHOOK_URL[[:space:]]*}}' "$WORKFLOW" \
+              | grep -vE ':[[:space:]]+[A-Z][A-Z_]*:[[:space:]]*\$\{\{' || true)
+[ -z "$bad_inlines" ] \
+  || fail "F10: secrets.DISCORD_WEBHOOK_URL interpolated outside env: key (CWE-78). Lines: $bad_inlines"
+
+# F11. No hardcoded Discord webhook URL.
+if grep -qE 'https://discord(app)?\.com/api/webhooks/[0-9]+/' "$WORKFLOW"; then
+  fail "F11: hardcoded Discord webhook URL detected — must use secrets context only"
+fi
+
+# F12. dry_run input is type: boolean.
+grep -A4 '^[[:space:]]*dry_run:' "$WORKFLOW" | grep -q 'type: boolean' \
+  || fail "F12: dry_run input is not 'type: boolean'"
+
+# F13. dry_run default: true (fail-safe).
+grep -A5 '^[[:space:]]*dry_run:' "$WORKFLOW" | grep -q 'default: true' \
+  || fail "F13: dry_run default is not 'true' (fail-safe required)"
+
+# F14. curl uses --fail or -f flag (AC #5).
+# Match either '--fail' or any short-flag bundle containing 'f' (e.g. -fsSL).
+echo "$ND_BLOCK" | grep -qE 'curl[[:space:]][^#|]*(--fail|-[a-zA-Z]*f[a-zA-Z]*)' \
+  || fail "F14: curl in notify-discord lacks --fail / -f flag (HTTP errors would not propagate)"
+
+# F15. jq used to build payload (avoids JSON quoting / injection bugs).
+echo "$ND_BLOCK" | grep -q 'jq' \
+  || fail "F15: 'jq' missing in notify-discord — payload must be built with jq -n --arg"
+
+# F16. Empty-secret guard before curl (clear error vs cryptic curl exit 7).
+echo "$ND_BLOCK" | grep -qE '\[[[:space:]]+-n[[:space:]]+"\$\{?DISCORD_WEBHOOK_URL\}?"[[:space:]]+\]|test[[:space:]]+-n[[:space:]]+"\$\{?DISCORD_WEBHOOK_URL\}?"' \
+  || fail "F16: empty-secret guard '[ -n \"\${DISCORD_WEBHOOK_URL}\" ]' missing — curl would fail cryptically"
+
+# F17. actionlint clean (AC #7).
+if ! command -v actionlint >/dev/null 2>&1; then
+  echo "verify-issue-507: SKIP F17 — actionlint not installed (brew install actionlint)" >&2
+else
+  actionlint "$WORKFLOW" \
+    || fail "F17: actionlint reported findings on $WORKFLOW (AC #7 demands clean)"
+fi
+
+echo "verify-issue-507: PASS — all 17 assertions ok"


### PR DESCRIPTION
## Summary

- Adds a `notify-discord` job to `.github/workflows/release.yml` that POSTs a plain-content message to the channel webhook after the release job creates a GitHub Release. Parallel to `update-homebrew`, both `needs: release`.
- Pre-release tags suppressed via job-level `if:` blocklist (`alpha`, `beta`, `rc`, `pre`, `dev`, `canary`, `smoketest`). Production semver and the `v0.0.0-test` sentinel trigger normally.
- `workflow_dispatch` trigger with `dry_run` (default `true`, fail-safe) and `target_tag` (default `v0.0.0-test`) inputs lets maintainers verify the payload from the Actions UI without posting.
- Hardening: `permissions: {}` per-job lockdown, `env:` indirection for tag/repo/secret (CWE-78), `jq -n --arg` payload (JSON-injection safe), `curl -fsS --retry 3` (no `-L`, no `--retry-all-errors`), tag-shape regex, empty-secret guard, dry-run output piped through `jq .` to neutralize log injection.
- Bundled scope justified by AC #7 (workflow file passes actionlint clean): SC2035 fix on the existing checksums step (`sha256sum ./*.tar.gz`) and a `.gitignore` block for `.env*` files.
- `scripts/verify-issue-507.sh` (17 assertions + actionlint) is the TDD RED/GREEN gate for a CI-only task that `cargo test` cannot validate. Follows the `verify-issue-485.sh` convention.

Closes #507

## Test plan

Pre-merge (already run locally):
- [x] `bash scripts/verify-issue-507.sh` — all 17 assertions PASS
- [x] `actionlint .github/workflows/release.yml` — clean
- [x] `cargo test` — 13 tests pass (regression guard, no Rust files touched)
- [x] Architect, QA, and security reviews all approved (security: no blockers, 4 of 5 hardening items applied inline)

Post-merge smoke-test plan (per QA blueprint, requires the `DISCORD_WEBHOOK_URL_TEST` secret to be added first):
- [ ] **Dry-run dispatch**: `gh workflow run release.yml --ref main -F dry_run=true -F target_tag=v0.0.0-test` → confirm payload printed to log, no Discord message
- [ ] **Suppression smoke**: push `v0.0.0-smoketest` tag → confirm `notify-discord` job is **skipped** by the `if:` filter; clean up the auto-created GitHub Release after
- [ ] **Happy-path smoke**: temporarily swap secret to `DISCORD_WEBHOOK_URL_TEST` (or add an environment selector), push `v0.0.0-test` tag → confirm message in staging channel, clean up release after
- [ ] **Failure-path smoke** (optional): point webhook at `https://httpstat.us/404` → confirm `notify-discord` job exits non-zero (validates AC #5 behaviorally)

## Acceptance criteria coverage

| AC | Pre-merge | Post-merge smoke |
|----|-----------|------------------|
| #1 message within 2 min of release | — | step 3 |
| #2 message contains version + upgrade + URL | — | step 3 |
| #3 pre-release skip | structural (F6 grep) | step 2 |
| #4 build fails → notify skipped | structural (F5 `needs: release`) | implicit |
| #5 non-2xx → step fails | structural (F14 `--fail`) | step 4 |
| #6 webhook from secret only | structural (F9, F10, F11) | — |
| #7 actionlint clean | F17 + local run | — |
| #8 staging-webhook smoke | — | step 3 |

## Notes

- Post-merge: the Discord webhook URL passed through local setup was rotated; the new value is in `DISCORD_WEBHOOK_URL`. No action needed.
- Security review flagged 5 hardening items; 4 applied inline (M1 tag-shape regex, M2 dropped `--retry-all-errors`, M3 `jq .` log sanitizer, L2 dropped `-L`). L3 (`target_tag` default rename) deferred — current default matches issue Test Hint #2.
- Follow-ups not addressed in this PR: optional Discord-side `@everyone`/channel-permission lockdown and an `audit-log dispatcher` line in the Resolve step. Both are defense-in-depth, not blockers.