### PR TITLE
fix(security): sanitize linux notify-send inputs

### DIFF
--- a/.claude/hooks/notify.sh
+++ b/.claude/hooks/notify.sh
@@ -134,6 +134,14 @@ escape_powershell_string() {
   printf '%s' "$input" | tr -d '\r\n' | sed "s/'/''/g"
 }
 
+escape_pango_markup() {
+  local input="$1"
+  printf '%s' "$input" | sed \
+    -e 's/&/\&amp;/g' \
+    -e 's/</\&lt;/g' \
+    -e 's/>/\&gt;/g'
+}
+
 send_slack_notification() {
   local channel="$1"
   local text="$2"
@@ -187,7 +195,12 @@ send_windows_notification() {
 send_linux_notification() {
   local title="$1"
   local message="$2"
-  notify-send "$title" "$message"
+
+  local safe_title safe_message
+  safe_title=$(escape_pango_markup "$title")
+  safe_message=$(escape_pango_markup "$message")
+
+  notify-send -- "$safe_title" "$safe_message"
 }
 
 send_desktop_notification() {

--- a/tests/hooks/notify.bats
+++ b/tests/hooks/notify.bats
@@ -6,6 +6,7 @@
 #   - Slack JSON payload built via jq --arg (no heredoc interpolation).
 #   - PowerShell title/message single-quote escape and newline strip.
 #   - macOS tr-based sanitization regression guard.
+#   - Linux notify-send Pango markup escape and option separator.
 #   - shellcheck static-analysis gate.
 
 setup() {
@@ -136,6 +137,42 @@ STUB
 
   [[ "$log_content" != *"it's"* ]]
   [[ "$log_content" != *"!"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Linux regression test
+# ---------------------------------------------------------------------------
+
+@test "linux notification escapes markup and terminates options (regression)" {
+  cat > "$FAKE_BIN/notify-send" <<'STUB'
+#!/bin/bash
+{
+  printf '%s\n' "$#"
+  for arg in "$@"; do
+    printf '<%s>\n' "$arg"
+  done
+} > "$FAKE_BIN/notify-send.log"
+STUB
+  chmod +x "$FAKE_BIN/notify-send"
+  PATH="$FAKE_BIN:$PATH"
+  export PATH FAKE_BIN
+
+  local title="--icon=/etc/passwd & <bad>"
+  local message='<a href="https://evil/">click</a> &amp; >'
+
+  run send_linux_notification "$title" "$message"
+  [ "$status" -eq 0 ]
+
+  [ -f "$FAKE_BIN/notify-send.log" ]
+  argv_count="$(sed -n '1p' "$FAKE_BIN/notify-send.log")"
+  argv_separator="$(sed -n '2p' "$FAKE_BIN/notify-send.log")"
+  argv_title="$(sed -n '3p' "$FAKE_BIN/notify-send.log")"
+  argv_message="$(sed -n '4p' "$FAKE_BIN/notify-send.log")"
+
+  [ "$argv_count" = "3" ]
+  [ "$argv_separator" = "<-->" ]
+  [ "$argv_title" = "<--icon=/etc/passwd &amp; &lt;bad&gt;>" ]
+  [ "$argv_message" = '<&lt;a href="https://evil/"&gt;click&lt;/a&gt; &amp;amp; &gt;>' ]
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Escape Pango markup metacharacters in Linux desktop notification titles and messages.
- Pass `--` to `notify-send` so leading-dash titles are treated as positional values.
- Add a Bats regression test for crafted markup and option-looking input.

Closes #586

## Test plan
- [x] bats tests/hooks/notify.bats
- [x] shellcheck -x .claude/hooks/notify.sh