### PR TITLE
ci(audit): grant checks:write and ignore RUSTSEC-2026-0002

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,14 @@ jobs:
     #
     # Cargo.lock is .gitignored (binary-crate convention in this repo), so we
     # generate it on the runner before the audit-check action runs.
+    #
+    # RUSTSEC-2026-0002 (lru "unsound") is gated by ratatui 0.29 → 0.30 bump;
+    # see deny.toml for the per-advisory rationale.
     name: Cargo Audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -81,7 +87,7 @@ jobs:
       - uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ignore: RUSTSEC-2025-0141,RUSTSEC-2024-0436,RUSTSEC-2024-0320,RUSTSEC-2026-0097,RUSTSEC-2026-0098,RUSTSEC-2026-0099,RUSTSEC-2026-0104
+          ignore: RUSTSEC-2025-0141,RUSTSEC-2024-0436,RUSTSEC-2024-0320,RUSTSEC-2026-0097,RUSTSEC-2026-0098,RUSTSEC-2026-0099,RUSTSEC-2026-0104,RUSTSEC-2026-0002
 
   coverage:
     # Wave 2.1 — report mode during baseline phase.

--- a/deny.toml
+++ b/deny.toml
@@ -49,6 +49,13 @@ ignore = [
     # (same chain). Maestro does not configure custom CRL handling; stock
     # rustls defaults are not exercised in the vulnerable code path.
     "RUSTSEC-2026-0104",
+    # Transitive via `ratatui` 0.29 → `lru` 0.12.5 — IterMut Stacked Borrows
+    # unsoundness, not a known vulnerability. Fixed in lru 0.16.3+. Reachable
+    # only after ratatui 0.30 migration (separate issue: TUI breaking changes
+    # in 0.30 — Alignment rename, List::highlight_symbol signature, layout-cache
+    # feature flag).
+    # RUSTSEC-2026-0002: https://rustsec.org/advisories/RUSTSEC-2026-0002
+    "RUSTSEC-2026-0002",
 ]
 
 [licenses]

--- a/docs/RUST-GUARDRAILS.md
+++ b/docs/RUST-GUARDRAILS.md
@@ -318,7 +318,7 @@ Current CI (`.github/workflows/ci.yml`):
 
 Added by this guardrails bundle:
 
-5. **deny** — `cargo deny check advisories bans licenses sources`. Ignore list for transitive-only unmaintained advisories (bincode via syntect, paste via ratatui/tui-textarea, yaml-rust via syntect) is documented in `deny.toml` with RUSTSEC links.
+5. **deny** — `cargo deny check advisories bans licenses sources`. The ignore list for transitive-only advisories is documented in `deny.toml` with inline RUSTSEC links and rationale comments; `deny.toml` is the canonical source of truth for which advisories are suppressed and why.
 6. **audit** — `cargo audit` (RustSec advisory scan, same ignore list as deny).
 
 Runtime enforcement via `maestro.toml [sessions.completion_gates]` (fmt/clippy/test required) — orthogonal to CI; fires post-session.


### PR DESCRIPTION
## Summary

- Add job-scoped `permissions: { contents: read, checks: write }` to the `audit:` job in `.github/workflows/ci.yml`. Fixes the `Resource not accessible by integration` failure when `rustsec/audit-check@v2.0.0` tries to `POST /repos/.../check-runs`. No other job's permissions are widened; no top-level `permissions:` block.
- Triage `RUSTSEC-2026-0002` (lru 0.12.5 unsound IterMut) by appending it to the audit `ignore:` string and to `deny.toml [advisories].ignore`, matching the existing pattern. The unsound code path is structurally unreachable from maestro source — `lru` is purely transitive via ratatui's internal layout cache and not declared as a direct dep.
- Refresh `docs/RUST-GUARDRAILS.md` §13 to defer to `deny.toml` as the canonical advisory source instead of an exhaustive enumeration that was already partially stale.

Closes #517

## Test plan

- [x] `actionlint .github/workflows/ci.yml` exits 0 (binding gate)
- [x] RED proof — `actionlint` rejects an invalid permission value (`writy`) with a clear error
- [x] `cargo test --quiet` exits 0 (3578 tests passed — regression guard)
- [x] `cargo fmt --check`, `cargo clippy -- -D warnings -A dead_code`, `cargo build`, `bash scripts/check-file-size.sh` all exit 0
- [x] YAML structural sanity: audit job has exactly `{contents: read, checks: write}`; only `audit` and `actionlint` carry job-scoped `permissions`
- [x] `deny.toml` parses as valid TOML; ignore array has 8 entries, last is `RUSTSEC-2026-0002`
- [x] Advisory sets in sync between `ci.yml` ignore string and `deny.toml` ignore array (8 entries each)
- [x] `secrets.GITHUB_TOKEN` interpolation on the audit-check action is untouched
- [x] `rg 'lru::|LruCache' src/` returns no hits — confirms the unsound `IterMut` path is unreachable
- [ ] On PR run: `Cargo Audit` job flips ❌ → ✅; all other jobs (`test`, `clippy`, `fmt`, `file-size`, `deny`, `coverage`, `layers`, `actionlint`) stay ✅

## Out-of-scope follow-ups

- SHA-pin all third-party actions across `ci.yml` (currently mixed: only `actionlint`'s `actions/checkout` is SHA-pinned)
- `persist-credentials: false` on read-only checkout steps
- ratatui 0.29 → 0.30 migration — the canonical fix that lets `RUSTSEC-2026-0002` come off the ignore list