### PR TITLE
feat(tui): Shift+P keybinding to manually trigger PR creation (#521)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- feat(tui): `Shift+P` keybinding to manually trigger PR creation when auto-PR was skipped (#521)
+  - Recovery path for sessions whose auto-PR didn't fire — GitHub auth was missing then restored, retries exhausted, AC4 detection saw a stale PR, or `pending_completions` were rehydrated after a crash.
+  - Wired into `handle_global_shortcuts` in `src/tui/input_handler.rs`; eligibility is `app.pending_prs` membership for the selected session's `issue_number` (the codebase's encoding of "session needs PR"). Gated by `is_text_input_mode` to avoid colliding with prompt input.
+  - Calls `App::trigger_manual_pr_retry`, which mutates the matching `PendingPr` (status → `RetryScheduled`, `attempt` → 0, `next_retry_at` → now) so the next `process_pending_pr_retries` tick picks it up. The AC4 preflight from #514 still runs inside that cycle, so manual triggers cannot create a duplicate PR.
+  - Help overlay updated in `src/tui/navigation/keymap.rs` (Session Control group).
+  - 6 new tests: 3 in `src/tui/app/pr_retry.rs` cover the state mutation + log entry + isolation between unrelated `PendingPr`s; 3 in `src/tui/input_handler.rs` cover the keypress path (eligible → fires; no pending → noop; text-input mode → noop).
+
 ### Fixed
 
 - fix(tui): auto-PR pipeline reliability and observability (#514)

--- a/src/tui/app/pr_retry.rs
+++ b/src/tui/app/pr_retry.rs
@@ -120,7 +120,6 @@ impl App {
     }
 
     /// Trigger a manual PR retry for a specific issue. Called from TUI key handler.
-    #[allow(dead_code)] // Reason: manual PR retry from TUI — to be wired into key handler
     pub fn trigger_manual_pr_retry(&mut self, issue_number: u64) {
         if let Some(pending) = self
             .pending_prs
@@ -136,5 +135,90 @@ impl App {
                 LogLevel::Info,
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::provider::github::types::{PendingPr, PendingPrStatus};
+    use crate::tui::activity_log::LogLevel;
+
+    fn make_pending_pr(issue_number: u64) -> PendingPr {
+        PendingPr {
+            issue_number,
+            issue_numbers: vec![],
+            branch: format!("maestro/issue-{}", issue_number),
+            base_branch: "main".into(),
+            files_touched: vec![],
+            cost_usd: 0.0,
+            attempt: 3,
+            max_attempts: 3,
+            last_error: String::new(),
+            last_attempt_at: chrono::Utc::now(),
+            next_retry_at: None,
+            status: PendingPrStatus::AwaitingManualRetry,
+        }
+    }
+
+    #[test]
+    fn trigger_manual_pr_retry_matching_issue_resets_attempt_and_logs() {
+        let mut app = crate::tui::make_test_app("pr-retry-match");
+        app.pending_prs.push(make_pending_pr(42));
+
+        app.trigger_manual_pr_retry(42);
+
+        let p = &app.pending_prs[0];
+        assert_eq!(p.status, PendingPrStatus::RetryScheduled);
+        assert!(p.next_retry_at.is_some(), "next_retry_at must be set");
+        assert_eq!(p.attempt, 0, "attempt counter must reset to 0");
+
+        let last = app
+            .activity_log
+            .entries()
+            .last()
+            .expect("log must not be empty");
+        assert_eq!(last.session_label, "#42");
+        assert_eq!(last.level, LogLevel::Info);
+        assert!(
+            last.message.contains("Manual PR retry queued"),
+            "got: {}",
+            last.message
+        );
+    }
+
+    #[test]
+    fn trigger_manual_pr_retry_no_match_is_noop() {
+        let mut app = crate::tui::make_test_app("pr-retry-noop");
+        app.pending_prs.push(make_pending_pr(99));
+        let log_len_before = app.activity_log.entries().len();
+
+        app.trigger_manual_pr_retry(42);
+
+        assert_eq!(
+            app.pending_prs[0].status,
+            PendingPrStatus::AwaitingManualRetry,
+            "unrelated entry must be untouched"
+        );
+        assert_eq!(
+            app.activity_log.entries().len(),
+            log_len_before,
+            "no log entry for a no-op call"
+        );
+    }
+
+    #[test]
+    fn trigger_manual_pr_retry_only_matching_issue_mutated() {
+        let mut app = crate::tui::make_test_app("pr-retry-isolation");
+        app.pending_prs.push(make_pending_pr(10));
+        app.pending_prs.push(make_pending_pr(20));
+
+        app.trigger_manual_pr_retry(10);
+
+        assert_eq!(app.pending_prs[0].status, PendingPrStatus::RetryScheduled);
+        assert_eq!(
+            app.pending_prs[1].status,
+            PendingPrStatus::AwaitingManualRetry,
+            "issue 20 must be untouched"
+        );
     }
 }

--- a/src/tui/input_handler.rs
+++ b/src/tui/input_handler.rs
@@ -517,6 +517,19 @@ fn handle_global_shortcuts(app: &mut App, key: &KeyEvent) -> bool {
         return true;
     }
 
+    // Shift+P manually triggers PR creation for the selected session
+    // when a PendingPr entry awaits retry (#521).
+    if key.code == KeyCode::Char('P') && !is_text_input_mode(app) {
+        if let Some(issue_number) = app
+            .pool
+            .session_at_index(app.panel_view.selected_index())
+            .and_then(|s| s.issue_number)
+        {
+            app.trigger_manual_pr_retry(issue_number);
+        }
+        return true;
+    }
+
     // Ctrl+B toggles bypass mode from any screen (#328 AC: TUI toggle).
     if key.code == KeyCode::Char('b') && key.modifiers.contains(KeyModifiers::CONTROL) {
         let pushed = app.request_bypass_toggle();
@@ -1471,5 +1484,86 @@ mod tests {
         assert_eq!(app.pool.total_count(), count_before);
         let sessions = app.pool.all_sessions();
         assert_eq!(sessions[0].status, SessionStatus::Running);
+    }
+
+    // ── Issue #521: Shift+P manual PR retry keybinding ──────────────────
+
+    fn make_awaiting_pending_pr(issue_number: u64) -> crate::provider::github::types::PendingPr {
+        use crate::provider::github::types::{PendingPr, PendingPrStatus};
+        PendingPr {
+            issue_number,
+            issue_numbers: vec![],
+            branch: format!("maestro/issue-{}", issue_number),
+            base_branch: "main".into(),
+            files_touched: vec![],
+            cost_usd: 0.0,
+            attempt: 3,
+            max_attempts: 3,
+            last_error: String::new(),
+            last_attempt_at: chrono::Utc::now(),
+            next_retry_at: None,
+            status: PendingPrStatus::AwaitingManualRetry,
+        }
+    }
+
+    #[tokio::test]
+    async fn shift_p_with_pending_pr_queues_retry() {
+        use crate::provider::github::types::PendingPrStatus;
+        let mut app = make_app();
+        app.tui_mode = TuiMode::Overview;
+        let s = Session::new(
+            "task".into(),
+            "claude-opus-4-5".into(),
+            "orchestrator".into(),
+            Some(42),
+        );
+        app.pool.enqueue(s);
+        app.panel_view.selected = Some(0);
+        app.pending_prs.push(make_awaiting_pending_pr(42));
+
+        let _ = handle_key(&mut app, key('P')).await;
+
+        assert_eq!(
+            app.pending_prs[0].status,
+            PendingPrStatus::RetryScheduled,
+            "Shift+P must queue the pending PR for retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn shift_p_without_pending_pr_is_noop() {
+        let mut app = make_app();
+        app.tui_mode = TuiMode::Overview;
+        let s = Session::new(
+            "task".into(),
+            "claude-opus-4-5".into(),
+            "orchestrator".into(),
+            Some(42),
+        );
+        app.pool.enqueue(s);
+        app.panel_view.selected = Some(0);
+
+        let log_len_before = app.activity_log.entries().len();
+
+        let _ = handle_key(&mut app, key('P')).await;
+
+        assert!(app.pending_prs.is_empty());
+        assert_eq!(app.activity_log.entries().len(), log_len_before);
+    }
+
+    #[tokio::test]
+    async fn shift_p_in_text_input_mode_is_noop() {
+        use crate::provider::github::types::PendingPrStatus;
+        let mut app = make_app();
+        app.tui_mode = TuiMode::PromptInput;
+        app.pending_prs.push(make_awaiting_pending_pr(42));
+
+        let _ = handle_key(&mut app, key('P')).await;
+
+        assert_eq!(
+            app.pending_prs[0].status,
+            PendingPrStatus::AwaitingManualRetry,
+            "text-input mode must block Shift+P"
+        );
     }
 }

--- a/src/tui/navigation/keymap.rs
+++ b/src/tui/navigation/keymap.rs
@@ -88,6 +88,10 @@ pub fn global_keybindings() -> &'static [KeyBindingGroup] {
                         description: "Kill selected session",
                     },
                     KeyBinding {
+                        key: "Shift+P",
+                        description: "Manually retry PR creation for selected session",
+                    },
+                    KeyBinding {
                         key: "d",
                         description: "Toggle activity log",
                     },


### PR DESCRIPTION
## Summary

- Adds `Shift+P` keybinding in `handle_global_shortcuts` that fires `App::trigger_manual_pr_retry` for the selected session when a `PendingPr` entry is awaiting retry.
- Recovery path for sessions whose auto-PR didn't fire — auth restored after the fact, retries exhausted, AC4 detection saw a stale PR, or `pending_completions` rehydrated after a crash.
- Reuses #514's AC4 preflight inside `process_pending_pr_retries` — manual triggers cannot create a duplicate PR.
- Help overlay (`src/tui/navigation/keymap.rs`, Session Control group) gets the new entry.

Closes #521

## Test plan

- [x] `cargo test` — 3686 passed, 0 failed (6 new tests)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings -A dead_code` clean
- [x] RED → GREEN TDD verified (`shift_p_with_pending_pr_queues_retry` panics before the arm is wired)
- [ ] Manual smoke: trigger a session whose auto-PR was skipped, focus it, press `Shift+P`, verify activity log shows "Manual PR retry queued" and a PR is created on the next retry tick
- [ ] Manual smoke: press `Shift+P` while typing in PromptInput → verifies no-op