### PR TITLE
chore: silence 2 post-#564 dead_code warnings

### DIFF
--- a/src/provider/github/client.rs
+++ b/src/provider/github/client.rs
@@ -474,6 +474,12 @@ impl GhCliClient {
     /// Validates the input through `validate_gh_arg` (rejects shell
     /// metacharacters and `--`-prefixed values) and enforces the
     /// `owner/repo` shape via `parse_owner_repo`.
+    ///
+    /// Currently exercised only by unit tests — the wiring from
+    /// `Config::project::repo` through every `GhCliClient::new()` call
+    /// site is tracked as #565. Until that lands, every shellout
+    /// falls back to gh's worktree-remote inference.
+    #[allow(dead_code)]
     pub fn with_repo(mut self, repo: String) -> Result<Self> {
         validate_gh_arg(&repo, "repo")?;
         crate::provider::github::types::parse_owner_repo(&repo)

--- a/src/tui/agent_graph/personalities.rs
+++ b/src/tui/agent_graph/personalities.rs
@@ -69,6 +69,12 @@ const DEVOPS: Sprite = Sprite([
 /// All five roles in declaration order. Useful for exhaustive iteration in
 /// tests (so adding a `Role` variant fails the build until the new role is
 /// covered) and for cross-module helpers that need to fan out over every role.
+///
+/// `#[cfg(test)]`-gated: every current consumer is in a test module
+/// (inline tests in this file + `snapshot_tests/activity_log_dispatch.rs`,
+/// itself test-only). Drop the gate when production code starts iterating
+/// roles.
+#[cfg(test)]
 pub(crate) const ALL_ROLES: [Role; 5] = [
     Role::Implementer,
     Role::Orchestrator,


### PR DESCRIPTION
## Summary

`cargo build` after #564 merged was flagging two unused symbols. Both are honest signal — one is real deferred work, one is a test-only const.

- **`GhCliClient::with_repo`** (added by #545 P2.3) — the wire scaffolding is in place (field + builder + validation + 8 argv builders accepting `Option<&str>`) but the actual call from `Config::project::repo` is not yet threaded through the ~25 `GhCliClient::new()` instantiation sites. `#[allow(dead_code)]` with a comment pointing at the follow-up issue. The proper wiring is tracked in #565.
- **`tui::agent_graph::personalities::ALL_ROLES`** (from #543) — every consumer is in a test module (three inline tests in `personalities.rs` itself plus a `snapshot_tests/` import that is itself test-only). `#[cfg(test)]`-gated so the const exists during test compilation only.

After this PR: `cargo build` emits zero warnings, `cargo test` still passes 3890 tests.

Closes none — files #565 as the follow-up for the proper `with_repo` wiring.

## Test plan

- [ ] `cargo build` — zero warnings
- [ ] `cargo test` — 3890 passed
- [ ] `cargo fmt --check`, `cargo clippy -- -D warnings -A dead_code`, `scripts/check-file-size.sh` clean