### PR TITLE
feat(session): add Role enum, derive_role classifier, and Session::role field (#538)

### DIFF
--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-29 14:00 (UTC)
+> Last updated: 2026-04-30 00:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -243,7 +243,8 @@ maestro/
 │   │   ├── image.rs                       # Image attachment helpers: VALID_IMAGE_EXTENSIONS constant, path validation, base64 encoding for multimodal session prompts
 │   │   ├── logger.rs                      # SessionLogger: logs ContextUpdate events; logs Thinking events with "THINKING:" prefix; per-session timestamped file logging  [Phase 3, Issue #102]
 │   │   ├── context_monitor.rs             # ContextMonitor trait + ProductionContextMonitor: tracks per-session context usage, overflow and commit-prompt thresholds  [Issue #12]
-│   │   └── fork.rs                        # SessionForker trait + ForkPolicy: auto-fork on overflow, continuation prompt builder, max depth enforcement  [Issue #12]
+│   │   ├── fork.rs                        # SessionForker trait + ForkPolicy: auto-fork on overflow, continuation prompt builder, max depth enforcement  [Issue #12]
+│   │   └── role.rs                        # Role enum (5 variants: Orchestrator, Implementer, Reviewer, QA, Unknown) + derive_role() keyword classifier; Session::role field (O(1) lookup at render time)  [Issue #538]
 │   ├── state/
 │   │   ├── mod.rs                         # Module exports (includes file_claims, progress)
 │   │   ├── file_claims.rs                 # File claim system: FileClaimManager, conflict prevention  [Phase 1]
@@ -601,6 +602,7 @@ maestro/
 | `src/session/logger.rs` | Per-session file logging to .maestro/logs/ (Phase 3) |
 | `src/session/context_monitor.rs` | ContextMonitor trait + ProductionContextMonitor: per-session context tracking (Issue #12) |
 | `src/session/fork.rs` | SessionForker trait + ForkPolicy: auto-fork on overflow, continuation prompt builder (Issue #12) |
+| `src/session/role.rs` | Role enum (5 variants) + derive_role() keyword classifier; Session::role field for O(1) render-time lookup (Issue #538) |
 | `src/state/` | State persistence and file conflict management |
 | `src/state/file_claims.rs` | Per-session file claim registry |
 | `src/state/progress.rs` | Session phase tracking (Phase 3) |

--- a/scripts/allowlist-large-files.txt
+++ b/scripts/allowlist-large-files.txt
@@ -129,3 +129,17 @@ src/tui/app/pr_retry.rs # deadline: 2026-08-22, owner: @carlos, ticket: #TBD, pl
 # locking; keeping them co-located is the point. Plan to compact tests with
 # a #[macro_rules!] argv_eq! once the surface stops shifting.
 src/provider/github/gh_argv.rs # deadline: 2026-09-30, owner: @carlos, ticket: #TBD, plan: introduce an argv_eq! macro to compress the 18 snapshot tests once the gh subcommand surface stabilizes
+
+# --- Issue #538 Role enum + derive_role classifier (lifted from ADR 002 spike) ---
+# 5-variant Role enum + 21-test classifier corpus + serde/clap derives.
+# 425 LOC, 25 over the cap. The test corpus is the main bulk; per ADR-002
+# §Data Model the corpus is co-located with the classifier so changes are
+# atomic. A future extraction could split classifier vs tests, but the corpus
+# is what makes the classifier trustworthy and splitting risks drift.
+src/session/role.rs # deadline: 2026-08-22, owner: @carlos, ticket: #538, plan: extract test corpus into src/session/role/tests/ once the keyword set stabilizes; classifier itself stays in role.rs
+
+# state/types.rs is now 401 LOC after #538's Role round-trip test landed on
+# top of #544's PendingPr last_errors/manual_retry_count round-trip tests.
+# Both test additions are deliberate (they prevent silent state-schema
+# regressions). Trimming one would weaken the schema guard.
+src/state/types.rs # deadline: 2026-08-22, owner: @carlos, ticket: #538, plan: split per-resource sub-modules (state/sessions.rs, state/pending.rs) once the schema stops shifting

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,6 +31,20 @@ pub enum SanitizeSeverityFilter {
     Info,
 }
 
+/// CLI-local Role argument (converted to `session::role::Role` in main).
+///
+/// Kept in this file because `build.rs` includes `src/cli.rs` directly with
+/// `#[path]` and must not pull in the rest of the crate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[clap(rename_all = "snake_case")]
+pub enum RoleArg {
+    Implementer,
+    Orchestrator,
+    Reviewer,
+    Docs,
+    DevOps,
+}
+
 #[derive(Parser)]
 #[command(
     name = "maestro",
@@ -104,6 +118,11 @@ pub enum Commands {
         /// Disable a feature flag (repeatable, e.g. --disable-flag auto_fork)
         #[arg(long = "disable-flag", value_name = "FLAG")]
         disable_flags: Vec<String>,
+
+        /// Override role classification for the spawned session(s).
+        /// If omitted, the role is derived from the prompt text.
+        #[arg(long, value_enum)]
+        role: Option<RoleArg>,
 
         /// Skip the startup splash screen
         #[arg(long)]
@@ -1114,5 +1133,120 @@ mod tests {
         } else {
             panic!("Expected Commands::Adapt");
         }
+    }
+
+    // ------------------------------------------------------------------
+    // --role flag parsing (Issue #538)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn run_role_flag_defaults_to_none() {
+        let cli = Cli::try_parse_from(["maestro", "run", "--prompt", "hello"]).unwrap();
+        if let Some(Commands::Run { role, .. }) = cli.command {
+            assert!(role.is_none(), "--role must default to None");
+        } else {
+            panic!("Expected Commands::Run");
+        }
+    }
+
+    #[test]
+    fn run_role_flag_accepts_orchestrator() {
+        let cli = Cli::try_parse_from([
+            "maestro",
+            "run",
+            "--prompt",
+            "hello",
+            "--role",
+            "orchestrator",
+        ])
+        .unwrap();
+        if let Some(Commands::Run { role, .. }) = cli.command {
+            assert_eq!(role, Some(RoleArg::Orchestrator));
+        } else {
+            panic!("Expected Commands::Run");
+        }
+    }
+
+    #[test]
+    fn run_role_flag_accepts_implementer() {
+        let cli = Cli::try_parse_from([
+            "maestro",
+            "run",
+            "--prompt",
+            "hello",
+            "--role",
+            "implementer",
+        ])
+        .unwrap();
+        if let Some(Commands::Run { role, .. }) = cli.command {
+            assert_eq!(role, Some(RoleArg::Implementer));
+        } else {
+            panic!("Expected Commands::Run");
+        }
+    }
+
+    #[test]
+    fn run_role_flag_accepts_reviewer() {
+        let cli =
+            Cli::try_parse_from(["maestro", "run", "--prompt", "x", "--role", "reviewer"]).unwrap();
+        if let Some(Commands::Run { role, .. }) = cli.command {
+            assert_eq!(role, Some(RoleArg::Reviewer));
+        } else {
+            panic!("Expected Commands::Run");
+        }
+    }
+
+    #[test]
+    fn run_role_flag_accepts_docs() {
+        let cli =
+            Cli::try_parse_from(["maestro", "run", "--prompt", "x", "--role", "docs"]).unwrap();
+        if let Some(Commands::Run { role, .. }) = cli.command {
+            assert_eq!(role, Some(RoleArg::Docs));
+        } else {
+            panic!("Expected Commands::Run");
+        }
+    }
+
+    #[test]
+    fn run_role_flag_accepts_dev_ops_snake_case() {
+        let cli =
+            Cli::try_parse_from(["maestro", "run", "--prompt", "x", "--role", "dev_ops"]).unwrap();
+        if let Some(Commands::Run { role, .. }) = cli.command {
+            assert_eq!(
+                role,
+                Some(RoleArg::DevOps),
+                "--role dev_ops must parse as DevOps"
+            );
+        } else {
+            panic!("Expected Commands::Run");
+        }
+    }
+
+    #[test]
+    fn run_role_flag_rejects_invalid_value() {
+        let result =
+            Cli::try_parse_from(["maestro", "run", "--prompt", "hello", "--role", "bogus"]);
+        assert!(result.is_err(), "--role bogus must be rejected by clap");
+    }
+
+    #[test]
+    fn run_role_flag_rejects_devops_without_underscore() {
+        // clap rename_all = "snake_case" exposes "dev_ops" only, not "devops".
+        let result =
+            Cli::try_parse_from(["maestro", "run", "--prompt", "hello", "--role", "devops"]);
+        assert!(
+            result.is_err(),
+            "--role devops (without underscore) must be rejected; only dev_ops is valid"
+        );
+    }
+
+    #[test]
+    fn resume_subcommand_has_no_role_flag() {
+        // Resume inherits the saved session's role; --role on resume is intentionally not exposed.
+        let result = Cli::try_parse_from(["maestro", "resume", "--role", "orchestrator"]);
+        assert!(
+            result.is_err(),
+            "resume must NOT accept --role (saved role is inherited)"
+        );
     }
 }

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -53,6 +53,7 @@ pub async fn cmd_resume(session_filter: Option<String>) -> anyhow::Result<()> {
             s.model.clone(),
             s.mode.clone(),
             s.issue_number,
+            Some(s.role),
         );
         new_session.issue_title = s.issue_title.clone();
         new_session.retry_count = s.retry_count;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -23,6 +23,7 @@ pub async fn cmd_run(
     continuous: bool,
     enable_flags: Vec<String>,
     disable_flags: Vec<String>,
+    role_override: Option<crate::session::role::Role>,
     no_splash: bool,
     bypass_review: bool,
 ) -> anyhow::Result<()> {
@@ -103,8 +104,14 @@ pub async fn cmd_run(
     }
 
     if let Some(prompt_text) = prompt {
-        let session = Session::new(prompt_text, model, session_mode.clone(), None)
-            .with_image_paths(images.clone());
+        let session = Session::new(
+            prompt_text,
+            model,
+            session_mode.clone(),
+            None,
+            role_override,
+        )
+        .with_image_paths(images.clone());
         app.add_session(session).await?;
     } else if let Some(milestone_name) = milestone {
         let client = GhCliClient::new();
@@ -143,8 +150,9 @@ pub async fn cmd_run(
             let prompt = crate::prompts::PromptBuilder::build_issue_prompt_with_images(
                 &gh_issue, &config, &images,
             );
-            let mut session = Session::new(prompt, model.clone(), issue_mode, Some(num))
-                .with_image_paths(images.clone());
+            let mut session =
+                Session::new(prompt, model.clone(), issue_mode, Some(num), role_override)
+                    .with_image_paths(images.clone());
             session.issue_title = Some(gh_issue.title.clone());
 
             app.state.issue_cache.insert(num, gh_issue);

--- a/src/integration_tests/concurrent_sessions.rs
+++ b/src/integration_tests/concurrent_sessions.rs
@@ -83,6 +83,7 @@ fn fifo_ordering_preserved_under_promotion() {
                 "opus".to_string(),
                 "orchestrator".to_string(),
                 Some(100 + i as u64),
+                None,
             )
         })
         .collect();

--- a/src/integration_tests/mod.rs
+++ b/src/integration_tests/mod.rs
@@ -48,6 +48,7 @@ mod helpers {
             "opus".to_string(),
             "orchestrator".to_string(),
             None,
+            None,
         )
     }
 
@@ -65,6 +66,7 @@ mod helpers {
             "opus".to_string(),
             "orchestrator".to_string(),
             Some(issue),
+            None,
         )
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub mod util {
 pub mod session {
     pub mod intent;
     pub mod parser;
+    pub mod role;
     pub mod transition;
     pub mod types;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ mod turboquant;
 mod integration_tests;
 
 use clap::Parser;
-use cli::{Cli, Commands, PrdSourceArg};
+use cli::{Cli, Commands, PrdSourceArg, RoleArg};
 use commands::*;
 
 impl From<PrdSourceArg> for adapt::prd_source::PrdSource {
@@ -55,6 +55,18 @@ impl From<PrdSourceArg> for adapt::prd_source::PrdSource {
             PrdSourceArg::Github => Self::Github,
             PrdSourceArg::Azure => Self::Azure,
             PrdSourceArg::Both => Self::Both,
+        }
+    }
+}
+
+impl From<RoleArg> for session::role::Role {
+    fn from(arg: RoleArg) -> Self {
+        match arg {
+            RoleArg::Implementer => Self::Implementer,
+            RoleArg::Orchestrator => Self::Orchestrator,
+            RoleArg::Reviewer => Self::Reviewer,
+            RoleArg::Docs => Self::Docs,
+            RoleArg::DevOps => Self::DevOps,
         }
     }
 }
@@ -195,6 +207,7 @@ async fn main() -> anyhow::Result<()> {
             continuous,
             enable_flags,
             disable_flags,
+            role,
             no_splash,
         }) => {
             cmd_run(
@@ -211,6 +224,7 @@ async fn main() -> anyhow::Result<()> {
                 continuous,
                 enable_flags,
                 disable_flags,
+                role.map(Into::into),
                 no_splash,
                 cli.bypass_review,
             )
@@ -410,6 +424,7 @@ mod tests {
                 "opus".into(),
                 "orchestrator".into(),
                 None,
+                None,
             ));
         }
         app.pool.try_promote();
@@ -426,6 +441,7 @@ mod tests {
                 format!("prompt {i}"),
                 "opus".into(),
                 "orchestrator".into(),
+                None,
                 None,
             ));
         }

