### PR TITLE
refactor(security): parse notify JSON with jq

### DIFF
--- a/.claude/hooks/notify.sh
+++ b/.claude/hooks/notify.sh
@@ -52,12 +52,12 @@ load_config() {
 extract_json_field() {
   local json="$1"
   local field="$2"
-  echo "$json" | grep -o "\"$field\":\"[^\"]*\"" | cut -d'"' -f4 || true
+  jq -r --arg field "$field" '.[$field] // empty' 2>/dev/null <<< "$json" || true
 }
 
 extract_message_field() {
   local json="$1"
-  echo "$json" | sed -n 's/.*"message":"\([^"]*\)".*/\1/p'
+  jq -r '.message // empty' 2>/dev/null <<< "$json" || true
 }
 
 # =============================================================================

--- a/tests/hooks/notify.bats
+++ b/tests/hooks/notify.bats
@@ -27,6 +27,30 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
+# JSON parsing tests
+# ---------------------------------------------------------------------------
+
+@test "extract_json_field decodes JSON escapes" {
+  local json='{"tool_name":"Bash \"quoted\" path\\to\\file \u00e9"}'
+  local expected
+  expected="$(printf 'Bash "quoted" path\\to\\file \303\251')"
+
+  run extract_json_field "$json" "tool_name"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}
+
+@test "extract_message_field decodes JSON escapes and embedded newline" {
+  local json='{"message":"line1\nline2 \"quoted\" path\\to\\file \u263a"}'
+  local expected
+  expected="$(printf 'line1\nline2 "quoted" path\\to\\file \342\230\272')"
+
+  run extract_message_field "$json"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}
+
+# ---------------------------------------------------------------------------
 # Slack payload tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Replaces regex/sed JSON field extraction in `notify.sh` with `jq` parsing.
- Adds Bats coverage for escaped quotes, backslashes, unicode, and embedded newlines.

Closes #587

## Test plan
- [x] `bats tests/hooks/notify.bats`
- [x] `shellcheck -x .claude/hooks/notify.sh`