### PR TITLE
fix(#558): retain worktree on post-completion gate failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- fix(session): post-completion gate failure no longer destroys uncommitted model edits (#558)
+  - Root cause: on any gate failure (clippy, tests, etc.) the completion dispatcher called
+    `git worktree remove --force`, silently deleting all uncommitted work the model had
+    written to the worktree between the session ending and the gates running.
+  - New terminal `SessionStatus::FailedGates` is set on the session instead of tearing
+    down. The dispatcher in `App::check_completions` routes `FailedGates` to
+    `SessionPool::finalize_retain_worktree` (new), which moves the session to the
+    finished bucket and releases file claims but does NOT remove the worktree at
+    `.maestro/worktrees/issue-NNN/`.
+  - An activity-log entry `Worktree retained at <path> for recovery` at `LogLevel::Warn`
+    is emitted so the path is visible in the TUI. Recovery affordance (TUI action to
+    resume from the retained tree) is tracked in sister issue #560.
+
+  **State-file format bump (v0.17.0):** `SessionStatus` gains the `"failed_gates"` serde
+  variant. A v0.16 binary deserializing a v0.17 `maestro-state.json` will fail to parse
+  the file. Delete `maestro-state.json` before downgrading.
+
+  **API changes (in-tree only):**
+  - New: `SessionStatus::FailedGates` — terminal variant; `is_terminal()` returns `true`
+  - New: `SessionPool::finalize_retain_worktree(id)` — moves session to finished without
+    removing the worktree
+  - New: `SessionPool::worktree_exists(slug)` — delegates to the underlying
+    `WorktreeManager`; used in tests to assert retain vs. teardown behaviour
+  - Renamed: `SessionPool::on_session_completed` → `SessionPool::finalize_and_teardown`
+    (all in-tree callers updated; public only to integration-test crate)
+
+  **Sister issues:** #559 (label-update logs error on gate failure), #560 (TUI recovery
+  affordance — depends on #558), #562 (auto-commit before gates run).
+
 ### Added
 
 - feat(session): classify subagent dispatches and surface their Role (#542)

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-04-30 23:59 (UTC)
+> Last updated: 2026-05-01 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -424,6 +424,7 @@ maestro/
 │   │   ├── stream_parsing.rs              # 22 tests: stream event parsing and parser round-trips
 │   │   ├── completion_pipeline.rs         # 9 tests: label transitions and PR creation
 │   │   ├── concurrent_sessions.rs         # 6 tests: max_concurrent enforcement
+│   │   ├── gate_failure_retention.rs      # 5 tests: gate-failure worktree retention vs. teardown; uses real git worktree commands (not MockWorktreeManager) to guard against the #558 regression  [Issue #558]
 │   │   ├── worktree_lifecycle.rs          # 8 tests: worktree create/cleanup and health monitoring
 │   │   ├── upgrade.rs                     # End-to-end upgrade flow tests: version check, banner states, installer backup/swap, restart command construction  [Issue #118]
 │   │   ├── milestone_health_wizard.rs     # 9 end-to-end tests for the Milestone Review wizard against MockGitHubClient: DOR detection, graph anomaly detection, patch round-trip, patch_milestone_description dispatch  [Issue #500]
@@ -715,6 +716,7 @@ maestro/
 | `src/integration_tests/stream_parsing.rs` | 22 tests covering stream event parsing and parser round-trips |
 | `src/integration_tests/completion_pipeline.rs` | 9 tests covering label transitions and PR creation |
 | `src/integration_tests/concurrent_sessions.rs` | 6 tests covering `max_concurrent` enforcement |
+| `src/integration_tests/gate_failure_retention.rs` | 5 tests covering gate-failure worktree retention; uses real `git worktree` commands so the #558 regression (force-remove on gate failure) is guarded end-to-end (Issue #558) |
 | `src/integration_tests/worktree_lifecycle.rs` | 8 tests covering worktree create/cleanup and health monitoring |
 | `src/integration_tests/upgrade.rs` | End-to-end upgrade flow tests: version check, banner state transitions, installer backup/swap, `RestartCommand` construction (Issue #118) |
 | `src/turboquant/` | Vector quantization for context compression (Issues #242-253, #343-345, #347) |

--- a/src/integration_tests/concurrent_sessions.rs
+++ b/src/integration_tests/concurrent_sessions.rs
@@ -41,7 +41,7 @@ fn completing_one_session_frees_slot_for_next() {
     assert_eq!(pool.active_count(), 1);
     assert_eq!(pool.queued_count(), 1);
 
-    pool.on_session_completed(id1);
+    pool.finalize_and_teardown(id1);
     let promoted = pool.try_promote();
 
     assert_eq!(
@@ -131,22 +131,22 @@ fn multiple_promotions_saturate_and_drain() {
     let p1 = pool.try_promote();
     assert_eq!(p1.len(), 2);
 
-    pool.on_session_completed(ids[0]);
-    pool.on_session_completed(ids[1]);
+    pool.finalize_and_teardown(ids[0]);
+    pool.finalize_and_teardown(ids[1]);
 
     // Round 2
     let p2 = pool.try_promote();
     assert_eq!(p2.len(), 2);
 
-    pool.on_session_completed(ids[2]);
-    pool.on_session_completed(ids[3]);
+    pool.finalize_and_teardown(ids[2]);
+    pool.finalize_and_teardown(ids[3]);
 
     // Round 3
     let p3 = pool.try_promote();
     assert_eq!(p3.len(), 2);
 
-    pool.on_session_completed(ids[4]);
-    pool.on_session_completed(ids[5]);
+    pool.finalize_and_teardown(ids[4]);
+    pool.finalize_and_teardown(ids[5]);
 
     assert!(pool.all_done());
     assert_eq!(pool.total_count(), 6);

--- a/src/integration_tests/gate_failure_retention.rs
+++ b/src/integration_tests/gate_failure_retention.rs
@@ -1,0 +1,220 @@
+//! Issue #558: post-completion gate failure must NOT tear down the worktree.
+//!
+//! These tests use real `git worktree` commands (not the `MockWorktreeManager`)
+//! so the regression we're guarding — a real `git worktree remove --force`
+//! call landing on the gate-failure path — is covered end to end.
+
+use crate::integration_tests::helpers::make_session_with_issue;
+use crate::session::pool::SessionPool;
+use crate::session::transition::TransitionReason;
+use crate::session::types::{Session, SessionStatus};
+use crate::session::worktree::GitWorktreeManager;
+use std::path::Path;
+use std::process::Command;
+use tokio::sync::mpsc;
+
+fn run_git(dir: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .status()
+        .expect("git must be on PATH");
+    assert!(status.success(), "git {:?} failed in {:?}", args, dir);
+}
+
+fn init_git_repo(dir: &Path) {
+    run_git(dir, &["init", "-q", "-b", "main"]);
+    run_git(dir, &["config", "user.email", "test@example.com"]);
+    run_git(dir, &["config", "user.name", "Test"]);
+    std::fs::write(dir.join("README.md"), "init").expect("write README");
+    run_git(dir, &["add", "README.md"]);
+    run_git(dir, &["commit", "-q", "-m", "init"]);
+}
+
+fn promote_one(pool: &mut SessionPool, session: Session) -> uuid::Uuid {
+    let id = session.id;
+    pool.enqueue(session);
+    pool.try_promote();
+    id
+}
+
+#[test]
+fn finalize_retain_worktree_keeps_real_git_worktree_and_uncommitted_file() {
+    // The literal bug-reproducer from session #542: model edits in the
+    // worktree, never commits, gate fails, expect the worktree (and its
+    // uncommitted file) to survive.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    init_git_repo(tmp.path());
+
+    let wt_mgr = GitWorktreeManager::new(tmp.path().to_path_buf());
+    let (tx, _rx) = mpsc::unbounded_channel();
+    let mut pool = SessionPool::new(1, Box::new(wt_mgr), tx);
+    let id = promote_one(&mut pool, make_session_with_issue(558));
+
+    let wt_path = tmp.path().join(".maestro/worktrees/issue-558");
+    assert!(
+        wt_path.exists(),
+        "precondition: try_promote must create the real worktree"
+    );
+
+    let model_file = wt_path.join("model_work.rs");
+    std::fs::write(&model_file, "fn pretend_model_wrote_this() {}")
+        .expect("write uncommitted model file");
+
+    pool.finalize_retain_worktree(id);
+
+    assert!(
+        wt_path.exists(),
+        "real worktree directory must survive finalize_retain_worktree"
+    );
+    assert!(
+        model_file.exists(),
+        "uncommitted file inside the worktree must survive"
+    );
+    let contents = std::fs::read_to_string(&model_file).expect("read model file");
+    assert_eq!(
+        contents, "fn pretend_model_wrote_this() {}",
+        "uncommitted model content must be intact byte-for-byte"
+    );
+}
+
+#[test]
+fn finalize_and_teardown_removes_real_git_worktree() {
+    // Counterpart sanity: the success path (explicit teardown) must still
+    // tear down the real worktree, otherwise we'd silently leak directories
+    // forever after the fix.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    init_git_repo(tmp.path());
+
+    let wt_mgr = GitWorktreeManager::new(tmp.path().to_path_buf());
+    let (tx, _rx) = mpsc::unbounded_channel();
+    let mut pool = SessionPool::new(1, Box::new(wt_mgr), tx);
+    let id = promote_one(&mut pool, make_session_with_issue(558));
+
+    let wt_path = tmp.path().join(".maestro/worktrees/issue-558");
+    assert!(wt_path.exists(), "precondition: worktree was created");
+
+    pool.finalize_and_teardown(id);
+
+    assert!(
+        !wt_path.exists(),
+        "real worktree must be removed by finalize_and_teardown (success path)"
+    );
+}
+
+#[tokio::test]
+async fn check_completions_retains_worktree_when_terminal_status_is_failed_gates() {
+    // Pipeline-level proof of the bug fix: when the dispatcher in
+    // `check_completions` sees a terminal session whose status is
+    // `FailedGates`, it must route to `finalize_retain_worktree` (keep the
+    // worktree), NOT `finalize_and_teardown` (delete it).
+    let mut app = crate::tui::make_test_app("issue-558-pipeline-fail");
+
+    let session = make_session_with_issue(558);
+    let id = session.id;
+    app.pool.enqueue(session);
+    app.pool.try_promote();
+    assert!(
+        app.pool.worktree_exists("issue-558"),
+        "precondition: worktree was created on promote"
+    );
+
+    // Walk the state machine: Queued -> Spawning -> Running -> GatesRunning -> FailedGates.
+    let managed = app
+        .pool
+        .get_active_mut(id)
+        .expect("session is active after promote");
+    managed
+        .session
+        .transition_to(SessionStatus::Spawning, TransitionReason::Promoted)
+        .expect("Queued -> Spawning");
+    managed
+        .session
+        .transition_to(SessionStatus::Running, TransitionReason::Spawned)
+        .expect("Spawning -> Running");
+    managed
+        .session
+        .transition_to(SessionStatus::GatesRunning, TransitionReason::GatesStarted)
+        .expect("Running -> GatesRunning");
+    managed
+        .session
+        .transition_to(SessionStatus::FailedGates, TransitionReason::GatesFailed)
+        .expect("GatesRunning -> FailedGates");
+
+    app.check_completions()
+        .await
+        .expect("check_completions must not error");
+
+    assert!(
+        app.pool.worktree_exists("issue-558"),
+        "worktree must be retained when terminal status is FailedGates"
+    );
+    let session_after = app
+        .pool
+        .get_session(id)
+        .expect("session must be findable in finished bucket");
+    assert_eq!(session_after.status, SessionStatus::FailedGates);
+}
+
+#[tokio::test]
+async fn check_completions_tears_down_worktree_when_terminal_status_is_completed() {
+    // Counterpart sanity at the pipeline level: success path still tears down.
+    let mut app = crate::tui::make_test_app("issue-558-pipeline-success");
+
+    let session = make_session_with_issue(558);
+    let id = session.id;
+    app.pool.enqueue(session);
+    app.pool.try_promote();
+    assert!(app.pool.worktree_exists("issue-558"));
+
+    let managed = app
+        .pool
+        .get_active_mut(id)
+        .expect("session is active after promote");
+    managed
+        .session
+        .transition_to(SessionStatus::Spawning, TransitionReason::Promoted)
+        .expect("Queued -> Spawning");
+    managed
+        .session
+        .transition_to(SessionStatus::Running, TransitionReason::Spawned)
+        .expect("Spawning -> Running");
+    managed
+        .session
+        .transition_to(SessionStatus::Completed, TransitionReason::StreamCompleted)
+        .expect("Running -> Completed");
+
+    app.check_completions()
+        .await
+        .expect("check_completions must not error");
+
+    assert!(
+        !app.pool.worktree_exists("issue-558"),
+        "worktree MUST be torn down when terminal status is Completed"
+    );
+}
+
+#[test]
+fn gate_failure_transition_to_failed_gates_is_valid() {
+    // Lock the state-machine transition the pipeline relies on.
+    let mut session = make_session_with_issue(558);
+    session
+        .transition_to(SessionStatus::Spawning, TransitionReason::Promoted)
+        .expect("Queued -> Spawning");
+    session
+        .transition_to(SessionStatus::Running, TransitionReason::Spawned)
+        .expect("Spawning -> Running");
+    session
+        .transition_to(SessionStatus::GatesRunning, TransitionReason::GatesStarted)
+        .expect("Running -> GatesRunning");
+    session
+        .transition_to(SessionStatus::FailedGates, TransitionReason::GatesFailed)
+        .expect("GatesRunning -> FailedGates must be a valid transition");
+
+    assert_eq!(session.status, SessionStatus::FailedGates);
+    assert!(
+        session.status.is_terminal(),
+        "FailedGates must be terminal so the dispatcher routes it to \
+         finalize_retain_worktree"
+    );
+}

--- a/src/integration_tests/mod.rs
+++ b/src/integration_tests/mod.rs
@@ -10,6 +10,8 @@ mod completion_pipeline;
 #[cfg(test)]
 mod concurrent_sessions;
 #[cfg(test)]
+mod gate_failure_retention;
+#[cfg(test)]
 mod init;
 #[cfg(test)]
 mod milestone_health_wizard;

--- a/src/integration_tests/session_lifecycle.rs
+++ b/src/integration_tests/session_lifecycle.rs
@@ -85,7 +85,7 @@ fn on_completed_moves_from_active_to_finished() {
     pool.try_promote();
     assert_eq!(pool.active_count(), 1);
 
-    pool.on_session_completed(id);
+    pool.finalize_and_teardown(id);
 
     assert_eq!(pool.active_count(), 0);
     assert_eq!(pool.total_count(), 1); // 1 in finished
@@ -101,7 +101,7 @@ fn completed_session_cleans_up_worktree() {
     pool.enqueue(s);
     pool.try_promote();
 
-    pool.on_session_completed(id);
+    pool.finalize_and_teardown(id);
 
     // Re-enqueueing same issue slug succeeds (proves worktree was cleaned up)
     let s2 = make_session_with_issue(10);
@@ -123,10 +123,10 @@ fn all_done_only_true_after_every_session_finishes() {
 
     assert!(!pool.all_done());
 
-    pool.on_session_completed(id1);
+    pool.finalize_and_teardown(id1);
     assert!(!pool.all_done());
 
-    pool.on_session_completed(id2);
+    pool.finalize_and_teardown(id2);
     assert!(pool.all_done());
 }
 

--- a/src/session/pool.rs
+++ b/src/session/pool.rs
@@ -174,20 +174,55 @@ impl SessionPool {
         promoted
     }
 
-    /// Handle a session reaching terminal state: move to finished, cleanup worktree.
-    pub fn on_session_completed(&mut self, session_id: Uuid) {
+    /// Move a terminal session from `active` to `finished`, deciding whether
+    /// to tear down the worktree based on status: `FailedGates` retains the
+    /// worktree (uncommitted model edits live there); every other terminal
+    /// status tears it down. Returns `true` when a session was finalized.
+    pub fn finalize(&mut self, session_id: Uuid) -> bool {
+        let Some(idx) = self.active.iter().position(|m| m.session.id == session_id) else {
+            return false;
+        };
+        let retain = self.active[idx].session.status == SessionStatus::FailedGates;
+        self.finalize_at(idx, retain);
+        true
+    }
+
+    /// Move a terminal session to `finished` and tear down its worktree.
+    /// Use only when the work is committed/merged or the user explicitly
+    /// authorized cleanup. The recovery-on-gate-failure path retains the
+    /// worktree — see [`Self::finalize_retain_worktree`].
+    pub fn finalize_and_teardown(&mut self, session_id: Uuid) {
         if let Some(idx) = self.active.iter().position(|m| m.session.id == session_id) {
-            let managed = self.active.remove(idx);
-            let slug = session_slug(&managed.session);
-
-            // Release all file claims for this session
-            self.file_claims.release_all(session_id);
-
-            // Cleanup worktree
-            let _ = self.worktree_mgr.remove(&slug);
-
-            self.finished.push(managed);
+            self.finalize_at(idx, false);
         }
+    }
+
+    /// Move a terminal session to `finished` without removing its worktree,
+    /// so uncommitted model edits in `.maestro/worktrees/issue-NNN/` survive
+    /// for recovery. File claims are still released so future sessions see
+    /// the freed slot.
+    pub fn finalize_retain_worktree(&mut self, session_id: Uuid) {
+        if let Some(idx) = self.active.iter().position(|m| m.session.id == session_id) {
+            self.finalize_at(idx, true);
+        }
+    }
+
+    fn finalize_at(&mut self, idx: usize, retain_worktree: bool) {
+        let managed = self.active.remove(idx);
+        let session_id = managed.session.id;
+        self.file_claims.release_all(session_id);
+        if !retain_worktree {
+            let slug = session_slug(&managed.session);
+            let _ = self.worktree_mgr.remove(&slug);
+        }
+        self.finished.push(managed);
+    }
+
+    /// Whether a worktree exists for the given slug. Delegates to the
+    /// underlying `WorktreeManager` so callers can assert teardown vs. retain
+    /// without exposing the manager itself.
+    pub fn worktree_exists(&self, slug: &str) -> bool {
+        self.worktree_mgr.exists(slug)
     }
 
     /// Get all sessions for display: active first, then finished, then queued.
@@ -482,29 +517,29 @@ mod tests {
     }
 
     #[test]
-    fn on_session_completed_moves_to_finished() {
+    fn finalize_and_teardown_moves_to_finished() {
         let mut pool = make_pool(2);
         let session = make_session("done");
         let id = session.id;
         pool.enqueue(session);
         pool.try_promote();
 
-        pool.on_session_completed(id);
+        pool.finalize_and_teardown(id);
         assert_eq!(pool.active_count(), 0);
         assert_eq!(pool.total_count(), 1); // in finished
     }
 
     #[test]
-    fn on_session_completed_unknown_id_is_noop() {
+    fn finalize_and_teardown_unknown_id_is_noop() {
         let mut pool = make_pool(2);
         pool.enqueue(make_session("running"));
         pool.try_promote();
-        pool.on_session_completed(Uuid::new_v4());
+        pool.finalize_and_teardown(Uuid::new_v4());
         assert_eq!(pool.active_count(), 1);
     }
 
     #[test]
-    fn on_session_completed_frees_slot_for_promotion() {
+    fn finalize_and_teardown_frees_slot_for_promotion() {
         let mut pool = make_pool(1);
         let s1 = make_session("first");
         let id1 = s1.id;
@@ -512,7 +547,7 @@ mod tests {
         pool.enqueue(make_session("second"));
         pool.try_promote(); // promotes first, second stays queued
 
-        pool.on_session_completed(id1);
+        pool.finalize_and_teardown(id1);
         let promoted = pool.try_promote();
         assert_eq!(promoted.len(), 1);
         assert_eq!(pool.active_count(), 1);
@@ -545,7 +580,7 @@ mod tests {
         let id = session.id;
         pool.enqueue(session);
         pool.try_promote();
-        pool.on_session_completed(id);
+        pool.finalize_and_teardown(id);
         assert!(pool.get_session_mut(id).is_some());
     }
 
@@ -586,8 +621,8 @@ mod tests {
         pool.enqueue(s1);
         pool.enqueue(s2);
         pool.try_promote();
-        pool.on_session_completed(id1);
-        pool.on_session_completed(id2);
+        pool.finalize_and_teardown(id1);
+        pool.finalize_and_teardown(id2);
         assert!(pool.all_done());
     }
 
@@ -618,7 +653,7 @@ mod tests {
     }
 
     #[test]
-    fn on_session_completed_releases_claims() {
+    fn finalize_and_teardown_releases_claims() {
         let mut pool = make_pool(2);
         let session = make_session("claimer");
         let id = session.id;
@@ -627,7 +662,7 @@ mod tests {
         pool.file_claims.claim("src/a.rs", id);
         pool.file_claims.claim("src/b.rs", id);
 
-        pool.on_session_completed(id);
+        pool.finalize_and_teardown(id);
         assert_eq!(pool.file_claims.total_claims(), 0);
     }
 
@@ -667,7 +702,7 @@ mod tests {
         assert_eq!(pool.all_sessions().len(), 2);
 
         // Complete s1 to move it to finished
-        pool.on_session_completed(id1);
+        pool.finalize_and_teardown(id1);
         pool.try_promote(); // promotes s2
 
         assert_eq!(pool.all_sessions().len(), 2);
@@ -684,7 +719,7 @@ mod tests {
         let id = s.id;
         pool.enqueue(s);
         pool.try_promote();
-        pool.on_session_completed(id);
+        pool.finalize_and_teardown(id);
         assert_eq!(pool.total_count(), 1); // 1 finished
 
         assert!(pool.dismiss_session(id));
@@ -723,7 +758,7 @@ mod tests {
                     .session
                     .transition_to(SessionStatus::Completed, TransitionReason::StreamCompleted);
             }
-            pool.on_session_completed(id);
+            pool.finalize_and_teardown(id);
         }
         assert_eq!(pool.total_count(), 2);
 
@@ -844,8 +879,100 @@ mod tests {
             .unwrap()
             .session
             .transition_flash_remaining = 3;
-        pool.on_session_completed(id);
+        pool.finalize_and_teardown(id);
         pool.tick_flash_counters();
         assert_eq!(pool.get_session(id).unwrap().transition_flash_remaining, 2);
+    }
+
+    // --- Issue #558: finalize_retain_worktree (gate-failure recovery path) ---
+
+    #[test]
+    fn finalize_retain_worktree_moves_session_to_finished() {
+        let mut pool = make_pool(2);
+        let session = make_session_with_issue("retain", 558);
+        let id = session.id;
+        pool.enqueue(session);
+        pool.try_promote();
+        assert_eq!(pool.active_count(), 1);
+
+        pool.finalize_retain_worktree(id);
+        assert_eq!(pool.active_count(), 0);
+        assert_eq!(pool.total_count(), 1);
+    }
+
+    #[test]
+    fn finalize_retain_worktree_does_not_call_remove() {
+        let mut pool = make_pool(2);
+        let session = make_session_with_issue("keep-worktree", 558);
+        let id = session.id;
+        pool.enqueue(session);
+        pool.try_promote();
+        assert!(
+            pool.worktree_exists("issue-558"),
+            "worktree must exist after promotion"
+        );
+
+        pool.finalize_retain_worktree(id);
+
+        assert!(
+            pool.worktree_exists("issue-558"),
+            "worktree must NOT have been removed after finalize_retain_worktree"
+        );
+    }
+
+    #[test]
+    fn finalize_retain_worktree_releases_file_claims() {
+        let mut pool = make_pool(2);
+        let session = make_session_with_issue("claimer", 558);
+        let id = session.id;
+        pool.enqueue(session);
+        pool.try_promote();
+        pool.file_claims.claim("src/a.rs", id);
+        pool.file_claims.claim("src/b.rs", id);
+        assert_eq!(pool.file_claims.total_claims(), 2);
+
+        pool.finalize_retain_worktree(id);
+        assert_eq!(pool.file_claims.total_claims(), 0);
+    }
+
+    #[test]
+    fn finalize_and_teardown_calls_remove() {
+        let mut pool = make_pool(2);
+        let session = make_session_with_issue("teardown", 558);
+        let id = session.id;
+        pool.enqueue(session);
+        pool.try_promote();
+        assert!(pool.worktree_exists("issue-558"));
+
+        pool.finalize_and_teardown(id);
+
+        assert!(
+            !pool.worktree_exists("issue-558"),
+            "worktree MUST be removed after finalize_and_teardown"
+        );
+    }
+
+    #[test]
+    fn finalize_retain_worktree_idempotent_when_called_twice() {
+        let mut pool = make_pool(2);
+        let session = make_session_with_issue("idempotent", 558);
+        let id = session.id;
+        pool.enqueue(session);
+        pool.try_promote();
+
+        pool.finalize_retain_worktree(id);
+        pool.finalize_retain_worktree(id);
+
+        assert_eq!(
+            pool.total_count(),
+            1,
+            "second call must not duplicate or panic"
+        );
+    }
+
+    #[test]
+    fn worktree_exists_returns_false_for_unknown_slug() {
+        let pool = make_pool(2);
+        assert!(!pool.worktree_exists("issue-99999"));
     }
 }

--- a/src/session/transition.rs
+++ b/src/session/transition.rs
@@ -215,6 +215,7 @@ mod tests {
             SessionStatus::GatesRunning,
             &[
                 SessionStatus::NeedsReview,
+                SessionStatus::FailedGates,
                 SessionStatus::Completed,
                 SessionStatus::Errored,
             ],
@@ -224,6 +225,11 @@ mod tests {
     #[test]
     fn valid_transitions_needs_review_is_empty() {
         assert!(SessionStatus::NeedsReview.valid_transitions().is_empty());
+    }
+
+    #[test]
+    fn valid_transitions_failed_gates_is_empty() {
+        assert!(SessionStatus::FailedGates.valid_transitions().is_empty());
     }
 
     #[test]

--- a/src/session/types.rs
+++ b/src/session/types.rs
@@ -12,6 +12,10 @@ pub enum SessionStatus {
     Completed,
     GatesRunning,
     NeedsReview,
+    /// Terminal status used when post-completion gates fail. Distinct from
+    /// `Errored` so the dispatcher knows to retain the worktree for recovery
+    /// rather than tear it down with the rest of the session state.
+    FailedGates,
     Errored,
     Paused,
     Killed,
@@ -37,6 +41,7 @@ impl SessionStatus {
             Self::Completed => IconId::CheckCircle,
             Self::GatesRunning => IconId::Search,
             Self::NeedsReview => IconId::NeedsReview,
+            Self::FailedGates => IconId::XCircle,
             Self::Errored => IconId::XCircle,
             Self::Paused => IconId::Pause,
             Self::Killed => IconId::Skull,
@@ -56,6 +61,7 @@ impl SessionStatus {
             Self::Completed => "[+]",
             Self::GatesRunning => "[?]",
             Self::NeedsReview => "[!]",
+            Self::FailedGates => "[!G]",
             Self::Errored => "[X]",
             Self::Paused => "[-]",
             Self::Killed => "[x]",
@@ -83,6 +89,7 @@ impl SessionStatus {
             Self::Completed => "COMPLETED",
             Self::GatesRunning => "GATES_RUNNING",
             Self::NeedsReview => "NEEDS_REVIEW",
+            Self::FailedGates => "FAILED_GATES",
             Self::Errored => "ERRORED",
             Self::Paused => "PAUSED",
             Self::Killed => "KILLED",
@@ -114,8 +121,9 @@ impl SessionStatus {
             Paused => &[Running, Killed],
             Stalled => &[Retrying, Killed, Errored],
             Completed => &[],
-            GatesRunning => &[NeedsReview, Completed, Errored],
+            GatesRunning => &[NeedsReview, FailedGates, Completed, Errored],
             NeedsReview => &[],
+            FailedGates => &[],
             Errored => &[Retrying],
             Retrying => &[Spawning, Errored, Killed],
             CiFix => &[Spawning, Errored, Killed],
@@ -962,6 +970,50 @@ mod tests {
         let stripped = json.replace(r#","conflict_fix_context":null"#, "");
         let rt: Session = serde_json::from_str(&stripped).unwrap();
         assert!(rt.conflict_fix_context.is_none());
+    }
+
+    // --- Issue #558: SessionStatus::FailedGates ---
+
+    #[test]
+    fn failed_gates_status_is_terminal() {
+        assert!(SessionStatus::FailedGates.is_terminal());
+    }
+
+    #[test]
+    fn failed_gates_status_serializes_as_snake_case() {
+        let json = serde_json::to_string(&SessionStatus::FailedGates).unwrap();
+        assert_eq!(json, r#""failed_gates""#);
+    }
+
+    #[test]
+    fn failed_gates_status_deserializes_from_snake_case() {
+        let status: SessionStatus = serde_json::from_str(r#""failed_gates""#).unwrap();
+        assert_eq!(status, SessionStatus::FailedGates);
+    }
+
+    #[test]
+    fn valid_transitions_gates_running_includes_failed_gates() {
+        let transitions = SessionStatus::GatesRunning.valid_transitions();
+        assert!(
+            transitions.contains(&SessionStatus::FailedGates),
+            "GatesRunning must allow transition to FailedGates"
+        );
+    }
+
+    #[test]
+    fn failed_gates_has_label_and_symbol() {
+        let status = SessionStatus::FailedGates;
+        assert!(!status.symbol().is_empty());
+        assert_eq!(status.label(), "FAILED_GATES");
+    }
+
+    #[test]
+    fn session_with_failed_gates_round_trips_via_serde() {
+        let mut s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
+        s.status = SessionStatus::FailedGates;
+        let json = serde_json::to_string(&s).unwrap();
+        let rt: Session = serde_json::from_str(&json).unwrap();
+        assert_eq!(rt.status, SessionStatus::FailedGates);
     }
 
     // --- Issue #169: Hollow completion detection ---

--- a/src/tui/agent_graph/render.rs
+++ b/src/tui/agent_graph/render.rs
@@ -231,7 +231,7 @@ pub(super) fn status_modifier(status: SessionStatus) -> Modifier {
     use SessionStatus::*;
     match status {
         Running | GatesRunning | NeedsReview | NeedsPr | CiFix | ConflictFix => Modifier::BOLD,
-        Errored => Modifier::DIM | Modifier::BOLD,
+        Errored | FailedGates => Modifier::DIM | Modifier::BOLD,
         Completed | Killed | Paused => Modifier::DIM,
         Stalled => Modifier::DIM | Modifier::REVERSED,
         Spawning | Queued | Retrying => Modifier::empty(),

--- a/src/tui/app/completion_pipeline.rs
+++ b/src/tui/app/completion_pipeline.rs
@@ -112,12 +112,27 @@ impl App {
                     if let Some(managed) = self.pool.find_by_issue_mut(completion.issue_number) {
                         managed.session.gate_results = failed_gate_results;
                         let _ = managed.session.transition_to(
-                            SessionStatus::NeedsReview,
+                            SessionStatus::FailedGates,
                             TransitionReason::GatesFailed,
                         );
                         managed
                             .session
                             .log_activity(format!("Gates failed: {}", failures.join("; ")));
+                        if let Some(wt_path) = &completion.worktree_path {
+                            let retain_msg =
+                                format!("Worktree retained at {} for recovery", wt_path.display());
+                            managed.session.log_activity(retain_msg.clone());
+                            tracing::warn!(
+                                issue = completion.issue_number,
+                                worktree = %wt_path.display(),
+                                "retaining worktree after gate failure",
+                            );
+                            self.activity_log.push_simple(
+                                issue_label.clone(),
+                                retain_msg,
+                                LogLevel::Warn,
+                            );
+                        }
                     }
 
                     completion.success = false;
@@ -369,10 +384,8 @@ impl App {
             .map(|s| s.id)
             .collect();
 
-        // Only process sessions that are actually in the active list
         for id in &completed_ids {
-            if self.pool.get_active_mut(*id).is_some() {
-                self.pool.on_session_completed(*id);
+            if self.pool.finalize(*id) {
                 self.health_monitor.remove(*id);
                 self.progress_tracker.remove(id);
             }

--- a/src/tui/app/tests.rs
+++ b/src/tui/app/tests.rs
@@ -973,7 +973,7 @@ fn dismissed_flag_prevents_summary_retrigger_scenario() {
     app.pool.enqueue(session);
     let promoted = app.pool.try_promote();
     for id in promoted {
-        app.pool.on_session_completed(id);
+        app.pool.finalize_and_teardown(id);
     }
     assert!(app.pool.all_done(), "pool must be all_done");
 

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -672,6 +672,7 @@ impl Theme {
             SessionStatus::CiFix => self.status_ci_fix,
             SessionStatus::NeedsPr => self.status_stalled, // Reuse stalled color (amber warning)
             SessionStatus::ConflictFix => self.status_ci_fix, // Reuse CI fix color (repair yellow)
+            SessionStatus::FailedGates => self.status_errored, // Same red as Errored — gate failure is an error class
         }
     }
 


### PR DESCRIPTION
## Summary

- Post-completion gate failures (clippy/test/security/docs/label_update) no longer destroy the session's worktree at `.maestro/worktrees/issue-NNN/`. Pre-fix: any gate failure ran `git worktree remove --force`, silently dropping uncommitted model edits (this bit session #542 — ~21 min of work lost).
- New `SessionStatus::FailedGates` (terminal) is the gate-failure target. The dispatcher in `App::check_completions` routes through a single `SessionPool::finalize(id)` entry point that decides retain-vs-teardown based on status.
- Activity log + structured `tracing::warn!` emit `Worktree retained at <path> for recovery` so operators know where the work lives.

Closes #558

## Test plan

- [x] `cargo test --quiet` — 4246 tests pass (3908 lib + 325 + 13 + 0)
- [x] `cargo clippy -- -D warnings -A dead_code` — clean
- [x] `cargo fmt --check` — clean
- [x] New unit tests in `src/session/types.rs`, `src/session/pool.rs`, and `src/session/transition.rs` cover the variant, the finalize split, the worktree_exists accessor, and the GatesRunning→FailedGates transition.
- [x] New integration tests in `src/integration_tests/gate_failure_retention.rs` use real `git init` + `git worktree add` on a tempdir to assert (a) `finalize_retain_worktree` keeps both the worktree directory AND its uncommitted file byte-for-byte, (b) `finalize_and_teardown` still removes the worktree on the success path, (c) `App::check_completions` correctly dispatches by terminal status.

## Notes

- **State-file format bump.** A v0.16 binary deserializing a v0.17 state file will fail on the new `"failed_gates"` serde variant. Downgrades require deleting `maestro-state.json`. Documented in `CHANGELOG.md`.
- **Public API.** Renamed `SessionPool::on_session_completed` → `finalize_and_teardown` (all callers updated). Added `finalize_retain_worktree`, `finalize`, and `worktree_exists`.
- **Out of scope** (sister issues): TUI recovery affordance for retained worktrees (#560), label-update error logging (#559), auto-commit before gates (#562).
- Security review (subagent-security-analyst): GREEN-LIGHT, no Critical/High. The Medium item (unbounded retained-worktree accumulation) is the explicit TTL/grace-period scope deferral named in the issue body.