### PR TITLE
docs(security): document config supply-chain risk

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,18 @@
 
 Maestro plugins execute arbitrary shell commands by design. When a plugin is configured in `maestro.toml`, its `run` field is passed directly to `sh -c`.
 
+## Configuration Supply-Chain Risk
+
+Treat `maestro.toml` as an executable runbook. Plugin `run` fields in that file are executed as shell commands the next time the matching hook runs, including hooks such as `session_completed`. The execution path is `src/plugins/runner.rs`, where `PluginRunner` creates `Command::new("sh")` and passes `["-c", &plugin.run]`.
+
+In shared or collaborative repositories, review `maestro.toml` changes from pulls, rebases, or PR branches before running `maestro` locally. A practical check is:
+
+```sh
+git diff HEAD -- maestro.toml
+```
+
+If the branch was just pulled or checked out, inspect any added or changed plugin `run` commands before invoking `maestro`.
+
 ### Environment Variable Isolation
 
 Plugin commands receive environment variables from `HookContext`. To prevent override of security-sensitive system variables (`PATH`, `LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, etc.), only variables with the `MAESTRO_` prefix are injected into the plugin subprocess.


### PR DESCRIPTION
## Summary
- Document that `maestro.toml` plugin `run` fields execute through `sh -c`.
- Add guidance to review `maestro.toml` diffs before running maestro after pulls, rebases, or PR checkouts.

Closes #584

## Test plan
- [x] `git diff --check -- SECURITY.md`
- [x] Manually verified wording against `src/plugins/runner.rs`