### PR TITLE
feat(tui): keybinding `g` to toggle agent graph at runtime

### DIFF
--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-29 23:00 (UTC)
+> Last updated: 2026-04-29 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -303,7 +303,7 @@ maestro/
 │   │   │   ├── mod.rs                     # Module exports for navigation subsystem
 │   │   │   ├── focus.rs                   # Focus management: FocusManager, focus ring, widget focus state
 │   │   │   ├── keymap.rs                  # Keymap definitions: action-to-key bindings, context-sensitive keymaps; F-key bar actions registered (F1 Help, F2 Summary, F3 Full, F4 Costs, F5 Tokens, F6 Deps, F9 Pause, F10 Kill, Alt-X Exit); KeyBindingGroup, InlineHint, FKeyRelevance, ModeKeyMap, global_keybindings() LazyLock  [Issue #218]
-│   │   │   └── mode_hints.rs              # mode_keymap() builds ModeKeyMap for a given TuiMode + optional session status; maps TuiMode variants to mode labels, F-key visibility rules, and context-sensitive inline hints; consumes screen_bindings from KeymapProvider::keybindings(); 'c Copy' hint added to Overview mode; MilestoneHealth mode-hint entry added; AgentGraph mode-hint arm added  [Issue #482, #500, #527]
+│   │   │   └── mode_hints.rs              # mode_keymap() builds ModeKeyMap for a given TuiMode + optional session status; maps TuiMode variants to mode labels, F-key visibility rules, and context-sensitive inline hints; consumes screen_bindings from KeymapProvider::keybindings(); 'c Copy' hint added to Overview mode; MilestoneHealth mode-hint entry added; AgentGraph mode-hint arm added; Overview hint bar gains '[g] Graph' when views.agent_graph_enabled = true; AgentGraph hint bar advertises '[Esc] Back  [g] Panels'  [Issue #482, #500, #527, #528]
 │   │   ├── background_tasks.rs            # Background task spawners and async data-event producers for the TUI event loop
 │   │   ├── issue_refs.rs                  # Issue reference helpers: parses and formats #N issue references for display
 │   │   ├── session_summary.rs             # Session summary widget rendered in the completion overlay and detail pane
@@ -312,8 +312,8 @@ maestro/
 │   │   ├── summary.rs                     # Compact per-session summary row widget used in panel and list views
 │   │   ├── token_dashboard.rs             # Token usage dashboard widget: per-session and aggregate token counts; TQ Ratio column removed (#346)
 │   │   ├── turboquant_dashboard.rs        # TurboQuant savings dashboard: classify_savings(), aggregate_savings(), AggregateSavings; renders "Estimated Savings (projection)" header when no real handoff data exists, "Actual Savings" when at least one session has fork-handoff compression metrics; ACTUAL / proj. kind markers per row  [Issue #346]
-│   │   ├── snapshot_tests/                # TUI snapshot tests using insta (48 tests, 11 views)  [Issue #16, #490, #526, #527]
-│   │   │   ├── mod.rs                     # Module declarations for snapshot test submodules; mod agent_graph and mod agent_graph_dispatcher wired  [Issue #526, #527]
+│   │   ├── snapshot_tests/                # TUI snapshot tests using insta (51 tests, 12 views)  [Issue #16, #490, #526, #527, #528]
+│   │   │   ├── mod.rs                     # Module declarations for snapshot test submodules; mod agent_graph, mod agent_graph_dispatcher, and mod agent_graph_keybinding_hint wired  [Issue #526, #527, #528]
 │   │   │   ├── overview.rs                # 6 snapshot tests for PanelView (empty, single, multiple, selected, context overflow, forked)
 │   │   │   ├── detail.rs                  # 6 snapshot tests for DetailView (basic, progress, activity log, no files, retries, markdown)
 │   │   │   ├── fullscreen.rs              # 4 snapshot tests for FullscreenView (markdown, plain text, empty placeholder, auto-scroll)
@@ -326,7 +326,8 @@ maestro/
 │   │   │   ├── copy_keybinding_hint.rs    # Insta snapshot tests for keybinding hint bar: copy_keybinding_hint_enabled and copy_keybinding_hint_disabled  [Issue #482]
 │   │   │   ├── agent_graph.rs             # 4 snapshot tests for agent graph: renders_at_80x24, renders_at_100x30, renders_at_120x40, single_agent_card  [Issue #526]
 │   │   │   ├── agent_graph_dispatcher.rs  # 3 snapshot tests for render dispatcher: toggle_on_renders_graph, toggle_off_renders_panels, toggle_disabled_by_default  [Issue #527]