--- a/src/session/fork.rs
+++ b/src/session/fork.rs
@@ -108,6 +108,7 @@ impl SessionForker for ForkPolicy {
             parent.model.clone(),
             parent.mode.clone(),
             parent.issue_number,
+            Some(parent.role),
         );
         child.parent_session_id = Some(parent.id);
         child.fork_depth = parent.fork_depth + 1;
@@ -179,6 +180,7 @@ mod tests {
             "opus".into(),
             "orchestrator".into(),
             Some(42),
+            None,
         );
         s.status = status;
         s.fork_depth = fork_depth;
@@ -255,6 +257,43 @@ mod tests {
                 assert_eq!(child.parent_session_id, Some(parent.id));
             }
             ForkResult::Denied { reason } => panic!("Fork denied: {}", reason),
+        }
+    }
+
+    #[test]
+    fn fork_inherits_parent_role_not_re_derived() {
+        use crate::session::role::Role;
+
+        // Parent has an explicit Orchestrator override.
+        // Its prompt starts with "implement" — without override it would be Implementer.
+        let mut parent = Session::new(
+            "implement feature X".into(),
+            "opus".into(),
+            "orchestrator".into(),
+            Some(42),
+            Some(Role::Orchestrator),
+        );
+        parent.status = SessionStatus::Running;
+
+        let policy = ForkPolicy::new(5);
+        let result = policy.prepare_fork(
+            &parent,
+            None,
+            ForkReason::ContextOverflow { context_pct: 0.85 },
+        );
+
+        match result {
+            ForkResult::Forked { child, .. } => {
+                // The child prompt includes "--- FORK CONTEXT ---" with text like "review the
+                // files already modified" that would re-classify as Reviewer if we re-derived.
+                // Inheriting parent.role keeps the child's role frozen at Orchestrator.
+                assert_eq!(
+                    child.role,
+                    Role::Orchestrator,
+                    "fork child must inherit parent role, not re-derive"
+                );
+            }
+            ForkResult::Denied { reason } => panic!("Fork denied unexpectedly: {}", reason),
         }
     }
 

--- a/src/session/manager.rs
+++ b/src/session/manager.rs
@@ -437,6 +437,7 @@ mod tests {
             tq_handoff_compressed_tokens: None,
             transition_history: vec![],
             intent: crate::session::intent::SessionIntent::default(),
+            role: crate::session::role::Role::default(),
             consultation_skip_logged: false,
             adapt_follow_up_considered: false,
         };

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -10,6 +10,7 @@ pub mod parser;
 pub mod pool;
 pub mod pr_capture;
 pub mod retry;
+pub mod role;
 pub mod transition;
 pub mod types;
 pub mod worktree;

--- a/src/session/pool.rs
+++ b/src/session/pool.rs
@@ -409,6 +409,7 @@ mod tests {
             "opus".to_string(),
             "orchestrator".to_string(),
             None,
+            None,
         )
     }
 
@@ -418,6 +419,7 @@ mod tests {
             "opus".to_string(),
             "orchestrator".to_string(),
             Some(issue),
+            None,
         )
     }
 

