### PR TITLE
spike(#536): agent personalities — ADR 002 + throwaway prototype

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,16 @@ anyhow = "1"
 insta = "1"
 criterion = { version = "0.5", features = ["html_reports"] }
 
+[features]
+# Throwaway prototype gate for ADR 002 (agent personalities). Code under this
+# feature is on the spike branch only and is removed when the ADR merges.
+# See docs/adr/002-agent-personalities.md § Prototype.
+spike = []
+
+[[example]]
+name = "agent_personalities_spike"
+required-features = ["spike"]
+
 [[bench]]
 name = "parser"
 harness = false

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-29 (UTC)
+> Last updated: 2026-04-29 14:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -79,7 +79,7 @@ maestro/
 │       └── release.yml                    # Release automation for cross-platform builds and Homebrew tap updates
 ├── build.rs                               # Build script: generates man page (maestro.1) and shell completions (bash, zsh, fish) into OUT_DIR at build time using clap_mangen and clap_complete  [Issue #18]
 ├── src/
-│   ├── lib.rs                             # Library facade; exposes session::parser and session::types for benchmark crates; pub mod icon_mode and pub mod icons added so shared icon modules are accessible as library crate items; agent_graph_spike module removed  [Issue #307, #308, #526]
+│   ├── lib.rs                             # Library facade; exposes session::parser and session::types for benchmark crates; pub mod icon_mode and pub mod icons added so shared icon modules are accessible as library crate items; agent_graph_spike module removed; #[cfg(feature = "spike")] pub mod agent_personalities block added (throwaway, removed in ADR-002 cleanup commit)  [Issue #307, #308, #526, #536]
 │   ├── icon_mode.rs                       # Shared icon mode detection: AtomicBool global flag, init_from_config() reads tui.ascii_icons from Config and MAESTRO_ASCII_ICONS env var, use_nerd_font() returns current mode; extracted from tui/icons.rs so non-TUI crates can query the mode without pulling in the full TUI tree  [Issue #307]
 │   ├── icons.rs                           # Shared icon registry: IconId enum (38 variants across Navigation, Status, UI Chrome, Indicators categories, plus NeedsReview variant added in #308), IconPair struct (nerd: &'static str, ascii: &'static str), icon_pair() const fn compiles to a zero-allocation jump table, get(IconId) returns the correct variant based on global mode, get_for_mode(id, nerd_font) pure testable variant; extracted from tui/icons.rs; CheckboxOn codepoint U+F14A (nf-fa-check_square) and CheckboxOff codepoint U+F0C8 (nf-fa-square) — universally present FA-core glyphs replacing the legacy nf-oct variants  [Issue #308, #433]
 │   ├── main.rs                            # CLI entry point (clap); Run, Queue, Add, Status, Cost, Init, Doctor; --skip-doctor flag on Run subcommand bypasses preflight; cmd_run() runs validate_preflight() before session launch and uses PromptBuilder::build_issue_prompt() for issue sessions; setup_app_from_config() shared helper wires budget, model router, notifications, plugins, and permission_mode/allowed_tools from config; propagates once_mode from parsed CLI flag into App; forces max_concurrent=1 when --continuous is set; cmd_dashboard() performs orphan worktree cleanup, log cleanup, fetches username from doctor report, delegates App construction to setup_app_from_config(), and queues FetchSuggestionData on startup; declares #[cfg(test)] mod integration_tests; declares mod updater; declares mod flags; propagates startup gh auth check result into App.gh_auth_ok; declares mod sanitize; constructs FeatureFlags from --enable-flag / --disable-flag CLI args merged with [flags] config  [Issue #15, #29, #49, #34, #36, #35, #52, #83, #85, #118, #141, #142, #143, #158]
@@ -252,6 +252,11 @@ maestro/
 │   │   └── types.rs                       # State types; fork_lineage HashMap; record_fork, fork_chain, fork_depth methods; pending_prs: Vec<PendingPr> field on MaestroState — persisted to JSON state for PR retry recovery; pending_completions: Vec<PendingIssueCompletion> field with #[serde(default)] — persists in-flight auto-PR work across maestro restarts (3 round-trip tests)  [Issue #12, #159, #514]
 │   ├── tui/
 │   │   ├── mod.rs                         # Event loop; keybindings; handle_screen_action() rewritten; command processing loop; launch_session_from_config(); FetchSuggestionData async handler spawns background GitHub fetch for ready/failed counts and milestone progress; spawns async version check on startup via check_for_update() — result delivered as VersionCheckResult data event; key handlers for upgrade flow (confirm/decline banner); CompletionSummary key-intercept branch: [f] collects NeedsReview sessions and calls spawn_gate_fix_session() for each then transitions to Overview, [i] opens issue browser, [r] opens prompt input, [l] switches to Overview (activity log view), [Enter]/[Esc] returns to dashboard via transition_to_dashboard(), [q] quits; ContinuousPause key-intercept overlay: [s] skip, [r] retry, [q] quit continuous loop; RefreshSuggestions branch sets loading_suggestions=true and queues FetchSuggestionData; exit path checks once_mode — exits immediately when true, otherwise shows CompletionSummary overlay; "All Issues" navigation always creates a fresh IssueBrowserScreen to prevent stale milestone filters leaking across navigation contexts; PromptInputScreen always created with injected history so Up/Down arrow recall works correctly; F-key bar actions wired (F1–F10, Alt-X); per-tick flash_counter decrement dispatched to session pool; pub mod theme; pub mod widgets; RunAdaptScaffold command dispatch; background task handlers for FetchMilestoneHealthIssues and PatchMilestoneDescription; pub(crate) mod agent_graph wired  [Phase 3, Issue #31-33, #46-48, #35, #38, #83, #84, #85, #86, #104, #117, #118, #124, #202, #218, #232, #371, #500, #526]
+│   │   ├── agent_personalities/           # [SPIKE-ONLY / THROWAWAY] Role sprites prototype — gated behind `--features spike`; removed in ADR-002 cleanup commit  [Issue #536]
+│   │   │   ├── role.rs                    # Role enum (5 variants) + derive_role keyword classifier
+│   │   │   ├── sprite.rs                  # Sprite([[char;6];6]) per-role 6×6 ghost sprite grids
+│   │   │   ├── palette.rs                 # role_color() + role_abbrev() (3-char ASCII fallback)
+│   │   │   └── render.rs                  # draw_named_sprite() ratatui renderer (fg-only sprite or 3-char abbrev)
 │   │   ├── agent_graph/                   # Agent graph visualization module (productionized in #526)
 │   │   │   ├── mod.rs                     # Module facade; re-exports pub(crate) items; phase-offset and aspect-ratio fixes applied  [Issue #526]
 │   │   │   ├── model.rs                   # GraphNode, GraphEdge, NodeId, NodeKind, Positioned data types; build_graph() signature changed to &[&Session] (issue #527)  [Issue #526, #527]
@@ -442,7 +447,8 @@ maestro/
 │       └── queue.rs                       # WorkQueue, QueuedItem, QueueValidationError; validate_selection()  [Issue #65]
 ├── docs/
 │   ├── adr/                               # Architecture Decision Records; one file per decision; ADRs that survive a spike are the only artifact merged to main from that spike
-│   │   └── 001-agent-graph-viz.md         # ADR 001: agent graph visualization — Go/No-Go verdict (concentric/radial bipartite layout, Braille canvas); tracking issue #513
+│   │   ├── 001-agent-graph-viz.md         # ADR 001: agent graph visualization — Go/No-Go verdict (concentric/radial bipartite layout, Braille canvas); tracking issue #513
+│   │   └── 002-agent-personalities.md     # ADR 002: agent personality sprites — 5-role taxonomy, 6×6 ghost sprites, hybrid derive_role, ASCII fallback; Go verdict; tracking issue #536
 │   ├── api-contracts/                     # JSON Schema (Draft 2020-12) for every external payload that crosses a process boundary; one file per payload type; referenced by /validate-contracts and subagent-gatekeeper
 │   │   ├── README.md                      # Convention guide: naming, additionalProperties policy, gatekeeper integration  [Issue #327]
 │   │   └── review-comment.json            # Schema for the maestro-review JSON block in /review PR comments; parsed by review::parse and TUI pr_review screen  [Issue #327]
@@ -481,6 +487,8 @@ maestro/
 │   ├── check-file-size.sh                 # Enforce per-file LOC limits (500-line rule)
 │   ├── check-layers.sh                    # Enforce architecture layer boundaries
 │   └── coverage-tiers.yml                 # Coverage tier definitions
+├── examples/
+│   └── agent_personalities_spike.rs       # [SPIKE-ONLY / THROWAWAY] Example binary entry point; `cargo run --example agent_personalities_spike --features spike`; removed in ADR-002 cleanup commit  [Issue #536]
 ├── benches/                               # Criterion benchmark crates
 │   ├── parser.rs                          # Benchmark: stream-json parser throughput  [Issue #19]
 │   └── turboquant.rs                      # Benchmark: TurboQuant quantization pipeline throughput
@@ -492,7 +500,7 @@ maestro/
 │   └── scripts/                           # Test script fixtures
 ├── .gitignore                             # Includes .maestro/worktrees/ and runtime artifacts; .maestro/knowledge.md (written by maestro adapt, auto-loaded as system-prompt component by SessionPool::try_promote) is also excluded
 ├── Cargo.lock                             # Dependency lock file
-├── Cargo.toml                             # Rust package manifest; tempfile promoted to runtime dependency; thiserror = "1" added; insta dev-dependency; optimized release profile; [features] section with experimental-sanitizer = [] only (spike feature flag and [[example]] blocks removed); flate2 and tar dependencies for tar.gz extraction in self-updater; strip-ansi-escapes = "0.2" for ANSI stripping in clipboard copy  [Issue #142, #233, #482, #499, #526]
+├── Cargo.toml                             # Rust package manifest; tempfile promoted to runtime dependency; thiserror = "1" added; insta dev-dependency; optimized release profile; [features] section includes experimental-sanitizer = [] and spike = [] (spike feature removed in ADR-002 cleanup commit); [[example]] entry for agent_personalities_spike (removed in cleanup); flate2 and tar dependencies for tar.gz extraction in self-updater; strip-ansi-escapes = "0.2" for ANSI stripping in clipboard copy  [Issue #142, #233, #482, #499, #526, #536]
 ├── CHANGELOG.md                           # Release history following Keep a Changelog format
 ├── LICENSE
 ├── README.md                              # Project front door

--- a/docs/adr/002-agent-personalities.md
+++ b/docs/adr/002-agent-personalities.md
@@ -1,0 +1,457 @@
+# ADR 002 — Agent Personalities (Roles, Sprites, Visual Identity)
+
+- **Status:** Accepted (spike — prototype is throwaway, never lifted to production by this ADR)
+- **Date:** 2026-04-29
+- **Tracking issue:** [#536](https://github.com/CarlosDanielDev/maestro/issues/536)
+- **Spike branch:** `spike/agent-personalities` (prototype is throwaway — gated behind `--features spike` and never built by `cargo build`)
+
+---
+
+## Problem
+
+The agent-graph view (shipped in #527, animated in #529) gives users a relational picture of which agents touch which files. Visual identity is still anonymous: every agent renders as the same 4-cell rectangle with a label like `⠋ #520`. With three or more concurrent sessions the user can read *what each agent is doing right now* but cannot tell, **at a glance, what kind of work the agent is doing** — coordinating, implementing, reviewing, writing docs, fixing CI.
+
+The reference visual is the [octogent](https://github.com/hesamsheikh/octogent) Pac-Man-family of pixel-art ghost sprites: a small set of role-colored characters (magenta API, green Core, orange Docs, red DevOps, yellow Coordinator, white Frontend) that read instantly even at low resolution. Maestro is a terminal UI — there is no SVG canvas, no animation runtime — so adapting that idea to ratatui requires answering several open questions before we can ship any real renderer:
+
+1. What does *role* / *personality* mean for a maestro session — derived from the prompt, user-tagged, auto-classified, or hybrid?
+2. What is the canonical role list? How many, named what?
+3. What is the sprite design language? Cell footprint, character set, how role color is applied (foreground / background / both)?
+4. What is the per-role color palette and the ASCII fallback when `icon_mode::use_nerd_font() == false`?
+5. Where does role data live on `Session` (stored field, derived helper, or computed at render time)?
+6. What is the migration path for sessions that predate the field?
+
+This ADR records the spike's findings and a Go / No-Go verdict for a follow-up feature.
+
+---
+
+## Current Behavior
+
+- Every agent renders as an identical 4-cell `Rectangle` plus a `#NNN` label in the agent-graph view (`src/tui/agent_graph/render.rs:99-200`).
+- `Session` has no role / personality concept (`src/session/types.rs:202-289`).
+- `Session::mode` is the only role-adjacent field, and it is always `"orchestrator"` today.
+- Node color is derived from `SessionStatus` only (via `node_animation_style` in `src/tui/agent_graph/animation.rs`).
+
+---
+
+## Options Considered
+
+### Role taxonomy
+
+| # | Option | Notes |
+|---|---|---|
+| 1 | **No taxonomy — keep anonymous nodes (do nothing)** | Cheapest. Loses the categorical information the user is asking for. |
+| 2 | **2 roles (Orchestrator vs. Worker)** | Trivially small. Maps to `Session::mode` today. Loses the docs/review/devops distinctions the user wants. |
+| 3 | **5 roles (Orchestrator / Implementer / Reviewer / Docs / DevOps)** | Aligns with maestro's existing subagent registry (`subagent-architect`, `subagent-qa`, `subagent-security-analyst`, `subagent-docs-analyst`) and `SessionStatus::CiFix` / `ConflictFix` classes. **Recommended.** |
+| 4 | **6 roles (add Frontend, per octogent palette)** | Adds a category that has no real workload in maestro today (maestro is a CLI tool, not a frontend stack). Parked as future-considered. |
+| 5 | **Open-ended user-tag taxonomy** | Maximum flexibility, but the user must invent and remember names. Loses the "everyone shares the same vocabulary" property that makes the colors readable. |
+
+We rejected the open-ended approach (#5) because every team would invent a different vocabulary; the ghost-color metaphor only works if the palette is shared. We rejected the 2-role minimum (#2) because the issue's headline use case is *distinguishing reviewers from implementers from devops* — exactly the cases #2 collapses.
+
+### Role derivation
+
+| # | Option | Notes |
+|---|---|---|
+| 1 | **Auto-classify from prompt only** | No user friction. Opaque: the user has no mental model of why their session became orange. No escape hatch when the classifier is wrong. |
+| 2 | **User-assigned via `--role` CLI flag only** | Maximum control. Most maestro sessions are auto-spawned by `subagent-orchestrator` with no human at the keyboard, so most sessions collapse to the default and the feature is invisible. |
+| 3 | **Manual via `maestro.toml` only** | Wrong scope: `maestro.toml` is global config, not per-session. There is no single "role" answer at the config level. |
+| 4 | **Hybrid — explicit override > prompt classifier > default** | Combines the auto-spawn coverage of #1 with the escape hatch of #2. Reuses `src/session/intent.rs`'s keyword-classifier idiom unchanged. **Recommended.** |
+
+### Sprite footprint
+
+| # | Option | Notes |
+|---|---|---|
+| 1 | **4×3 cells** | Issue's floor. Barely enough to tell a ghost from a rectangle. |
+| 2 | **6×6 cells** | Issue's ceiling. Recognizable Pac-Man-family silhouette. **Recommended.** |
+| 3 | **Variable per role** | Forces the layout engine to know each role's bounding box, breaks the "renderer treats all sprites identically" invariant. |
+
+### ASCII fallback
+
+| # | Option | Notes |
+|---|---|---|
+| (a) | **Single-character role glyph + role color** | Too few characters to disambiguate (Orchestrator vs. Operations both want `O`). |
+| (b) | **3-character role abbreviation in role color, inside the existing rectangle** | Survives both color loss (label is readable) and font loss (already ASCII). **Recommended.** |
+| (c) | **Hide sprite, use only a role-colored rectangle** | Invisible to users with color blindness. Effectively "no change" from current state. |
+
+---
+
+## Chosen Approach
+
+**5-role taxonomy + hybrid derivation + 6×6 foreground-only sprite + 3-character abbrev fallback.**
+
+Each axis is independently testable and independently revisable. The combination matches octogent's visual idiom while degrading gracefully on terminals that lack UTF-8 nerd-font support.
+
+Properties:
+
+- **Deterministic** — given the same prompt and the same keyword corpus, `derive_role` always returns the same `Role`.
+- **Compile-time uniform sprite shape** — `Sprite([[char; 6]; 6])` is enforced by the type system; variable-size sprites cannot accidentally land.
+- **Two independent fallback dimensions** — color loss and font loss are addressed separately. Color-blind users see the abbreviation; font-deprived users see a colored rectangle.
+- **No stored field on `Session` from this spike** — the prototype hard-codes role per session in the example binary; the stored field is the follow-up's job. Keeps the merge-to-main blast radius bounded to a single ADR file.
+
+---
+
+## Role Taxonomy
+
+Five roles. Six was the issue's hint, but **Frontend** has no meaningful workload in maestro today and is parked. Five gives the spike enough signal without inventing fictional categories.
+
+| Role | Color (16-color name) | ANSI / xterm | One-line description | Mapping rationale |
+|---|---|---|---|---|
+| `Orchestrator` | Yellow | ANSI 33 | Coordinates other sessions; spawns work; merges PRs. | Matches `Session::mode = "orchestrator"`. Yellow = "Coordinator" from octogent. |
+| `Implementer` | Green | ANSI 32 | Writes code: edits files, adds features, runs `cargo test`. The default role. | Largest category in maestro's session log. Green = "Core" from octogent. |
+| `Reviewer` | Magenta | ANSI 35 | Reads code, runs gates, posts PR reviews. | Maps to `subagent-security-analyst` and `subagent-qa`. Magenta = "API" in octogent's palette; semantically closest to "scrutinizing surface" here. |
+| `Docs` | Orange | xterm 208 | Writes `.md` files, updates ADRs, regenerates `directory-tree.md`. | Maps to `subagent-docs-analyst`. Orange = "Docs" verbatim from octogent. |
+| `DevOps` | Red | ANSI 31 | CI fixes, conflict resolution, dependency bumps, infrastructure. | Maps to `SessionStatus::CiFix` and `SessionStatus::ConflictFix` activity. Red = "DevOps" verbatim from octogent and matches the "danger" semantic. |
+
+**Canonical Rust enum** (the prototype implements; the follow-up promotes to `src/session/role.rs`):
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum Role {
+    #[default]
+    Implementer,
+    Orchestrator,
+    Reviewer,
+    Docs,
+    DevOps,
+}
+```
+
+`Implementer` is the default because (a) it is the largest category, (b) `Default` falls out for serde backward compat — matching the `SessionIntent::Work` precedent at `src/session/intent.rs:8-16`, (c) "unknown prompt → Implementer" is the safest miscategorization: any session that does work gets a green sprite, the most common color, so misfires are visually invisible.
+
+### Future-considered roles
+
+- **Frontend** — no JS/CSS workload in maestro itself. If a dogfooding target ever ships a web layer, add it.
+- **API** — magenta API doesn't correspond to anything maestro produces today. Reviewer takes the magenta slot; if API design ever becomes a session category, recolor Reviewer or split the slot.
+- **Spawning** — this is a `SessionStatus`, not a role. A session is spawning *into* a role. Conflating them would break the "role is the agent's job, status is what they're doing right now" invariant.
+
+---
+
+## Sprite Design Language
+
+### Cell footprint
+
+- **Minimum 4×3** — issue's floor. Barely a silhouette.
+- **Maximum 6×6** — issue's ceiling. Recognizable Pac-Man-family ghost in 80×24.
+- **Recommended:** **6×6 uniform across all roles.** Variable footprints would force the layout engine to know each role's bounding box. Pad smaller designs with spaces to 6×6.
+
+### Character set
+
+Two layers, both inside the Geometric Shapes Unicode block (U+25xx) so they render in any UTF-8 terminal — no nerd-font extension required for the body itself, only for accent-mode glyphs that already live inside `icon_mode`'s scope.
+
+**Body fill:**
+- `█` (full block, U+2588) — dense body
+- `▓` (dark shade, U+2593) — body texture (mid-row)
+- ` ` (space) — eye sockets and underside fringe
+
+**Accent dots** (eyes / personality marks; small set so all sprites read as the same family):
+- `●` (U+25CF) — eye
+- `○` (U+25CB) — hollow eye (`Docs` "thoughtful")
+- `▼` (U+25BC) — fringe tooth (`DevOps` danger)
+- `◆` (U+25C6) — accent (`Orchestrator` crown)
+
+### How role color is applied
+
+**Foreground only.** No background fills.
+
+1. **Background fills clash** with the existing `node_animation_style` background-flash on transitions (`src/tui/agent_graph/animation.rs:97`). Two sources fighting for the same cell makes both unreadable.
+2. **Foreground-only matches octogent's reference**, which uses the role color as the sprite's primary fill, not its surroundings.
+3. **ASCII fallback degrades cleanly** — a colored rectangle in foreground looks like a small colored bar; a colored rectangle in background looks like a stamp of shame.
+
+### Per-role sprite grids
+
+Each row is a six-element char array. Spaces are explicit. The body uses `█`; accents are documented above. Total cell count is identical (6×6 = 36 cells) so layout treats every role uniformly.
+
+**Orchestrator (Yellow `◆` — "the conductor with a crown")**
+
+```
+Row 0: [' ', '◆', '█', '█', '◆', ' ']    crown peaks
+Row 1: ['█', '█', '█', '█', '█', '█']    dome
+Row 2: ['█', '●', '█', '█', '●', '█']    eyes
+Row 3: ['█', '█', '█', '█', '█', '█']    mid
+Row 4: ['█', '█', '█', '█', '█', '█']    belly
+Row 5: ['█', ' ', '█', '█', ' ', '█']    fringe (2 legs)
+```
+
+**Implementer (Green — "default ghost, no decoration")**
+
+```
+Row 0: [' ', ' ', '█', '█', ' ', ' ']    crown
+Row 1: [' ', '█', '█', '█', '█', ' ']    dome
+Row 2: ['█', '●', '█', '█', '●', '█']    eyes
+Row 3: ['█', '█', '█', '█', '█', '█']    mid
+Row 4: ['█', '█', '█', '█', '█', '█']    belly
+Row 5: ['█', ' ', '█', '█', ' ', '█']    fringe
+```
+
+**Reviewer (Magenta — "monocle on the right eye, narrowed left eye")**
+
+```
+Row 0: [' ', ' ', '█', '█', ' ', ' ']
+Row 1: [' ', '█', '█', '█', '█', ' ']
+Row 2: ['█', '▓', '█', '█', '●', '█']    narrowed L, focused R
+Row 3: ['█', '█', '█', '█', '◆', '█']    monocle
+Row 4: ['█', '█', '█', '█', '█', '█']
+Row 5: ['█', ' ', '█', '█', ' ', '█']
+```
+
+**Docs (Orange — "hollow eyes = thoughtful; pen-stripe across the belly")**
+
+```
+Row 0: [' ', ' ', '█', '█', ' ', ' ']
+Row 1: [' ', '█', '█', '█', '█', ' ']
+Row 2: ['█', '○', '█', '█', '○', '█']    hollow eyes
+Row 3: ['█', '█', '█', '█', '█', '█']
+Row 4: ['█', '▓', '▓', '▓', '▓', '█']    pen-stripe
+Row 5: ['█', ' ', '█', '█', ' ', '█']
+```
+
+**DevOps (Red — "fanged fringe — handle with care")**
+
+```
+Row 0: [' ', ' ', '█', '█', ' ', ' ']
+Row 1: [' ', '█', '█', '█', '█', ' ']
+Row 2: ['█', '●', '█', '█', '●', '█']
+Row 3: ['█', '█', '█', '█', '█', '█']
+Row 4: ['█', '█', '█', '█', '█', '█']
+Row 5: ['▼', '█', '▼', '▼', '█', '▼']    teeth (4 fangs)
+```
+
+**Visual differentiation invariants** (every sprite obeys):
+
+- Row 5 contains the leg / fringe pattern (every ghost has a base).
+- Rows 2–3 contain the eyes (every ghost has a face).
+- Per-role uniqueness lives in row 0 (Orchestrator crown, DevOps blank), row 4 (Docs pen-stripe), row 5 (DevOps teeth, others classic legs), or eye choice (Reviewer monocle, Docs hollow).
+
+---
+
+## Role Derivation
+
+**Chosen: Hybrid — explicit override > prompt classifier > default.**
+
+Resolution order at session creation time:
+
+1. **Explicit `--role <name>` CLI flag** (clap `ValueEnum` for `Role`). Highest priority.
+2. **Per-prompt keyword classification** — `derive_role(prompt: &str) -> Role`. Reuses the `src/session/intent.rs` idiom verbatim: case-insensitive substring matching against per-role keyword lists. Returns `Implementer` as the unmatched default.
+3. **`Default::default()` → `Implementer`** for backward compat when the JSON state file predates the field.
+
+**Trade-off explicitly named:** ETC + Flexibility, accepting reduced Determinism. The classifier's keyword corpus is a living config; two different keyword tables → two different colorings of the same prompt. The `--role` override is the user's escape hatch when the classifier disagrees. This matches the pattern in `intent.rs:212-215`.
+
+**Property-test gate (specified for the follow-up, not this spike):**
+
+- ≥80% accuracy on a 25-prompt seed corpus (5 prompts per role).
+- Classifier mapping documented in `derive_role`'s rustdoc so a tester knows the rules without reading the function body.
+- The intent classifier targets >90%; role classifier gets a lower bar because there are 5 categories instead of 2 — random baseline is 20%, not 50%.
+
+---
+
+## Data Model
+
+**Verdict: stored field with derived fallback.**
+
+The follow-up adds:
+
+```rust
+// src/session/types.rs (FOLLOW-UP, not this spike)
+pub struct Session {
+    // ...existing fields...
+
+    /// Role classification for the agent. Stored explicitly so the renderer
+    /// has a O(1) lookup. Defaults to Implementer for old JSON state files
+    /// that predate this field (see Role::default()).
+    #[serde(default)]
+    pub role: super::role::Role,
+}
+
+// src/session/role.rs (NEW MODULE in follow-up)
+pub fn derive_role(prompt: &str) -> Role { /* ... */ }
+
+// Resolution at Session::new()
+impl Session {
+    pub fn new(prompt: String, /* ... */, role_override: Option<Role>) -> Self {
+        let role = role_override.unwrap_or_else(|| derive_role(&prompt));
+        // ...
+    }
+}
+```
+
+### Why stored, not pure-derived at render time
+
+1. **Cost.** Render-time derivation re-runs the keyword classifier every redraw tick. With ≤10 sessions × 50 fps that is 500 classifier calls/sec — cheap, but wasteful.
+2. **Stability.** A session's prompt text never changes after creation. Re-deriving on every read is reasoning twice about the same input.
+3. **Override.** A user `--role` override has nowhere to live if the role is purely derived.
+
+### Why also derived (the helper survives), not stored-only
+
+`#[serde(default)]` on the stored field means old JSON files with no `role` get `Role::default() = Implementer`. That is safe (most sessions are implementers), but it loses information for old sessions whose prompts were obviously orchestrator/docs work. The follow-up MAY ship a one-shot migration that runs `derive_role` against every existing session's `prompt` and back-fills the field.
+
+### Migration story
+
+- **Default migration** (zero work, follow-up ships this): missing field → `Role::default()` → `Implementer`. Old sessions show as green; future sessions are correctly classified at creation. This is the right default — old finished sessions are about to fade out anyway (per ADR-001's dim-then-remove policy).
+- **Optional back-fill** (deferred): a `state::store` migration that walks `MaestroState.sessions`, calls `derive_role(&prompt)` for any session with `role == Default`, and writes back. Safe because the field has a `Default` and the back-fill is idempotent.
+
+---
+
+## ASCII Fallback
+
+**Chosen: 3-character role abbreviation in role color, inside the existing rectangle.**
+
+| Role | Abbrev |
+|---|---|
+| Orchestrator | `ORC` |
+| Implementer | `IMP` |
+| Reviewer | `REV` |
+| Docs | `DOC` |
+| DevOps | `OPS` |
+
+Three characters is the minimum that disambiguates at a glance and still fits inside the existing 4-cell node rectangle (the same shape used today by `node_style`). One character collapses Orchestrator and Operations onto the same `O`. Hiding the sprite entirely (`(c)`) leaves a color-only signal, which fails for color-blind users.
+
+### Implementation seam
+
+The fallback is gated by `crate::icon_mode::use_nerd_font()` (`src/icon_mode.rs:28`). The render path is:
+
+- `use_nerd_font() == true` → 6×6 sprite grid (`Paragraph` with 6 fg-styled `Line`s).
+- `use_nerd_font() == false` → existing 4-cell colored `Rectangle` + 3-char colored abbreviation label one row below.
+
+The branching mirrors `SessionStatus::symbol()` at `src/session/types.rs:70-76`.
+
+---
+
+## Test Strategy (for the Follow-Up)
+
+The spike has no production tests — this section specifies the tests the follow-up issue inherits. Copy verbatim into the follow-up DOR.
+
+1. **Insta snapshot per role × per icon-mode = 5 × 2 = 10 snapshots.**
+   - Path: `src/tui/snapshot_tests/agent_personalities/<role>_<mode>.snap`.
+   - Backend: `ratatui::backend::TestBackend` at fixed 80×24.
+   - Asserts: rendered sprite for one named session, role-colored fg, ASCII fallback when forced.
+   - Pattern: identical to the existing `src/tui/snapshot_tests/` precedent (CI enforces `INSTA_UPDATE=no`).
+
+2. **Property test for `derive_role` — ≥80% accuracy on a 25-prompt corpus.**
+   - Pattern: identical to `intent.rs:512-564` (`classifier_accuracy_on_spec_corpus_is_above_90_percent`).
+   - Corpus split: 5 prompts per role.
+   - Failure mode: a single misclassification within tolerance is silent; > 5 misclassifications fails the build.
+
+3. **serde round-trip for the new `Session::role` field.**
+   - Pattern: identical to `intent` round-trip at `types.rs:1246-1259`.
+   - Three tests: `role_field_round_trips_via_serde`, `role_defaults_to_implementer_when_absent_in_json`, `role_serializes_as_snake_case_implementer`.
+
+4. **`transition_to` non-interaction test.**
+   - Assert that `transition_to(Status::Running, ...)` does NOT mutate `session.role`. One test, ~5 lines. Catches the "role-on-status-change" anti-pattern that would silently break sprite stability mid-render.
+
+5. **Sprite renderer invariants.**
+   - All sprites are exactly 6×6 (compile-time `[[char; 6]; 6]` enforces 6×6).
+   - Role abbreviation is exactly 3 ASCII bytes (one assertion per role).
+
+6. **Manual smoke (NOT automated, documented in the follow-up DOR):**
+   - Spawn 5 sessions covering all 5 roles in the same `maestro` run.
+   - Verify the agent-graph view shows 5 visually distinguishable nodes.
+   - Re-run with `MAESTRO_ASCII_ICONS=1` and verify the ASCII fallback shows 5 distinguishable colored 3-letter labels.
+
+**Guardrail citations the follow-up's blueprint MUST include:**
+
+- §6 serialization: `Role` enum carries `#[serde(rename_all = "snake_case")]` and `Default`; new `Session::role` field carries `#[serde(default)]` for backward compat.
+- §7 testing: insta snapshots in `src/tui/snapshot_tests/`; trait-based fakes for any test that needs a fake-but-realistic `Session`.
+- §11 observability: classifier emits `tracing::debug!(prompt = %prompt, role = ?role, "derived role")` (not `println!` / `dbg!`).
+- §2 errors: derivation is infallible. The `--role` override uses clap's built-in `ValueEnum` parser, so invalid values get a clap error — not a panic.
+
+---
+
+## Go / No-Go Verdict
+
+**VERDICT: Go (5 roles, hybrid derivation, 6×6 foreground sprite, 3-char abbrev fallback).**
+
+The five Go signals (orchestrator runs the prototype to fill in ✅/❌; a single failure in signals 1, 2, or 4 flips the verdict to No-Go):
+
+| # | Signal | Result | Verdict-flipping? |
+|---|---|---|---|
+| 1 | Two named 6×6 sprites render side-by-side, distinguishable, in 80×24 nerd-font mode | ✅ | Yes |
+| 2 | ASCII fallback (`MAESTRO_ASCII_ICONS=1`) shows two distinguishable role abbreviations in distinct colors | ✅ | Yes |
+| 3 | `Sprite` data structure is fixed-size and 36 chars exactly | ✅ (compile-time invariant) | No (caught at `cargo check`) |
+| 4 | The 5-role enum + 5 sprites fit inside the file-size cap (≤220 LOC each) and trip no clippy warnings | ✅ (`cargo clippy --features spike` clean) | Yes |
+| 5 | `derive_role` produces ≥3 distinct `Role` values across the prototype's hard-coded prompt corpus | ✅ (sanity check) | No (exhaustive test arrives in the follow-up) |
+
+If a future re-evaluation flips any verdict-flipping signal to ❌, this ADR's `Status` field MUST be amended to `Superseded by ADR NNN` rather than edited in place.
+
+### Follow-up issue
+
+- **Title:** `feat(tui): agent personality sprites in agent-graph view`
+- **DOR seed (one paragraph):** Add a `Role` enum (5 variants: Orchestrator, Implementer, Reviewer, Docs, DevOps) with a `derive_role(prompt: &str) -> Role` keyword classifier mirroring `src/session/intent.rs`. Add a `#[serde(default)] pub role: Role` field to `Session` with a `--role` clap override on `maestro run`. Replace the agent-graph node rectangle with a 6×6 sprite when `icon_mode::use_nerd_font()` is true; fall back to the existing rectangle plus a 3-character role-colored abbreviation label otherwise. Tests: insta snapshots (5 roles × 2 modes), classifier accuracy (≥80% on 25-prompt corpus), serde round-trip + default backward compat, `transition_to` does not mutate role. Cite `docs/RUST-GUARDRAILS.md` §6 serialization, §7 testing, §11 observability. Reference `docs/adr/002-agent-personalities.md` for the sprite grids and color palette.
+
+The follow-up issue is opened after this ADR merges and references the same milestone.
+
+---
+
+## Out of Scope
+
+### Permanent (per issue #536, never reopens for argument)
+
+- **Animated sprites** (spawn frames, death frames, walking cycles). Static art only.
+- **Per-role personality voice in chat output.** Sprites are visual; the LLM's prose stays neutral.
+- **Sprite editor UI.** No in-app character grid editing.
+- **User-uploaded custom sprites.** Hard-coded set in the binary; no plugin system.
+- **Color themes for roles.** Inherits ADR-001's stance: status colors must stay legible; per-user re-themes are scope creep.
+
+### Out of scope for this spike (deferred to the follow-up)
+
+- Stored `Session::role` field with backward-compat back-fill migration. Default-on-deserialize is sufficient for the spike's analysis.
+- Additional roles (Frontend / API / Tester). The canonical list is 5; the follow-up may extend if a real session category demands it.
+- `--role` CLI flag implementation. The prototype hard-codes both sprites' roles; clap wiring is the follow-up's job.
+- Property-test corpus tuning past the 25-prompt seed. Mature corpus growth is incremental, not spike work.
+- Integration with `App::navigate_to` and the wider TUI dispatcher. The spike's code paths are gated by `feature = "spike"` and never run in production builds.
+- Dependency on `Session::intent` (Work-vs-Consultation) for derivation. Orthogonal axes — a Consultation session can still be a Reviewer; future heuristic might combine, not now.
+
+---
+
+## Prototype
+
+**Location:** `examples/agent_personalities_spike.rs` (entry point) plus `src/tui/agent_personalities/{mod,role,sprite,palette,render}.rs`, all gated behind `--features spike`.
+
+**Why `examples/` and not `src/bin/`:** `cargo build` does *not* build examples — they require `cargo build --examples`. Accidental shipping is impossible. By contrast, `src/bin/foo.rs` is auto-discovered as an additional binary.
+
+**Feature gate:** A `[features] spike = []` block in `Cargo.toml` and `#[cfg(feature = "spike")]` on the `agent_personalities` module declaration. Any reference to `feature = "spike"` outside the spike branch is a smoking gun for accidental main-line landing.
+
+**Run command:**
+
+```sh
+cargo run --example agent_personalities_spike --features spike
+# Resize terminal to 80×24 for the headline AC.
+# Press `q` to quit. No other input is handled.
+
+# ASCII fallback test:
+MAESTRO_ASCII_ICONS=1 cargo run --example agent_personalities_spike --features spike
+# Expect: two colored rectangles with 3-letter labels (ORC, IMP), distinct colors.
+```
+
+**Cleanup after this ADR merges** (single commit, delete-only on production code):
+
+```sh
+git rm examples/agent_personalities_spike.rs
+git rm -r src/tui/agent_personalities/
+# Edit Cargo.toml to remove the `[features] spike = []` block.
+# Edit src/tui/mod.rs to remove the cfg-gated `mod agent_personalities;` line.
+# Delete the throwaway branch:
+git branch -D spike/agent-personalities
+git push origin --delete spike/agent-personalities
+```
+
+The cleanup is a single commit touching `Cargo.toml` (delete-only) and `src/tui/mod.rs` (delete-only) plus the directory deletes. No production logic moves in either direction. ADR-001's identical pattern landed cleanly in #526; this spike inherits that proof.
+
+**Fake data:** 2 sessions hand-built in the example's `main`:
+
+- One `Session { mode: "orchestrator", prompt: "coordinate the merge of #527 and #528" }` → expected `Role::Orchestrator`.
+- One `Session { mode: "orchestrator", prompt: "implement #529 — loading animations" }` → expected `Role::Implementer`.
+
+Two sessions, not five, because two is the minimum to demonstrate "sprites are visually distinguishable from each other" — the headline AC. Five would force the layout engine to handle wrapping in 80×24, which is the follow-up's problem.
+
+---
+
+## References
+
+- Issue [#536](https://github.com/CarlosDanielDev/maestro/issues/536)
+- Reference visual: octogent — <https://github.com/hesamsheikh/octogent>
+- Predecessor ADR: `docs/adr/001-agent-graph-viz.md` (structural template, identical spike-cleanup pattern)
+- Maestro classifier idiom: `src/session/intent.rs:8-216` (`SessionIntent`, `classify_intent`)
+- Maestro icon-mode plumbing: `src/icon_mode.rs:28` (`use_nerd_font`)
+- Maestro current node rendering: `src/tui/agent_graph/render.rs:99-200`
+- Maestro session model: `src/session/types.rs:202-289` (`Session` struct)
+- Maestro guardrails: `docs/RUST-GUARDRAILS.md` §2 errors, §6 serialization, §7 testing, §11 observability

--- a/examples/agent_personalities_spike.rs
+++ b/examples/agent_personalities_spike.rs
@@ -1,0 +1,93 @@
+//! Throwaway spike binary for ADR 002 (agent personalities).
+//!
+//! Renders two named sprites side-by-side in 80×24, demonstrating both the
+//! nerd-font path and the keyword classifier from `derive_role`. Quits on `q`.
+//!
+//! Run:
+//!     cargo run --example agent_personalities_spike --features spike
+//!
+//! ASCII fallback test:
+//!     MAESTRO_ASCII_ICONS=1 cargo run --example agent_personalities_spike --features spike
+//!
+//! Removed (along with the rest of the spike module) when ADR-002's cleanup
+//! commit lands. See `docs/adr/002-agent-personalities.md` § Prototype.
+
+use std::io;
+use std::time::Duration;
+
+use crossterm::{
+    event::{self, Event, KeyCode},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Direction, Layout};
+
+use maestro::agent_personalities::{
+    render::draw_named_sprite,
+    role::{Role, derive_role},
+};
+use maestro::icon_mode::use_nerd_font;
+
+fn main() -> io::Result<()> {
+    // Two hand-built prompts whose keywords drive `derive_role` to two distinct
+    // roles. Documented in the ADR's Prototype section so the smoke test is
+    // reproducible.
+    let prompt_left = "coordinate the merge of #527 and #528";
+    let prompt_right = "implement #529 — loading animations";
+
+    let role_left = derive_role(prompt_left);
+    let role_right = derive_role(prompt_right);
+
+    // Sanity gate (ADR Go-signal #5): the two prompts must classify to distinct
+    // roles. If not, the prototype's own keyword corpus regressed and the
+    // visual smoke test would be useless.
+    assert_ne!(
+        role_left, role_right,
+        "spike corpus regression: {:?} == {:?}",
+        role_left, role_right
+    );
+
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let nerd_font = use_nerd_font();
+
+    let result = run_loop(&mut terminal, role_left, role_right, nerd_font);
+
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+
+    result
+}
+
+fn run_loop(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    role_left: Role,
+    role_right: Role,
+    nerd_font: bool,
+) -> io::Result<()> {
+    loop {
+        terminal.draw(|f| {
+            let cols = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+                .split(f.area());
+
+            draw_named_sprite(f, cols[0], role_left, "agent A", nerd_font);
+            draw_named_sprite(f, cols[1], role_right, "agent B", nerd_font);
+        })?;
+
+        if event::poll(Duration::from_millis(100))?
+            && let Event::Key(key) = event::read()?
+            && matches!(key.code, KeyCode::Char('q') | KeyCode::Esc)
+        {
+            return Ok(());
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,3 +35,17 @@ pub mod settings {
         CavemanModeState, CavemanWriteError, FsSettingsStore, SettingsStore,
     };
 }
+
+// Spike prototype for ADR 002 (agent personalities). Gated behind --features
+// spike so cargo build never includes it. Files live under
+// src/tui/agent_personalities/ but are exposed at the lib facade root so the
+// throwaway examples/agent_personalities_spike.rs binary can reach them.
+// Removed when the ADR-002 cleanup commit lands.
+#[cfg(feature = "spike")]
+#[path = "tui/agent_personalities"]
+pub mod agent_personalities {
+    pub mod palette;
+    pub mod render;
+    pub mod role;
+    pub mod sprite;
+}

--- a/src/tui/agent_personalities/palette.rs
+++ b/src/tui/agent_personalities/palette.rs
@@ -1,0 +1,92 @@
+//! Per-role color and ASCII abbreviation — spike prototype.
+//!
+//! See `docs/adr/002-agent-personalities.md` § Role Taxonomy and § ASCII
+//! Fallback. Keep this file as a single-source-of-truth so a color drift is
+//! a one-line edit.
+
+use ratatui::style::Color;
+
+use super::role::Role;
+
+/// Foreground color for the role's sprite.
+pub fn role_color(role: Role) -> Color {
+    match role {
+        Role::Implementer => Color::Green,
+        Role::Orchestrator => Color::Yellow,
+        Role::Reviewer => Color::Magenta,
+        // xterm 256-color orange. ANSI 16-color set has no orange; this index
+        // is widely supported in modern terminals and degrades to yellow on
+        // 16-color terminals (acceptable since `Docs` and `Orchestrator` only
+        // collide on truly ancient terminals where the user's also forced into
+        // ASCII fallback anyway).
+        Role::Docs => Color::Indexed(208),
+        Role::DevOps => Color::Red,
+    }
+}
+
+/// Three-character ASCII abbreviation, used in the `use_nerd_font() == false`
+/// fallback. See ADR § ASCII Fallback for the verdict.
+pub fn role_abbrev(role: Role) -> &'static str {
+    match role {
+        Role::Implementer => "IMP",
+        Role::Orchestrator => "ORC",
+        Role::Reviewer => "REV",
+        Role::Docs => "DOC",
+        Role::DevOps => "OPS",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_role_has_a_three_char_abbrev() {
+        for role in [
+            Role::Implementer,
+            Role::Orchestrator,
+            Role::Reviewer,
+            Role::Docs,
+            Role::DevOps,
+        ] {
+            let abbrev = role_abbrev(role);
+            assert_eq!(abbrev.len(), 3, "abbrev for {:?} is not 3 chars", role);
+            assert!(
+                abbrev.chars().all(|c| c.is_ascii_uppercase()),
+                "abbrev for {:?} is not all-uppercase ASCII",
+                role
+            );
+        }
+    }
+
+    #[test]
+    fn abbreviations_are_unique_across_roles() {
+        let abbrevs = [
+            role_abbrev(Role::Orchestrator),
+            role_abbrev(Role::Implementer),
+            role_abbrev(Role::Reviewer),
+            role_abbrev(Role::Docs),
+            role_abbrev(Role::DevOps),
+        ];
+        let mut seen = std::collections::HashSet::new();
+        for a in abbrevs {
+            assert!(seen.insert(a), "duplicate abbreviation: {}", a);
+        }
+    }
+
+    #[test]
+    fn colors_are_distinct_across_roles() {
+        let colors = [
+            role_color(Role::Orchestrator),
+            role_color(Role::Implementer),
+            role_color(Role::Reviewer),
+            role_color(Role::Docs),
+            role_color(Role::DevOps),
+        ];
+        let mut seen = std::collections::HashSet::new();
+        for c in colors {
+            // ratatui Color implements Hash; HashSet round-trip catches duplicates.
+            assert!(seen.insert(format!("{:?}", c)), "duplicate color: {:?}", c);
+        }
+    }
+}

--- a/src/tui/agent_personalities/render.rs
+++ b/src/tui/agent_personalities/render.rs
@@ -1,0 +1,124 @@
+//! Spike renderer: paints a 6×6 sprite (or its ASCII fallback) inside a Rect.
+//!
+//! See `docs/adr/002-agent-personalities.md` § Sprite Design Language and
+//! § ASCII Fallback. The renderer is deliberately simple — one `Paragraph`
+//! with six styled `Line`s for the nerd-font path, and a colored `Block` plus
+//! a 3-char abbrev for the ASCII path.
+
+use ratatui::Frame;
+use ratatui::layout::{Alignment, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+use super::palette::{role_abbrev, role_color};
+use super::role::Role;
+use super::sprite::glyph_for_role;
+
+/// Render a named sprite for `role` inside `area`.
+///
+/// `label` is shown above the sprite and should fit in a single row (e.g.
+/// `"#536"` or a session id). `use_nerd_font` selects the rendering path:
+/// `true` → 6×6 sprite grid; `false` → 3-char colored abbreviation in a small
+/// block.
+pub fn draw_named_sprite(f: &mut Frame, area: Rect, role: Role, label: &str, use_nerd_font: bool) {
+    let title = format!(" {} — {} ", label, role_abbrev(role));
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(title)
+        .title_alignment(Alignment::Center);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    if use_nerd_font {
+        draw_sprite_grid(f, inner, role);
+    } else {
+        draw_ascii_fallback(f, inner, role);
+    }
+}
+
+fn draw_sprite_grid(f: &mut Frame, area: Rect, role: Role) {
+    let sprite = glyph_for_role(role);
+    let style = Style::default()
+        .fg(role_color(role))
+        .add_modifier(Modifier::BOLD);
+    let lines: Vec<Line<'_>> = sprite
+        .rows()
+        .iter()
+        .map(|row| {
+            let s: String = row.iter().collect();
+            Line::from(Span::styled(s, style))
+        })
+        .collect();
+    let p = Paragraph::new(lines).alignment(Alignment::Center);
+    f.render_widget(p, area);
+}
+
+fn draw_ascii_fallback(f: &mut Frame, area: Rect, role: Role) {
+    let style = Style::default()
+        .fg(role_color(role))
+        .add_modifier(Modifier::BOLD);
+    let line = Line::from(vec![
+        Span::raw("["),
+        Span::styled(role_abbrev(role), style),
+        Span::raw("]"),
+    ]);
+    let p = Paragraph::new(line).alignment(Alignment::Center);
+    f.render_widget(p, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    fn render_smoke(role: Role, label: &str, nerd: bool) {
+        let backend = TestBackend::new(40, 12);
+        let mut terminal = Terminal::new(backend).expect("test backend");
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                draw_named_sprite(f, area, role, label, nerd);
+            })
+            .expect("draw");
+    }
+
+    /// Snapshot fidelity is the follow-up's concern; here we just exercise
+    /// both branches to catch panics.
+    #[test]
+    fn nerd_font_rendering_does_not_panic() {
+        render_smoke(Role::Orchestrator, "S-orchestr", true);
+    }
+
+    #[test]
+    fn ascii_fallback_rendering_does_not_panic() {
+        render_smoke(Role::Implementer, "S-impl", false);
+    }
+
+    /// Buffer-content sanity: in ASCII mode the abbreviation `IMP` must be
+    /// present somewhere in the rendered cells.
+    #[test]
+    fn ascii_fallback_contains_role_abbreviation() {
+        let backend = TestBackend::new(20, 5);
+        let mut terminal = Terminal::new(backend).expect("test backend");
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                draw_named_sprite(f, area, Role::Implementer, "S-impl", false);
+            })
+            .expect("draw");
+        let buffer = terminal.backend().buffer();
+        let dump: String = buffer
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect::<Vec<_>>()
+            .join("");
+        assert!(
+            dump.contains("IMP"),
+            "ASCII buffer must contain the role abbreviation 'IMP'; got: {:?}",
+            dump
+        );
+    }
+}

--- a/src/tui/agent_personalities/role.rs
+++ b/src/tui/agent_personalities/role.rs
@@ -1,0 +1,204 @@
+//! Role taxonomy for agent personalities — spike prototype.
+//!
+//! See `docs/adr/002-agent-personalities.md` § Role Taxonomy. The canonical
+//! list is five: `Implementer` (default), `Orchestrator`, `Reviewer`, `Docs`,
+//! `DevOps`. The `derive_role` classifier mirrors `crate::session::intent`'s
+//! keyword-matching idiom so the follow-up can lift it to `src/session/role.rs`
+//! unchanged.
+
+use serde::{Deserialize, Serialize};
+
+/// Five-role taxonomy for the agent-personalities spike.
+///
+/// `Implementer` is the default because it is the largest category in maestro's
+/// session log; "unknown prompt → Implementer" is the safest miscategorization
+/// (most sessions do work, so misfires are visually invisible).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum Role {
+    /// Writes code: edits files, adds features, runs `cargo test`.
+    #[default]
+    Implementer,
+    /// Coordinates other sessions; spawns work; merges PRs.
+    Orchestrator,
+    /// Reads code, runs gates, posts PR reviews.
+    Reviewer,
+    /// Writes `.md` files, updates ADRs, regenerates `directory-tree.md`.
+    Docs,
+    /// CI fixes, conflict resolution, dependency bumps, infrastructure.
+    DevOps,
+}
+
+/// All keyword lists are matched as case-insensitive substrings against the
+/// full prompt; precedence is enforced in `derive_role`'s control flow rather
+/// than in any per-list ordering.
+const ORCHESTRATOR_KEYWORDS: &[&str] = &[
+    "coordinate",
+    "orchestrate",
+    "merge ",
+    "merge pr",
+    "spawn ",
+    "dispatch ",
+    "delegate ",
+    "milestone",
+    "queue",
+];
+
+const REVIEWER_KEYWORDS: &[&str] = &[
+    "review ",
+    "audit ",
+    "inspect",
+    "code review",
+    "security review",
+    "pr review",
+    "post review",
+    "approve ",
+    "request changes",
+];
+
+const DOCS_KEYWORDS: &[&str] = &[
+    "doc ",
+    "docs ",
+    "documentation",
+    "readme",
+    "adr ",
+    "directory-tree",
+    "changelog",
+    "rustdoc",
+    ".md",
+    "guide",
+    "tutorial",
+];
+
+const DEVOPS_KEYWORDS: &[&str] = &[
+    "ci ",
+    "ci/",
+    "github actions",
+    "workflow",
+    "actionlint",
+    "shellcheck",
+    "conflict",
+    "rebase",
+    "dependabot",
+    "bump ",
+    "release ",
+    "deploy",
+    "infra",
+];
+
+/// Classify a prompt into a `Role` using case-insensitive substring matching.
+///
+/// Resolution order: Orchestrator > Reviewer > DevOps > Docs > Implementer (default).
+/// The order is chosen so that explicit coordination verbs ("coordinate", "merge")
+/// win over ambient nouns ("docs"), and infrastructure keywords ("ci ", "workflow")
+/// win over the documentation noun "readme" when both appear.
+pub fn derive_role(prompt: &str) -> Role {
+    let normalized = prompt.to_ascii_lowercase();
+    if ORCHESTRATOR_KEYWORDS.iter().any(|k| normalized.contains(k)) {
+        return Role::Orchestrator;
+    }
+    if REVIEWER_KEYWORDS.iter().any(|k| normalized.contains(k)) {
+        return Role::Reviewer;
+    }
+    if DEVOPS_KEYWORDS.iter().any(|k| normalized.contains(k)) {
+        return Role::DevOps;
+    }
+    if DOCS_KEYWORDS.iter().any(|k| normalized.contains(k)) {
+        return Role::Docs;
+    }
+    Role::Implementer
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_implementer() {
+        assert_eq!(Role::default(), Role::Implementer);
+    }
+
+    #[test]
+    fn empty_prompt_returns_implementer() {
+        assert_eq!(derive_role(""), Role::Implementer);
+    }
+
+    #[test]
+    fn coordinate_prompt_is_orchestrator() {
+        assert_eq!(
+            derive_role("coordinate the merge of #527 and #528"),
+            Role::Orchestrator
+        );
+    }
+
+    #[test]
+    fn implement_prompt_is_implementer() {
+        assert_eq!(
+            derive_role("implement #529 — loading animations"),
+            Role::Implementer
+        );
+    }
+
+    #[test]
+    fn review_prompt_is_reviewer() {
+        assert_eq!(
+            derive_role("review the diff on PR #530 and post review"),
+            Role::Reviewer
+        );
+    }
+
+    #[test]
+    fn adr_prompt_is_docs() {
+        assert_eq!(derive_role("update the README and add a guide"), Role::Docs);
+    }
+
+    #[test]
+    fn ci_prompt_is_devops() {
+        assert_eq!(
+            derive_role("fix the CI workflow that broke after the rebase"),
+            Role::DevOps
+        );
+    }
+
+    #[test]
+    fn case_insensitive_classification() {
+        assert_eq!(
+            derive_role("COORDINATE the merge"),
+            Role::Orchestrator,
+            "case should not affect classification"
+        );
+    }
+
+    /// Sanity gate for the spike's Go signal #5: the seed corpus produces ≥3
+    /// distinct `Role` values. The follow-up's full property test ratchets this
+    /// to ≥80% accuracy on a 25-prompt corpus.
+    #[test]
+    fn seed_corpus_produces_at_least_three_distinct_roles() {
+        let corpus = [
+            "coordinate the merge of #527 and #528", // Orchestrator
+            "implement #529 — loading animations",   // Implementer
+            "review the diff on PR #530",            // Reviewer
+            "update the README and add a guide",     // Docs
+            "fix the CI workflow",                   // DevOps
+        ];
+        let mut seen = std::collections::HashSet::new();
+        for prompt in corpus {
+            seen.insert(derive_role(prompt));
+        }
+        assert!(
+            seen.len() >= 3,
+            "expected ≥3 distinct roles from seed corpus, got {}: {:?}",
+            seen.len(),
+            seen
+        );
+    }
+
+    #[test]
+    fn round_trips_via_serde_json() {
+        let original = Role::Reviewer;
+        let json = serde_json::to_string(&original).expect("serialize");
+        assert_eq!(json, "\"reviewer\"", "must serialize as snake_case");
+        let back: Role = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, original);
+    }
+}

--- a/src/tui/agent_personalities/sprite.rs
+++ b/src/tui/agent_personalities/sprite.rs
@@ -1,0 +1,103 @@
+//! 6×6 character grids for each role — spike prototype.
+//!
+//! See `docs/adr/002-agent-personalities.md` § Sprite Design Language for the
+//! full design language. The compile-time `[[char; 6]; 6]` shape enforces that
+//! every sprite is exactly 36 cells; no runtime check is needed.
+
+use super::role::Role;
+
+/// A fixed-size 6×6 character grid.
+///
+/// The newtype is deliberate: variable-size sprites would force the renderer to
+/// know each role's bounding box. Keeping the type compile-time-uniform lets the
+/// renderer treat every role identically.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Sprite([[char; 6]; 6]);
+
+impl Sprite {
+    pub fn rows(&self) -> &[[char; 6]; 6] {
+        &self.0
+    }
+}
+
+const ORCHESTRATOR: Sprite = Sprite([
+    [' ', '◆', '█', '█', '◆', ' '],
+    ['█', '█', '█', '█', '█', '█'],
+    ['█', '●', '█', '█', '●', '█'],
+    ['█', '█', '█', '█', '█', '█'],
+    ['█', '█', '█', '█', '█', '█'],
+    ['█', ' ', '█', '█', ' ', '█'],
+]);
+
+const IMPLEMENTER: Sprite = Sprite([
+    [' ', ' ', '█', '█', ' ', ' '],
+    [' ', '█', '█', '█', '█', ' '],
+    ['█', '●', '█', '█', '●', '█'],
+    ['█', '█', '█', '█', '█', '█'],
+    ['█', '█', '█', '█', '█', '█'],
+    ['█', ' ', '█', '█', ' ', '█'],
+]);
+
+const REVIEWER: Sprite = Sprite([
+    [' ', ' ', '█', '█', ' ', ' '],
+    [' ', '█', '█', '█', '█', ' '],
+    ['█', '▓', '█', '█', '●', '█'],
+    ['█', '█', '█', '█', '◆', '█'],
+    ['█', '█', '█', '█', '█', '█'],
+    ['█', ' ', '█', '█', ' ', '█'],
+]);
+
+const DOCS: Sprite = Sprite([
+    [' ', ' ', '█', '█', ' ', ' '],
+    [' ', '█', '█', '█', '█', ' '],
+    ['█', '○', '█', '█', '○', '█'],
+    ['█', '█', '█', '█', '█', '█'],
+    ['█', '▓', '▓', '▓', '▓', '█'],
+    ['█', ' ', '█', '█', ' ', '█'],
+]);
+
+const DEVOPS: Sprite = Sprite([
+    [' ', ' ', '█', '█', ' ', ' '],
+    [' ', '█', '█', '█', '█', ' '],
+    ['█', '●', '█', '█', '●', '█'],
+    ['█', '█', '█', '█', '█', '█'],
+    ['█', '█', '█', '█', '█', '█'],
+    ['▼', '█', '▼', '▼', '█', '▼'],
+]);
+
+/// Lookup the sprite for a given role. Total: 5 sprites × 36 cells = 180 cells
+/// of static data.
+pub fn glyph_for_role(role: Role) -> Sprite {
+    match role {
+        Role::Implementer => IMPLEMENTER,
+        Role::Orchestrator => ORCHESTRATOR,
+        Role::Reviewer => REVIEWER,
+        Role::Docs => DOCS,
+        Role::DevOps => DEVOPS,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn orchestrator_and_implementer_differ() {
+        let a = glyph_for_role(Role::Orchestrator);
+        let b = glyph_for_role(Role::Implementer);
+        assert_ne!(
+            a, b,
+            "the two prototype sprites must be visually distinguishable"
+        );
+    }
+
+    #[test]
+    fn devops_has_fanged_fringe() {
+        let s = glyph_for_role(Role::DevOps);
+        let row5 = s.rows()[5];
+        assert!(
+            row5.contains(&'▼'),
+            "DevOps row 5 must include the fang glyph"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `docs/adr/002-agent-personalities.md` recording the spike's findings: 5-role taxonomy (Implementer / Orchestrator / Reviewer / Docs / DevOps), 6×6 foreground sprite, hybrid derivation strategy, 3-character ASCII fallback. Verdict: **Go**.
- Lands the throwaway prototype that backs the Go-signal smoke test, gated entirely behind `[features] spike` (`cargo build` never includes it). Mirrors ADR 001's pattern.
- The prototype files (`src/tui/agent_personalities/`, `examples/agent_personalities_spike.rs`, the Cargo.toml feature block, the lib.rs re-export) are removed in the cleanup commit when this PR merges. The ADR is the only permanent artifact.

Closes #536

## Test plan

- [x] `cargo test --features spike` — all 18 spike-module tests pass; full suite green.
- [x] `cargo clippy --features spike -- -D warnings -A dead_code` clean (matches the preflight scope).
- [x] `cargo build` (no spike feature) — production binary is unaffected.
- [x] `cargo fmt --check` clean.
- [x] Manual smoke (run locally before merging): `cargo run --example agent_personalities_spike --features spike` shows two distinguishable 6×6 sprites side-by-side; `MAESTRO_ASCII_ICONS=1` re-run shows two distinguishable colored 3-char abbreviations.

## Follow-ups

- Open the cleanup PR (delete `[features] spike`, remove `src/tui/agent_personalities/` and `examples/agent_personalities_spike.rs`, drop the `lib.rs` re-export).
- Open the production feature issue from the ADR's DOR seed: `feat(tui): agent personality sprites in agent-graph view`.