### PR TITLE
ci: move nightly-freshness to weekly schedule

### DIFF
--- a/.github/workflows/freshness.yml
+++ b/.github/workflows/freshness.yml
@@ -1,13 +1,15 @@
 name: Nightly Freshness
 
-# Runs on every PR to main. Verifies the most recent scheduled nightly
-# workflow on main succeeded within the last 3 days. Status check
-# named `nightly-freshness` is required by branch protection (once
-# Wave 3 warmup completes).
+# Runs on a weekly schedule (Mondays 04:00 UTC) and on manual dispatch.
+# Verifies the most recent scheduled `nightly.yml` workflow run on main
+# succeeded within the last 3 days. Originally a per-PR gate; moved to
+# a weekly cadence because every PR was paying the cost of a check that
+# describes the health of `nightly.yml`, not the PR itself.
 
 on:
-  pull_request:
-    branches: [main]
+  schedule:
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
 
 jobs:
   freshness:


### PR DESCRIPTION
## Summary

The freshness workflow was running on every PR to main and asserting that the most recent scheduled `nightly.yml` run (mutation + miri) succeeded within the last 3 days. The mutation matrix shards have been getting cancelled, so the gate has been failing on every PR without indicating any actual problem on the PR branch.

Switch the trigger from `pull_request` to a weekly cron (Mondays 04:00 UTC) plus `workflow_dispatch` for ad-hoc runs. The freshness window stays at 3 days so a multi-day nightly outage still flags loudly when the weekly check fires.

`nightly-freshness` is **not** in the branch-protection ruleset's required-status-checks list. The required set is:

- Test
- Format
- Clippy
- File Size Lint
- Cargo Audit
- Cargo Deny
- Coverage Tiers
- Architecture Layers
- Actionlint

So dropping the per-PR trigger does not change merge gating.

## Why now

Surfaced while shipping CarlosDanielDev/maestro#519: every PR in recent history has the same `nightly-freshness` red X for the same reason. Moving to a weekly schedule keeps the monitoring signal without polluting every PR's status list.

## Follow-up

Separately, the underlying nightly mutation cancellation issue still needs investigation — that's why the freshness check fires red in the first place. Tracking that as a separate concern.

## Test plan

- [ ] PR shows no `nightly-freshness` check on its own status list
- [ ] After merge, the next PR opened against main also has no `nightly-freshness` check
- [ ] `gh workflow run "Nightly Freshness"` manually triggers the workflow successfully
- [ ] The workflow's next scheduled run lands on a Monday 04:00 UTC