-│   │   │   └── snapshots/                 # Committed insta snapshot files (.snap files); includes caveman_row renders (default, error, explicit_false, explicit_true, focused_explicit_true); copy_keybinding_hint_enabled and copy_keybinding_hint_disabled; agent_graph renders at 80x24, 100x30, 120x40, and single_agent_card; agent_graph_dispatcher toggle_on and toggle_off baselines  [Issue #490, #482, #526, #527]
+│   │   │   ├── agent_graph_keybinding_hint.rs  # 3 snapshot tests for keybinding hint bar: overview_hints_with_agent_graph_flag_on_includes_g_entry, overview_hints_with_agent_graph_flag_off_excludes_g_entry, agent_graph_mode_hints_include_esc_back_and_g_panels  [Issue #528]
+│   │   │   └── snapshots/                 # Committed insta snapshot files (.snap files); includes caveman_row renders (default, error, explicit_false, explicit_true, focused_explicit_true); copy_keybinding_hint_enabled and copy_keybinding_hint_disabled; agent_graph renders at 80x24, 100x30, 120x40, and single_agent_card; agent_graph_dispatcher toggle_on and toggle_off baselines; agent_graph_keybinding_hint snapshots for flag-on/flag-off overview hints and agent_graph mode hints  [Issue #490, #482, #526, #527, #528]
 │   │   ├── screen_dispatch.rs             # ScreenDispatch: routes key events and render calls to the active screen; constructor receives FeatureFlags for settings screen injection; always injects prompt history when constructing PromptInputScreen; ScreenAction::Push delegates to navigate_to(), ScreenAction::Pop delegates to navigate_back(); Scaffolding case in StartAdaptPipeline dispatch; reads app.config_path directly for settings save (removed relative-path probe at TuiMode::Settings); tracing::warn! when config_path is absent; MilestoneHealth Push/Pop arms added; drains milestone_health_screen pending command channel after each input  [Issue #146, #232, #342, #371, #437, #500]
 │   │   └── screens/                       # Interactive screen components  [Issue #31-33]
 │   │       ├── mod.rs                     # Screen types: ScreenAction enum (+ RefreshSuggestions variant), SessionConfig; re-exports HomeScreen, IssueBrowserScreen, MilestoneScreen; pub mod wizard_fields (added #447); pub mod milestone_health (added #500); wizard_paste removed  [Issue #31-33, #86, #447, #500]

