### PR TITLE
fix(github): swallow 'label not found' on remove_label (#559)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- fix(github): `remove_label` no longer logs an Error when the label is absent from the repo (#559)
+  - Root cause: on gate failure the completion path called `remove_label("maestro:in-progress")`
+    against repos whose label set never included that label. The `gh` CLI exits non-zero with
+    `Label 'maestro:in-progress' not found` on stderr, which the client surfaced as a user-visible
+    Error-level activity-log entry — noise with no remediation action.
+  - New private predicate `is_label_not_found_error(stderr, label)` detects the pattern.
+    `remove_label` now matches on the predicate: a matching error is swallowed and re-emitted at
+    `tracing::debug!` level; all other errors still propagate normally.
+  - 7 new unit tests in `src/provider/github/client.rs` cover the predicate against
+    matching, mismatched-label, issue-not-found, auth-shape, case-mismatch, URL-form,
+    and empty-stderr inputs.
+
 - fix(session): post-completion gate failure no longer destroys uncommitted model edits (#558)
   - Root cause: on any gate failure (clippy, tests, etc.) the completion dispatcher called
     `git worktree remove --force`, silently deleting all uncommitted work the model had

--- a/src/provider/github/client.rs
+++ b/src/provider/github/client.rs
@@ -364,6 +364,16 @@ pub fn is_auth_error(stderr: &str) -> bool {
 /// Sentinel prefix used to tag gh auth errors in anyhow messages.
 const GH_AUTH_ERROR_SENTINEL: &str = "[gh-auth-error]";
 
+/// True when stderr matches `gh issue edit --remove-label`'s
+/// "label missing" shape, keyed on the label literal so unrelated
+/// `not found` errors (issue/repo/branch) don't trigger. Both
+/// "not on repo" and "not on issue" share this stderr (gh v2.x);
+/// both are no-ops for remove.
+fn is_label_not_found_error(stderr: &str, label: &str) -> bool {
+    let needle = format!("'{}' not found", label);
+    stderr.contains(&needle)
+}
+
 /// Extract the PR number from `gh pr create` stdout.
 ///
 /// `gh pr create` does not accept `--json`; it prints the new PR's URL
@@ -613,8 +623,18 @@ impl GitHubClient for GhCliClient {
     async fn remove_label(&self, issue_number: u64, label: &str) -> Result<()> {
         validate_gh_arg(label, "label")?;
         let argv = gh_argv::build_remove_label_argv(issue_number, label, self.repo_arg());
-        self.run_gh(&argv_refs(&argv)).await?;
-        Ok(())
+        match self.run_gh(&argv_refs(&argv)).await {
+            Ok(_) => Ok(()),
+            Err(e) if is_label_not_found_error(&e.to_string(), label) => {
+                tracing::debug!(
+                    issue = issue_number,
+                    label = label,
+                    "remove_label: label not found on repo or issue — treating as no-op"
+                );
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
     }
 
     async fn create_pr(
@@ -1672,6 +1692,50 @@ mod tests {
     fn is_gh_auth_error_returns_false_for_regular_error() {
         let err = anyhow::anyhow!("gh command failed: branch not found");
         assert!(!is_gh_auth_error(&err));
+    }
+
+    // -- is_label_not_found_error (#559) --
+
+    #[test]
+    fn is_label_not_found_error_matches_quoted_label() {
+        let stderr = "failed to update https://github.com/foo/bar: 'maestro:in-progress' not found";
+        assert!(is_label_not_found_error(stderr, "maestro:in-progress"));
+    }
+
+    #[test]
+    fn is_label_not_found_error_rejects_issue_not_found() {
+        let stderr = "GraphQL: Could not resolve to an Issue";
+        assert!(!is_label_not_found_error(stderr, "maestro:in-progress"));
+    }
+
+    #[test]
+    fn is_label_not_found_error_rejects_label_mismatch() {
+        let stderr = "'maestro:done' not found";
+        assert!(!is_label_not_found_error(stderr, "maestro:in-progress"));
+    }
+
+    #[test]
+    fn is_label_not_found_error_rejects_auth_shape() {
+        let stderr = "[gh-auth-error] gh auth status failed";
+        assert!(!is_label_not_found_error(stderr, "maestro:in-progress"));
+    }
+
+    #[test]
+    fn is_label_not_found_error_matches_issue_url_form() {
+        let stderr = "failed to update https://github.com/CarlosDanielDev/maestro/issues/542: \
+                      'maestro:in-progress' not found";
+        assert!(is_label_not_found_error(stderr, "maestro:in-progress"));
+    }
+
+    #[test]
+    fn is_label_not_found_error_rejects_case_mismatch() {
+        let stderr = "'maestro:in-progress' not found";
+        assert!(!is_label_not_found_error(stderr, "Maestro:In-Progress"));
+    }
+
+    #[test]
+    fn is_label_not_found_error_rejects_empty_stderr() {
+        assert!(!is_label_not_found_error("", "maestro:in-progress"));
     }
 
     // -- create_milestone / create_issue mock tests --


### PR DESCRIPTION
## Summary
- Swallows `'<label>' not found` errors from `gh issue edit --remove-label` (label absent from repo or unset on issue) — both are idempotent no-ops for removal.
- Adds private predicate `is_label_not_found_error(stderr, label)` keyed on the label literal so unrelated `not found` errors (issue/repo/branch) still propagate.
- Re-emits the swallowed condition at `tracing::debug!` level; the user-visible activity-log noise observed on session #542 is gone.

Closes #559

## Test plan
- [x] 7 unit tests cover the predicate (matching shape, mismatched label, issue-not-found, auth shape, case mismatch, URL form, empty stderr).
- [x] `cargo test` — 4253 passed, 0 failed.
- [x] `cargo clippy -- -D warnings -A dead_code` clean.
- [x] `cargo fmt --check` clean.
- [ ] Manual: run a session against a fork without `maestro:in-progress` label and confirm the activity log stays clean.