### PR TITLE
feat(github): thread configured repo into gh client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- feat(github): thread configured `project.repo` into production `GhCliClient` shellouts via `--repo`, with validation and bare-client fallback when config is unavailable or invalid (#565).
+
 ## [0.17.0] - 2026-05-02
 
 ### Added

--- a/src/adapt/mod.rs
+++ b/src/adapt/mod.rs
@@ -274,7 +274,9 @@ pub async fn cmd_adapt(config: AdaptConfig) -> anyhow::Result<()> {
 
     // Phase 4: Materialize
     eprintln!("Phase 4: Creating GitHub artifacts...");
-    let github = crate::provider::github::client::GhCliClient::new();
+    let github = crate::provider::github::client::GhCliClient::from_config_repo(
+        project_cfg.as_ref().map(|c| c.project.repo.clone()),
+    );
     let materializer = GhMaterializer::new(github);
     let result = materializer.materialize(&plan, &report, false).await?;
 
@@ -352,7 +354,9 @@ pub async fn detect_milestone_hint(
         ));
     }
 
-    let github = crate::provider::github::client::GhCliClient::new();
+    let github = crate::provider::github::client::GhCliClient::from_config_repo(
+        project_cfg.map(|c| c.project.repo.clone()),
+    );
     let mut titles: Vec<String> = Vec::new();
     for state in ["open", "closed"] {
         match crate::provider::github::client::GitHubClient::list_milestones(&github, state).await {

--- a/src/commands/dashboard.rs
+++ b/src/commands/dashboard.rs
@@ -31,6 +31,7 @@ pub async fn cmd_dashboard() -> anyhow::Result<()> {
 
     let loaded = Config::find_and_load_with_path().ok();
     let config = loaded.as_ref().map(|l| l.config.clone());
+    let github_repo = config.as_ref().map(|c| c.project.repo.clone());
 
     let repo_name = config
         .as_ref()
@@ -111,7 +112,7 @@ pub async fn cmd_dashboard() -> anyhow::Result<()> {
 
     let mut app = if let Some(lc) = loaded {
         let mut app = setup_app_from_config(lc, store, worktree_mgr, None);
-        app.github_client = Some(Box::new(GhCliClient::new()));
+        app.github_client = Some(Box::new(GhCliClient::from_config_repo(github_repo)));
         app
     } else {
         App::new(

--- a/src/commands/queue.rs
+++ b/src/commands/queue.rs
@@ -5,7 +5,7 @@ use crate::work::types::WorkItem;
 
 pub async fn cmd_queue() -> anyhow::Result<()> {
     let config = Config::find_and_load()?;
-    let client = GhCliClient::new();
+    let client = GhCliClient::from_config_repo(Some(config.project.repo.clone()));
     let label_refs: Vec<&str> = config
         .github
         .issue_filter_labels
@@ -75,7 +75,8 @@ pub async fn cmd_queue() -> anyhow::Result<()> {
 }
 
 pub async fn cmd_add(issue_number: u64) -> anyhow::Result<()> {
-    let client = GhCliClient::new();
+    let repo = Config::find_and_load().ok().map(|c| c.project.repo);
+    let client = GhCliClient::from_config_repo(repo);
     client.add_label(issue_number, "maestro:ready").await?;
     println!("Added 'maestro:ready' label to issue #{}", issue_number);
     Ok(())

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -7,6 +7,7 @@ use crate::state::store::StateStore;
 
 pub async fn cmd_resume(session_filter: Option<String>) -> anyhow::Result<()> {
     let loaded = Config::find_and_load_with_path()?;
+    let repo = Some(loaded.config.project.repo.clone());
     let store = StateStore::new(StateStore::default_path());
     let state = store.load()?;
     let repo_root = std::env::current_dir()?;
@@ -60,7 +61,7 @@ pub async fn cmd_resume(session_filter: Option<String>) -> anyhow::Result<()> {
         app.add_session(new_session).await?;
     }
 
-    app.github_client = Some(Box::new(GhCliClient::new()));
+    app.github_client = Some(Box::new(GhCliClient::from_config_repo(repo)));
 
     crate::tui::run(app).await
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -114,7 +114,7 @@ pub async fn cmd_run(
         .with_image_paths(images.clone());
         app.add_session(session).await?;
     } else if let Some(milestone_name) = milestone {
-        let client = GhCliClient::new();
+        let client = GhCliClient::from_config_repo(Some(config.project.repo.clone()));
         let issues = client.list_issues_by_milestone(&milestone_name).await?;
         if issues.is_empty() {
             anyhow::bail!("No open issues found in milestone '{}'", milestone_name);
@@ -136,7 +136,7 @@ pub async fn cmd_run(
             tracing::info!("--continuous ignored: Flag::ContinuousMode is disabled");
         }
     } else if let Some(issue_str) = issue {
-        let client = GhCliClient::new();
+        let client = GhCliClient::from_config_repo(Some(config.project.repo.clone()));
 
         for num_str in issue_str.split(',') {
             let num: u64 = num_str
@@ -162,7 +162,7 @@ pub async fn cmd_run(
 
         app.github_client = Some(Box::new(client));
     } else {
-        let client = GhCliClient::new();
+        let client = GhCliClient::from_config_repo(Some(config.project.repo.clone()));
         let label_refs: Vec<&str> = issue_filter_labels.iter().map(|s| s.as_str()).collect();
         let issues = client.list_issues(&label_refs).await?;
 

--- a/src/provider/github/client.rs
+++ b/src/provider/github/client.rs
@@ -477,6 +477,20 @@ impl GhCliClient {
         Self { repo: None }
     }
 
+    pub fn from_config_repo(repo: Option<String>) -> Self {
+        let Some(repo) = repo.map(|r| r.trim().to_string()).filter(|r| !r.is_empty()) else {
+            return Self::new();
+        };
+
+        match Self::new().with_repo(repo) {
+            Ok(client) => client,
+            Err(e) => {
+                tracing::warn!("Ignoring invalid configured GitHub repo: {e}");
+                Self::new()
+            }
+        }
+    }
+
     /// Builder: thread an explicit `owner/repo` through every read-only
     /// and label-edit shellout. PR creation deliberately ignores this —
     /// see `build_create_pr_argv`.
@@ -485,11 +499,6 @@ impl GhCliClient {
     /// metacharacters and `--`-prefixed values) and enforces the
     /// `owner/repo` shape via `parse_owner_repo`.
     ///
-    /// Currently exercised only by unit tests — the wiring from
-    /// `Config::project::repo` through every `GhCliClient::new()` call
-    /// site is tracked as #565. Until that lands, every shellout
-    /// falls back to gh's worktree-remote inference.
-    #[allow(dead_code)]
     pub fn with_repo(mut self, repo: String) -> Result<Self> {
         validate_gh_arg(&repo, "repo")?;
         crate::provider::github::types::parse_owner_repo(&repo)
@@ -2173,6 +2182,25 @@ mod tests {
     fn with_repo_accepts_owner_slash_repo() {
         let c = GhCliClient::new().with_repo("CarlosDanielDev/maestro".into());
         assert!(c.is_ok());
+    }
+
+    #[test]
+    fn from_config_repo_injects_repo_into_list_open_prs_argv() {
+        let c = GhCliClient::from_config_repo(Some("CarlosDanielDev/maestro".into()));
+        let argv = gh_argv::build_list_open_prs_argv("number", c.repo_arg());
+        assert!(
+            argv.windows(2)
+                .any(|w| w == ["--repo", "CarlosDanielDev/maestro"])
+        );
+    }
+
+    #[test]
+    fn from_config_repo_falls_back_for_missing_or_invalid_repo() {
+        assert_eq!(GhCliClient::from_config_repo(None).repo_arg(), None);
+        assert_eq!(
+            GhCliClient::from_config_repo(Some("not-owner-repo-shape".into())).repo_arg(),
+            None
+        );
     }
 
     #[test]

--- a/src/tui/background_tasks.rs
+++ b/src/tui/background_tasks.rs
@@ -5,12 +5,13 @@ use crate::provider::github::client::{GhCliClient, GitHubClient};
 pub(super) fn spawn_issue_fetch(
     tx: tokio::sync::mpsc::UnboundedSender<app::TuiDataEvent>,
     config: screens::SessionConfig,
+    repo: Option<String>,
 ) {
     let custom_prompt = config.custom_prompt.clone();
     match config.issue_number {
         Some(issue_number) => {
             tokio::spawn(async move {
-                let client = GhCliClient::new();
+                let client = GhCliClient::from_config_repo(repo);
                 let result = client.get_issue(issue_number).await;
                 let _ = tx.send(app::TuiDataEvent::Issue(result, custom_prompt));
             });

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -61,6 +61,10 @@ async fn run_claude_print_for_wizard(prompt: &str) -> Result<String, String> {
         .map_err(|e| e.to_string())
 }
 
+fn github_repo_from_app(app: &App) -> Option<String> {
+    app.config.as_ref().map(|c| c.project.repo.clone())
+}
+
 pub(crate) fn enter_tui_mode<W: io::Write>(out: &mut W) -> io::Result<()> {
     execute!(
         out,
@@ -184,16 +188,18 @@ async fn event_loop(
             match cmd {
                 app::TuiCommand::FetchIssues => {
                     let tx = app.data_tx.clone();
+                    let repo = github_repo_from_app(app);
                     tokio::spawn(async move {
-                        let client = GhCliClient::new();
+                        let client = GhCliClient::from_config_repo(repo);
                         let result = client.list_issues(&[]).await;
                         let _ = tx.send(app::TuiDataEvent::Issues(result));
                     });
                 }
                 app::TuiCommand::FetchSuggestionData => {
                     let tx = app.data_tx.clone();
+                    let repo = github_repo_from_app(app);
                     tokio::spawn(async move {
-                        let client = GhCliClient::new();
+                        let client = GhCliClient::from_config_repo(repo);
                         let (ready_result, failed_result, milestones_result) = tokio::join!(
                             client.list_issues(&["maestro:ready"]),
                             client.list_issues(&["maestro:failed"]),
@@ -228,8 +234,9 @@ async fn event_loop(
                 }
                 app::TuiCommand::FetchMilestones => {
                     let tx = app.data_tx.clone();
+                    let repo = github_repo_from_app(app);
                     tokio::spawn(async move {
-                        let client = GhCliClient::new();
+                        let client = GhCliClient::from_config_repo(repo);
                         match client.list_milestones("open").await {
                             Ok(milestones) => {
                                 let futures: Vec<_> = milestones
@@ -251,19 +258,21 @@ async fn event_loop(
                     });
                 }
                 app::TuiCommand::LaunchSession(config) => {
-                    spawn_issue_fetch(app.data_tx.clone(), config);
+                    spawn_issue_fetch(app.data_tx.clone(), config, github_repo_from_app(app));
                 }
                 app::TuiCommand::LaunchSessions(configs) => {
+                    let repo = github_repo_from_app(app);
                     for config in configs {
-                        spawn_issue_fetch(app.data_tx.clone(), config);
+                        spawn_issue_fetch(app.data_tx.clone(), config, repo.clone());
                     }
                 }
                 app::TuiCommand::LaunchUnifiedSession(config) => {
                     let tx = app.data_tx.clone();
                     let issue_numbers: Vec<u64> = config.issues.iter().map(|(n, _)| *n).collect();
                     let custom_prompt = config.custom_prompt.clone();
+                    let repo = github_repo_from_app(app);
                     tokio::spawn(async move {
-                        let client = GhCliClient::new();
+                        let client = GhCliClient::from_config_repo(repo);
                         let futures: Vec<_> = issue_numbers
                             .iter()
                             .map(|num| client.get_issue(*num))
@@ -326,8 +335,9 @@ async fn event_loop(
                 }
                 app::TuiCommand::FetchOpenPrs => {
                     let tx = app.data_tx.clone();
+                    let repo = github_repo_from_app(app);
                     tokio::spawn(async move {
-                        let client = GhCliClient::new();
+                        let client = GhCliClient::from_config_repo(repo);
                         let result = client.list_open_prs().await;
                         let _ = tx.send(app::TuiDataEvent::PullRequests(result));
                     });
@@ -338,8 +348,9 @@ async fn event_loop(
                     body,
                 } => {
                     let tx = app.data_tx.clone();
+                    let repo = github_repo_from_app(app);
                     tokio::spawn(async move {
-                        let client = GhCliClient::new();
+                        let client = GhCliClient::from_config_repo(repo);
                         let result = client.submit_pr_review(pr_number, event, &body).await;
                         let _ = tx.send(app::TuiDataEvent::PrReviewSubmitted(result));
                     });
@@ -423,9 +434,11 @@ async fn event_loop(
                 }
                 app::TuiCommand::RunAdaptMaterialize(plan, report) => {
                     let tx = app.data_tx.clone();
+                    let repo = github_repo_from_app(app);
                     tokio::spawn(async move {
                         use crate::adapt::materializer::{GhMaterializer, PlanMaterializer};
-                        let github = crate::provider::github::client::GhCliClient::new();
+                        let github =
+                            crate::provider::github::client::GhCliClient::from_config_repo(repo);
                         let materializer = GhMaterializer::new(github);
                         let result = materializer.materialize(&plan, &report, false).await;
                         let _ = tx.send(app::TuiDataEvent::AdaptMaterializeResult(result));
@@ -433,12 +446,13 @@ async fn event_loop(
                 }
                 app::TuiCommand::CreateIssue(payload) => {
                     let tx = app.data_tx.clone();
+                    let repo = github_repo_from_app(app);
                     tokio::spawn(async move {
                         use crate::provider::github::client::CreateOutcome;
                         let body =
                             crate::tui::screens::issue_wizard::render_body_markdown(&payload);
                         let labels = crate::tui::screens::issue_wizard::render_labels(&payload);
-                        let client = GhCliClient::new();
+                        let client = GhCliClient::from_config_repo(repo);
                         let result = client
                             .create_issue(&payload.title, &body, &labels, payload.milestone)
                             .await;
@@ -458,8 +472,9 @@ async fn event_loop(
                 }
                 app::TuiCommand::FetchWizardDependencies => {
                     let tx = app.data_tx.clone();
+                    let repo = github_repo_from_app(app);
                     tokio::spawn(async move {
-                        let client = GhCliClient::new();
+                        let client = GhCliClient::from_config_repo(repo);
                         let result = client.list_issues(&[]).await;
                         let _ = tx.send(app::TuiDataEvent::WizardDependencyIssues(result));
                     });
@@ -490,9 +505,11 @@ async fn event_loop(
                 }
                 app::TuiCommand::CreateMilestoneWithIssues(plan) => {
                     let tx = app.data_tx.clone();
+                    let repo = github_repo_from_app(app);
                     tokio::spawn(async move {
                         let res =
-                            crate::tui::screens::milestone_wizard::materialize_plan(&plan).await;
+                            crate::tui::screens::milestone_wizard::materialize_plan(&plan, repo)
+                                .await;
                         let _ = tx.send(app::TuiDataEvent::MilestonePlanCreated(res));
                     });
                 }
@@ -512,8 +529,9 @@ async fn event_loop(
                     let tx = app.data_tx.clone();
                     let local_sessions: Vec<crate::session::types::Session> =
                         app.pool.all_sessions().into_iter().cloned().collect();
+                    let repo = github_repo_from_app(app);
                     tokio::spawn(async move {
-                        let client = GhCliClient::new();
+                        let client = GhCliClient::from_config_repo(repo);
                         let (
                             open_result,
                             closed_result,
@@ -543,8 +561,9 @@ async fn event_loop(
                 }
                 app::TuiCommand::SyncPrd => {
                     let tx = app.data_tx.clone();
+                    let repo = github_repo_from_app(app);
                     tokio::spawn(async move {
-                        let client = GhCliClient::new();
+                        let client = GhCliClient::from_config_repo(repo);
                         let result = crate::prd::sync::GitHubPrdSyncer::new(Box::new(client))
                             .fetch_current_state()
                             .await;
@@ -553,8 +572,9 @@ async fn event_loop(
                 }
                 app::TuiCommand::SyncRoadmap => {
                     let tx = app.data_tx.clone();
+                    let repo = github_repo_from_app(app);
                     tokio::spawn(async move {
-                        let client = GhCliClient::new();
+                        let client = GhCliClient::from_config_repo(repo);
                         let result =
                             crate::tui::screens::roadmap::loader::load_roadmap(&client).await;
                         let _ = tx.send(app::TuiDataEvent::RoadmapResult(result));
@@ -575,8 +595,9 @@ async fn event_loop(
                 }
                 app::TuiCommand::FetchMilestoneHealthIssues { milestone } => {
                     let tx = app.data_tx.clone();
+                    let repo = github_repo_from_app(app);
                     tokio::spawn(async move {
-                        let client = GhCliClient::new();
+                        let client = GhCliClient::from_config_repo(repo);
                         let result = client
                             .list_issues_by_milestone(&milestone.title)
                             .await
@@ -589,8 +610,9 @@ async fn event_loop(
                     description,
                 } => {
                     let tx = app.data_tx.clone();
+                    let repo = github_repo_from_app(app);
                     tokio::spawn(async move {
-                        let client = GhCliClient::new();
+                        let client = GhCliClient::from_config_repo(repo);
                         let result = client
                             .patch_milestone_description(milestone_number, &description)
                             .await;

--- a/src/tui/screens/milestone_wizard/mod.rs
+++ b/src/tui/screens/milestone_wizard/mod.rs
@@ -96,9 +96,12 @@ pub fn level_buckets(issues: &[AiProposedIssue]) -> Vec<Vec<usize>> {
 /// each accepted issue in dependency order with its `Blocked By` section
 /// rewritten to use actual issue numbers. Used by the `Materializing`
 /// step's background task (#297, duplicate-aware via #455).
-pub async fn materialize_plan(plan: &AiGeneratedPlan) -> Result<MilestoneCreationResult, String> {
+pub async fn materialize_plan(
+    plan: &AiGeneratedPlan,
+    repo: Option<String>,
+) -> Result<MilestoneCreationResult, String> {
     use crate::provider::github::client::GhCliClient;
-    let client = GhCliClient::new();
+    let client = GhCliClient::from_config_repo(repo);
     materialize_plan_with_client(plan, &client).await
 }
 


### PR DESCRIPTION
## Summary
- Thread configured `project.repo` into production `GhCliClient` construction across CLI, TUI, adapt, PRD, roadmap, and milestone workflows.
- Add `GhCliClient::from_config_repo` so invalid or missing repo config falls back to gh worktree inference without injecting unsafe argv.
- Cover configured-repo argv injection and invalid-repo fallback with unit tests.

Closes #565

## Test plan
- [x] `cargo test from_config_repo`
- [x] `cargo fmt --check`
- [x] `git diff --check`