--- a/src/tui/app/mod.rs
+++ b/src/tui/app/mod.rs
@@ -82,7 +82,7 @@ pub struct App {
     pub plugin_runner: Option<PluginRunner>,
     pub help_state: Option<crate::tui::help::HelpOverlayState>,
     pub cached_mode_km: Option<crate::tui::navigation::keymap::ModeKeyMap>,
-    pub cached_mode_km_key: (TuiMode, Option<crate::session::types::SessionStatus>),
+    pub cached_mode_km_key: (TuiMode, Option<crate::session::types::SessionStatus>, bool),
     pub context_monitor: Box<dyn ContextMonitor>,
     pub fork_policy: Option<ForkPolicy>,
     pub home_screen: Option<crate::tui::screens::HomeScreen>,
@@ -248,7 +248,7 @@ impl App {
             plugin_runner: None,
             help_state: None,
             cached_mode_km: None,
-            cached_mode_km_key: (TuiMode::Overview, None),
+            cached_mode_km_key: (TuiMode::Overview, None, false),
             context_monitor: Box::new(ProductionContextMonitor::new()),
             fork_policy: None,
             home_screen: None,
@@ -465,6 +465,19 @@ impl App {
             .as_ref()
             .map(|c| c.views.agent_graph_enabled)
             .unwrap_or(false)
+    }
+
+    /// Bypasses `navigate_to` deliberately so `Esc` does not pop back through
+    /// every toggle press — this is a flat view-switch, not navigation.
+    pub fn toggle_agent_graph(&mut self) {
+        if !self.is_agent_graph_enabled() {
+            return;
+        }
+        self.tui_mode = match self.tui_mode {
+            TuiMode::Overview => TuiMode::AgentGraph,
+            TuiMode::AgentGraph => TuiMode::Overview,
+            _ => return,
+        };
     }
 
     /// Navigate to a new mode, pushing the current mode onto the back-stack.

--- a/src/tui/app/tests.rs
+++ b/src/tui/app/tests.rs
@@ -1404,6 +1404,77 @@ fn navigate_to_agent_graph_with_no_config_redirects_to_overview() {
     );
 }
 
+// -- Issue #528: App::toggle_agent_graph ---------------------------------
+
+#[test]
+fn toggle_agent_graph_with_flag_off_is_noop() {
+    let mut app = make_app_with_views_toml("[views]\nagent_graph_enabled = false\n");
+    app.tui_mode = TuiMode::Overview;
+    app.toggle_agent_graph();
+    assert_eq!(app.tui_mode, TuiMode::Overview);
+    assert!(app.nav_stack.is_empty());
+}
+
+#[test]
+fn toggle_agent_graph_with_no_config_is_noop() {
+    let mut app = make_app();
+    app.tui_mode = TuiMode::Overview;
+    app.toggle_agent_graph();
+    assert_eq!(app.tui_mode, TuiMode::Overview);
+}
+
+#[test]
+fn toggle_agent_graph_overview_to_graph_when_enabled() {
+    let mut app = make_app_with_views_toml("[views]\nagent_graph_enabled = true\n");
+    app.tui_mode = TuiMode::Overview;
+    app.toggle_agent_graph();
+    assert_eq!(app.tui_mode, TuiMode::AgentGraph);
+}
+
+#[test]
+fn toggle_agent_graph_graph_to_overview_when_enabled() {
+    let mut app = make_app_with_views_toml("[views]\nagent_graph_enabled = true\n");
+    app.tui_mode = TuiMode::AgentGraph;
+    app.toggle_agent_graph();
+    assert_eq!(app.tui_mode, TuiMode::Overview);
+}
+
+#[test]
+fn toggle_agent_graph_round_trip_returns_to_overview() {
+    let mut app = make_app_with_views_toml("[views]\nagent_graph_enabled = true\n");
+    app.tui_mode = TuiMode::Overview;
+    app.toggle_agent_graph();
+    assert_eq!(app.tui_mode, TuiMode::AgentGraph);
+    app.toggle_agent_graph();
+    assert_eq!(app.tui_mode, TuiMode::Overview);
+}
+
+#[test]
+fn toggle_agent_graph_from_unrelated_mode_is_noop() {
+    let mut app = make_app_with_views_toml("[views]\nagent_graph_enabled = true\n");
+    app.tui_mode = TuiMode::Settings;
+    app.toggle_agent_graph();
+    assert_eq!(
+        app.tui_mode,
+        TuiMode::Settings,
+        "toggle must only act on Overview/AgentGraph"
+    );
+}
+
+#[test]
+fn toggle_agent_graph_does_not_push_nav_stack() {
+    let mut app = make_app_with_views_toml("[views]\nagent_graph_enabled = true\n");
+    app.tui_mode = TuiMode::Overview;
+    let depth_before = app.nav_stack.depth();
+    app.toggle_agent_graph();
+    app.toggle_agent_graph();
+    assert_eq!(
+        app.nav_stack.depth(),
+        depth_before,
+        "toggle must not grow nav_stack — Esc should not pop back through toggle history"
+    );
+}
+
 // -- Adapt pipeline data chaining integration tests --
 
 mod adapt_chaining {

--- a/src/tui/input_handler.rs
+++ b/src/tui/input_handler.rs
@@ -761,6 +761,9 @@ fn handle_overview_keys(app: &mut App, key: &KeyEvent) {
         (KeyCode::Char('d'), _) => {
             app.show_activity_log = !app.show_activity_log;
         }
+        (KeyCode::Char('g'), KeyModifiers::NONE) if app.is_agent_graph_enabled() => {
+            app.toggle_agent_graph();
+        }
         (KeyCode::Char('D'), _) => {
             app.dismiss_all_completed();
         }
@@ -1197,7 +1200,7 @@ mod tests {
     fn completion_summary_hints_dispatch_to_advertised_mode() {
         use crate::tui::navigation::keymap::mode_keymap;
 
-        let km = mode_keymap(TuiMode::CompletionSummary, None, &[]);
+        let km = mode_keymap(TuiMode::CompletionSummary, None, &[], false);
         let mut checked = 0;
 
         for hint in km.hints {
@@ -1273,7 +1276,7 @@ mod tests {
     #[test]
     fn fkey_dashboard_mode_advertises_f4_f5_f6_and_each_dispatches() {
         use crate::tui::navigation::keymap::mode_keymap;
-        let km = mode_keymap(TuiMode::Dashboard, None, &[]);
+        let km = mode_keymap(TuiMode::Dashboard, None, &[], false);
         let mut checked = 0;
         for fkey in &km.fkeys {
             let Some(expected) = fkey_action_target_mode(fkey.action) else {
@@ -1388,5 +1391,85 @@ mod tests {
         assert!(!app.running);
         assert_eq!(mock.write_count(), 0);
         assert!(app.copy_toast.is_none());
+    }
+
+    // ── Issue #528: agent-graph toggle keybinding (`g`) ──────────────────
+
+    fn agent_graph_app(enabled: bool) -> App {
+        let mut app = make_app();
+        let toml = format!(
+            "[project]\nrepo = \"owner/repo\"\n[sessions]\n[budget]\n\
+             per_session_usd = 5.0\ntotal_usd = 50.0\nalert_threshold_pct = 80\n\
+             [github]\n[notifications]\n[views]\nagent_graph_enabled = {enabled}\n"
+        );
+        app.config = Some(toml::from_str(&toml).expect("test config parse"));
+        app
+    }
+
+    #[tokio::test]
+    async fn g_key_with_flag_on_overview_to_agent_graph() {
+        let mut app = agent_graph_app(true);
+        app.tui_mode = TuiMode::Overview;
+        let _ = handle_key(&mut app, key('g')).await;
+        assert_eq!(app.tui_mode, TuiMode::AgentGraph);
+    }
+
+    #[tokio::test]
+    async fn g_key_with_flag_off_is_noop() {
+        let mut app = agent_graph_app(false);
+        app.tui_mode = TuiMode::Overview;
+        let _ = handle_key(&mut app, key('g')).await;
+        assert_eq!(app.tui_mode, TuiMode::Overview);
+    }
+
+    #[tokio::test]
+    async fn g_key_round_trips_overview_graph_overview() {
+        let mut app = agent_graph_app(true);
+        app.tui_mode = TuiMode::Overview;
+        let _ = handle_key(&mut app, key('g')).await;
+        assert_eq!(app.tui_mode, TuiMode::AgentGraph);
+        let _ = handle_key(&mut app, key('g')).await;
+        assert_eq!(app.tui_mode, TuiMode::Overview);
+    }
+
+    /// Regression guard: LogViewer also binds `g` (scroll to top). The
+    /// secondary-mode dispatch fires before `handle_overview_keys`, so the
+    /// LogViewer `g` must NOT cross over into the agent-graph toggle.
+    #[tokio::test]
+    async fn g_key_in_log_viewer_scrolls_to_top_not_toggle() {
+        let mut app = agent_graph_app(true);
+        let id = uuid::Uuid::new_v4();
+        app.tui_mode = TuiMode::LogViewer(id);
+        app.log_viewer_scroll = 42;
+        let _ = handle_key(&mut app, key('g')).await;
+        assert!(
+            matches!(app.tui_mode, TuiMode::LogViewer(_)),
+            "g in LogViewer must stay in LogViewer, got {:?}",
+            app.tui_mode
+        );
+        assert_eq!(app.log_viewer_scroll, 0, "g in LogViewer scrolls to top");
+    }
+
+    /// AC: "Switching does not interrupt running sessions."
+    #[tokio::test]
+    async fn g_key_does_not_modify_session_pool() {
+        let mut app = agent_graph_app(true);
+        app.tui_mode = TuiMode::Overview;
+        let mut s = Session::new(
+            "running task".into(),
+            "claude-opus-4-5".into(),
+            "orchestrator".into(),
+            Some(42),
+        );
+        s.status = SessionStatus::Running;
+        app.pool.enqueue(s);
+        let count_before = app.pool.total_count();
+
+        let _ = handle_key(&mut app, key('g')).await;
+
+        assert_eq!(app.tui_mode, TuiMode::AgentGraph);
+        assert_eq!(app.pool.total_count(), count_before);
+        let sessions = app.pool.all_sessions();
+        assert_eq!(sessions[0].status, SessionStatus::Running);
     }
 }

--- a/src/tui/navigation/keymap.rs
+++ b/src/tui/navigation/keymap.rs
@@ -364,7 +364,7 @@ mod tests {
 
     #[test]
     fn mode_keymap_overview_shows_all_fkeys() {
-        let km = mode_keymap(TuiMode::Overview, Some(SessionStatus::Running), &[]);
+        let km = mode_keymap(TuiMode::Overview, Some(SessionStatus::Running), &[], false);
         assert_eq!(km.mode_label, "Overview");
         assert_eq!(km.fkeys.len(), 9);
         assert!(km.fkeys.iter().all(|f| f.visible));
@@ -372,7 +372,7 @@ mod tests {
 
     #[test]
     fn mode_keymap_overview_running_session_activates_pause_kill() {
-        let km = mode_keymap(TuiMode::Overview, Some(SessionStatus::Running), &[]);
+        let km = mode_keymap(TuiMode::Overview, Some(SessionStatus::Running), &[], false);
         let f9 = km.fkeys.iter().find(|f| f.key == "F9").unwrap();
         assert!(f9.active, "F9 Pause should be active when running");
         let f10 = km.fkeys.iter().find(|f| f.key == "F10").unwrap();
@@ -381,7 +381,7 @@ mod tests {
 
     #[test]
     fn mode_keymap_overview_no_session_dims_session_keys() {
-        let km = mode_keymap(TuiMode::Overview, None, &[]);
+        let km = mode_keymap(TuiMode::Overview, None, &[], false);
         let f3 = km.fkeys.iter().find(|f| f.key == "F3").unwrap();
         assert!(!f3.active);
         let f9 = km.fkeys.iter().find(|f| f.key == "F9").unwrap();
@@ -392,7 +392,12 @@ mod tests {
 
     #[test]
     fn mode_keymap_overview_completed_session_dims_pause_kill() {
-        let km = mode_keymap(TuiMode::Overview, Some(SessionStatus::Completed), &[]);
+        let km = mode_keymap(
+            TuiMode::Overview,
+            Some(SessionStatus::Completed),
+            &[],
+            false,
+        );
         let f9 = km.fkeys.iter().find(|f| f.key == "F9").unwrap();
         assert!(!f9.active);
         let f10 = km.fkeys.iter().find(|f| f.key == "F10").unwrap();
@@ -401,7 +406,7 @@ mod tests {
 
     #[test]
     fn mode_keymap_dashboard_shows_reduced_fkeys() {
-        let km = mode_keymap(TuiMode::Dashboard, None, &[]);
+        let km = mode_keymap(TuiMode::Dashboard, None, &[], false);
         assert_eq!(km.mode_label, "Dashboard");
         assert_eq!(km.fkeys.len(), 5);
         let keys: Vec<&str> = km.fkeys.iter().map(|f| f.key).collect();
@@ -412,7 +417,7 @@ mod tests {
 
     #[test]
     fn mode_keymap_settings_shows_minimal_fkeys() {
-        let km = mode_keymap(TuiMode::Settings, None, &[]);
+        let km = mode_keymap(TuiMode::Settings, None, &[], false);
         assert_eq!(km.fkeys.len(), 2);
         assert_eq!(km.fkeys[0].key, "F1");
         assert_eq!(km.fkeys[1].key, "^X");
@@ -420,7 +425,7 @@ mod tests {
 
     #[test]
     fn mode_keymap_prompt_input_shows_minimal_fkeys() {
-        let km = mode_keymap(TuiMode::PromptInput, None, &[]);
+        let km = mode_keymap(TuiMode::PromptInput, None, &[], false);
         assert_eq!(km.fkeys.len(), 2);
     }
 
@@ -433,14 +438,14 @@ mod tests {
                 description: "Do X",
             }],
         }];
-        let km = mode_keymap(TuiMode::Dashboard, None, &screen_bindings);
+        let km = mode_keymap(TuiMode::Dashboard, None, &screen_bindings, false);
         assert_eq!(km.help_groups[0].title, "Screen Actions");
         assert!(km.help_groups.len() > 1);
     }
 
     #[test]
     fn mode_keymap_help_groups_include_global_keybindings() {
-        let km = mode_keymap(TuiMode::Overview, None, &[]);
+        let km = mode_keymap(TuiMode::Overview, None, &[], false);
         let global_titles: Vec<&str> = global_keybindings().iter().map(|g| g.title).collect();
         let km_titles: Vec<&str> = km.help_groups.iter().map(|g| g.title).collect();
         for title in &global_titles {
@@ -450,7 +455,7 @@ mod tests {
 
     #[test]
     fn mode_keymap_overview_has_hints() {
-        let km = mode_keymap(TuiMode::Overview, None, &[]);
+        let km = mode_keymap(TuiMode::Overview, None, &[], false);
         assert!(!km.hints.is_empty());
         assert_eq!(km.hints[0].key, "Enter");
         assert_eq!(km.hints[0].action, "Detail");
@@ -458,7 +463,7 @@ mod tests {
 
     #[test]
     fn mode_keymap_dashboard_has_hints() {
-        let km = mode_keymap(TuiMode::Dashboard, None, &[]);
+        let km = mode_keymap(TuiMode::Dashboard, None, &[], false);
         let keys: Vec<&str> = km.hints.iter().map(|h| h.key).collect();
         assert!(keys.contains(&"i"));
         assert!(keys.contains(&"r"));
@@ -466,7 +471,7 @@ mod tests {
 
     #[test]
     fn fit_fkeys_full_width_includes_all() {
-        let km = mode_keymap(TuiMode::Overview, Some(SessionStatus::Running), &[]);
+        let km = mode_keymap(TuiMode::Overview, Some(SessionStatus::Running), &[], false);
         let fitted = fit_fkeys_to_width(&km.fkeys, 120);
         assert_eq!(fitted.len(), 9);
         for (_, label, _) in &fitted {
@@ -476,7 +481,7 @@ mod tests {
 
     #[test]
     fn fit_fkeys_narrow_drops_labels() {
-        let km = mode_keymap(TuiMode::Overview, None, &[]);
+        let km = mode_keymap(TuiMode::Overview, None, &[], false);
         let fitted = fit_fkeys_to_width(&km.fkeys, 35);
         for (_, label, _) in &fitted {
             assert!(label.is_none());
@@ -485,7 +490,7 @@ mod tests {
 
     #[test]
     fn fit_fkeys_very_narrow_truncates() {
-        let km = mode_keymap(TuiMode::Overview, None, &[]);
+        let km = mode_keymap(TuiMode::Overview, None, &[], false);
         let fitted = fit_fkeys_to_width(&km.fkeys, 20);
         assert!(!fitted.is_empty());
         assert!(fitted.len() < 9);
@@ -493,28 +498,28 @@ mod tests {
 
     #[test]
     fn fit_fkeys_dashboard_fewer_entries() {
-        let km = mode_keymap(TuiMode::Dashboard, None, &[]);
+        let km = mode_keymap(TuiMode::Dashboard, None, &[], false);
         let fitted = fit_fkeys_to_width(&km.fkeys, 120);
         assert_eq!(fitted.len(), 5);
     }
 
     #[test]
     fn fit_fkeys_settings_only_two_entries() {
-        let km = mode_keymap(TuiMode::Settings, None, &[]);
+        let km = mode_keymap(TuiMode::Settings, None, &[], false);
         let fitted = fit_fkeys_to_width(&km.fkeys, 120);
         assert_eq!(fitted.len(), 2);
     }
 
     #[test]
     fn fit_hints_wide_includes_all() {
-        let km = mode_keymap(TuiMode::Overview, None, &[]);
+        let km = mode_keymap(TuiMode::Overview, None, &[], false);
         let fitted = fit_hints_to_width(km.hints, 120);
         assert_eq!(fitted.len(), km.hints.len());
     }
 
     #[test]
     fn fit_hints_narrow_truncates_gracefully() {
-        let km = mode_keymap(TuiMode::Overview, None, &[]);
+        let km = mode_keymap(TuiMode::Overview, None, &[], false);
         let fitted = fit_hints_to_width(km.hints, 30);
         assert!(!fitted.is_empty());
         assert!(fitted.len() < km.hints.len());
@@ -522,14 +527,14 @@ mod tests {
 
     #[test]
     fn fit_hints_sorted_by_priority() {
-        let km = mode_keymap(TuiMode::Overview, None, &[]);
+        let km = mode_keymap(TuiMode::Overview, None, &[], false);
         let fitted = fit_hints_to_width(km.hints, 120);
         assert_eq!(fitted[0].0, "Enter");
     }
 
     #[test]
     fn fit_hints_empty_at_zero_width() {
-        let km = mode_keymap(TuiMode::Overview, None, &[]);
+        let km = mode_keymap(TuiMode::Overview, None, &[], false);
         let fitted = fit_hints_to_width(km.hints, 0);
         assert!(fitted.is_empty());
     }

--- a/src/tui/navigation/mode_hints.rs
+++ b/src/tui/navigation/mode_hints.rs
@@ -5,14 +5,89 @@ use super::keymap::{
     FKeyAction, FKeyRelevance, InlineHint, KeyBindingGroup, ModeKeyMap, global_keybindings,
 };
 
+// `c` keeps priority 1 so it survives narrow widths — the dimmed-when-disabled
+// state means the hint is the user's only signal that copy exists.
+const HINT_OV_DETAIL: InlineHint = InlineHint {
+    key: "Enter",
+    action: "Detail",
+    priority: 0,
+};
+const HINT_OV_COPY: InlineHint = InlineHint {
+    key: "c",
+    action: "Copy",
+    priority: 1,
+};
+const HINT_OV_LOG: InlineHint = InlineHint {
+    key: "d",
+    action: "Log",
+    priority: 2,
+};
+const HINT_OV_FULL: InlineHint = InlineHint {
+    key: "f",
+    action: "Full",
+    priority: 3,
+};
+const HINT_OV_GRAPH: InlineHint = InlineHint {
+    key: "g",
+    action: "Graph",
+    priority: 4,
+};
+const HINT_OV_SWITCHER: InlineHint = InlineHint {
+    key: "w",
+    action: "Switcher",
+    priority: 4,
+};
+const HINT_OV_CYCLE: InlineHint = InlineHint {
+    key: "Tab",
+    action: "Cycle Views",
+    priority: 5,
+};
+
+const OVERVIEW_HINTS_BASE: &[InlineHint] = &[
+    HINT_OV_DETAIL,
+    HINT_OV_COPY,
+    HINT_OV_LOG,
+    HINT_OV_FULL,
+    HINT_OV_SWITCHER,
+    HINT_OV_CYCLE,
+];
+
+const OVERVIEW_HINTS_WITH_GRAPH: &[InlineHint] = &[
+    HINT_OV_DETAIL,
+    HINT_OV_COPY,
+    HINT_OV_LOG,
+    HINT_OV_FULL,
+    HINT_OV_GRAPH,
+    HINT_OV_SWITCHER,
+    HINT_OV_CYCLE,
+];
+
+const AGENT_GRAPH_HINTS: &[InlineHint] = &[
+    InlineHint {
+        key: "Esc",
+        action: "Back",
+        priority: 0,
+    },
+    InlineHint {
+        key: "g",
+        action: "Panels",
+        priority: 1,
+    },
+];
+
 /// Build the `ModeKeyMap` for a given `TuiMode`.
 ///
 /// `screen_bindings` should come from the active screen's `KeymapProvider::keybindings()`
 /// (empty slice for modes that don't implement `Screen`).
+///
+/// `agent_graph_enabled` controls the visibility of the `[g] Graph` entry in
+/// the Overview hint bar (#528). When `false`, the hint is absent so the
+/// keybinding is invisible; when `true`, the entry advertises the toggle.
 pub fn mode_keymap(
     mode: TuiMode,
     session_status: Option<SessionStatus>,
     screen_bindings: &[KeyBindingGroup],
+    agent_graph_enabled: bool,
 ) -> ModeKeyMap {
     let has_session = session_status.is_some();
     let is_terminal = session_status.is_some_and(|s| s.is_terminal());
@@ -22,41 +97,11 @@ pub fn mode_keymap(
         TuiMode::Overview => (
             "Overview",
             FKeyVis::SessionAware,
-            &[
-                InlineHint {
-                    key: "Enter",
-                    action: "Detail",
-                    priority: 0,
-                },
-                // `c` is given priority 1 so it survives narrow widths —
-                // the dimmed-when-disabled state means the hint is the
-                // user's only signal that copy exists.
-                InlineHint {
-                    key: "c",
-                    action: "Copy",
-                    priority: 1,
-                },
-                InlineHint {
-                    key: "d",
-                    action: "Log",
-                    priority: 2,
-                },
-                InlineHint {
-                    key: "f",
-                    action: "Full",
-                    priority: 3,
-                },
-                InlineHint {
-                    key: "w",
-                    action: "Switcher",
-                    priority: 4,
-                },
-                InlineHint {
-                    key: "Tab",
-                    action: "Cycle Views",
-                    priority: 5,
-                },
-            ],
+            if agent_graph_enabled {
+                OVERVIEW_HINTS_WITH_GRAPH
+            } else {
+                OVERVIEW_HINTS_BASE
+            },
         ),
         TuiMode::Detail(_) => (
             "Detail",
@@ -273,15 +318,7 @@ pub fn mode_keymap(
                 },
             ],
         ),
-        TuiMode::AgentGraph => (
-            "Agent Graph",
-            FKeyVis::DashboardLike,
-            &[InlineHint {
-                key: "Esc",
-                action: "Back",
-                priority: 0,
-            }],
-        ),
+        TuiMode::AgentGraph => ("Agent Graph", FKeyVis::DashboardLike, AGENT_GRAPH_HINTS),
         TuiMode::CompletionSummary => (
             "Completion Summary",
             FKeyVis::Minimal,

--- a/src/tui/snapshot_tests/agent_graph_keybinding_hint.rs
+++ b/src/tui/snapshot_tests/agent_graph_keybinding_hint.rs
@@ -1,0 +1,57 @@
+use crate::tui::app::TuiMode;
+use crate::tui::keybinding_hints::keybinding_hints_spans;
+use crate::tui::navigation::keymap::{fit_hints_to_width, mode_keymap};
+use crate::tui::theme::Theme;
+use insta::assert_debug_snapshot;
+use ratatui::text::Span;
+
+fn render_overview_hints(agent_graph_enabled: bool) -> Vec<Span<'static>> {
+    let km = mode_keymap(TuiMode::Overview, None, &[], agent_graph_enabled);
+    let theme = Theme::dark();
+    let fitted = fit_hints_to_width(km.hints, 120);
+    keybinding_hints_spans(&fitted, false, &theme)
+}
+
+fn render_agent_graph_hints() -> Vec<Span<'static>> {
+    let km = mode_keymap(TuiMode::AgentGraph, None, &[], true);
+    let theme = Theme::dark();
+    let fitted = fit_hints_to_width(km.hints, 120);
+    keybinding_hints_spans(&fitted, false, &theme)
+}
+
+#[test]
+fn overview_hints_with_agent_graph_flag_on_includes_g_entry() {
+    let spans = render_overview_hints(true);
+    let rendered: String = spans.iter().map(|s| s.content.as_ref()).collect();
+    assert!(
+        rendered.contains("[g]"),
+        "Overview hints must include [g] when toggle is on; got: {rendered:?}"
+    );
+    assert_debug_snapshot!(spans);
+}
+
+#[test]
+fn overview_hints_with_agent_graph_flag_off_excludes_g_entry() {
+    let spans = render_overview_hints(false);
+    let rendered: String = spans.iter().map(|s| s.content.as_ref()).collect();
+    assert!(
+        !rendered.contains("[g]"),
+        "Overview hints must NOT include [g] when toggle is off; got: {rendered:?}"
+    );
+    assert_debug_snapshot!(spans);
+}
+
+#[test]
+fn agent_graph_mode_hints_include_esc_back_and_g_panels() {
+    let spans = render_agent_graph_hints();
+    let rendered: String = spans.iter().map(|s| s.content.as_ref()).collect();
+    assert!(
+        rendered.contains("[Esc]"),
+        "must include [Esc]; got: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("[g]"),
+        "must include [g]; got: {rendered:?}"
+    );
+    assert_debug_snapshot!(spans);
+}

--- a/src/tui/snapshot_tests/copy_keybinding_hint.rs
+++ b/src/tui/snapshot_tests/copy_keybinding_hint.rs
@@ -7,7 +7,12 @@ use insta::assert_debug_snapshot;
 use ratatui::text::Span;
 
 fn render_spans(copy_enabled: bool) -> Vec<Span<'static>> {
-    let km = mode_keymap(TuiMode::Overview, Some(SessionStatus::Completed), &[]);
+    let km = mode_keymap(
+        TuiMode::Overview,
+        Some(SessionStatus::Completed),
+        &[],
+        false,
+    );
     let theme = Theme::dark();
     let fitted = fit_hints_to_width(km.hints, 120);
     keybinding_hints_spans(&fitted, copy_enabled, &theme)

--- a/src/tui/snapshot_tests/mod.rs
+++ b/src/tui/snapshot_tests/mod.rs
@@ -1,5 +1,6 @@
 mod agent_graph;
 mod agent_graph_dispatcher;
+mod agent_graph_keybinding_hint;
 mod caveman_row;
 mod copy_keybinding_hint;
 mod cost_dashboard;

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__agent_graph_keybinding_hint__agent_graph_mode_hints_include_esc_back_and_g_panels.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__agent_graph_keybinding_hint__agent_graph_mode_hints_include_esc_back_and_g_panels.snap
@@ -1,0 +1,11 @@
+---
+source: src/tui/snapshot_tests/agent_graph_keybinding_hint.rs
+expression: spans
+---
+[
+    Span::from("[Esc]").green(),
+    Span::from(" Back").dark_gray(),
+    Span::from("  "),
+    Span::from("[g]").green(),
+    Span::from(" Panels").dark_gray(),
+]

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__agent_graph_keybinding_hint__overview_hints_with_agent_graph_flag_off_excludes_g_entry.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__agent_graph_keybinding_hint__overview_hints_with_agent_graph_flag_off_excludes_g_entry.snap
@@ -1,0 +1,23 @@
+---
+source: src/tui/snapshot_tests/agent_graph_keybinding_hint.rs
+expression: spans
+---
+[
+    Span::from("[Enter]").green(),
+    Span::from(" Detail").dark_gray(),
+    Span::from("  "),
+    Span::from("[c]").dark_gray().dim(),
+    Span::from(" Copy").dark_gray().dim(),
+    Span::from("  "),
+    Span::from("[d]").green(),
+    Span::from(" Log").dark_gray(),
+    Span::from("  "),
+    Span::from("[f]").green(),
+    Span::from(" Full").dark_gray(),
+    Span::from("  "),
+    Span::from("[w]").green(),
+    Span::from(" Switcher").dark_gray(),
+    Span::from("  "),
+    Span::from("[Tab]").green(),
+    Span::from(" Cycle Views").dark_gray(),
+]

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__agent_graph_keybinding_hint__overview_hints_with_agent_graph_flag_on_includes_g_entry.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__agent_graph_keybinding_hint__overview_hints_with_agent_graph_flag_on_includes_g_entry.snap
@@ -1,0 +1,26 @@
+---
+source: src/tui/snapshot_tests/agent_graph_keybinding_hint.rs
+expression: spans
+---
+[
+    Span::from("[Enter]").green(),
+    Span::from(" Detail").dark_gray(),
+    Span::from("  "),
+    Span::from("[c]").dark_gray().dim(),
+    Span::from(" Copy").dark_gray().dim(),
+    Span::from("  "),
+    Span::from("[d]").green(),
+    Span::from(" Log").dark_gray(),
+    Span::from("  "),
+    Span::from("[f]").green(),
+    Span::from(" Full").dark_gray(),
+    Span::from("  "),
+    Span::from("[g]").green(),
+    Span::from(" Graph").dark_gray(),
+    Span::from("  "),
+    Span::from("[w]").green(),
+    Span::from(" Switcher").dark_gray(),
+    Span::from("  "),
+    Span::from("[Tab]").green(),
+    Span::from(" Cycle Views").dark_gray(),
+]

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -65,13 +65,15 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         .pool
         .session_at_index(app.panel_view.selected_index())
         .map(|s| s.status);
-    let cache_key = (app.tui_mode, selected_status);
+    let agent_graph_enabled = app.is_agent_graph_enabled();
+    let cache_key = (app.tui_mode, selected_status, agent_graph_enabled);
     if app.cached_mode_km.is_none() || app.cached_mode_km_key != cache_key {
         let screen_bindings = active_screen_bindings(app);
         app.cached_mode_km = Some(keymap::mode_keymap(
             app.tui_mode,
             selected_status,
             &screen_bindings,
+            agent_graph_enabled,
         ));
         app.cached_mode_km_key = cache_key;
     }
@@ -1321,7 +1323,7 @@ fn draw_completion_overlay(
     // Hint bar: single source of truth is `mode_hints.rs`. The conditional
     // `[f] Fix` is prepended here because it only applies when the summary
     // actually has suggestions — static hint tables can't encode that.
-    let km = keymap::mode_keymap(TuiMode::CompletionSummary, None, &[]);
+    let km = keymap::mode_keymap(TuiMode::CompletionSummary, None, &[], false);
     let mut keybind_spans = vec![Span::raw("  ")];
     if summary.has_needs_review() || summary.has_conflict_suggestions() {
         keybind_spans.push(Span::styled("[f]", Style::default().fg(theme.keybind_key)));
@@ -1427,7 +1429,7 @@ fn draw_queue_execution_overlay(
             Span::raw("  "),
         ]);
     }
-    let km = keymap::mode_keymap(TuiMode::QueueExecution, None, &[]);
+    let km = keymap::mode_keymap(TuiMode::QueueExecution, None, &[], false);
     keybind_spans.extend(keymap::hint_bar_spans(
         km.hints,
         theme.keybind_key,
@@ -1504,7 +1506,7 @@ fn draw_continuous_pause_overlay(
     ]));
 
     lines.push(Line::from(""));
-    let km = keymap::mode_keymap(TuiMode::ContinuousPause, None, &[]);
+    let km = keymap::mode_keymap(TuiMode::ContinuousPause, None, &[], false);
     let mut keybind_spans = vec![Span::raw("  ")];
     keybind_spans.extend(keymap::hint_bar_spans(
         km.hints,


### PR DESCRIPTION
## Summary
- Adds a runtime `g` keybinding that toggles `TuiMode::Overview ↔ TuiMode::AgentGraph` when `views.agent_graph_enabled = true`.
- Hint bar advertises `[g] Graph` in Overview and `[g] Panels` in AgentGraph; entry is hidden when the flag is off so the binding is invisible.
- LogViewer's existing `g` (scroll-to-top) is preserved — secondary-mode dispatch fires before the Overview fall-through. Pinned by a regression test.

Closes #528

## Test plan
- [x] `cargo test` — 3640 lib + 275 doc + 13 integration tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings -A dead_code` clean
- [x] File-size guardrail clean
- [x] 7 unit tests for `App::toggle_agent_graph` (no-op when flag off / no config / unrelated mode; round-trip; nav_stack untouched)
- [x] 5 input-handler integration tests (`g` round-trip, flag-off no-op, LogViewer regression, session-pool unaffected)
- [x] 3 insta snapshots for hint visibility (Overview flag-on, Overview flag-off, AgentGraph mode)
- [x] Manual smoke: launch with `views.agent_graph_enabled = true`, press `g` in Overview, confirm graph renders; press `g` again to return.
- [x] Manual smoke: launch with `views.agent_graph_enabled = false`, press `g`, confirm no-op and no `[g]` in hint bar.