--- a/src/session/retry.rs
+++ b/src/session/retry.rs
@@ -150,6 +150,7 @@ impl RetryPolicy {
             original.model.clone(),
             original.mode.clone(),
             original.issue_number,
+            Some(original.role),
         );
         new_session.retry_count = original.retry_count + 1;
         new_session.last_retry_at = Some(Utc::now());
@@ -187,7 +188,13 @@ mod tests {
     }
 
     fn hollow_session_with_intent(intent: SessionIntent) -> Session {
-        let mut s = Session::new("prompt".into(), "opus".into(), "orchestrator".into(), None);
+        let mut s = Session::new(
+            "prompt".into(),
+            "opus".into(),
+            "orchestrator".into(),
+            None,
+            None,
+        );
         s.status = SessionStatus::Completed;
         s.is_hollow_completion = true;
         s.intent = intent;
@@ -200,6 +207,7 @@ mod tests {
             "opus".into(),
             "orchestrator".into(),
             Some(1),
+            None,
         );
         s.status = status;
         s.retry_count = retry_count;
@@ -211,6 +219,32 @@ mod tests {
         let policy = RetryPolicy::new(2, 0, legacy_hollow(1));
         let session = make_session(SessionStatus::Stalled, 0);
         assert!(policy.should_retry(&session));
+    }
+
+    #[test]
+    fn retry_inherits_original_role_not_re_derived() {
+        use crate::session::role::Role;
+
+        // Original prompt would derive Implementer, but explicit override makes it Orchestrator.
+        let mut original = Session::new(
+            "fix the tests".into(),
+            "opus".into(),
+            "orchestrator".into(),
+            Some(1),
+            Some(Role::Orchestrator),
+        );
+        original.status = SessionStatus::Errored;
+
+        let policy = RetryPolicy::new(2, 0, legacy_hollow(1));
+        let retry = policy.prepare_retry(&original, None, None);
+
+        // The retry prompt appends a `--- RETRY CONTEXT ---` block that contains the word
+        // "review" — without inheriting role, this would mis-classify as Reviewer.
+        assert_eq!(
+            retry.role,
+            Role::Orchestrator,
+            "retry must inherit original role, not re-derive from retry-appended text"
+        );
     }
 
     #[test]
@@ -404,6 +438,7 @@ mod tests {
             "opus".into(),
             "orchestrator".into(),
             None,
+            None,
         );
         s.status = SessionStatus::Completed;
         s.is_hollow_completion = true;
@@ -417,6 +452,7 @@ mod tests {
             "opus".into(),
             "orchestrator".into(),
             Some(1),
+            None,
         );
         s.status = SessionStatus::Completed;
         s.is_hollow_completion = true;

--- a/src/session/role.rs
+++ b/src/session/role.rs
@@ -1,0 +1,425 @@
+//! Role taxonomy for sessions.
+//!
+//! Lifted from `src/tui/agent_personalities/role.rs` (the ADR-002 spike).
+//! See `docs/adr/002-agent-personalities.md` § Data Model for the verdict
+//! ("stored field with derived fallback") and § Role Taxonomy for the keyword
+//! corpus rationale.
+//!
+//! The canonical list is five: `Implementer` (default), `Orchestrator`,
+//! `Reviewer`, `Docs`, `DevOps`. The `derive_role` classifier mirrors
+//! `crate::session::intent`'s keyword-matching idiom (case-insensitive
+//! substring scan).
+
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+
+/// Five-role taxonomy for agent sessions.
+///
+/// `Implementer` is the default because it is the largest category in maestro's
+/// session log; "unknown prompt → Implementer" is the safest miscategorization
+/// (most sessions do work, so misfires are visually invisible).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default, ValueEnum)]
+#[serde(rename_all = "snake_case")]
+#[clap(rename_all = "snake_case")]
+pub enum Role {
+    /// Writes code: edits files, adds features, runs `cargo test`.
+    #[default]
+    Implementer,
+    /// Coordinates other sessions; spawns work; merges PRs.
+    Orchestrator,
+    /// Reads code, runs gates, posts PR reviews.
+    Reviewer,
+    /// Writes `.md` files, updates ADRs, regenerates `directory-tree.md`.
+    Docs,
+    /// CI fixes, conflict resolution, dependency bumps, infrastructure.
+    DevOps,
+}
+
+/// All keyword lists are matched as case-insensitive substrings against the
+/// full prompt; precedence is enforced in `derive_role`'s control flow rather
+/// than in any per-list ordering.
+const ORCHESTRATOR_KEYWORDS: &[&str] = &[
+    "coordinate",
+    "orchestrate",
+    "merge ",
+    "merge pr",
+    "spawn ",
+    "dispatch ",
+    "delegate ",
+    "milestone",
+    "queue",
+];
+
+const REVIEWER_KEYWORDS: &[&str] = &[
+    "review ",
+    "audit ",
+    "inspect",
+    "code review",
+    "security review",
+    "pr review",
+    "post review",
+    "approve ",
+    "request changes",
+];
+
+const DOCS_KEYWORDS: &[&str] = &[
+    "doc ",
+    "docs ",
+    "documentation",
+    "readme",
+    "adr ",
+    "directory-tree",
+    "changelog",
+    "rustdoc",
+    ".md",
+    "guide",
+    "tutorial",
+];
+
+const DEVOPS_KEYWORDS: &[&str] = &[
+    "ci ",
+    "ci/",
+    "github actions",
+    "workflow",
+    "actionlint",
+    "shellcheck",
+    "conflict",
+    "rebase",
+    "dependabot",
+    "bump ",
+    "release ",
+    "deploy",
+    "infra",
+];
+
+/// Classify a prompt into a `Role` using case-insensitive substring matching.
+///
+/// Resolution order: Orchestrator > Reviewer > DevOps > Docs > Implementer (default).
+/// The order is chosen so that explicit coordination verbs ("coordinate", "merge")
+/// win over ambient nouns ("docs"), and infrastructure keywords ("ci ", "workflow")
+/// win over the documentation noun "readme" when both appear.
+pub fn derive_role(prompt: &str) -> Role {
+    let normalized = prompt.to_ascii_lowercase();
+    let role = if ORCHESTRATOR_KEYWORDS.iter().any(|k| normalized.contains(k)) {
+        Role::Orchestrator
+    } else if REVIEWER_KEYWORDS.iter().any(|k| normalized.contains(k)) {
+        Role::Reviewer
+    } else if DEVOPS_KEYWORDS.iter().any(|k| normalized.contains(k)) {
+        Role::DevOps
+    } else if DOCS_KEYWORDS.iter().any(|k| normalized.contains(k)) {
+        Role::Docs
+    } else {
+        Role::Implementer
+    };
+    tracing::debug!(prompt = %prompt, role = ?role, "derived role");
+    role
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- Role enum & serde ---
+
+    #[test]
+    fn default_is_implementer() {
+        assert_eq!(Role::default(), Role::Implementer);
+    }
+
+    #[test]
+    fn role_serializes_as_snake_case_implementer() {
+        let json = serde_json::to_string(&Role::Implementer).unwrap();
+        assert_eq!(json, r#""implementer""#);
+    }
+
+    #[test]
+    fn role_serializes_as_snake_case_orchestrator() {
+        let json = serde_json::to_string(&Role::Orchestrator).unwrap();
+        assert_eq!(json, r#""orchestrator""#);
+    }
+
+    #[test]
+    fn role_serializes_as_snake_case_reviewer() {
+        let json = serde_json::to_string(&Role::Reviewer).unwrap();
+        assert_eq!(json, r#""reviewer""#);
+    }
+
+    #[test]
+    fn role_serializes_as_snake_case_docs() {
+        let json = serde_json::to_string(&Role::Docs).unwrap();
+        assert_eq!(json, r#""docs""#);
+    }
+
+    #[test]
+    fn role_serializes_as_snake_case_dev_ops() {
+        let json = serde_json::to_string(&Role::DevOps).unwrap();
+        assert_eq!(
+            json, r#""dev_ops""#,
+            "DevOps must serialize as 'dev_ops' (snake_case), not 'devops'"
+        );
+    }
+
+    #[test]
+    fn role_deserializes_from_implementer() {
+        let v: Role = serde_json::from_str(r#""implementer""#).unwrap();
+        assert_eq!(v, Role::Implementer);
+    }
+
+    #[test]
+    fn role_deserializes_from_orchestrator() {
+        let v: Role = serde_json::from_str(r#""orchestrator""#).unwrap();
+        assert_eq!(v, Role::Orchestrator);
+    }
+
+    #[test]
+    fn role_deserializes_from_reviewer() {
+        let v: Role = serde_json::from_str(r#""reviewer""#).unwrap();
+        assert_eq!(v, Role::Reviewer);
+    }
+
+    #[test]
+    fn role_deserializes_from_docs() {
+        let v: Role = serde_json::from_str(r#""docs""#).unwrap();
+        assert_eq!(v, Role::Docs);
+    }
+
+    #[test]
+    fn role_deserializes_from_dev_ops() {
+        let v: Role = serde_json::from_str(r#""dev_ops""#).unwrap();
+        assert_eq!(v, Role::DevOps);
+    }
+
+    // --- derive_role basic ---
+
+    #[test]
+    fn derive_role_empty_prompt_is_implementer() {
+        assert_eq!(derive_role(""), Role::Implementer);
+    }
+
+    // --- Resolution-order tests (highest-value) ---
+    //
+    // These validate the priority spec: Orchestrator > Reviewer > DevOps > Docs > Implementer.
+
+    #[test]
+    fn derive_role_orchestrator_beats_reviewer() {
+        // "coordinate" (Orchestrator) + "review " (Reviewer) → Orchestrator wins.
+        assert_eq!(
+            derive_role("coordinate the review of PR #530 before merging"),
+            Role::Orchestrator
+        );
+    }
+
+    #[test]
+    fn derive_role_orchestrator_beats_devops() {
+        // "orchestrate" (Orchestrator) + "deploy" (DevOps) → Orchestrator wins.
+        assert_eq!(
+            derive_role("orchestrate the CI workflow fix and deploy to staging"),
+            Role::Orchestrator
+        );
+    }
+
+    #[test]
+    fn derive_role_orchestrator_beats_docs() {
+        // "coordinate" (Orchestrator) + "readme" (Docs) → Orchestrator wins.
+        assert_eq!(
+            derive_role("coordinate the documentation sprint and update the readme"),
+            Role::Orchestrator
+        );
+    }
+
+    #[test]
+    fn derive_role_reviewer_beats_devops() {
+        // "audit " (Reviewer) + "workflow" (DevOps) → Reviewer wins.
+        assert_eq!(
+            derive_role("audit the CI workflow configuration for security issues"),
+            Role::Reviewer
+        );
+    }
+
+    #[test]
+    fn derive_role_reviewer_beats_docs() {
+        // "inspect" (Reviewer) + "guide" (Docs) → Reviewer wins.
+        assert_eq!(
+            derive_role("inspect the documentation guide for accuracy"),
+            Role::Reviewer
+        );
+    }
+
+    #[test]
+    fn derive_role_devops_beats_docs() {
+        // "bump " (DevOps) + "changelog" (Docs) → DevOps wins.
+        assert_eq!(
+            derive_role("bump the dependabot deps and update the changelog"),
+            Role::DevOps
+        );
+    }
+
+    // --- Case insensitivity ---
+
+    #[test]
+    fn derive_role_case_insensitive() {
+        assert_eq!(derive_role("COORDINATE the sessions"), Role::Orchestrator);
+        assert_eq!(derive_role("AUDIT the codebase"), Role::Reviewer);
+        assert_eq!(derive_role("FIX THE CI WORKFLOW"), Role::DevOps);
+        assert_eq!(derive_role("UPDATE THE README"), Role::Docs);
+    }
+
+    // --- Accuracy property test (≥80% on a 25-prompt corpus, 5 per role) ---
+
+    #[test]
+    fn derive_role_accuracy_on_25_prompt_corpus_is_above_80_percent() {
+        let orchestrator: &[(&str, Role)] = &[
+            // "coordinate" + "dispatch " keywords
+            (
+                "coordinate the sprint and dispatch tasks to available sessions",
+                Role::Orchestrator,
+            ),
+            // "orchestrate" + "merge " keywords
+            (
+                "orchestrate the release by merging open PRs in milestone order",
+                Role::Orchestrator,
+            ),
+            // "milestone" + "queue" keywords
+            (
+                "advance the milestone by queuing all unblocked issues",
+                Role::Orchestrator,
+            ),
+            // "delegate " keyword
+            (
+                "delegate issue #538 to the implementer session pool",
+                Role::Orchestrator,
+            ),
+            // "spawn " keyword
+            (
+                "spawn a reviewer session for PR #540 and wait for approval",
+                Role::Orchestrator,
+            ),
+        ];
+        let reviewer: &[(&str, Role)] = &[
+            // "code review" keyword
+            (
+                "perform a code review on the new session/role module before merge",
+                Role::Reviewer,
+            ),
+            // "pr review" keyword
+            (
+                "run a pr review for #538 and post review comments on the diff",
+                Role::Reviewer,
+            ),
+            // "security review" + "audit " keywords
+            (
+                "security review the auth flow in manager.rs and audit the token handling",
+                Role::Reviewer,
+            ),
+            // "inspect" + "request changes" keywords
+            (
+                "inspect the serde round-trip tests and request changes if any are missing",
+                Role::Reviewer,
+            ),
+            // "approve " keyword
+            (
+                "approve the PR once all CI checks pass and the review is signed off",
+                Role::Reviewer,
+            ),
+        ];
+        let devops: &[(&str, Role)] = &[
+            // "github actions" + "workflow" + "rebase" keywords
+            (
+                "fix the github actions workflow that broke on the rebase of main",
+                Role::DevOps,
+            ),
+            // "ci " + "rebase" keywords
+            (
+                "resolve ci failures after rebasing feat/role onto main",
+                Role::DevOps,
+            ),
+            // "bump " + "deploy" keywords
+            (
+                "bump the tokio version in Cargo.toml and deploy to staging",
+                Role::DevOps,
+            ),
+            // "dependabot" keyword (avoid "review" which would beat DevOps)
+            (
+                "triage the dependabot update for serde 1.0.197 and merge if CI passes",
+                Role::DevOps,
+            ),
+            // "conflict" + "release " keywords
+            (
+                "fix the merge conflict in src/session/types.rs blocking the release",
+                Role::DevOps,
+            ),
+        ];
+        let docs: &[(&str, Role)] = &[
+            // "readme" keyword
+            (
+                "update the README with the new --role flag documentation",
+                Role::Docs,
+            ),
+            // "adr " keyword
+            (
+                "write an adr for the role taxonomy decision in issue #538",
+                Role::Docs,
+            ),
+            // "changelog" keyword
+            (
+                "add the role classifier feature to the changelog under Unreleased",
+                Role::Docs,
+            ),
+            // "rustdoc" + "documentation" keywords
+            (
+                "regenerate the rustdoc documentation for the session module",
+                Role::Docs,
+            ),
+            // ".md" keyword
+            (
+                "create CONTRIBUTING.md explaining the TDD workflow for contributors",
+                Role::Docs,
+            ),
+        ];
+        let implementer: &[(&str, Role)] = &[
+            (
+                "implement issue #538: add Role enum and derive_role classifier",
+                Role::Implementer,
+            ),
+            (
+                "fix the serde deserialization bug in session/types.rs line 282",
+                Role::Implementer,
+            ),
+            (
+                "add unit tests for the fork depth limit in session/fork.rs",
+                Role::Implementer,
+            ),
+            (
+                "refactor the SessionStatus transition matrix to remove dead states",
+                Role::Implementer,
+            ),
+            (
+                "wire up the new flag in src/main.rs and pass it to Session constructors",
+                Role::Implementer,
+            ),
+        ];
+
+        let mut correct = 0usize;
+        let mut total = 0usize;
+        for (prompt, expected) in orchestrator
+            .iter()
+            .chain(reviewer)
+            .chain(devops)
+            .chain(docs)
+            .chain(implementer)
+        {
+            total += 1;
+            if derive_role(prompt) == *expected {
+                correct += 1;
+            }
+        }
+        let accuracy = correct as f64 / total as f64;
+        assert!(
+            accuracy > 0.80,
+            "accuracy {:.1}% on {} prompts (correct: {})",
+            accuracy * 100.0,
+            total,
+            correct
+        );
+    }
+}

--- a/src/session/transition.rs
+++ b/src/session/transition.rs
@@ -71,6 +71,7 @@ mod tests {
             "opus".into(),
             "orchestrator".into(),
             None,
+            None,
         )
     }
 

--- a/src/session/types.rs
+++ b/src/session/types.rs
@@ -282,6 +282,13 @@ pub struct Session {
     /// Classified intent of the prompt (Work vs. Consultation). Derived at spawn time.
     #[serde(default)]
     pub intent: super::intent::SessionIntent,
+    /// Role classification for the agent. Stored explicitly so the agent-graph
+    /// renderer has an O(1) lookup and so a `--role` override survives across
+    /// resume/restart. Set once at `Session::new` and frozen for the session
+    /// lifetime; `transition_to` does NOT mutate this field. See
+    /// `docs/adr/002-agent-personalities.md` § Data Model.
+    #[serde(default)]
+    pub role: super::role::Role,
     /// Set once after the "consultation satisfied — retry skipped" log line
     /// has been emitted, so the completion pipeline doesn't re-log each tick.
     #[serde(skip)]
@@ -328,8 +335,15 @@ pub struct ActivityEntry {
 }
 
 impl Session {
-    pub fn new(prompt: String, model: String, mode: String, issue_number: Option<u64>) -> Self {
+    pub fn new(
+        prompt: String,
+        model: String,
+        mode: String,
+        issue_number: Option<u64>,
+        role_override: Option<super::role::Role>,
+    ) -> Self {
         let intent = super::intent::classify_intent(&prompt);
+        let role = role_override.unwrap_or_else(|| super::role::derive_role(&prompt));
         Self {
             id: Uuid::new_v4(),
             status: SessionStatus::Queued,
@@ -367,6 +381,7 @@ impl Session {
             tq_handoff_compressed_tokens: None,
             transition_history: Vec::new(),
             intent,
+            role,
             consultation_skip_logged: false,
             adapt_follow_up_considered: false,
         }
@@ -521,7 +536,7 @@ mod tests {
 
     #[test]
     fn session_new_initializes_fork_fields_to_defaults() {
-        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None);
+        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
         assert_eq!(s.parent_session_id, None);
         assert!(s.child_session_ids.is_empty());
         assert_eq!(s.fork_depth, 0);
@@ -613,6 +628,7 @@ mod tests {
             "opus".into(),
             "orchestrator".into(),
             Some(10),
+            None,
         );
         assert!(s.ci_fix_context.is_none());
     }
@@ -621,13 +637,13 @@ mod tests {
 
     #[test]
     fn session_new_initializes_image_paths_as_empty() {
-        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None);
+        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
         assert!(s.image_paths.is_empty());
     }
 
     #[test]
     fn session_with_image_paths_builder() {
-        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None)
+        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None)
             .with_image_paths(vec![
                 std::path::PathBuf::from("/tmp/a.png"),
                 std::path::PathBuf::from("/tmp/b.jpg"),
@@ -637,7 +653,7 @@ mod tests {
 
     #[test]
     fn session_with_image_paths_round_trips_via_serde() {
-        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None)
+        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None)
             .with_image_paths(vec![
                 std::path::PathBuf::from("img/a.png"),
                 std::path::PathBuf::from("img/b.jpg"),
@@ -649,7 +665,7 @@ mod tests {
 
     #[test]
     fn session_image_paths_deserializes_with_default_when_field_absent() {
-        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None);
+        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
         let json = serde_json::to_string(&s).unwrap();
         let stripped = json.replace(r#","image_paths":[]"#, "");
         let rt: Session = serde_json::from_str(&stripped).unwrap();
@@ -660,14 +676,14 @@ mod tests {
 
     #[test]
     fn session_is_thinking_defaults_to_false() {
-        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None);
+        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
         assert!(!s.is_thinking);
         assert!(s.thinking_started_at.is_none());
     }
 
     #[test]
     fn session_thinking_fields_skipped_in_serde() {
-        let mut s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None);
+        let mut s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
         s.is_thinking = true;
         s.thinking_started_at = Some(std::time::Instant::now());
 
@@ -762,6 +778,7 @@ mod tests {
             "opus".into(),
             "orchestrator".into(),
             Some(1),
+            None,
         );
         s.ci_fix_context = Some(CiFixContext {
             pr_number: 5,
@@ -780,7 +797,7 @@ mod tests {
 
     #[test]
     fn session_gate_results_defaults_to_empty() {
-        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None);
+        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
         assert!(s.gate_results.is_empty());
     }
 
@@ -791,6 +808,7 @@ mod tests {
             "opus".into(),
             "orchestrator".into(),
             Some(1),
+            None,
         );
         s.gate_results = vec![
             GateResultEntry::pass("tests", "all passed"),
@@ -805,7 +823,7 @@ mod tests {
 
     #[test]
     fn session_gate_results_deserializes_with_default_when_field_absent() {
-        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None);
+        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
         let json = serde_json::to_string(&s).unwrap();
         let stripped = json.replace(r#","gate_results":[]"#, "");
         let rt: Session = serde_json::from_str(&stripped).unwrap();
@@ -868,7 +886,7 @@ mod tests {
 
     #[test]
     fn session_conflict_fix_context_defaults_to_none() {
-        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None);
+        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
         assert!(s.conflict_fix_context.is_none());
     }
 
@@ -879,6 +897,7 @@ mod tests {
             "opus".into(),
             "orchestrator".into(),
             Some(1),
+            None,
         );
         s.conflict_fix_context = Some(ConflictFixContext {
             pr_number: 99,
@@ -897,7 +916,7 @@ mod tests {
 
     #[test]
     fn session_conflict_fix_context_deserializes_with_default_when_field_absent() {
-        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None);
+        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
         let json = serde_json::to_string(&s).unwrap();
         let stripped = json.replace(r#","conflict_fix_context":null"#, "");
         let rt: Session = serde_json::from_str(&stripped).unwrap();
@@ -911,6 +930,7 @@ mod tests {
             "test prompt".into(),
             "claude-sonnet-4-6".into(),
             "orchestrator".into(),
+            None,
             None,
         )
     }
@@ -1128,7 +1148,7 @@ mod tests {
 
     #[test]
     fn session_token_usage_defaults_when_absent_in_json() {
-        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None);
+        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
         let json = serde_json::to_string(&s).unwrap();
         // Strip the token_usage field to simulate old JSON
         let stripped = json.replace(
@@ -1152,14 +1172,14 @@ mod tests {
 
     #[test]
     fn flash_counter_starts_at_zero() {
-        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None);
+        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
         assert_eq!(s.transition_flash_remaining, 0);
     }
 
     #[test]
     fn transition_to_sets_flash_counter() {
         use crate::session::transition::TransitionReason;
-        let mut s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None);
+        let mut s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
         s.transition_to(SessionStatus::Spawning, TransitionReason::Promoted)
             .unwrap();
         assert_eq!(s.transition_flash_remaining, 4);
@@ -1168,7 +1188,7 @@ mod tests {
     #[test]
     fn transition_to_resets_flash_counter_on_each_transition() {
         use crate::session::transition::TransitionReason;
-        let mut s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None);
+        let mut s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
         s.transition_to(SessionStatus::Spawning, TransitionReason::Promoted)
             .unwrap();
         s.transition_flash_remaining = 1; // simulate partial decay
@@ -1179,7 +1199,7 @@ mod tests {
 
     #[test]
     fn failed_transition_does_not_set_flash_counter() {
-        let mut s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None);
+        let mut s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
         // Queued -> Completed is invalid
         let _ = s.transition_to(
             SessionStatus::Completed,
@@ -1191,7 +1211,7 @@ mod tests {
     #[test]
     fn transition_to_logs_status_change_in_activity_log() {
         use crate::session::transition::TransitionReason;
-        let mut s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None);
+        let mut s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
         s.transition_to(SessionStatus::Spawning, TransitionReason::Promoted)
             .unwrap();
         let last = s
@@ -1224,6 +1244,7 @@ mod tests {
             "opus".into(),
             "orchestrator".into(),
             None,
+            None,
         );
         assert_eq!(s.intent, crate::session::intent::SessionIntent::Work);
     }
@@ -1234,6 +1255,7 @@ mod tests {
             "how are you?".into(),
             "opus".into(),
             "orchestrator".into(),
+            None,
             None,
         );
         assert_eq!(
@@ -1249,6 +1271,7 @@ mod tests {
             "opus".into(),
             "orchestrator".into(),
             None,
+            None,
         );
         let json = serde_json::to_string(&s).unwrap();
         let rt: Session = serde_json::from_str(&json).unwrap();
@@ -1262,14 +1285,14 @@ mod tests {
 
     #[test]
     fn session_tq_handoff_fields_default_to_none() {
-        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None);
+        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
         assert!(s.tq_handoff_original_tokens.is_none());
         assert!(s.tq_handoff_compressed_tokens.is_none());
     }
 
     #[test]
     fn session_tq_handoff_fields_round_trip_via_serde() {
-        let mut s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None);
+        let mut s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
         s.tq_handoff_original_tokens = Some(10_000);
         s.tq_handoff_compressed_tokens = Some(2_500);
         let json = serde_json::to_string(&s).unwrap();
@@ -1280,7 +1303,7 @@ mod tests {
 
     #[test]
     fn session_tq_handoff_fields_deserialize_when_absent_in_json() {
-        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None);
+        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
         let json = serde_json::to_string(&s).unwrap();
         let stripped = json
             .replace(r#","tq_handoff_original_tokens":null"#, "")
@@ -1292,16 +1315,107 @@ mod tests {
 
     #[test]
     fn session_intent_defaults_to_work_when_absent_in_json() {
-        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None);
+        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
         let json = serde_json::to_string(&s).unwrap();
         let stripped = json.replace(r#","intent":"work""#, "");
         let rt: Session = serde_json::from_str(&stripped).unwrap();
         assert_eq!(rt.intent, crate::session::intent::SessionIntent::Work);
     }
 
+    // --- Issue #538: Role wiring on Session ---
+
+    #[test]
+    fn session_new_classifies_orchestrator_prompt_as_orchestrator() {
+        use crate::session::role::Role;
+        let s = Session::new(
+            "coordinate the sprint and dispatch tasks".into(),
+            "opus".into(),
+            "orchestrator".into(),
+            None,
+            None,
+        );
+        assert_eq!(s.role, Role::Orchestrator);
+    }
+
+    #[test]
+    fn session_new_classifies_implementer_prompt_as_implementer_default() {
+        use crate::session::role::Role;
+        let s = Session::new(
+            "fix the bug in session/parser.rs".into(),
+            "opus".into(),
+            "orchestrator".into(),
+            None,
+            None,
+        );
+        assert_eq!(s.role, Role::Implementer);
+    }
+
+    #[test]
+    fn session_new_with_role_override_uses_override_not_derive() {
+        use crate::session::role::Role;
+        // Prompt would derive Orchestrator, but the explicit override forces Reviewer.
+        let s = Session::new(
+            "coordinate the release milestone".into(),
+            "opus".into(),
+            "orchestrator".into(),
+            None,
+            Some(Role::Reviewer),
+        );
+        assert_eq!(s.role, Role::Reviewer);
+    }
+
+    #[test]
+    fn role_field_round_trips_via_serde() {
+        use crate::session::role::Role;
+        let s = Session::new(
+            "coordinate the sprint".into(),
+            "opus".into(),
+            "orchestrator".into(),
+            None,
+            None,
+        );
+        assert_eq!(s.role, Role::Orchestrator);
+        let json = serde_json::to_string(&s).unwrap();
+        let rt: Session = serde_json::from_str(&json).unwrap();
+        assert_eq!(rt.role, Role::Orchestrator);
+    }
+
+    #[test]
+    fn role_defaults_to_implementer_when_absent_in_json() {
+        use crate::session::role::Role;
+        let s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
+        let json = serde_json::to_string(&s).unwrap();
+        let stripped = json.replace(r#","role":"implementer""#, "");
+        let rt: Session = serde_json::from_str(&stripped).unwrap();
+        assert_eq!(rt.role, Role::Implementer);
+    }
+
+    #[test]
+    fn transition_to_does_not_mutate_role() {
+        use crate::session::role::Role;
+        use crate::session::transition::TransitionReason;
+        let mut s = Session::new(
+            "coordinate the milestone".into(),
+            "opus".into(),
+            "orchestrator".into(),
+            None,
+            None,
+        );
+        assert_eq!(s.role, Role::Orchestrator);
+        s.transition_to(SessionStatus::Spawning, TransitionReason::Promoted)
+            .unwrap();
+        assert_eq!(s.role, Role::Orchestrator);
+        s.transition_to(SessionStatus::Running, TransitionReason::Spawned)
+            .unwrap();
+        assert_eq!(s.role, Role::Orchestrator);
+        s.transition_to(SessionStatus::Completed, TransitionReason::StreamCompleted)
+            .unwrap();
+        assert_eq!(s.role, Role::Orchestrator);
+    }
+
     #[test]
     fn flash_counter_skipped_in_serde() {
-        let mut s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None);
+        let mut s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
         s.transition_flash_remaining = 4;
         let json = serde_json::to_string(&s).unwrap();
         assert!(!json.contains("transition_flash_remaining"));

--- a/src/state/store.rs
+++ b/src/state/store.rs
@@ -106,6 +106,7 @@ mod tests {
             "opus".into(),
             "orchestrator".into(),
             None,
+            None,
         );
         for _ in 0..5 {
             s.activity_log.push(crate::session::types::ActivityEntry {
@@ -131,6 +132,7 @@ mod tests {
             "p".into(),
             "opus".into(),
             "orchestrator".into(),
+            None,
             None,
         );
         s.status = crate::session::types::SessionStatus::Running;

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -177,12 +177,14 @@ mod tests {
             "opus".into(),
             "orchestrator".into(),
             None,
+            None,
         );
         s1.cost_usd = 1.0;
         let mut s2 = crate::session::types::Session::new(
             "b".into(),
             "opus".into(),
             "orchestrator".into(),
+            None,
             None,
         );
         s2.cost_usd = 1.0;
@@ -321,6 +323,7 @@ mod tests {
             "opus".into(),
             "orchestrator".into(),
             None,
+            None,
         );
         for _ in 0..5 {
             s.activity_log.push(ActivityEntry {
@@ -342,6 +345,7 @@ mod tests {
             "opus".into(),
             "orchestrator".into(),
             None,
+            None,
         );
         s1.status = SessionStatus::Running;
         for _ in 0..8 {
@@ -354,6 +358,7 @@ mod tests {
             "b".into(),
             "opus".into(),
             "orchestrator".into(),
+            None,
             None,
         );
         s2.status = SessionStatus::Running;
@@ -374,6 +379,7 @@ mod tests {
             "a".into(),
             "opus".into(),
             "orchestrator".into(),
+            None,
             None,
         );
         s.status = SessionStatus::Running;

--- a/src/tui/agent_graph/model.rs
+++ b/src/tui/agent_graph/model.rs
@@ -89,7 +89,7 @@ mod tests {
     use super::*;
 
     fn fake(status: SessionStatus, files: &[&str]) -> Session {
-        let mut s = Session::new(String::new(), String::new(), String::new(), None);
+        let mut s = Session::new(String::new(), String::new(), String::new(), None, None);
         s.status = status;
         s.files_touched = files.iter().map(|s| (*s).to_string()).collect();
         s

--- a/src/tui/agent_graph/render_tests.rs
+++ b/src/tui/agent_graph/render_tests.rs
@@ -15,6 +15,7 @@ fn make_session_with(id: u128, issue: u64, status: SessionStatus, files: &[&str]
         "claude-opus-4-5".to_string(),
         "orchestrator".to_string(),
         Some(issue),
+        None,
     );
     s.id = Uuid::from_u128(id);
     s.status = status;

--- a/src/tui/app/clipboard_action.rs
+++ b/src/tui/app/clipboard_action.rs
@@ -134,6 +134,7 @@ mod tests {
             "claude-opus-4-5".to_string(),
             "orchestrator".to_string(),
             None,
+            None,
         );
         s.status = status;
         s.last_message = last_message.to_string();

--- a/src/tui/app/data_handler.rs
+++ b/src/tui/app/data_handler.rs
@@ -137,7 +137,7 @@ impl App {
                 let (model, issue_mode) = self.resolve_model_and_mode(&gh_issue.labels);
                 let prompt = self.build_issue_prompt_with_custom(&gh_issue, &custom_prompt);
                 let issue_number = gh_issue.number;
-                let mut session = Session::new(prompt, model, issue_mode, Some(issue_number));
+                let mut session = Session::new(prompt, model, issue_mode, Some(issue_number), None);
                 session.issue_title = Some(gh_issue.title.clone());
                 self.state.issue_cache.insert(issue_number, gh_issue);
                 self.pending_session_launches.push(session);
@@ -389,7 +389,8 @@ impl App {
                 }
 
                 let primary_issue = issue_numbers.first().copied();
-                let mut session = Session::new(combined_prompt, model, issue_mode, primary_issue);
+                let mut session =
+                    Session::new(combined_prompt, model, issue_mode, primary_issue, None);
                 session.issue_numbers = issue_numbers;
                 session.issue_title = Some(format!(
                     "Unified: {}",

--- a/src/tui/app/event_handler_tests.rs
+++ b/src/tui/app/event_handler_tests.rs
@@ -16,6 +16,7 @@ fn session_with_issue(issue: u64) -> Session {
         "claude-opus-4-5".to_string(),
         "orchestrator".to_string(),
         Some(issue),
+        None,
     );
     s.issue_title = Some(format!("Issue #{}", issue));
     s

--- a/src/tui/app/session_spawners.rs
+++ b/src/tui/app/session_spawners.rs
@@ -37,6 +37,7 @@ pub(crate) fn create_ci_fix_session(
         model.to_string(),
         mode.to_string(),
         Some(issue_number),
+        None,
     );
     let _ = session.transition_to(SessionStatus::CiFix, TransitionReason::CiFixStarted);
     session.issue_title = Some(format!("CI Fix #{} for PR #{}", attempt, pr_number));
@@ -62,6 +63,7 @@ pub(crate) fn create_gate_fix_session(
         model.to_string(),
         mode.to_string(),
         Some(issue_number),
+        None,
     );
     session.issue_title = Some(format!("Gate Fix for #{}", issue_number));
     session
@@ -142,7 +144,7 @@ impl App {
             &config.conflicting_files,
         );
 
-        let mut session = Session::new(prompt, model, mode, Some(config.issue_number));
+        let mut session = Session::new(prompt, model, mode, Some(config.issue_number), None);
         let _ = session.transition_to(
             SessionStatus::ConflictFix,
             TransitionReason::ConflictFixStarted,

--- a/src/tui/app/tests.rs
+++ b/src/tui/app/tests.rs
@@ -80,6 +80,7 @@ fn build_completion_summary_label_uses_issue_number_when_present() {
         "opus".into(),
         "orchestrator".into(),
         Some(99),
+        None,
     );
     app.pool.enqueue(session);
     let summary = app.build_completion_summary();
@@ -97,6 +98,7 @@ fn build_completion_summary_label_uses_short_id_when_no_issue() {
         "do something".into(),
         "opus".into(),
         "orchestrator".into(),
+        None,
         None,
     );
     let short_id = session.id.to_string()[..8].to_string();
@@ -117,6 +119,7 @@ fn build_completion_summary_aggregates_cost() {
         "opus".into(),
         "orchestrator".into(),
         Some(1),
+        None,
     );
     s1.cost_usd = 1.50;
     let mut s2 = crate::session::types::Session::new(
@@ -124,6 +127,7 @@ fn build_completion_summary_aggregates_cost() {
         "opus".into(),
         "orchestrator".into(),
         Some(2),
+        None,
     );
     s2.cost_usd = 2.75;
     app.pool.enqueue(s1);
@@ -283,6 +287,7 @@ fn build_completion_summary_sets_pr_link_when_pending_check_matches() {
         "opus".into(),
         "orchestrator".into(),
         Some(10),
+        None,
     );
     session.status = crate::session::types::SessionStatus::Completed;
     app.pool.enqueue(session);
@@ -313,6 +318,7 @@ fn build_completion_summary_pr_link_empty_when_no_matching_check() {
         "opus".into(),
         "orchestrator".into(),
         Some(99),
+        None,
     );
     app.pool.enqueue(session);
     app.ci_poller.add_check(PendingPrCheck {
@@ -342,6 +348,7 @@ fn build_completion_summary_pr_link_empty_when_no_issue_number() {
         "opus".into(),
         "orchestrator".into(),
         None,
+        None,
     );
     app.pool.enqueue(session);
     app.ci_poller.add_check(PendingPrCheck {
@@ -369,6 +376,7 @@ fn build_completion_summary_error_summary_for_errored_session() {
         "opus".into(),
         "orchestrator".into(),
         Some(5),
+        None,
     );
     session.status = crate::session::types::SessionStatus::Errored;
     session.log_activity("Process started".into());
@@ -390,6 +398,7 @@ fn build_completion_summary_error_summary_empty_for_completed() {
         "opus".into(),
         "orchestrator".into(),
         Some(6),
+        None,
     );
     session.status = crate::session::types::SessionStatus::Completed;
     session.log_activity("Some activity".into());
@@ -410,6 +419,7 @@ fn build_completion_summary_error_summary_empty_when_no_activity() {
         "opus".into(),
         "orchestrator".into(),
         Some(7),
+        None,
     );
     session.status = crate::session::types::SessionStatus::Errored;
     app.pool.enqueue(session);
@@ -429,6 +439,7 @@ fn build_completion_summary_error_summary_truncates_long_messages() {
         "opus".into(),
         "orchestrator".into(),
         Some(8),
+        None,
     );
     session.status = crate::session::types::SessionStatus::Errored;
     session.log_activity(format!("Error: {}", "x".repeat(200)));
@@ -452,6 +463,7 @@ fn build_completion_summary_pr_link_from_ci_fix_context() {
         "opus".into(),
         "orchestrator".into(),
         Some(15),
+        None,
     );
     session.status = crate::session::types::SessionStatus::Completed;
     session.ci_fix_context = Some(crate::session::types::CiFixContext {
@@ -639,6 +651,7 @@ fn build_completion_summary_gate_failures_empty_for_completed_session() {
         "opus".into(),
         "orchestrator".into(),
         Some(10),
+        None,
     );
     session.status = crate::session::types::SessionStatus::Completed;
     session.gate_results = vec![GateResultEntry::pass("tests", "all passed")];
@@ -659,6 +672,7 @@ fn build_completion_summary_gate_failures_populated_for_needs_review() {
         "opus".into(),
         "orchestrator".into(),
         Some(20),
+        None,
     );
     session.status = crate::session::types::SessionStatus::NeedsReview;
     session.gate_results = vec![GateResultEntry::fail("tests", "3 tests failed")];
@@ -682,6 +696,7 @@ fn build_completion_summary_gate_failures_multiple_failed_gates() {
         "opus".into(),
         "orchestrator".into(),
         Some(30),
+        None,
     );
     session.status = crate::session::types::SessionStatus::NeedsReview;
     session.gate_results = vec![
@@ -702,6 +717,7 @@ fn build_completion_summary_gate_failures_skips_passing_gates() {
         "opus".into(),
         "orchestrator".into(),
         Some(40),
+        None,
     );
     session.status = crate::session::types::SessionStatus::NeedsReview;
     session.gate_results = vec![
@@ -723,6 +739,7 @@ fn build_completion_summary_gate_failures_empty_when_needs_review_has_no_gate_re
         "opus".into(),
         "orchestrator".into(),
         Some(50),
+        None,
     );
     session.status = crate::session::types::SessionStatus::NeedsReview;
     app.pool.enqueue(session);
@@ -739,6 +756,7 @@ fn build_completion_summary_populates_issue_number() {
         "opus".into(),
         "orchestrator".into(),
         Some(77),
+        None,
     );
     app.pool.enqueue(session);
 
@@ -753,6 +771,7 @@ fn build_completion_summary_issue_number_is_none_when_session_has_none() {
         "task".into(),
         "opus".into(),
         "orchestrator".into(),
+        None,
         None,
     );
     app.pool.enqueue(session);
@@ -769,6 +788,7 @@ fn build_completion_summary_populates_model() {
         "claude-opus-4".into(),
         "orchestrator".into(),
         Some(88),
+        None,
     );
     app.pool.enqueue(session);
 
@@ -784,6 +804,7 @@ fn build_completion_summary_gate_failure_message_truncated() {
         "opus".into(),
         "orchestrator".into(),
         Some(60),
+        None,
     );
     session.status = crate::session::types::SessionStatus::NeedsReview;
     session.gate_results = vec![GateResultEntry::fail("tests", &"x".repeat(300))];
@@ -927,6 +948,7 @@ async fn add_session_resets_dismissed_flag() {
         "opus".to_string(),
         "orchestrator".to_string(),
         None,
+        None,
     );
     let _ = app.add_session(session).await;
     assert!(
@@ -945,6 +967,7 @@ fn dismissed_flag_prevents_summary_retrigger_scenario() {
         "done".to_string(),
         "opus".to_string(),
         "orchestrator".to_string(),
+        None,
         None,
     );
     app.pool.enqueue(session);

--- a/src/tui/app/work_assigner.rs
+++ b/src/tui/app/work_assigner.rs
@@ -159,6 +159,7 @@ impl App {
                 assignment.model,
                 assignment.mode,
                 Some(assignment.issue_number),
+                None,
             );
             session.issue_title = Some(assignment.title);
 

--- a/src/tui/input_handler.rs
+++ b/src/tui/input_handler.rs
@@ -1331,6 +1331,7 @@ mod tests {
             "claude-opus-4-5".into(),
             "orchestrator".into(),
             None,
+            None,
         );
         s.status = SessionStatus::Completed;
         s.last_message = last_message.to_string();
@@ -1361,6 +1362,7 @@ mod tests {
             "task".into(),
             "claude-opus-4-5".into(),
             "orchestrator".into(),
+            None,
             None,
         );
         s.status = SessionStatus::Running;
@@ -1473,6 +1475,7 @@ mod tests {
             "claude-opus-4-5".into(),
             "orchestrator".into(),
             Some(42),
+            None,
         );
         s.status = SessionStatus::Running;
         app.pool.enqueue(s);
@@ -1518,6 +1521,7 @@ mod tests {
             "claude-opus-4-5".into(),
             "orchestrator".into(),
             Some(42),
+            None,
         );
         app.pool.enqueue(s);
         app.panel_view.selected = Some(0);
@@ -1541,6 +1545,7 @@ mod tests {
             "claude-opus-4-5".into(),
             "orchestrator".into(),
             Some(42),
+            None,
         );
         app.pool.enqueue(s);
         app.panel_view.selected = Some(0);

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -309,7 +309,8 @@ async fn event_loop(
                         format!("{}{}", config.prompt, image_refs)
                     };
 
-                    let session = crate::session::types::Session::new(prompt, model, mode, None);
+                    let session =
+                        crate::session::types::Session::new(prompt, model, mode, None, None);
 
                     // Record in prompt history
                     app.prompt_history

--- a/src/tui/session_switcher.rs
+++ b/src/tui/session_switcher.rs
@@ -166,7 +166,13 @@ mod tests {
     use crate::session::types::Session;
 
     fn make_session(prompt: &str, issue: Option<u64>) -> Session {
-        Session::new(prompt.into(), "opus".into(), "orchestrator".into(), issue)
+        Session::new(
+            prompt.into(),
+            "opus".into(),
+            "orchestrator".into(),
+            issue,
+            None,
+        )
     }
 
     #[test]

--- a/src/tui/snapshot_tests/agent_graph.rs
+++ b/src/tui/snapshot_tests/agent_graph.rs
@@ -19,6 +19,7 @@ fn make_session(
         "claude-opus-4-5".to_string(),
         "orchestrator".to_string(),
         Some(issue),
+        None,
     );
     s.id = Uuid::from_u128(id);
     s.status = status;

--- a/src/tui/snapshot_tests/agent_graph_dispatcher.rs
+++ b/src/tui/snapshot_tests/agent_graph_dispatcher.rs
@@ -23,6 +23,7 @@ fn two_agent_sessions() -> (Session, Session) {
         "claude-opus-4-5".to_string(),
         "orchestrator".to_string(),
         Some(101),
+        None,
     );
     s1.id = Uuid::nil();
     s1.status = SessionStatus::Running;
@@ -35,6 +36,7 @@ fn two_agent_sessions() -> (Session, Session) {
         "claude-opus-4-5".to_string(),
         "orchestrator".to_string(),
         Some(102),
+        None,
     );
     s2.id = Uuid::from_u128(1);
     s2.status = SessionStatus::Running;

--- a/src/tui/snapshot_tests/mod.rs
+++ b/src/tui/snapshot_tests/mod.rs
@@ -42,6 +42,7 @@ pub fn make_session(status: SessionStatus, issue_number: Option<u64>) -> Session
         "claude-opus-4-5".to_string(),
         "orchestrator".to_string(),
         issue_number,
+        None,
     );
     s.id = Uuid::nil();
     s.status = status;

--- a/src/tui/turboquant_dashboard.rs
+++ b/src/tui/turboquant_dashboard.rs
@@ -289,7 +289,13 @@ mod tests {
     }
 
     fn make_session(input_tokens: u64, cost_usd: f64, issue: Option<u64>) -> Session {
-        let mut s = Session::new("prompt".into(), "opus".into(), "orchestrator".into(), issue);
+        let mut s = Session::new(
+            "prompt".into(),
+            "opus".into(),
+            "orchestrator".into(),
+            issue,
+            None,
+        );
         s.status = SessionStatus::Running;
         s.token_usage = TokenUsage {
             input_tokens,

--- a/src/turboquant/adapter.rs
+++ b/src/turboquant/adapter.rs
@@ -745,13 +745,13 @@ mod tests {
     }
 
     fn make_running_session() -> Session {
-        let mut s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None);
+        let mut s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
         s.status = SessionStatus::Running;
         s
     }
 
     fn make_terminal_session() -> Session {
-        let mut s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None);
+        let mut s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
         s.status = SessionStatus::Completed;
         s
     }
@@ -1162,7 +1162,7 @@ mod tests {
         compressed: u64,
         cost_usd: f64,
     ) -> Session {
-        let mut s = Session::new("p".into(), "m".into(), "orchestrator".into(), None);
+        let mut s = Session::new("p".into(), "m".into(), "orchestrator".into(), None, None);
         s.token_usage = usage_with_input(input_tokens);
         s.tq_handoff_original_tokens = Some(original);
         s.tq_handoff_compressed_tokens = Some(compressed);
@@ -1171,7 +1171,7 @@ mod tests {
     }
 
     fn session_no_handoff(input_tokens: u64, cost_usd: f64) -> Session {
-        let mut s = Session::new("p".into(), "m".into(), "orchestrator".into(), None);
+        let mut s = Session::new("p".into(), "m".into(), "orchestrator".into(), None, None);
         s.token_usage = usage_with_input(input_tokens);
         s.cost_usd = cost_usd;
         s


### PR DESCRIPTION
## Summary

- Lifts the `Role` taxonomy + `derive_role` keyword classifier from the spike (`src/tui/agent_personalities/role.rs`) into the production `crate::session::role` module
- Adds `#[serde(default)] pub role: Role` to `Session`; old state files deserialize cleanly to `Role::Implementer`
- Wires `--role <role>` clap flag on session-spawning subcommands; resolution order is explicit override > `derive_role(&prompt)` > `Role::default()`
- `transition_to(...)` is non-mutating w.r.t. `role` (frozen at construction)

Implements the data-model decision in [ADR 002](docs/adr/002-agent-personalities.md) § Data Model. The renderer follow-up will lift the spike module wholesale.

## Acceptance criteria status

- [x] `src/session/role.rs` exists with 5-variant `Role` enum (snake_case, default Implementer) and `derive_role`
- [x] `Session::role` field with `#[serde(default)]`
- [x] `Session::new` accepts `role_override: Option<Role>`
- [x] `--role` clap flag wired (run / resume)
- [x] 25-prompt corpus test passes ≥80% accuracy threshold
- [x] serde round-trip + default + snake_case tests
- [x] `transition_to` non-interaction test
- [x] Classifier emits `tracing::debug!` (no `println!`/`dbg!`)
- [x] `cargo clippy -- -D warnings -A dead_code` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test` green (24/24 role-specific tests pass; one pre-existing flaky markdown perf test unrelated to this change)

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings -A dead_code`
- [x] `cargo test --lib role` — 24 passed
- [x] Resolution order verified: Orchestrator > Reviewer > DevOps > Docs > Implementer
- [x] Empty prompt → `Implementer`
- [x] Case-insensitive matching verified
- [x] Old JSON without `role` field deserializes to `Implementer`

Closes #538.