### PR TITLE
ci(nightly): cache cargo-mutants and double shards from 4 to 8

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,21 +13,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      # `taiki-e/install-action` fetches the prebuilt cargo-mutants binary
+      # from its GitHub release and caches it across runs, replacing the
+      # previous `cargo install cargo-mutants --locked` step that re-built
+      # the binary on every nightly (~5–10 min/shard).
       - name: Install cargo-mutants
-        run: cargo install cargo-mutants --locked
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-mutants
       # --baseline=skip is mandatory when sharding.
       # The baseline-green assumption is enforced by the regular `test`
       # job in ci.yml (per-PR, blocking); mutation only runs nightly
       # after main's test suite is known-green.
-      - name: Run mutation tests (shard ${{ matrix.shard }}/4)
-        run: cargo mutants --shard ${{ matrix.shard }}/4 --no-shuffle --baseline=skip
+      #
+      # Shard count was raised from 4 to 8 so each shard handles half the
+      # mutation surface and lands well inside the 180-minute job budget.
+      # The matrix length above and the `--shard X/N` arg below must match.
+      - name: Run mutation tests (shard ${{ matrix.shard }}/8)
+        run: cargo mutants --shard ${{ matrix.shard }}/8 --no-shuffle --baseline=skip
       - name: Upload results
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Every recent `nightly.yml` run has been getting cancelled because each mutation shard hit the 180-minute job timeout exactly (the last 8 nightlies all ended `cancelled` or `failure`, with shard runtimes of ~10,821 s = 3:00:21). Two compounding causes:

1. **Binary rebuild every run.** `cargo install cargo-mutants --locked` was re-compiling the binary from source on every shard of every nightly run, eating ~5–10 min before any mutation work started.
2. **Shard size too coarse.** Each of the 4 shards was responsible for ~25% of the mutation surface, which exceeded what fits in the remaining ~170 minutes.

Two changes:

- Switch to `taiki-e/install-action@v2` with `tool: cargo-mutants` so the prebuilt binary is fetched from the upstream GitHub release and cached across runs (no more rebuild).
- Bump the shard count from 4 to 8 so each shard handles ~12.5% of the mutation surface; expected wall time ~75–90 min per shard, comfortably under the 180-minute ceiling.

Total runner-minutes roughly doubles in the worst case but stays within the previous wall time. The two shard-count locations stay in sync: the matrix `shard:` list and the `--shard X/N` argument.

## Why now

Surfaced while shipping #514 (PR #519): the `nightly-freshness` PR gate kept failing because no recent nightly was successful. PR #523 moved that gate from per-PR to weekly; this PR addresses the underlying nightly failure that the gate was reporting on.

## Test plan

- [ ] After merge, manually trigger via `gh workflow run nightly.yml` and confirm:
  - [ ] Each shard finishes (success or expected mutation failures) within the 180-minute window
  - [ ] `Install cargo-mutants` step takes < 1 minute (binary fetch, not source build)
  - [ ] All 8 `mutants-shard-*` artifacts are uploaded
- [ ] First scheduled nightly after merge (03:00 UTC) completes with conclusion ≠ `cancelled`
- [ ] First scheduled `Nightly Freshness` (Mondays 04:00 UTC, per #523) reports green