### PR TITLE
fix(security): sanitize Slack and PowerShell injection in notify.sh (#583)

### DIFF
--- a/.claude/hooks/notify.sh
+++ b/.claude/hooks/notify.sh
@@ -33,8 +33,10 @@ load_config() {
 
   # Prioridade: config do projeto > config global
   if [[ -f "$CONFIG_FILE" ]]; then
+    # shellcheck source=/dev/null
     source "$CONFIG_FILE"
   elif [[ -f "$LEGACY_CONFIG_FILE" ]]; then
+    # shellcheck source=/dev/null
     source "$LEGACY_CONFIG_FILE"
   fi
 
@@ -114,22 +116,41 @@ truncate_message() {
 # NOTIFICATION SENDERS
 # =============================================================================
 
+# Build a Slack chat.postMessage JSON payload using jq so all JSON-special
+# characters in the user-controlled text are escaped safely.
+build_slack_payload() {
+  local channel="$1"
+  local text="$2"
+  jq -n --arg channel "$channel" --arg text "$text" \
+    '{channel: $channel, text: $text}'
+}
+
+# Escape a value for embedding inside a PowerShell single-quoted string literal.
+# The only character that needs escaping inside '...' is the single quote
+# itself, which is doubled. Newlines/CRs would terminate our single-line literal
+# and allow injection of additional statements, so they are stripped.
+escape_powershell_string() {
+  local input="$1"
+  printf '%s' "$input" | tr -d '\r\n' | sed "s/'/''/g"
+}
+
 send_slack_notification() {
   local channel="$1"
   local text="$2"
-  local tmp_payload="/tmp/claude_slack_$$.json"
 
-  cat > "$tmp_payload" <<EOF
-{"channel":"$channel","text":"$text"}
-EOF
+  if ! command -v jq &> /dev/null; then
+    echo "notify.sh: jq is required for Slack notifications but is not installed; skipping" >&2
+    return 0
+  fi
+
+  local payload
+  payload=$(build_slack_payload "$channel" "$text")
 
   curl -s -X POST \
     -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
     -H "Content-type: application/json; charset=utf-8" \
-    -d @"$tmp_payload" \
-    "$SLACK_API_URL" > /dev/null 2>&1
-
-  rm -f "$tmp_payload" 2>/dev/null
+    --data-binary "$payload" \
+    "$SLACK_API_URL" > /dev/null 2>&1 || true
 }
 
 send_macos_notification() {
@@ -144,12 +165,17 @@ send_macos_notification() {
 send_windows_notification() {
   local title="$1"
   local message="$2"
+
+  local safe_title safe_message
+  safe_title=$(escape_powershell_string "$title")
+  safe_message=$(escape_powershell_string "$message")
+
   powershell.exe -ExecutionPolicy Bypass -Command "
     Add-Type -AssemblyName System.Windows.Forms
     \$balloon = New-Object System.Windows.Forms.NotifyIcon
     \$balloon.Icon = [System.Drawing.SystemIcons]::Information
-    \$balloon.BalloonTipTitle = '$title'
-    \$balloon.BalloonTipText = '$message'
+    \$balloon.BalloonTipTitle = '$safe_title'
+    \$balloon.BalloonTipText = '$safe_message'
     \$balloon.BalloonTipIcon = [System.Windows.Forms.ToolTipIcon]::Info
     \$balloon.Visible = \$true
     \$balloon.ShowBalloonTip(5000)
@@ -245,4 +271,9 @@ main() {
   fi
 }
 
-main "$@"
+# Run main only when this script is executed directly, not when sourced
+# (e.g. by bats tests). `(return 0 2>/dev/null)` succeeds in a sourced
+# context and fails when the script is invoked as a process.
+if ! (return 0 2>/dev/null); then
+  main "$@"
+fi

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-05-01 (UTC)
+> Last updated: 2026-05-02 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -40,7 +40,7 @@ maestro/
 │   │   │   └── idea_triager_pass.txt              # Golden-path fixture: full valid idea-triager report
 │   │   ├── implement-gates.sh             # Pre-implementation gate: DOR / blocker / contract checks
 │   │   ├── notify.ps1                     # Windows notification hook
-│   │   ├── notify.sh                      # Unix notification hook
+│   │   ├── notify.sh                      # Unix notification hook; Slack payload built via `jq -n --arg` (soft dep: no-ops gracefully when jq absent); PowerShell single-quote escaping via escape_powershell_string helper  [Issue #583]
 │   │   ├── parse_gatekeeper_report.py     # Validates and re-emits gatekeeper JSON reports (exit 1 on contract violation)
 │   │   ├── parse_idea_triager_report.py   # Validates and re-emits idea-triager JSON reports; enforces fence, version, enums (exit 1 on violation)  [Issue #484]
 │   │   ├── preflight.sh                   # Preflight environment checks run before session launch
@@ -511,7 +511,9 @@ maestro/
 ├── tests/                                 # Cargo integration tests (run as a separate binary, full crate access)
 │   ├── settings_caveman.rs                # Integration tests for FsSettingsStore against real tempfiles: read/write/toggle round-trips for caveman mode, missing-key defaults, malformed JSON handling  [Issue #490]
 │   ├── gatekeeper/                        # Gatekeeper harness fixtures and tests
-│   ├── hooks/                             # Hook script tests
+│   ├── hooks/                             # Hook script bats tests (requires bats-core)
+│   │   ├── implement-gates.bats           # bats tests for implement-gates.sh
+│   │   └── notify.bats                    # 10 bats tests: Slack JSON payload construction, PowerShell escape, macOS regression, shellcheck  [Issue #583]
 │   ├── manifests/                         # Test manifest fixtures
 │   └── scripts/                           # Test script fixtures
 ├── .gitignore                             # Includes .maestro/worktrees/ and runtime artifacts; .maestro/knowledge.md (written by maestro adapt, auto-loaded as system-prompt component by SessionPool::try_promote) is also excluded
@@ -543,6 +545,7 @@ maestro/
 | `.claude/agents/` | Subagent definitions |
 | `.claude/commands/` | Slash command definitions |
 | `.claude/hooks/` | Pre/post command notification hooks |
+| `.claude/hooks/notify.sh` | Unix notification hook; Slack payload constructed with `jq -n --arg` (no raw string interpolation); PowerShell toast uses `escape_powershell_string` helper; `jq` is a soft runtime dependency — Slack notifications are skipped silently when absent (Issue #583) |
 | `.claude/skills/` | Reusable knowledge bases for subagents |
 | `.claude/worktrees/` | Worktree checkouts managed by maestro |
 | `build.rs` | Build script: generates `maestro.1` man page and bash/zsh/fish completions into `OUT_DIR` at build time (Issue #18) |

--- a/tests/hooks/notify.bats
+++ b/tests/hooks/notify.bats
@@ -1,0 +1,151 @@
+#!/usr/bin/env bats
+#
+# Tests for .claude/hooks/notify.sh
+#
+# Covers the sanitization fix from issue #583:
+#   - Slack JSON payload built via jq --arg (no heredoc interpolation).
+#   - PowerShell title/message single-quote escape and newline strip.
+#   - macOS tr-based sanitization regression guard.
+#   - shellcheck static-analysis gate.
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  HOOK="$REPO_ROOT/.claude/hooks/notify.sh"
+
+  # Sourcing the script only loads helpers; main is gated behind a
+  # sourced-vs-executed check inside the hook itself.
+  # shellcheck source=/dev/null
+  source "$HOOK"
+
+  FAKE_BIN="$(mktemp -d)"
+  export FAKE_BIN
+}
+
+teardown() {
+  rm -rf "$FAKE_BIN"
+}
+
+# ---------------------------------------------------------------------------
+# Slack payload tests
+# ---------------------------------------------------------------------------
+
+@test "slack payload is valid JSON for benign input" {
+  run build_slack_payload "U123" "Hello world"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e . > /dev/null
+}
+
+@test "slack payload preserves text verbatim under JSON injection attempt" {
+  local channel="U123"
+  local text='test", "channel": "#hijack'
+
+  run build_slack_payload "$channel" "$text"
+  [ "$status" -eq 0 ]
+
+  echo "$output" | jq -e . > /dev/null
+
+  parsed_text="$(echo "$output" | jq -r .text)"
+  [ "$parsed_text" = "$text" ]
+
+  parsed_channel="$(echo "$output" | jq -r .channel)"
+  [ "$parsed_channel" = "$channel" ]
+}
+
+@test "slack payload handles backslash and embedded newline" {
+  local text
+  text=$'path\\to\\file\nline2'
+
+  run build_slack_payload "U999" "$text"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e . > /dev/null
+
+  parsed_text="$(echo "$output" | jq -r .text)"
+  [ "$parsed_text" = "$text" ]
+}
+
+# ---------------------------------------------------------------------------
+# PowerShell escape tests
+# ---------------------------------------------------------------------------
+
+@test "escape_powershell_string strips newlines" {
+  local input
+  input=$'title with\nnewline'
+
+  run escape_powershell_string "$input"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *$'\n'* ]]
+}
+
+@test "escape_powershell_string strips carriage returns" {
+  local input
+  input=$'title with\rCR'
+
+  run escape_powershell_string "$input"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *$'\r'* ]]
+}
+
+@test "escape_powershell_string doubles single quotes" {
+  local input="it's a \"test\""
+
+  run escape_powershell_string "$input"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"''"* ]]
+}
+
+@test "escape_powershell_string handles combined quote and newline injection" {
+  local input
+  input=$'it\'s a "test"\nrm -rf /'
+
+  run escape_powershell_string "$input"
+  [ "$status" -eq 0 ]
+
+  [[ "$output" != *$'\n'* ]]
+  [[ "$output" == *"''"* ]]
+  [[ "$output" == *"rm -rf /"* ]]
+}
+
+@test "escape_powershell_string preserves empty input" {
+  run escape_powershell_string ""
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# macOS regression test
+# ---------------------------------------------------------------------------
+
+@test "macos sanitization strips special chars (regression)" {
+  if [[ "$OSTYPE" != "darwin"* ]]; then
+    skip "macOS only"
+  fi
+
+  cat > "$FAKE_BIN/osascript" <<'STUB'
+#!/bin/bash
+echo "$@" >> "$FAKE_BIN/osascript.log"
+STUB
+  chmod +x "$FAKE_BIN/osascript"
+  PATH="$FAKE_BIN:$PATH"
+  export PATH FAKE_BIN
+
+  run send_macos_notification "it's broken!" "rm -rf /"
+  [ "$status" -eq 0 ]
+
+  [ -f "$FAKE_BIN/osascript.log" ]
+  log_content="$(cat "$FAKE_BIN/osascript.log")"
+
+  [[ "$log_content" != *"it's"* ]]
+  [[ "$log_content" != *"!"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# shellcheck gate
+# ---------------------------------------------------------------------------
+
+@test "shellcheck passes on notify.sh with no warnings" {
+  if ! command -v shellcheck &> /dev/null; then
+    skip "shellcheck not installed"
+  fi
+  run shellcheck -x "$HOOK"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- Slack payload built via `jq -n --arg` (no more heredoc interpolation) — caller-controlled text can no longer break out of JSON structure or override the channel field.
- New `escape_powershell_string` helper doubles single quotes (`'` → `''`) and strips CR/LF so a malicious title/message can no longer terminate the PowerShell single-quoted literal and inject commands.
- macOS `tr -cd` sanitization is unchanged.
- Run-main guard switched from a `NOTIFY_TEST_MODE` env var to a sourced-vs-executed detection — cannot be flipped externally.

Closes #583.

## Test plan

- [x] `bats tests/hooks/notify.bats` — 10 new cases (Slack JSON injection, PowerShell escape, macOS regression, shellcheck).
- [x] `shellcheck -x .claude/hooks/notify.sh` — clean.
- [x] `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` — all green.
- [x] Manual: hook still executes correctly when invoked as a script (sourced-detection guard works).

## Out-of-scope follow-ups (filed)

- #586 — Linux `notify-send` markup/option-flag sanitization (HIGH; same vulnerability class on the Linux path).
- #587 — Replace regex JSON parsing in `extract_*_field` helpers with `jq` (MEDIUM; defense-in-depth).