### PR TITLE
chore(readme): add Discord community badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Release](https://img.shields.io/github/v/release/CarlosDanielDev/maestro)](https://github.com/CarlosDanielDev/maestro/releases/latest)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![MSRV](https://img.shields.io/badge/rustc-1.89%2B-orange.svg)](Cargo.toml)
+[![Discord](https://img.shields.io/discord/1498709440465998038?logo=discord&logoColor=white&label=Discord&color=5865F2)](https://discord.gg/vUTuhRmq)
 
 > Multi-session [Claude Code](https://claude.ai/claude-code) orchestrator with a Matrix-style terminal control center.
 


### PR DESCRIPTION
## Summary

Adds a shields.io Discord badge to the README header alongside the existing CI/Release/License/MSRV badges. Renders as a live "Discord 1.2k online"-style pill driven by the server's public widget endpoint, and clicks through to the project's Discord invite (https://discord.gg/vUTuhRmq).

The Discord-supplied `<iframe>` widget snippet is omitted intentionally — GitHub's Markdown sanitizer strips raw iframes, so the upstream embed wouldn't render on github.com. The shield badge is the GitHub-friendly equivalent.

## Test plan

- [x] README renders cleanly on GitHub with the new badge alongside the others
- [x] Badge shows the live online count from the server widget API
- [x] Clicking the badge opens the invite URL