### PR TITLE
refactor(tui): extract app state structs

### DIFF
--- a/src/commands/dashboard.rs
+++ b/src/commands/dashboard.rs
@@ -126,7 +126,7 @@ pub async fn cmd_dashboard() -> anyhow::Result<()> {
 
     app.gh_auth_ok = gh_auth_ok;
 
-    app.home_screen = Some(crate::tui::screens::HomeScreen::new(
+    app.screen_state.home_screen = Some(crate::tui::screens::HomeScreen::new(
         project_info,
         recent_sessions,
         doctor_warnings,

--- a/src/tui/app/bypass.rs
+++ b/src/tui/app/bypass.rs
@@ -13,6 +13,7 @@ impl App {
     pub fn activate_bypass_from_cli(&mut self) {
         self.bypass_active = true;
         self.bypass_warning_acknowledged = true;
+        self.session_config.permission_mode = "bypassPermissions".to_string();
         self.activity_log.push_simple(
             "BYPASS".into(),
             "Bypass mode enabled (cli) — auto-accepting review corrections".into(),
@@ -27,6 +28,7 @@ impl App {
         }
         self.bypass_active = false;
         self.pool.set_permission_mode("default".to_string());
+        self.session_config.permission_mode = "default".to_string();
         self.activity_log.push_simple(
             "BYPASS".into(),
             format!("Bypass mode disabled ({reason})"),
@@ -43,7 +45,7 @@ impl App {
             return false;
         }
         if !self.bypass_warning_acknowledged {
-            self.bypass_warning_screen =
+            self.screen_state.bypass_warning_screen =
                 Some(crate::tui::screens::bypass_warning::BypassWarningState::new());
             return true;
         }
@@ -57,6 +59,7 @@ impl App {
         self.bypass_warning_acknowledged = true;
         self.pool
             .set_permission_mode("bypassPermissions".to_string());
+        self.session_config.permission_mode = "bypassPermissions".to_string();
         self.activity_log.push_simple(
             "BYPASS".into(),
             format!("Bypass mode enabled ({source}) — auto-accepting review corrections"),
@@ -114,7 +117,7 @@ mod tests {
         let mut app = make_app();
         let pushed = app.request_bypass_toggle();
         assert!(pushed);
-        assert!(app.bypass_warning_screen.is_some());
+        assert!(app.screen_state.bypass_warning_screen.is_some());
         assert!(!app.bypass_active);
     }
 

--- a/src/tui/app/completion_pipeline.rs
+++ b/src/tui/app/completion_pipeline.rs
@@ -211,11 +211,7 @@ impl App {
         }
 
         // Stall detection: check for sessions that haven't produced events
-        let stall_timeout = self
-            .config
-            .as_ref()
-            .map(|c| Duration::from_secs(c.sessions.stall_timeout_secs))
-            .unwrap_or(Duration::from_secs(300));
+        let stall_timeout = Duration::from_secs(self.session_config.stall_timeout_secs);
 
         let stalled_ids = self.health_monitor.check_stalls(stall_timeout);
         for id in &stalled_ids {
@@ -328,7 +324,7 @@ impl App {
             self.add_session(session).await?;
         }
 
-        if self.adapt_follow_up_screen.is_none() {
+        if self.screen_state.adapt_follow_up_screen.is_none() {
             // Pick the first just-completed session we haven't yet evaluated;
             // mark the candidate "considered" so the overlay sticks when
             // dismissed and `parse_suggestions` doesn't run twice per tick.
@@ -351,7 +347,7 @@ impl App {
                     crate::adapt::suggestions::parse_suggestions(&managed.session.last_message);
                 if suggestions.len() >= 2 {
                     let label = session_label(&managed.session);
-                    self.adapt_follow_up_screen = Some(
+                    self.screen_state.adapt_follow_up_screen = Some(
                         crate::tui::screens::AdaptFollowUpScreen::new(label, suggestions),
                     );
                     self.tui_mode = TuiMode::AdaptFollowUp;
@@ -361,7 +357,7 @@ impl App {
 
         // Show hollow retry prompt for sessions that exceeded auto-retry limits.
         // Consultation-satisfied sessions are excluded — they're already "done".
-        if self.hollow_retry_screen.is_none()
+        if self.screen_state.hollow_retry_screen.is_none()
             && let Some(hollow_session) = self.pool.all_sessions().iter().find(|s| {
                 s.status == SessionStatus::Completed
                     && s.is_hollow_completion
@@ -375,12 +371,13 @@ impl App {
                 .as_ref()
                 .map(|p| p.effective_max(hollow_session))
                 .unwrap_or(0);
-            self.hollow_retry_screen = Some(crate::tui::screens::HollowRetryScreen::new(
-                hollow_session.id,
-                label,
-                hollow_session.retry_count,
-                max,
-            ));
+            self.screen_state.hollow_retry_screen =
+                Some(crate::tui::screens::HollowRetryScreen::new(
+                    hollow_session.id,
+                    label,
+                    hollow_session.retry_count,
+                    max,
+                ));
             self.tui_mode = TuiMode::HollowRetry;
         }
 

--- a/src/tui/app/completion_summary.rs
+++ b/src/tui/app/completion_summary.rs
@@ -131,7 +131,7 @@ impl App {
             .collect();
 
         // Initialize home screen if needed (cmd_run path has no home_screen)
-        if self.home_screen.is_none() {
+        if self.screen_state.home_screen.is_none() {
             let project_info = crate::tui::screens::home::ProjectInfo {
                 repo: self
                     .config
@@ -146,20 +146,20 @@ impl App {
                     .unwrap_or_else(|| "unknown".to_string()),
                 username: None,
             };
-            self.home_screen = Some(crate::tui::screens::HomeScreen::new(
+            self.screen_state.home_screen = Some(crate::tui::screens::HomeScreen::new(
                 project_info,
                 recent,
                 Vec::new(),
             ));
-        } else if let Some(ref mut screen) = self.home_screen {
+        } else if let Some(ref mut screen) = self.screen_state.home_screen {
             screen.recent_sessions = recent;
         }
 
         // Clear completion summary and stale screen state, then switch to dashboard
         self.completion_summary = None;
         self.completion_summary_dismissed = true;
-        self.issue_browser_screen = None;
-        if let Some(ref mut screen) = self.home_screen {
+        self.screen_state.issue_browser_screen = None;
+        if let Some(ref mut screen) = self.screen_state.home_screen {
             screen.start_loading_suggestions();
         }
         self.pending_commands.push(TuiCommand::FetchSuggestionData);

--- a/src/tui/app/data_handler.rs
+++ b/src/tui/app/data_handler.rs
@@ -50,16 +50,8 @@ fn fold_ingest_into_prd(prd_slot: &mut Option<Prd>, sync: &PrdSyncResult) -> Opt
 impl App {
     /// Resolve model and mode from config and issue labels.
     fn resolve_model_and_mode(&self, labels: &[String]) -> (String, String) {
-        let model = self
-            .config
-            .as_ref()
-            .map(|c| c.sessions.default_model.clone())
-            .unwrap_or_else(|| "opus".to_string());
-        let default_mode = self
-            .config
-            .as_ref()
-            .map(|c| c.sessions.default_mode.clone())
-            .unwrap_or_else(|| "orchestrator".to_string());
+        let model = self.session_config.default_model.clone();
+        let default_mode = self.session_config.default_mode.clone();
         let mode = crate::modes::mode_from_labels(labels).unwrap_or(default_mode);
         (model, mode)
     }
@@ -87,7 +79,7 @@ impl App {
     pub fn handle_data_event(&mut self, evt: TuiDataEvent) {
         match evt {
             TuiDataEvent::Issues(Ok(issues)) => {
-                if let Some(ref mut screen) = self.issue_browser_screen {
+                if let Some(ref mut screen) = self.screen_state.issue_browser_screen {
                     screen.set_issues(issues);
                 }
             }
@@ -98,20 +90,20 @@ impl App {
                     format!("Failed to fetch issues: {}", e),
                     LogLevel::Error,
                 );
-                if let Some(ref mut screen) = self.issue_browser_screen {
+                if let Some(ref mut screen) = self.screen_state.issue_browser_screen {
                     screen.loading = false;
                 }
             }
             TuiDataEvent::Milestones(Ok(entries)) => {
                 if matches!(self.tui_mode, crate::tui::app::TuiMode::MilestoneHealth)
-                    && let Some(ref mut screen) = self.milestone_health_screen
+                    && let Some(ref mut screen) = self.screen_state.milestone_health_screen
                 {
                     let milestones: Vec<_> = entries.iter().map(|(m, _)| m.clone()).collect();
                     if let Some(cmd) = screen.apply_milestones_loaded(Ok(milestones)) {
                         self.pending_commands.push(cmd);
                     }
                 }
-                if let Some(ref mut screen) = self.milestone_screen {
+                if let Some(ref mut screen) = self.screen_state.milestone_screen {
                     screen.milestones = entries.into_iter().map(MilestoneEntry::from).collect();
                     screen.loading = false;
                 }
@@ -124,12 +116,12 @@ impl App {
                     LogLevel::Error,
                 );
                 if matches!(self.tui_mode, crate::tui::app::TuiMode::MilestoneHealth)
-                    && let Some(ref mut screen) = self.milestone_health_screen
+                    && let Some(ref mut screen) = self.screen_state.milestone_health_screen
                 {
                     let _ = screen
                         .apply_milestones_loaded(Err(anyhow::anyhow!("milestones fetch failed")));
                 }
-                if let Some(ref mut screen) = self.milestone_screen {
+                if let Some(ref mut screen) = self.screen_state.milestone_screen {
                     screen.loading = false;
                 }
             }
@@ -173,7 +165,7 @@ impl App {
                     sessions_active: active,
                     sessions_total: total,
                 };
-                if let Some(ref mut screen) = self.home_screen {
+                if let Some(ref mut screen) = self.screen_state.home_screen {
                     screen.set_suggestions(suggestions);
                     screen.set_stats(stats);
                 }
@@ -210,7 +202,7 @@ impl App {
                 self.upgrade_state = crate::updater::UpgradeState::Failed(msg);
             }
             TuiDataEvent::AdaptScanResult(result) => {
-                if let Some(ref mut screen) = self.adapt_screen {
+                if let Some(ref mut screen) = self.screen_state.adapt_screen {
                     if screen.is_cancelled() {
                         return;
                     }
@@ -230,7 +222,7 @@ impl App {
                 }
             }
             TuiDataEvent::AdaptAnalyzeResult(result) => {
-                if let Some(ref mut screen) = self.adapt_screen {
+                if let Some(ref mut screen) = self.screen_state.adapt_screen {
                     if screen.is_cancelled() {
                         return;
                     }
@@ -250,7 +242,7 @@ impl App {
                 }
             }
             TuiDataEvent::AdaptConsolidateResult(result) => {
-                if let Some(ref mut screen) = self.adapt_screen {
+                if let Some(ref mut screen) = self.screen_state.adapt_screen {
                     if screen.is_cancelled() {
                         return;
                     }
@@ -270,7 +262,7 @@ impl App {
                 }
             }
             TuiDataEvent::AdaptPlanResult(result) => {
-                if let Some(ref mut screen) = self.adapt_screen {
+                if let Some(ref mut screen) = self.screen_state.adapt_screen {
                     if screen.is_cancelled() {
                         return;
                     }
@@ -290,7 +282,7 @@ impl App {
                 }
             }
             TuiDataEvent::AdaptScaffoldResult(result) => {
-                if let Some(ref mut screen) = self.adapt_screen {
+                if let Some(ref mut screen) = self.screen_state.adapt_screen {
                     if screen.is_cancelled() {
                         return;
                     }
@@ -310,7 +302,7 @@ impl App {
                 }
             }
             TuiDataEvent::PullRequests(Ok(prs)) => {
-                if let Some(ref mut screen) = self.pr_review_screen {
+                if let Some(ref mut screen) = self.screen_state.pr_review_screen {
                     screen.set_prs(prs);
                 }
             }
@@ -321,7 +313,7 @@ impl App {
                     format!("Failed to fetch pull requests: {}", e),
                     LogLevel::Error,
                 );
-                if let Some(ref mut screen) = self.pr_review_screen {
+                if let Some(ref mut screen) = self.screen_state.pr_review_screen {
                     screen.set_loading_error(&format!("{}", e));
                 }
             }
@@ -331,7 +323,7 @@ impl App {
                     "Review submitted successfully".into(),
                     LogLevel::Info,
                 );
-                if let Some(ref mut screen) = self.pr_review_screen {
+                if let Some(ref mut screen) = self.screen_state.pr_review_screen {
                     screen.set_done();
                 }
             }
@@ -342,12 +334,12 @@ impl App {
                     format!("Failed to submit review: {}", e),
                     LogLevel::Error,
                 );
-                if let Some(ref mut screen) = self.pr_review_screen {
+                if let Some(ref mut screen) = self.screen_state.pr_review_screen {
                     screen.set_error(&format!("{}", e));
                 }
             }
             TuiDataEvent::AdaptMaterializeResult(result) => {
-                if let Some(ref mut screen) = self.adapt_screen {
+                if let Some(ref mut screen) = self.screen_state.adapt_screen {
                     if screen.is_cancelled() {
                         return;
                     }
@@ -415,7 +407,7 @@ impl App {
                 );
             }
             TuiDataEvent::IssueCreated(result) => {
-                if let Some(ref mut screen) = self.issue_wizard_screen {
+                if let Some(ref mut screen) = self.screen_state.issue_wizard_screen {
                     screen.finish_create(result);
                 }
             }
@@ -424,23 +416,23 @@ impl App {
                 state,
                 title,
             } => {
-                if let Some(ref mut screen) = self.issue_wizard_screen {
+                if let Some(ref mut screen) = self.screen_state.issue_wizard_screen {
                     screen.finish_create_already_exists(number, state, title);
                 }
             }
             TuiDataEvent::ProjectStats(data) => {
-                if let Some(ref mut screen) = self.project_stats_screen {
+                if let Some(ref mut screen) = self.screen_state.project_stats_screen {
                     screen.set_data(data);
                 }
             }
             TuiDataEvent::AiPlanningResult(result) => {
-                if let Some(ref mut screen) = self.milestone_wizard_screen {
+                if let Some(ref mut screen) = self.screen_state.milestone_wizard_screen {
                     screen.apply_planning_result(result);
                 }
             }
             TuiDataEvent::WizardDependencyIssues(result) => match result {
                 Ok(issues) => {
-                    if let Some(ref mut screen) = self.issue_wizard_screen {
+                    if let Some(ref mut screen) = self.screen_state.issue_wizard_screen {
                         screen.apply_dep_issues(issues);
                     }
                 }
@@ -450,23 +442,23 @@ impl App {
                         format!("Failed to fetch issues for Dependencies step: {}", e),
                         LogLevel::Error,
                     );
-                    if let Some(ref mut screen) = self.issue_wizard_screen {
+                    if let Some(ref mut screen) = self.screen_state.issue_wizard_screen {
                         screen.apply_dep_issues(Vec::new());
                     }
                 }
             },
             TuiDataEvent::AiReviewResult(result) => {
-                if let Some(ref mut screen) = self.issue_wizard_screen {
+                if let Some(ref mut screen) = self.screen_state.issue_wizard_screen {
                     screen.apply_ai_review(result);
                 }
             }
             TuiDataEvent::AiImproveResult(result) => {
-                if let Some(ref mut screen) = self.issue_wizard_screen {
+                if let Some(ref mut screen) = self.screen_state.issue_wizard_screen {
                     screen.apply_improve_result(result);
                 }
             }
             TuiDataEvent::MilestonePlanCreated(result) => {
-                if let Some(ref mut screen) = self.milestone_wizard_screen {
+                if let Some(ref mut screen) = self.screen_state.milestone_wizard_screen {
                     screen.finish_materialization(result);
                 }
             }
@@ -486,7 +478,7 @@ impl App {
                     if let Some(prd) = self.prd.as_mut() {
                         prd.current_state = sync.current_state.clone();
                         prd.timeline = sync.timeline.clone();
-                        if let Some(s) = self.prd_screen.as_mut() {
+                        if let Some(s) = self.screen_state.prd_screen.as_mut() {
                             s.dirty = true;
                             s.sync_status = crate::tui::screens::prd::PrdSyncStatus::SyncedAt(
                                 std::time::Instant::now(),
@@ -511,7 +503,7 @@ impl App {
                 }
                 Err(e) => {
                     let msg = e.to_string();
-                    if let Some(s) = self.prd_screen.as_mut() {
+                    if let Some(s) = self.screen_state.prd_screen.as_mut() {
                         s.sync_status = crate::tui::screens::prd::PrdSyncStatus::Failed {
                             at: std::time::Instant::now(),
                             message: msg.clone(),
@@ -526,7 +518,7 @@ impl App {
             },
             TuiDataEvent::RoadmapResult(result) => match result {
                 Ok(entries) => {
-                    if let Some(s) = self.roadmap_screen.as_mut() {
+                    if let Some(s) = self.screen_state.roadmap_screen.as_mut() {
                         s.set_entries(entries);
                     }
                 }
@@ -562,7 +554,7 @@ impl App {
                 ),
             },
             TuiDataEvent::MilestoneHealthIssuesFetched(result) => {
-                if let Some(ref mut screen) = self.milestone_health_screen {
+                if let Some(ref mut screen) = self.screen_state.milestone_health_screen {
                     let cmd = screen.apply_issues_fetched(result);
                     if let Some(cmd) = cmd {
                         self.pending_commands.push(cmd);
@@ -570,7 +562,7 @@ impl App {
                 }
             }
             TuiDataEvent::MilestoneHealthPatched(result) => {
-                if let Some(ref mut screen) = self.milestone_health_screen {
+                if let Some(ref mut screen) = self.screen_state.milestone_health_screen {
                     screen.apply_patch_result(result);
                 }
             }

--- a/src/tui/app/mod.rs
+++ b/src/tui/app/mod.rs
@@ -100,14 +100,8 @@ pub struct App {
     pub cached_mode_km_key: (TuiMode, Option<crate::session::types::SessionStatus>, bool),
     pub context_monitor: Box<dyn ContextMonitor>,
     pub fork_policy: Option<ForkPolicy>,
-    pub home_screen: Option<crate::tui::screens::HomeScreen>,
-    pub landing_screen: Option<crate::tui::screens::LandingScreen>,
-    pub issue_wizard_screen: Option<crate::tui::screens::IssueWizardScreen>,
-    pub project_stats_screen: Option<crate::tui::screens::ProjectStatsScreen>,
-    pub milestone_wizard_screen: Option<crate::tui::screens::MilestoneWizardScreen>,
-    pub issue_browser_screen: Option<crate::tui::screens::IssueBrowserScreen>,
-    pub milestone_screen: Option<crate::tui::screens::MilestoneScreen>,
-    pub prompt_input_screen: Option<crate::tui::screens::PromptInputScreen>,
+    pub screen_state: ScreenState,
+    pub session_config: crate::tui::app::types::SessionConfig,
     pub pending_commands: Vec<TuiCommand>,
     pub pending_session_launches: Vec<Session>,
     pub data_tx: mpsc::UnboundedSender<TuiDataEvent>,
@@ -123,18 +117,9 @@ pub struct App {
     pub gh_auth_ok: bool,
     pub pending_prs: Vec<crate::provider::github::types::PendingPr>,
     pub flags: crate::flags::store::FeatureFlags,
-    pub queue_confirmation_screen: Option<crate::tui::screens::QueueConfirmationScreen>,
     pub queue_executor: Option<crate::work::executor::QueueExecutor>,
     pub queue_launch_configs: Option<Vec<crate::tui::screens::SessionConfig>>,
-    pub hollow_retry_screen: Option<crate::tui::screens::HollowRetryScreen>,
-    pub adapt_follow_up_screen: Option<crate::tui::screens::AdaptFollowUpScreen>,
-    pub sanitize_screen: Option<crate::sanitize::screen::SanitizeScreen>,
-    pub settings_screen: Option<crate::tui::screens::SettingsScreen>,
     pub prompt_history: crate::state::prompt_history::PromptHistoryStore,
-    pub session_switcher: Option<crate::tui::session_switcher::SessionSwitcher>,
-    pub adapt_screen: Option<crate::tui::screens::adapt::AdaptScreen>,
-    pub pr_review_screen: Option<crate::tui::screens::pr_review::PrReviewScreen>,
-    pub release_notes_screen: Option<crate::tui::screens::ReleaseNotesScreen>,
     pub tool_start_times: std::collections::HashMap<uuid::Uuid, (String, Instant)>,
     pub no_splash: bool,
     pub show_mascot: bool,
@@ -162,12 +147,6 @@ pub struct App {
     /// Live PRD (#321) loaded from `.maestro/prd.toml`; lazily populated by
     /// the PRD screen on first entry.
     pub prd: Option<crate::prd::model::Prd>,
-    pub prd_screen: Option<crate::tui::screens::prd::PrdScreen>,
-    pub bypass_warning_screen: Option<crate::tui::screens::bypass_warning::BypassWarningState>,
-    pub roadmap_screen: Option<crate::tui::screens::roadmap::RoadmapScreen>,
-    /// Milestone health-check wizard (#500).
-    pub milestone_health_screen:
-        Option<crate::tui::screens::milestone_health::MilestoneHealthScreen>,
     /// Last completed `/review` cycle (#327). Populated by data_handler;
     /// consumed by the PR-review screen on next render.
     pub pending_review_report: Option<crate::review::types::ReviewReport>,
@@ -240,8 +219,13 @@ impl App {
         let (data_tx, data_rx) = mpsc::unbounded_channel();
         let state = store.load().unwrap_or_default();
         let mut pool = SessionPool::new(max_concurrent, worktree_mgr, event_tx);
-        pool.set_permission_mode(permission_mode);
-        pool.set_allowed_tools(allowed_tools);
+        pool.set_permission_mode(permission_mode.clone());
+        pool.set_allowed_tools(allowed_tools.clone());
+        let session_config = crate::tui::app::types::SessionConfig::new(
+            max_concurrent,
+            permission_mode,
+            allowed_tools,
+        );
         // Recover any pending completions persisted from a prior run so the
         // auto-PR work is retried on next tick (#514). The AC4 preflight
         // (PR-already-exists check) prevents double-firing when the prior
@@ -295,14 +279,8 @@ impl App {
             cached_mode_km_key: (TuiMode::Overview, None, false),
             context_monitor: Box::new(ProductionContextMonitor::new()),
             fork_policy: None,
-            home_screen: None,
-            landing_screen: None,
-            issue_wizard_screen: None,
-            project_stats_screen: None,
-            milestone_wizard_screen: None,
-            issue_browser_screen: None,
-            milestone_screen: None,
-            prompt_input_screen: None,
+            screen_state: ScreenState::default(),
+            session_config,
             pending_commands: Vec::new(),
             pending_session_launches: Vec::new(),
             data_tx,
@@ -318,13 +296,8 @@ impl App {
             gh_auth_ok: true,
             pending_prs: recovered_prs,
             flags: crate::flags::store::FeatureFlags::default(),
-            queue_confirmation_screen: None,
             queue_executor: None,
             queue_launch_configs: None,
-            hollow_retry_screen: None,
-            adapt_follow_up_screen: None,
-            sanitize_screen: None,
-            settings_screen: None,
             prompt_history: crate::state::prompt_history::PromptHistoryStore::new(
                 crate::state::prompt_history::PromptHistoryStore::default_path(),
                 crate::config::default_max_prompt_history(),
@@ -333,10 +306,6 @@ impl App {
             show_mascot: true,
             mascot_style: crate::mascot::MascotStyle::default(),
             mascot_animator: MascotAnimator::new(&SystemClock),
-            session_switcher: None,
-            adapt_screen: None,
-            pr_review_screen: None,
-            release_notes_screen: None,
             tool_start_times: std::collections::HashMap::new(),
             session_ui_state: std::collections::HashMap::new(),
             log_viewer_scroll: 0,
@@ -349,10 +318,6 @@ impl App {
             bypass_active: false,
             bypass_warning_acknowledged: false,
             prd: None,
-            prd_screen: None,
-            bypass_warning_screen: None,
-            roadmap_screen: None,
-            milestone_health_screen: None,
             pending_review_report: None,
             concerns_cursor: 0,
             prd_candidates: Vec::new(),
@@ -480,6 +445,11 @@ impl App {
     }
 
     pub fn configure(&mut self, config: Config) {
+        self.session_config.apply_config(&config.sessions);
+        if self.bypass_active {
+            self.session_config.permission_mode = "bypassPermissions".to_string();
+        }
+
         // Shared adapter so fork and pool observe the same enabled state.
         let tq_adapter = if config.turboquant.enabled {
             Some(std::sync::Arc::new(

--- a/src/tui/app/session_spawners.rs
+++ b/src/tui/app/session_spawners.rs
@@ -8,6 +8,7 @@ use crate::session::types::{Session, SessionStatus};
 use crate::tui::activity_log::LogLevel;
 
 /// Resolve default model and mode from config (or built-in defaults).
+#[cfg(test)]
 pub(crate) fn default_model_and_mode(config: Option<&crate::config::Config>) -> (String, String) {
     let model = config
         .map(|c| c.sessions.default_model.clone())
@@ -71,7 +72,10 @@ pub(crate) fn create_gate_fix_session(
 
 impl App {
     pub(super) fn default_model_and_mode(&self) -> (String, String) {
-        default_model_and_mode(self.config.as_ref())
+        (
+            self.session_config.default_model.clone(),
+            self.session_config.default_mode.clone(),
+        )
     }
 
     pub(super) fn spawn_ci_fix_session(

--- a/src/tui/app/settings_actions.rs
+++ b/src/tui/app/settings_actions.rs
@@ -22,7 +22,7 @@ impl App {
     /// Surfaces a status flash on the screen, and reverts the in-screen
     /// widget on write failure.
     pub fn process_pending_caveman_toggle(&mut self) {
-        let Some(screen) = self.settings_screen.as_mut() else {
+        let Some(screen) = self.screen_state.settings_screen.as_mut() else {
             return;
         };
         let Some(new_value) = screen.take_pending_caveman_toggle() else {

--- a/src/tui/app/tests.rs
+++ b/src/tui/app/tests.rs
@@ -173,9 +173,9 @@ fn transition_to_dashboard_preserves_orthogonal_state() {
 #[test]
 fn transition_to_dashboard_creates_home_screen_when_missing() {
     let mut app = make_app();
-    assert!(app.home_screen.is_none());
+    assert!(app.screen_state.home_screen.is_none());
     app.transition_to_dashboard();
-    assert!(app.home_screen.is_some());
+    assert!(app.screen_state.home_screen.is_some());
 }
 
 #[test]
@@ -197,7 +197,8 @@ fn transition_to_dashboard_sets_loading_suggestions_flag() {
     let mut app = make_app();
     app.transition_to_dashboard();
     assert!(
-        app.home_screen
+        app.screen_state
+            .home_screen
             .as_ref()
             .map(|s| s.loading_suggestions)
             .unwrap_or(false),
@@ -209,7 +210,7 @@ fn transition_to_dashboard_sets_loading_suggestions_flag() {
 fn suggestion_data_event_clears_loading_flag_on_home_screen() {
     let mut app = make_app();
     app.transition_to_dashboard();
-    if let Some(ref mut screen) = app.home_screen {
+    if let Some(ref mut screen) = app.screen_state.home_screen {
         screen.loading_suggestions = true;
     }
     app.handle_data_event(TuiDataEvent::SuggestionData(SuggestionDataPayload {
@@ -220,7 +221,11 @@ fn suggestion_data_event_clears_loading_flag_on_home_screen() {
         closed_issue_count: 0,
     }));
     assert!(
-        !app.home_screen.as_ref().unwrap().loading_suggestions,
+        !app.screen_state
+            .home_screen
+            .as_ref()
+            .unwrap()
+            .loading_suggestions,
         "SuggestionData event must clear loading_suggestions"
     );
 }
@@ -943,10 +948,11 @@ fn transition_to_dashboard_sets_dismissed_flag() {
 #[test]
 fn transition_to_dashboard_clears_issue_browser_screen() {
     let mut app = make_app();
-    app.issue_browser_screen = Some(crate::tui::screens::IssueBrowserScreen::new(vec![]));
+    app.screen_state.issue_browser_screen =
+        Some(crate::tui::screens::IssueBrowserScreen::new(vec![]));
     app.transition_to_dashboard();
     assert!(
-        app.issue_browser_screen.is_none(),
+        app.screen_state.issue_browser_screen.is_none(),
         "transition_to_dashboard must clear stale issue_browser_screen"
     );
 }
@@ -1172,7 +1178,7 @@ fn ci_check_details_keyed_by_pr_number() {
 #[test]
 fn app_queue_confirmation_screen_defaults_to_none() {
     let app = make_app();
-    assert!(app.queue_confirmation_screen.is_none());
+    assert!(app.screen_state.queue_confirmation_screen.is_none());
 }
 
 // --- Issue #68: QueueExecutor state ---
@@ -1634,8 +1640,8 @@ mod adapt_chaining {
 
     fn app_with_adapt_screen() -> App {
         let mut app = make_app();
-        app.adapt_screen = Some(AdaptScreen::new());
-        app.adapt_screen.as_mut().unwrap().step = AdaptStep::Scanning;
+        app.screen_state.adapt_screen = Some(AdaptScreen::new());
+        app.screen_state.adapt_screen.as_mut().unwrap().step = AdaptStep::Scanning;
         app
     }
 
@@ -1644,7 +1650,7 @@ mod adapt_chaining {
         let mut app = app_with_adapt_screen();
         app.handle_data_event(TuiDataEvent::AdaptScanResult(Ok(Box::new(make_profile()))));
 
-        let screen = app.adapt_screen.as_ref().unwrap();
+        let screen = app.screen_state.adapt_screen.as_ref().unwrap();
         assert_eq!(screen.step, AdaptStep::Analyzing);
         assert!(screen.results.profile.is_some());
         assert_eq!(app.pending_commands.len(), 1);
@@ -1657,11 +1663,16 @@ mod adapt_chaining {
     #[test]
     fn scan_ok_with_scan_only_completes() {
         let mut app = app_with_adapt_screen();
-        app.adapt_screen.as_mut().unwrap().config.scan_only = true;
+        app.screen_state
+            .adapt_screen
+            .as_mut()
+            .unwrap()
+            .config
+            .scan_only = true;
 
         app.handle_data_event(TuiDataEvent::AdaptScanResult(Ok(Box::new(make_profile()))));
 
-        let screen = app.adapt_screen.as_ref().unwrap();
+        let screen = app.screen_state.adapt_screen.as_ref().unwrap();
         assert_eq!(screen.step, AdaptStep::Complete);
         assert!(app.pending_commands.is_empty());
     }
@@ -1673,7 +1684,7 @@ mod adapt_chaining {
             "scan failed"
         ))));
 
-        let screen = app.adapt_screen.as_ref().unwrap();
+        let screen = app.screen_state.adapt_screen.as_ref().unwrap();
         assert_eq!(screen.step, AdaptStep::Failed);
         assert_eq!(screen.error.as_ref().unwrap().phase, AdaptStep::Scanning);
     }
@@ -1681,15 +1692,16 @@ mod adapt_chaining {
     #[test]
     fn analyze_ok_chains_to_consolidate() {
         let mut app = app_with_adapt_screen();
-        app.adapt_screen.as_mut().unwrap().step = AdaptStep::Analyzing;
-        app.adapt_screen
+        app.screen_state.adapt_screen.as_mut().unwrap().step = AdaptStep::Analyzing;
+        app.screen_state
+            .adapt_screen
             .as_mut()
             .unwrap()
             .set_scan_result(make_profile());
 
         app.handle_data_event(TuiDataEvent::AdaptAnalyzeResult(Ok(make_report())));
 
-        let screen = app.adapt_screen.as_ref().unwrap();
+        let screen = app.screen_state.adapt_screen.as_ref().unwrap();
         assert_eq!(screen.step, AdaptStep::Consolidating);
         assert!(screen.results.report.is_some());
         assert_eq!(app.pending_commands.len(), 1);
@@ -1702,12 +1714,17 @@ mod adapt_chaining {
     #[test]
     fn analyze_ok_with_no_issues_completes() {
         let mut app = app_with_adapt_screen();
-        app.adapt_screen.as_mut().unwrap().step = AdaptStep::Analyzing;
-        app.adapt_screen.as_mut().unwrap().config.no_issues = true;
+        app.screen_state.adapt_screen.as_mut().unwrap().step = AdaptStep::Analyzing;
+        app.screen_state
+            .adapt_screen
+            .as_mut()
+            .unwrap()
+            .config
+            .no_issues = true;
 
         app.handle_data_event(TuiDataEvent::AdaptAnalyzeResult(Ok(make_report())));
 
-        let screen = app.adapt_screen.as_ref().unwrap();
+        let screen = app.screen_state.adapt_screen.as_ref().unwrap();
         assert_eq!(screen.step, AdaptStep::Complete);
         assert!(app.pending_commands.is_empty());
     }
@@ -1715,13 +1732,13 @@ mod adapt_chaining {
     #[test]
     fn analyze_err_sets_failed() {
         let mut app = app_with_adapt_screen();
-        app.adapt_screen.as_mut().unwrap().step = AdaptStep::Analyzing;
+        app.screen_state.adapt_screen.as_mut().unwrap().step = AdaptStep::Analyzing;
 
         app.handle_data_event(TuiDataEvent::AdaptAnalyzeResult(Err(anyhow::anyhow!(
             "analyze failed"
         ))));
 
-        let screen = app.adapt_screen.as_ref().unwrap();
+        let screen = app.screen_state.adapt_screen.as_ref().unwrap();
         assert_eq!(screen.step, AdaptStep::Failed);
         assert_eq!(screen.error.as_ref().unwrap().phase, AdaptStep::Analyzing);
     }
@@ -1729,19 +1746,21 @@ mod adapt_chaining {
     #[test]
     fn plan_ok_chains_to_materialize() {
         let mut app = app_with_adapt_screen();
-        app.adapt_screen.as_mut().unwrap().step = AdaptStep::Planning;
-        app.adapt_screen
+        app.screen_state.adapt_screen.as_mut().unwrap().step = AdaptStep::Planning;
+        app.screen_state
+            .adapt_screen
             .as_mut()
             .unwrap()
             .set_scan_result(make_profile());
-        app.adapt_screen
+        app.screen_state
+            .adapt_screen
             .as_mut()
             .unwrap()
             .set_analyze_result(make_report());
 
         app.handle_data_event(TuiDataEvent::AdaptPlanResult(Ok(make_plan())));
 
-        let screen = app.adapt_screen.as_ref().unwrap();
+        let screen = app.screen_state.adapt_screen.as_ref().unwrap();
         assert_eq!(screen.step, AdaptStep::Scaffolding);
         assert!(screen.results.plan.is_some());
         assert_eq!(app.pending_commands.len(), 1);
@@ -1754,12 +1773,17 @@ mod adapt_chaining {
     #[test]
     fn plan_ok_with_dry_run_completes() {
         let mut app = app_with_adapt_screen();
-        app.adapt_screen.as_mut().unwrap().step = AdaptStep::Planning;
-        app.adapt_screen.as_mut().unwrap().config.dry_run = true;
+        app.screen_state.adapt_screen.as_mut().unwrap().step = AdaptStep::Planning;
+        app.screen_state
+            .adapt_screen
+            .as_mut()
+            .unwrap()
+            .config
+            .dry_run = true;
 
         app.handle_data_event(TuiDataEvent::AdaptPlanResult(Ok(make_plan())));
 
-        let screen = app.adapt_screen.as_ref().unwrap();
+        let screen = app.screen_state.adapt_screen.as_ref().unwrap();
         assert_eq!(screen.step, AdaptStep::Complete);
         assert!(app.pending_commands.is_empty());
     }
@@ -1767,13 +1791,13 @@ mod adapt_chaining {
     #[test]
     fn plan_err_sets_failed() {
         let mut app = app_with_adapt_screen();
-        app.adapt_screen.as_mut().unwrap().step = AdaptStep::Planning;
+        app.screen_state.adapt_screen.as_mut().unwrap().step = AdaptStep::Planning;
 
         app.handle_data_event(TuiDataEvent::AdaptPlanResult(Err(anyhow::anyhow!(
             "plan failed"
         ))));
 
-        let screen = app.adapt_screen.as_ref().unwrap();
+        let screen = app.screen_state.adapt_screen.as_ref().unwrap();
         assert_eq!(screen.step, AdaptStep::Failed);
         assert_eq!(screen.error.as_ref().unwrap().phase, AdaptStep::Planning);
     }
@@ -1781,13 +1805,13 @@ mod adapt_chaining {
     #[test]
     fn materialize_ok_completes() {
         let mut app = app_with_adapt_screen();
-        app.adapt_screen.as_mut().unwrap().step = AdaptStep::Materializing;
+        app.screen_state.adapt_screen.as_mut().unwrap().step = AdaptStep::Materializing;
 
         app.handle_data_event(TuiDataEvent::AdaptMaterializeResult(Ok(
             make_materialize_result(),
         )));
 
-        let screen = app.adapt_screen.as_ref().unwrap();
+        let screen = app.screen_state.adapt_screen.as_ref().unwrap();
         assert_eq!(screen.step, AdaptStep::Complete);
         assert!(screen.results.materialize.is_some());
     }
@@ -1795,13 +1819,13 @@ mod adapt_chaining {
     #[test]
     fn materialize_err_sets_failed() {
         let mut app = app_with_adapt_screen();
-        app.adapt_screen.as_mut().unwrap().step = AdaptStep::Materializing;
+        app.screen_state.adapt_screen.as_mut().unwrap().step = AdaptStep::Materializing;
 
         app.handle_data_event(TuiDataEvent::AdaptMaterializeResult(Err(anyhow::anyhow!(
             "materialize failed"
         ))));
 
-        let screen = app.adapt_screen.as_ref().unwrap();
+        let screen = app.screen_state.adapt_screen.as_ref().unwrap();
         assert_eq!(screen.step, AdaptStep::Failed);
         assert_eq!(
             screen.error.as_ref().unwrap().phase,
@@ -1812,13 +1836,13 @@ mod adapt_chaining {
     #[test]
     fn cancelled_screen_ignores_scan_result() {
         let mut app = app_with_adapt_screen();
-        let screen = app.adapt_screen.as_mut().unwrap();
+        let screen = app.screen_state.adapt_screen.as_mut().unwrap();
         screen.cancelled = true;
         screen.results = crate::tui::screens::adapt::AdaptResults::default();
 
         app.handle_data_event(TuiDataEvent::AdaptScanResult(Ok(Box::new(make_profile()))));
 
-        let screen = app.adapt_screen.as_ref().unwrap();
+        let screen = app.screen_state.adapt_screen.as_ref().unwrap();
         // Step stays at Scanning (not transitioned)
         assert_eq!(screen.step, AdaptStep::Scanning);
         assert!(screen.results.profile.is_none());
@@ -1832,7 +1856,7 @@ mod adapt_chaining {
         // Phase 1: Scan
         app.handle_data_event(TuiDataEvent::AdaptScanResult(Ok(Box::new(make_profile()))));
         assert_eq!(
-            app.adapt_screen.as_ref().unwrap().step,
+            app.screen_state.adapt_screen.as_ref().unwrap().step,
             AdaptStep::Analyzing
         );
 
@@ -1841,7 +1865,7 @@ mod adapt_chaining {
         assert!(matches!(cmd, TuiCommand::RunAdaptAnalyze(_, _)));
         app.handle_data_event(TuiDataEvent::AdaptAnalyzeResult(Ok(make_report())));
         assert_eq!(
-            app.adapt_screen.as_ref().unwrap().step,
+            app.screen_state.adapt_screen.as_ref().unwrap().step,
             AdaptStep::Consolidating
         );
 
@@ -1851,14 +1875,17 @@ mod adapt_chaining {
         app.handle_data_event(TuiDataEvent::AdaptConsolidateResult(Ok(
             "# PRD: Test".to_string()
         )));
-        assert_eq!(app.adapt_screen.as_ref().unwrap().step, AdaptStep::Planning);
+        assert_eq!(
+            app.screen_state.adapt_screen.as_ref().unwrap().step,
+            AdaptStep::Planning
+        );
 
         // Phase 3: Plan
         let cmd = app.pending_commands.pop().unwrap();
         assert!(matches!(cmd, TuiCommand::RunAdaptPlan(_, _, _, _)));
         app.handle_data_event(TuiDataEvent::AdaptPlanResult(Ok(make_plan())));
         assert_eq!(
-            app.adapt_screen.as_ref().unwrap().step,
+            app.screen_state.adapt_screen.as_ref().unwrap().step,
             AdaptStep::Scaffolding
         );
 
@@ -1872,7 +1899,7 @@ mod adapt_chaining {
             skipped_count: 0,
         })));
         assert_eq!(
-            app.adapt_screen.as_ref().unwrap().step,
+            app.screen_state.adapt_screen.as_ref().unwrap().step,
             AdaptStep::Materializing
         );
 
@@ -1882,10 +1909,13 @@ mod adapt_chaining {
         app.handle_data_event(TuiDataEvent::AdaptMaterializeResult(Ok(
             make_materialize_result(),
         )));
-        assert_eq!(app.adapt_screen.as_ref().unwrap().step, AdaptStep::Complete);
+        assert_eq!(
+            app.screen_state.adapt_screen.as_ref().unwrap().step,
+            AdaptStep::Complete
+        );
 
         // All results stored
-        let screen = app.adapt_screen.as_ref().unwrap();
+        let screen = app.screen_state.adapt_screen.as_ref().unwrap();
         assert!(screen.results.profile.is_some());
         assert!(screen.results.report.is_some());
         assert!(screen.results.plan.is_some());

--- a/src/tui/app/types.rs
+++ b/src/tui/app/types.rs
@@ -2,10 +2,13 @@ use crate::adapt::AdaptConfig;
 use crate::adapt::types::{
     AdaptPlan, AdaptReport, MaterializeResult, ProjectProfile, ScaffoldResult,
 };
+use crate::config::SessionsConfig;
 use crate::plugins::hooks::{HookContext, HookPoint};
 use crate::provider::github::types::{GhIssue, GhMilestone};
 use crate::session::types::SessionStatus;
-use crate::tui::screens::{PromptSessionConfig, SessionConfig, UnifiedSessionConfig};
+use crate::tui::screens::{
+    PromptSessionConfig, SessionConfig as ScreenSessionConfig, UnifiedSessionConfig,
+};
 
 /// TUI display mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -187,6 +190,65 @@ pub struct SessionUiState {
     pub show_summary_popup: bool,
 }
 
+/// Screen-owned state kept out of the top-level App surface.
+#[derive(Default)]
+pub struct ScreenState {
+    pub home_screen: Option<crate::tui::screens::HomeScreen>,
+    pub landing_screen: Option<crate::tui::screens::LandingScreen>,
+    pub issue_wizard_screen: Option<crate::tui::screens::IssueWizardScreen>,
+    pub project_stats_screen: Option<crate::tui::screens::ProjectStatsScreen>,
+    pub milestone_wizard_screen: Option<crate::tui::screens::MilestoneWizardScreen>,
+    pub issue_browser_screen: Option<crate::tui::screens::IssueBrowserScreen>,
+    pub milestone_screen: Option<crate::tui::screens::MilestoneScreen>,
+    pub prompt_input_screen: Option<crate::tui::screens::PromptInputScreen>,
+    pub queue_confirmation_screen: Option<crate::tui::screens::QueueConfirmationScreen>,
+    pub hollow_retry_screen: Option<crate::tui::screens::HollowRetryScreen>,
+    pub adapt_follow_up_screen: Option<crate::tui::screens::AdaptFollowUpScreen>,
+    pub sanitize_screen: Option<crate::sanitize::screen::SanitizeScreen>,
+    pub settings_screen: Option<crate::tui::screens::SettingsScreen>,
+    pub session_switcher: Option<crate::tui::session_switcher::SessionSwitcher>,
+    pub adapt_screen: Option<crate::tui::screens::adapt::AdaptScreen>,
+    pub pr_review_screen: Option<crate::tui::screens::pr_review::PrReviewScreen>,
+    pub release_notes_screen: Option<crate::tui::screens::ReleaseNotesScreen>,
+    pub prd_screen: Option<crate::tui::screens::prd::PrdScreen>,
+    pub bypass_warning_screen: Option<crate::tui::screens::bypass_warning::BypassWarningState>,
+    pub roadmap_screen: Option<crate::tui::screens::roadmap::RoadmapScreen>,
+    pub milestone_health_screen:
+        Option<crate::tui::screens::milestone_health::MilestoneHealthScreen>,
+}
+
+/// Effective session defaults and limits used by TUI-launched sessions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionConfig {
+    pub max_concurrent: usize,
+    pub stall_timeout_secs: u64,
+    pub default_model: String,
+    pub default_mode: String,
+    pub permission_mode: String,
+    pub allowed_tools: Vec<String>,
+}
+
+impl SessionConfig {
+    pub fn new(max_concurrent: usize, permission_mode: String, allowed_tools: Vec<String>) -> Self {
+        Self {
+            max_concurrent,
+            stall_timeout_secs: 300,
+            default_model: "opus".to_string(),
+            default_mode: "orchestrator".to_string(),
+            permission_mode,
+            allowed_tools,
+        }
+    }
+
+    pub fn apply_config(&mut self, config: &SessionsConfig) {
+        self.stall_timeout_secs = config.stall_timeout_secs;
+        self.default_model.clone_from(&config.default_model);
+        self.default_mode.clone_from(&config.default_mode);
+        self.permission_mode.clone_from(&config.permission_mode);
+        self.allowed_tools.clone_from(&config.allowed_tools);
+    }
+}
+
 /// Payload for suggestion data fetched from GitHub.
 pub struct SuggestionDataPayload {
     pub ready_issue_count: usize,
@@ -225,8 +287,8 @@ pub enum TuiCommand {
     /// the milestone first, then each accepted issue with its
     /// `Blocked By` rewritten to actual issue numbers.
     CreateMilestoneWithIssues(crate::tui::screens::milestone_wizard::AiGeneratedPlan),
-    LaunchSession(SessionConfig),
-    LaunchSessions(Vec<SessionConfig>),
+    LaunchSession(ScreenSessionConfig),
+    LaunchSessions(Vec<ScreenSessionConfig>),
     LaunchPromptSession(PromptSessionConfig),
     LaunchUnifiedSession(UnifiedSessionConfig),
     RunAdaptScan(AdaptConfig),

--- a/src/tui/input_handler.rs
+++ b/src/tui/input_handler.rs
@@ -235,12 +235,12 @@ fn handle_completion_summary(app: &mut App, key: &KeyEvent) -> KeyAction {
             app.completion_summary_dismissed = true;
             let mut screen = screens::IssueBrowserScreen::new(vec![]);
             screen.loading = true;
-            app.issue_browser_screen = Some(screen);
+            app.screen_state.issue_browser_screen = Some(screen);
             app.pending_commands.push(app::TuiCommand::FetchIssues);
             app.tui_mode = app::TuiMode::IssueBrowser;
         }
         (KeyCode::Char('r'), _) => {
-            app.prompt_input_screen = Some(app::helpers::create_prompt_input_screen(
+            app.screen_state.prompt_input_screen = Some(app::helpers::create_prompt_input_screen(
                 &app.prompt_history,
             ));
             app.tui_mode = app::TuiMode::PromptInput;
@@ -550,16 +550,16 @@ async fn handle_confirm_kill(app: &mut App, key: &KeyEvent, session_id: uuid::Uu
 fn handle_session_switcher(app: &mut App, key: &KeyEvent) {
     match key.code {
         KeyCode::Esc => {
-            app.session_switcher = None;
+            app.screen_state.session_switcher = None;
             app.navigate_back_or_dashboard();
         }
         KeyCode::Up => {
-            if let Some(sw) = &mut app.session_switcher {
+            if let Some(sw) = &mut app.screen_state.session_switcher {
                 sw.move_up();
             }
         }
         KeyCode::Down => {
-            if let Some(sw) = &mut app.session_switcher {
+            if let Some(sw) = &mut app.screen_state.session_switcher {
                 let count = {
                     let sessions = app.pool.all_sessions();
                     let refs: Vec<&crate::session::types::Session> = sessions;
@@ -569,12 +569,12 @@ fn handle_session_switcher(app: &mut App, key: &KeyEvent) {
             }
         }
         KeyCode::Enter => {
-            let selected_id = app.session_switcher.as_ref().and_then(|sw| {
+            let selected_id = app.screen_state.session_switcher.as_ref().and_then(|sw| {
                 let sessions = app.pool.all_sessions();
                 sw.selected_session(&sessions).map(|s| s.id)
             });
             if let Some(id) = selected_id {
-                app.session_switcher = None;
+                app.screen_state.session_switcher = None;
                 app.navigate_to(app::TuiMode::Detail(id));
             }
         }
@@ -598,7 +598,7 @@ fn handle_global_shortcuts(app: &mut App, key: &KeyEvent) -> bool {
         };
         app.activity_log
             .push_simple("TQ".into(), label.into(), LogLevel::Info);
-        if let Some(ref mut screen) = app.settings_screen {
+        if let Some(ref mut screen) = app.screen_state.settings_screen {
             screen.sync_tq_enabled(new_state);
         }
         return true;
@@ -860,7 +860,8 @@ fn handle_overview_keys(app: &mut App, key: &KeyEvent) {
             }
         }
         (KeyCode::Char('w'), _) => {
-            app.session_switcher = Some(crate::tui::session_switcher::SessionSwitcher::default());
+            app.screen_state.session_switcher =
+                Some(crate::tui::session_switcher::SessionSwitcher::default());
             app.navigate_to(app::TuiMode::SessionSwitcher);
         }
         // Ctrl+C is short-circuited at the top of handle_key, so reaching
@@ -1023,7 +1024,7 @@ mod tests {
         while wizard.step() != IssueWizardStep::BasicInfo {
             wizard.try_advance();
         }
-        app.issue_wizard_screen = Some(wizard);
+        app.screen_state.issue_wizard_screen = Some(wizard);
         app.tui_mode = TuiMode::IssueWizard;
         assert!(is_text_input_mode(&app));
     }
@@ -1035,7 +1036,7 @@ mod tests {
         let mut app = make_app();
         let mut wizard = crate::tui::screens::IssueWizardScreen::new();
         wizard.try_advance(); // Context → TypeSelect
-        app.issue_wizard_screen = Some(wizard);
+        app.screen_state.issue_wizard_screen = Some(wizard);
         app.tui_mode = TuiMode::IssueWizard;
         assert!(!is_text_input_mode(&app));
     }
@@ -1043,7 +1044,8 @@ mod tests {
     #[test]
     fn is_text_input_mode_true_for_milestone_wizard_on_goal_definition() {
         let mut app = make_app();
-        app.milestone_wizard_screen = Some(crate::tui::screens::MilestoneWizardScreen::new());
+        app.screen_state.milestone_wizard_screen =
+            Some(crate::tui::screens::MilestoneWizardScreen::new());
         app.tui_mode = TuiMode::MilestoneWizard;
         assert!(is_text_input_mode(&app));
     }
@@ -1051,7 +1053,8 @@ mod tests {
     #[test]
     fn is_text_input_mode_false_for_project_stats() {
         let mut app = make_app();
-        app.project_stats_screen = Some(crate::tui::screens::ProjectStatsScreen::new());
+        app.screen_state.project_stats_screen =
+            Some(crate::tui::screens::ProjectStatsScreen::new());
         app.tui_mode = TuiMode::ProjectStats;
         assert!(!is_text_input_mode(&app));
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -96,8 +96,8 @@ pub async fn run(mut app: App) -> anyhow::Result<()> {
     // (#290). Only intercept the Dashboard boot path — session-launching
     // subcommands (cmd_run / cmd_resume) go straight to their work view.
     if !no_splash && matches!(app.tui_mode, app::TuiMode::Dashboard) {
-        if app.landing_screen.is_none() {
-            app.landing_screen = Some(screens::LandingScreen::new());
+        if app.screen_state.landing_screen.is_none() {
+            app.screen_state.landing_screen = Some(screens::LandingScreen::new());
         }
         app.tui_mode = app::TuiMode::Landing;
     }
@@ -296,16 +296,8 @@ async fn event_loop(
                     });
                 }
                 app::TuiCommand::LaunchPromptSession(config) => {
-                    let model = app
-                        .config
-                        .as_ref()
-                        .map(|c| c.sessions.default_model.clone())
-                        .unwrap_or_else(|| "opus".to_string());
-                    let mode = app
-                        .config
-                        .as_ref()
-                        .map(|c| c.sessions.default_mode.clone())
-                        .unwrap_or_else(|| "orchestrator".to_string());
+                    let model = app.session_config.default_model.clone();
+                    let mode = app.session_config.default_mode.clone();
 
                     let original_prompt = config.prompt.clone();
                     let prompt = if config.image_paths.is_empty() {
@@ -712,7 +704,7 @@ async fn event_loop(
                     | app::TuiMode::CompletionSummary
             )
         {
-            if app.home_screen.is_some() && app.pool.total_count() == 0 {
+            if app.screen_state.home_screen.is_some() && app.pool.total_count() == 0 {
                 app.tui_mode = app::TuiMode::Dashboard;
                 continue;
             }
@@ -758,7 +750,7 @@ mod handle_screen_action_tests {
         let mut app = make_app();
         app.transition_to_dashboard();
         app.pending_commands.clear();
-        if let Some(ref mut screen) = app.home_screen {
+        if let Some(ref mut screen) = app.screen_state.home_screen {
             screen.loading_suggestions = false;
         }
         handle_screen_action(&mut app, ScreenAction::RefreshSuggestions);
@@ -774,12 +766,13 @@ mod handle_screen_action_tests {
     fn handle_refresh_suggestions_action_sets_loading_flag_on_home_screen() {
         let mut app = make_app();
         app.transition_to_dashboard();
-        if let Some(ref mut screen) = app.home_screen {
+        if let Some(ref mut screen) = app.screen_state.home_screen {
             screen.loading_suggestions = false;
         }
         handle_screen_action(&mut app, ScreenAction::RefreshSuggestions);
         assert!(
-            app.home_screen
+            app.screen_state
+                .home_screen
                 .as_ref()
                 .map(|s| s.loading_suggestions)
                 .unwrap_or(false),
@@ -818,11 +811,12 @@ mod handle_screen_action_tests {
     #[test]
     fn push_issue_browser_from_all_issues_resets_stale_milestone_screen() {
         let mut app = make_app();
-        app.issue_browser_screen = Some(screens::IssueBrowserScreen::new(vec![make_issue(
-            1,
-            Some(42),
-        )]));
-        app.milestone_screen = None;
+        app.screen_state.issue_browser_screen =
+            Some(screens::IssueBrowserScreen::new(vec![make_issue(
+                1,
+                Some(42),
+            )]));
+        app.screen_state.milestone_screen = None;
         app.tui_mode = app::TuiMode::Dashboard;
         app.pending_commands.clear();
 
@@ -833,7 +827,7 @@ mod handle_screen_action_tests {
                 .iter()
                 .any(|c| matches!(c, app::TuiCommand::FetchIssues)),
         );
-        let screen = app.issue_browser_screen.as_ref().unwrap();
+        let screen = app.screen_state.issue_browser_screen.as_ref().unwrap();
         assert!(screen.loading);
         assert!(screen.issues.is_empty());
     }
@@ -850,9 +844,9 @@ mod handle_screen_action_tests {
             closed_issues: 0,
             issues: vec![make_issue(7, Some(3))],
         };
-        app.milestone_screen = Some(screens::MilestoneScreen::new(vec![entry]));
+        app.screen_state.milestone_screen = Some(screens::MilestoneScreen::new(vec![entry]));
         app.tui_mode = app::TuiMode::MilestoneView;
-        app.issue_browser_screen = None;
+        app.screen_state.issue_browser_screen = None;
         app.pending_commands.clear();
 
         handle_screen_action(&mut app, ScreenAction::Push(app::TuiMode::IssueBrowser));
@@ -862,7 +856,7 @@ mod handle_screen_action_tests {
                 .iter()
                 .any(|c| matches!(c, app::TuiCommand::FetchIssues)),
         );
-        let screen = app.issue_browser_screen.as_ref().unwrap();
+        let screen = app.screen_state.issue_browser_screen.as_ref().unwrap();
         assert_eq!(screen.issues.len(), 1);
         assert_eq!(screen.issues[0].number, 7);
     }
@@ -872,8 +866,8 @@ mod handle_screen_action_tests {
         let mut app = make_app();
         let mut stale_screen = screens::IssueBrowserScreen::new(vec![]);
         stale_screen.set_milestone_filter(Some(5));
-        app.issue_browser_screen = Some(stale_screen);
-        app.milestone_screen = None;
+        app.screen_state.issue_browser_screen = Some(stale_screen);
+        app.screen_state.milestone_screen = None;
         app.tui_mode = app::TuiMode::Dashboard;
         app.pending_commands.clear();
 
@@ -886,7 +880,7 @@ mod handle_screen_action_tests {
         ];
         app.handle_data_event(app::TuiDataEvent::Issues(Ok(fetched)));
 
-        let screen = app.issue_browser_screen.as_ref().unwrap();
+        let screen = app.screen_state.issue_browser_screen.as_ref().unwrap();
         assert_eq!(screen.filtered_indices.len(), 3);
     }
 
@@ -906,14 +900,14 @@ mod handle_screen_action_tests {
                 make_issue_with_state(12, Some(5), "open"),
             ],
         };
-        app.milestone_screen = Some(screens::MilestoneScreen::new(vec![entry]));
+        app.screen_state.milestone_screen = Some(screens::MilestoneScreen::new(vec![entry]));
         app.tui_mode = app::TuiMode::MilestoneView;
-        app.issue_browser_screen = None;
+        app.screen_state.issue_browser_screen = None;
         app.pending_commands.clear();
 
         handle_screen_action(&mut app, ScreenAction::Push(app::TuiMode::IssueBrowser));
 
-        let screen = app.issue_browser_screen.as_ref().unwrap();
+        let screen = app.screen_state.issue_browser_screen.as_ref().unwrap();
         assert_eq!(screen.issues.len(), 2);
         assert!(screen.issues.iter().all(|i| i.state == "open"));
     }
@@ -931,12 +925,13 @@ mod handle_paste_tests {
     #[test]
     fn dispatch_paste_routes_to_prompt_input_screen_when_active() {
         let mut app = make_app();
-        app.prompt_input_screen = Some(crate::tui::screens::PromptInputScreen::new());
+        app.screen_state.prompt_input_screen = Some(crate::tui::screens::PromptInputScreen::new());
         app.tui_mode = app::TuiMode::PromptInput;
 
         dispatch_paste_to_active_screen(&mut app, "hello from paste");
 
         let text = app
+            .screen_state
             .prompt_input_screen
             .as_ref()
             .expect("prompt_input_screen must be Some")
@@ -947,19 +942,24 @@ mod handle_paste_tests {
     #[test]
     fn dispatch_paste_preserves_embedded_newlines() {
         let mut app = make_app();
-        app.prompt_input_screen = Some(crate::tui::screens::PromptInputScreen::new());
+        app.screen_state.prompt_input_screen = Some(crate::tui::screens::PromptInputScreen::new());
         app.tui_mode = app::TuiMode::PromptInput;
 
         dispatch_paste_to_active_screen(&mut app, "line1\nline2\nline3");
 
-        let text = app.prompt_input_screen.as_ref().unwrap().editor_text();
+        let text = app
+            .screen_state
+            .prompt_input_screen
+            .as_ref()
+            .unwrap()
+            .editor_text();
         assert_eq!(text, "line1\nline2\nline3");
     }
 
     #[test]
     fn dispatch_paste_does_not_launch_session() {
         let mut app = make_app();
-        app.prompt_input_screen = Some(crate::tui::screens::PromptInputScreen::new());
+        app.screen_state.prompt_input_screen = Some(crate::tui::screens::PromptInputScreen::new());
         app.tui_mode = app::TuiMode::PromptInput;
         app.pending_commands.clear();
 
@@ -980,12 +980,17 @@ mod handle_paste_tests {
     #[test]
     fn app_handle_paste_with_prompt_input_active_inserts_text() {
         let mut app = make_app();
-        app.prompt_input_screen = Some(crate::tui::screens::PromptInputScreen::new());
+        app.screen_state.prompt_input_screen = Some(crate::tui::screens::PromptInputScreen::new());
         app.tui_mode = app::TuiMode::PromptInput;
 
         app.handle_paste("multi\nline\npaste");
 
-        let text = app.prompt_input_screen.as_ref().unwrap().editor_text();
+        let text = app
+            .screen_state
+            .prompt_input_screen
+            .as_ref()
+            .unwrap()
+            .editor_text();
         assert_eq!(text, "multi\nline\npaste");
     }
 

--- a/src/tui/screen_dispatch.rs
+++ b/src/tui/screen_dispatch.rs
@@ -11,16 +11,17 @@ pub(super) fn tick_wizard_step_hooks(app: &mut app::App) {
     if app.tui_mode != app::TuiMode::IssueWizard {
         return;
     }
-    let (start_dep_fetch, start_review, start_improve) = match app.issue_wizard_screen.as_ref() {
-        Some(s) => (
-            s.entered_dependencies_step(),
-            s.entered_ai_review_step(),
-            s.improve_requested(),
-        ),
-        None => (false, false, false),
-    };
+    let (start_dep_fetch, start_review, start_improve) =
+        match app.screen_state.issue_wizard_screen.as_ref() {
+            Some(s) => (
+                s.entered_dependencies_step(),
+                s.entered_ai_review_step(),
+                s.improve_requested(),
+            ),
+            None => (false, false, false),
+        };
     if start_dep_fetch {
-        if let Some(ref mut s) = app.issue_wizard_screen {
+        if let Some(ref mut s) = app.screen_state.issue_wizard_screen {
             s.begin_dependency_fetch();
         }
         app.pending_commands
@@ -28,11 +29,12 @@ pub(super) fn tick_wizard_step_hooks(app: &mut app::App) {
     }
     if start_review {
         let payload = app
+            .screen_state
             .issue_wizard_screen
             .as_ref()
             .map(|s| s.payload().clone());
         if let Some(payload) = payload {
-            if let Some(ref mut s) = app.issue_wizard_screen {
+            if let Some(ref mut s) = app.screen_state.issue_wizard_screen {
                 s.begin_ai_review();
             }
             app.pending_commands
@@ -40,14 +42,14 @@ pub(super) fn tick_wizard_step_hooks(app: &mut app::App) {
         }
     }
     if start_improve {
-        let pair = app.issue_wizard_screen.as_ref().map(|s| {
+        let pair = app.screen_state.issue_wizard_screen.as_ref().map(|s| {
             (
                 s.payload().clone(),
                 s.review_text().unwrap_or("").to_string(),
             )
         });
         if let Some((payload, critique)) = pair {
-            if let Some(ref mut s) = app.issue_wizard_screen {
+            if let Some(ref mut s) = app.screen_state.issue_wizard_screen {
                 s.mark_improve_enqueued();
             }
             app.pending_commands
@@ -56,6 +58,7 @@ pub(super) fn tick_wizard_step_hooks(app: &mut app::App) {
     }
 
     let needs_create = app
+        .screen_state
         .issue_wizard_screen
         .as_ref()
         .map(|s| {
@@ -68,11 +71,12 @@ pub(super) fn tick_wizard_step_hooks(app: &mut app::App) {
         .unwrap_or(false);
     if needs_create {
         let payload = app
+            .screen_state
             .issue_wizard_screen
             .as_ref()
             .map(|s| s.payload().clone());
         if let Some(payload) = payload {
-            if let Some(ref mut s) = app.issue_wizard_screen {
+            if let Some(ref mut s) = app.screen_state.issue_wizard_screen {
                 s.mark_create_enqueued();
             }
             app.pending_commands
@@ -82,24 +86,26 @@ pub(super) fn tick_wizard_step_hooks(app: &mut app::App) {
 
     // Milestone wizard: AiStructuring auto-launch + Materializing creation.
     if app.tui_mode == app::TuiMode::MilestoneWizard {
-        let (start_planning, start_creating) = match app.milestone_wizard_screen.as_ref() {
-            Some(s) => (
-                s.entered_ai_structuring_step(),
-                matches!(
-                    s.step(),
-                    crate::tui::screens::milestone_wizard::MilestoneWizardStep::Materializing
-                ) && s.materialize_progress().is_some()
-                    && !s.materialize_enqueued(),
-            ),
-            None => (false, false),
-        };
+        let (start_planning, start_creating) =
+            match app.screen_state.milestone_wizard_screen.as_ref() {
+                Some(s) => (
+                    s.entered_ai_structuring_step(),
+                    matches!(
+                        s.step(),
+                        crate::tui::screens::milestone_wizard::MilestoneWizardStep::Materializing
+                    ) && s.materialize_progress().is_some()
+                        && !s.materialize_enqueued(),
+                ),
+                None => (false, false),
+            };
         if start_planning {
             let payload = app
+                .screen_state
                 .milestone_wizard_screen
                 .as_ref()
                 .map(|s| s.payload().clone());
             if let Some(payload) = payload {
-                if let Some(ref mut s) = app.milestone_wizard_screen {
+                if let Some(ref mut s) = app.screen_state.milestone_wizard_screen {
                     s.start_planning();
                 }
                 app.pending_commands
@@ -108,11 +114,12 @@ pub(super) fn tick_wizard_step_hooks(app: &mut app::App) {
         }
         if start_creating {
             let plan = app
+                .screen_state
                 .milestone_wizard_screen
                 .as_ref()
                 .and_then(|s| s.generated_plan().cloned());
             if let Some(plan) = plan {
-                if let Some(ref mut s) = app.milestone_wizard_screen {
+                if let Some(ref mut s) = app.screen_state.milestone_wizard_screen {
                     s.mark_materialize_enqueued();
                 }
                 app.pending_commands
@@ -156,30 +163,30 @@ pub(super) fn dispatch_to_active_screen(app: &mut app::App, event: &Event) -> Op
     }
 
     let screen: &mut dyn Screen = match app.tui_mode {
-        app::TuiMode::Dashboard => app.home_screen.as_mut()?,
-        app::TuiMode::Landing => app.landing_screen.as_mut()?,
-        app::TuiMode::IssueWizard => app.issue_wizard_screen.as_mut()?,
-        app::TuiMode::ProjectStats => app.project_stats_screen.as_mut()?,
-        app::TuiMode::MilestoneWizard => app.milestone_wizard_screen.as_mut()?,
-        app::TuiMode::IssueBrowser => app.issue_browser_screen.as_mut()?,
-        app::TuiMode::MilestoneView => app.milestone_screen.as_mut()?,
-        app::TuiMode::PromptInput => app.prompt_input_screen.as_mut()?,
-        app::TuiMode::QueueConfirmation => app.queue_confirmation_screen.as_mut()?,
-        app::TuiMode::HollowRetry => app.hollow_retry_screen.as_mut()?,
-        app::TuiMode::AdaptFollowUp => app.adapt_follow_up_screen.as_mut()?,
-        app::TuiMode::Sanitize => app.sanitize_screen.as_mut()?,
-        app::TuiMode::Settings => app.settings_screen.as_mut()?,
-        app::TuiMode::AdaptWizard => app.adapt_screen.as_mut()?,
-        app::TuiMode::PrReview => app.pr_review_screen.as_mut()?,
-        app::TuiMode::ReleaseNotes => app.release_notes_screen.as_mut()?,
-        app::TuiMode::MilestoneHealth => app.milestone_health_screen.as_mut()?,
+        app::TuiMode::Dashboard => app.screen_state.home_screen.as_mut()?,
+        app::TuiMode::Landing => app.screen_state.landing_screen.as_mut()?,
+        app::TuiMode::IssueWizard => app.screen_state.issue_wizard_screen.as_mut()?,
+        app::TuiMode::ProjectStats => app.screen_state.project_stats_screen.as_mut()?,
+        app::TuiMode::MilestoneWizard => app.screen_state.milestone_wizard_screen.as_mut()?,
+        app::TuiMode::IssueBrowser => app.screen_state.issue_browser_screen.as_mut()?,
+        app::TuiMode::MilestoneView => app.screen_state.milestone_screen.as_mut()?,
+        app::TuiMode::PromptInput => app.screen_state.prompt_input_screen.as_mut()?,
+        app::TuiMode::QueueConfirmation => app.screen_state.queue_confirmation_screen.as_mut()?,
+        app::TuiMode::HollowRetry => app.screen_state.hollow_retry_screen.as_mut()?,
+        app::TuiMode::AdaptFollowUp => app.screen_state.adapt_follow_up_screen.as_mut()?,
+        app::TuiMode::Sanitize => app.screen_state.sanitize_screen.as_mut()?,
+        app::TuiMode::Settings => app.screen_state.settings_screen.as_mut()?,
+        app::TuiMode::AdaptWizard => app.screen_state.adapt_screen.as_mut()?,
+        app::TuiMode::PrReview => app.screen_state.pr_review_screen.as_mut()?,
+        app::TuiMode::ReleaseNotes => app.screen_state.release_notes_screen.as_mut()?,
+        app::TuiMode::MilestoneHealth => app.screen_state.milestone_health_screen.as_mut()?,
         _ => return None,
     };
     let mode = screen.desired_input_mode().unwrap_or(InputMode::Normal);
     let action = screen.handle_input(event, mode);
     // Drain any pending TuiCommand the milestone-health reducer enqueued.
     if matches!(app.tui_mode, app::TuiMode::MilestoneHealth)
-        && let Some(s) = app.milestone_health_screen.as_mut()
+        && let Some(s) = app.screen_state.milestone_health_screen.as_mut()
         && let Some(cmd) = s.take_pending_command()
     {
         app.pending_commands.push(cmd);
@@ -204,7 +211,7 @@ fn milestone_issues_if_applicable(app: &app::App) -> Option<Vec<GhIssue>> {
     if app.tui_mode != app::TuiMode::MilestoneView {
         return None;
     }
-    app.milestone_screen.as_ref().and_then(|ms| {
+    app.screen_state.milestone_screen.as_ref().and_then(|ms| {
         ms.selected_milestone().and_then(|entry| {
             let open_issues: Vec<GhIssue> = entry
                 .issues
@@ -305,7 +312,7 @@ fn handle_reset_settings_from_detection(app: &mut app::App) {
     let added = report.keys_added.len();
     let preserved = report.keys_preserved.len();
 
-    if let Some(s) = app.settings_screen.as_mut() {
+    if let Some(s) = app.screen_state.settings_screen.as_mut() {
         *s = crate::tui::screens::SettingsScreen::new(cfg.clone(), app.flags.clone())
             .with_config_path(target.clone());
         s.show_caveman_status(format!(
@@ -330,20 +337,24 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
         ScreenAction::Push(mode) => {
             match mode {
                 app::TuiMode::Landing => {
-                    app.landing_screen
+                    app.screen_state
+                        .landing_screen
                         .get_or_insert_with(screens::LandingScreen::new);
                 }
                 app::TuiMode::IssueWizard => {
-                    app.issue_wizard_screen
+                    app.screen_state
+                        .issue_wizard_screen
                         .get_or_insert_with(screens::IssueWizardScreen::new);
                 }
                 app::TuiMode::ProjectStats => {
-                    app.project_stats_screen = Some(screens::ProjectStatsScreen::new());
+                    app.screen_state.project_stats_screen =
+                        Some(screens::ProjectStatsScreen::new());
                     app.pending_commands
                         .push(app::TuiCommand::FetchProjectStats);
                 }
                 app::TuiMode::MilestoneWizard => {
-                    app.milestone_wizard_screen
+                    app.screen_state
+                        .milestone_wizard_screen
                         .get_or_insert_with(screens::MilestoneWizardScreen::new);
                 }
                 app::TuiMode::IssueBrowser => {
@@ -353,7 +364,7 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
                         .map(|c| c.tui.layout.clone())
                         .unwrap_or_default();
                     if let Some(issues) = milestone_issues_if_applicable(app) {
-                        app.issue_browser_screen =
+                        app.screen_state.issue_browser_screen =
                             Some(screens::IssueBrowserScreen::new(issues).with_layout(layout));
                     } else {
                         // Fresh screen for "All Issues" — never reuse a
@@ -361,14 +372,14 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
                         let mut screen =
                             screens::IssueBrowserScreen::new(vec![]).with_layout(layout);
                         screen.loading = true;
-                        app.issue_browser_screen = Some(screen);
+                        app.screen_state.issue_browser_screen = Some(screen);
                         app.pending_commands.push(app::TuiCommand::FetchIssues);
                     }
                 }
-                app::TuiMode::MilestoneView if app.milestone_screen.is_none() => {
+                app::TuiMode::MilestoneView if app.screen_state.milestone_screen.is_none() => {
                     let mut screen = screens::MilestoneScreen::new(vec![]);
                     screen.loading = true;
-                    app.milestone_screen = Some(screen);
+                    app.screen_state.milestone_screen = Some(screen);
                     app.pending_commands.push(app::TuiCommand::FetchMilestones);
                 }
                 app::TuiMode::Settings => {
@@ -385,27 +396,29 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
                                 "No config path resolved at boot — Settings save will surface an error"
                             );
                         }
-                        app.settings_screen = Some(screen);
+                        app.screen_state.settings_screen = Some(screen);
                     }
                 }
                 app::TuiMode::AdaptWizard => {
-                    app.adapt_screen = Some(crate::tui::screens::adapt::AdaptScreen::new());
+                    app.screen_state.adapt_screen =
+                        Some(crate::tui::screens::adapt::AdaptScreen::new());
                 }
                 app::TuiMode::PrReview => {
-                    app.pr_review_screen =
+                    app.screen_state.pr_review_screen =
                         Some(crate::tui::screens::pr_review::PrReviewScreen::new());
                     app.pending_commands.push(app::TuiCommand::FetchOpenPrs);
                 }
                 app::TuiMode::ReleaseNotes => {
-                    app.release_notes_screen = Some(crate::tui::screens::ReleaseNotesScreen::new());
+                    app.screen_state.release_notes_screen =
+                        Some(crate::tui::screens::ReleaseNotesScreen::new());
                 }
                 app::TuiMode::PromptInput => {
-                    app.prompt_input_screen = Some(app::helpers::create_prompt_input_screen(
-                        &app.prompt_history,
-                    ));
+                    app.screen_state.prompt_input_screen = Some(
+                        app::helpers::create_prompt_input_screen(&app.prompt_history),
+                    );
                 }
                 app::TuiMode::MilestoneHealth => {
-                    app.milestone_health_screen =
+                    app.screen_state.milestone_health_screen =
                         Some(crate::tui::screens::milestone_health::MilestoneHealthScreen::new());
                     app.pending_commands.push(app::TuiCommand::FetchMilestones);
                 }
@@ -417,50 +430,50 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
         ScreenAction::Pop => {
             match app.tui_mode {
                 app::TuiMode::IssueBrowser => {
-                    app.issue_browser_screen = None;
+                    app.screen_state.issue_browser_screen = None;
                 }
                 app::TuiMode::IssueWizard => {
-                    app.issue_wizard_screen = None;
+                    app.screen_state.issue_wizard_screen = None;
                 }
                 app::TuiMode::ProjectStats => {
-                    app.project_stats_screen = None;
+                    app.screen_state.project_stats_screen = None;
                 }
                 app::TuiMode::MilestoneWizard => {
-                    app.milestone_wizard_screen = None;
+                    app.screen_state.milestone_wizard_screen = None;
                 }
                 app::TuiMode::MilestoneView => {
-                    app.milestone_screen = None;
+                    app.screen_state.milestone_screen = None;
                 }
                 app::TuiMode::PromptInput => {
-                    app.prompt_input_screen = None;
+                    app.screen_state.prompt_input_screen = None;
                 }
                 app::TuiMode::QueueConfirmation => {
-                    app.queue_confirmation_screen = None;
+                    app.screen_state.queue_confirmation_screen = None;
                 }
                 app::TuiMode::HollowRetry => {
-                    app.hollow_retry_screen = None;
+                    app.screen_state.hollow_retry_screen = None;
                 }
                 app::TuiMode::AdaptFollowUp => {
-                    app.adapt_follow_up_screen = None;
+                    app.screen_state.adapt_follow_up_screen = None;
                 }
                 app::TuiMode::Sanitize => {
-                    app.sanitize_screen = None;
+                    app.screen_state.sanitize_screen = None;
                 }
                 app::TuiMode::Settings => {
                     app.preview_theme = None;
-                    app.settings_screen = None;
+                    app.screen_state.settings_screen = None;
                 }
                 app::TuiMode::AdaptWizard => {
-                    app.adapt_screen = None;
+                    app.screen_state.adapt_screen = None;
                 }
                 app::TuiMode::PrReview => {
-                    app.pr_review_screen = None;
+                    app.screen_state.pr_review_screen = None;
                 }
                 app::TuiMode::ReleaseNotes => {
-                    app.release_notes_screen = None;
+                    app.screen_state.release_notes_screen = None;
                 }
                 app::TuiMode::MilestoneHealth => {
-                    app.milestone_health_screen = None;
+                    app.screen_state.milestone_health_screen = None;
                 }
                 _ => {}
             }
@@ -468,11 +481,12 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
         }
         ScreenAction::RefreshSuggestions => {
             let already_loading = app
+                .screen_state
                 .home_screen
                 .as_ref()
                 .is_some_and(|s| s.loading_suggestions);
             if !already_loading {
-                if let Some(ref mut screen) = app.home_screen {
+                if let Some(ref mut screen) = app.screen_state.home_screen {
                     screen.start_loading_suggestions();
                 }
                 app.pending_commands
@@ -515,6 +529,7 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
             app.pool.set_permission_mode(new_permission_mode.clone());
             app.pool
                 .set_allowed_tools(config.sessions.allowed_tools.clone());
+            app.session_config.apply_config(&config.sessions);
             let guardrail = crate::prompts::resolve_guardrail(
                 config.sessions.guardrail_prompt.as_deref(),
                 &std::path::PathBuf::from("."),
@@ -630,8 +645,8 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
             app.tui_mode = app::TuiMode::Overview;
         }
         ScreenAction::LaunchPromptSession(config) => {
-            app.prompt_input_screen = None;
-            app.adapt_follow_up_screen = None;
+            app.screen_state.prompt_input_screen = None;
+            app.screen_state.adapt_follow_up_screen = None;
             app.pending_commands
                 .push(app::TuiCommand::LaunchPromptSession(config));
             app.nav_stack.clear();
@@ -666,15 +681,18 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
                     app.pending_session_launches.push(retry);
                 }
             }
-            app.hollow_retry_screen = None;
+            app.screen_state.hollow_retry_screen = None;
             app.tui_mode = app::TuiMode::Overview;
         }
         ScreenAction::FetchPrDetail(pr_number) => {
             let pr = app
+                .screen_state
                 .pr_review_screen
                 .as_ref()
                 .and_then(|s| s.find_pr(pr_number));
-            if let (Some(pr), Some(ref mut screen)) = (pr, app.pr_review_screen.as_mut()) {
+            if let (Some(pr), Some(ref mut screen)) =
+                (pr, app.screen_state.pr_review_screen.as_mut())
+            {
                 screen.set_pr_detail(pr);
             }
         }
@@ -696,17 +714,21 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
             // Reuse an existing wizard if present, otherwise spin one up.
             // Pre-fill milestone + suggested Blocked By so the user can
             // accept/override on the Dependencies step.
-            let mut wizard = app.issue_wizard_screen.take().unwrap_or_default();
+            let mut wizard = app
+                .screen_state
+                .issue_wizard_screen
+                .take()
+                .unwrap_or_default();
             {
                 let payload = wizard.payload_mut();
                 payload.milestone = Some(milestone);
                 payload.blocked_by = suggested_blocked_by;
             }
-            app.issue_wizard_screen = Some(wizard);
+            app.screen_state.issue_wizard_screen = Some(wizard);
             app.navigate_to(app::TuiMode::IssueWizard);
         }
         ScreenAction::StartAdaptPipeline(config) => {
-            if let Some(ref mut screen) = app.adapt_screen {
+            if let Some(ref mut screen) = app.screen_state.adapt_screen {
                 use crate::tui::screens::adapt::types::AdaptStep;
                 match screen.step {
                     AdaptStep::Configure | AdaptStep::Scanning => {

--- a/src/tui/screens/bypass_dispatch.rs
+++ b/src/tui/screens/bypass_dispatch.rs
@@ -11,19 +11,19 @@ pub fn dispatch_input(app: &mut App, event: &Event) -> ScreenAction {
     let Event::Key(key) = event else {
         return ScreenAction::None;
     };
-    let Some(state) = app.bypass_warning_screen.as_mut() else {
+    let Some(state) = app.screen_state.bypass_warning_screen.as_mut() else {
         return ScreenAction::Pop;
     };
     let outcome = warning_handle_key(state, *key);
     match outcome {
         BypassWarningOutcome::Pending => ScreenAction::None,
         BypassWarningOutcome::Confirmed => {
-            app.bypass_warning_screen = None;
+            app.screen_state.bypass_warning_screen = None;
             app.confirm_bypass_activation("tui");
             ScreenAction::Pop
         }
         BypassWarningOutcome::Cancelled => {
-            app.bypass_warning_screen = None;
+            app.screen_state.bypass_warning_screen = None;
             ScreenAction::Pop
         }
     }

--- a/src/tui/screens/prd_dispatch.rs
+++ b/src/tui/screens/prd_dispatch.rs
@@ -48,7 +48,7 @@ pub fn dispatch_input(app: &mut App, event: &Event) -> ScreenAction {
     let Some(prd) = app.prd.as_mut() else {
         return ScreenAction::None;
     };
-    let Some(screen) = app.prd_screen.as_mut() else {
+    let Some(screen) = app.screen_state.prd_screen.as_mut() else {
         return ScreenAction::None;
     };
 
@@ -99,7 +99,7 @@ fn ingest_chosen_candidate(app: &mut App) {
         return;
     };
     let report = prd.merge_ingested(&parsed);
-    if let Some(s) = app.prd_screen.as_mut() {
+    if let Some(s) = app.screen_state.prd_screen.as_mut() {
         s.dirty = true;
     }
     let identifier = if candidate.number > 0 {
@@ -128,7 +128,7 @@ fn reset_prd(app: &mut App) {
     let store = FilePrdStore::new(repo_root());
     let _ = std::fs::remove_file(store.prd_path());
     app.prd = Some(Prd::new());
-    if let Some(s) = app.prd_screen.as_mut() {
+    if let Some(s) = app.screen_state.prd_screen.as_mut() {
         s.dirty = false;
         s.sync_status = crate::tui::screens::prd::PrdSyncStatus::Idle;
         s.save_status = crate::tui::screens::prd::PrdSaveStatus::default();
@@ -164,7 +164,7 @@ fn drop_guard(action: PrdAction, app: &mut App) -> ScreenAction {
 }
 
 pub fn ensure_loaded(app: &mut App) {
-    if app.prd.is_some() && app.prd_screen.is_some() {
+    if app.prd.is_some() && app.screen_state.prd_screen.is_some() {
         return;
     }
     let store = FilePrdStore::new(repo_root());
@@ -181,7 +181,9 @@ pub fn ensure_loaded(app: &mut App) {
         }
     };
     app.prd.get_or_insert(prd);
-    app.prd_screen.get_or_insert_with(PrdScreen::new);
+    app.screen_state
+        .prd_screen
+        .get_or_insert_with(PrdScreen::new);
     // First-load on a fresh PRD: auto-sync from GitHub so Current State +
     // Timeline are populated immediately rather than blank. The user can
     // still press [y] to refresh later.
@@ -203,7 +205,7 @@ fn save_prd(app: &mut App) {
     let store = FilePrdStore::new(repo_root());
     match store.save(prd) {
         Ok(()) => {
-            if let Some(s) = app.prd_screen.as_mut() {
+            if let Some(s) = app.screen_state.prd_screen.as_mut() {
                 s.dirty = false;
                 s.save_status.last_saved = Some(Instant::now());
                 s.save_status.last_error = None;
@@ -215,7 +217,7 @@ fn save_prd(app: &mut App) {
             );
         }
         Err(e) => {
-            if let Some(s) = app.prd_screen.as_mut() {
+            if let Some(s) = app.screen_state.prd_screen.as_mut() {
                 s.save_status.last_error = Some(e.to_string());
             }
             app.activity_log.push_simple(
@@ -251,7 +253,7 @@ fn queue_sync(app: &mut App) {
     // Mark the screen state so the header chip flips to "⟳ Syncing…" on
     // the next render — without this the user has no immediate feedback
     // that their keypress did anything.
-    if let Some(s) = app.prd_screen.as_mut() {
+    if let Some(s) = app.screen_state.prd_screen.as_mut() {
         s.sync_status = PrdSyncStatus::Syncing {
             started_at: Instant::now(),
         };

--- a/src/tui/screens/roadmap_dispatch.rs
+++ b/src/tui/screens/roadmap_dispatch.rs
@@ -15,7 +15,7 @@ pub fn dispatch_input(app: &mut App, event: &Event) -> ScreenAction {
 
     ensure_loaded(app);
 
-    let Some(screen) = app.roadmap_screen.as_mut() else {
+    let Some(screen) = app.screen_state.roadmap_screen.as_mut() else {
         return ScreenAction::None;
     };
 
@@ -65,7 +65,7 @@ fn handle_filter_edit(
 }
 
 fn handle_view(app: &mut App, code: KeyCode) -> ScreenAction {
-    let Some(screen) = app.roadmap_screen.as_mut() else {
+    let Some(screen) = app.screen_state.roadmap_screen.as_mut() else {
         return ScreenAction::None;
     };
     match code {
@@ -121,8 +121,8 @@ fn handle_view(app: &mut App, code: KeyCode) -> ScreenAction {
 }
 
 pub fn ensure_loaded(app: &mut App) {
-    if app.roadmap_screen.is_none() {
-        app.roadmap_screen = Some(RoadmapScreen::new());
+    if app.screen_state.roadmap_screen.is_none() {
+        app.screen_state.roadmap_screen = Some(RoadmapScreen::new());
         app.pending_commands
             .push(crate::tui::app::TuiCommand::SyncRoadmap);
     }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -203,7 +203,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
             );
         }
         TuiMode::Dashboard => {
-            if let Some(ref mut screen) = app.home_screen {
+            if let Some(ref mut screen) = app.screen_state.home_screen {
                 screen.set_mascot(
                     app.show_mascot,
                     app.mascot_animator.state(),
@@ -214,7 +214,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
             }
         }
         TuiMode::Landing => {
-            if let Some(ref mut screen) = app.landing_screen {
+            if let Some(ref mut screen) = app.screen_state.landing_screen {
                 screen.set_mascot(
                     app.mascot_animator.state(),
                     app.mascot_animator.frame_index(),
@@ -224,37 +224,37 @@ pub fn draw(f: &mut Frame, app: &mut App) {
             }
         }
         TuiMode::IssueWizard => {
-            if let Some(ref mut screen) = app.issue_wizard_screen {
+            if let Some(ref mut screen) = app.screen_state.issue_wizard_screen {
                 screen.draw(f, chunks[1], &app.theme);
             }
         }
         TuiMode::ProjectStats => {
-            if let Some(ref mut screen) = app.project_stats_screen {
+            if let Some(ref mut screen) = app.screen_state.project_stats_screen {
                 screen.draw(f, chunks[1], &app.theme);
             }
         }
         TuiMode::MilestoneWizard => {
-            if let Some(ref mut screen) = app.milestone_wizard_screen {
+            if let Some(ref mut screen) = app.screen_state.milestone_wizard_screen {
                 screen.draw(f, chunks[1], &app.theme);
             }
         }
         TuiMode::IssueBrowser => {
-            if let Some(ref mut screen) = app.issue_browser_screen {
+            if let Some(ref mut screen) = app.screen_state.issue_browser_screen {
                 screen.draw(f, chunks[1], &app.theme);
             }
         }
         TuiMode::MilestoneView => {
-            if let Some(ref mut screen) = app.milestone_screen {
+            if let Some(ref mut screen) = app.screen_state.milestone_screen {
                 screen.draw(f, chunks[1], &app.theme);
             }
         }
         TuiMode::PromptInput => {
-            if let Some(ref mut screen) = app.prompt_input_screen {
+            if let Some(ref mut screen) = app.screen_state.prompt_input_screen {
                 screen.draw(f, chunks[1], &app.theme);
             }
         }
         TuiMode::QueueConfirmation => {
-            if let Some(ref mut screen) = app.queue_confirmation_screen {
+            if let Some(ref mut screen) = app.screen_state.queue_confirmation_screen {
                 screen.draw(f, chunks[1], &app.theme);
             }
         }
@@ -315,12 +315,12 @@ pub fn draw(f: &mut Frame, app: &mut App) {
             );
         }
         TuiMode::Sanitize => {
-            if let Some(ref mut screen) = app.sanitize_screen {
+            if let Some(ref mut screen) = app.screen_state.sanitize_screen {
                 screen.draw(f, chunks[1], &app.theme);
             }
         }
         TuiMode::Settings => {
-            if let Some(ref mut screen) = app.settings_screen {
+            if let Some(ref mut screen) = app.screen_state.settings_screen {
                 screen.draw(f, chunks[1], &app.theme);
             }
         }
@@ -335,13 +335,13 @@ pub fn draw(f: &mut Frame, app: &mut App) {
                 &theme,
                 spinner_tick,
             );
-            if let Some(ref sw) = app.session_switcher {
+            if let Some(ref sw) = app.screen_state.session_switcher {
                 let sessions = app.pool.all_sessions();
                 sw.draw(f, chunks[1], &sessions, &theme);
             }
         }
         TuiMode::AdaptWizard => {
-            if let Some(ref mut screen) = app.adapt_screen {
+            if let Some(ref mut screen) = app.screen_state.adapt_screen {
                 screen.tick();
                 screen.draw(f, chunks[1], &theme);
             }
@@ -358,13 +358,13 @@ pub fn draw(f: &mut Frame, app: &mut App) {
                     app.concerns_cursor,
                     &theme,
                 );
-            } else if let Some(ref mut screen) = app.pr_review_screen {
+            } else if let Some(ref mut screen) = app.screen_state.pr_review_screen {
                 screen.tick();
                 screen.draw(f, chunks[1], &theme);
             }
         }
         TuiMode::ReleaseNotes => {
-            if let Some(ref mut screen) = app.release_notes_screen {
+            if let Some(ref mut screen) = app.screen_state.release_notes_screen {
                 screen.draw(f, chunks[1], &theme);
             }
         }
@@ -411,12 +411,12 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         TuiMode::ConfirmExit => {
             match app.nav_stack.peek() {
                 Some(&TuiMode::Dashboard) => {
-                    if let Some(ref mut screen) = app.home_screen {
+                    if let Some(ref mut screen) = app.screen_state.home_screen {
                         screen.draw(f, chunks[1], &theme);
                     }
                 }
                 Some(&TuiMode::Landing) => {
-                    if let Some(ref mut screen) = app.landing_screen {
+                    if let Some(ref mut screen) = app.screen_state.landing_screen {
                         screen.set_mascot(
                             app.mascot_animator.state(),
                             app.mascot_animator.frame_index(),
@@ -426,12 +426,14 @@ pub fn draw(f: &mut Frame, app: &mut App) {
                     }
                 }
                 Some(&TuiMode::Prd) => {
-                    if let (Some(prd), Some(screen)) = (app.prd.as_ref(), app.prd_screen.as_ref()) {
+                    if let (Some(prd), Some(screen)) =
+                        (app.prd.as_ref(), app.screen_state.prd_screen.as_ref())
+                    {
                         crate::tui::screens::prd::draw::draw(f, chunks[1], screen, prd, &theme);
                     }
                 }
                 Some(&TuiMode::Roadmap) => {
-                    if let Some(screen) = app.roadmap_screen.as_ref() {
+                    if let Some(screen) = app.screen_state.roadmap_screen.as_ref() {
                         crate::tui::screens::roadmap::draw(f, chunks[1], screen, &theme);
                     }
                 }
@@ -495,7 +497,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
                 &theme,
                 spinner_tick,
             );
-            if let Some(ref mut screen) = app.hollow_retry_screen {
+            if let Some(ref mut screen) = app.screen_state.hollow_retry_screen {
                 screen.draw(f, chunks[1], &app.theme);
             }
         }
@@ -532,7 +534,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
                 &theme,
                 spinner_tick,
             );
-            if let Some(ref mut screen) = app.adapt_follow_up_screen {
+            if let Some(ref mut screen) = app.screen_state.adapt_follow_up_screen {
                 screen.draw(f, chunks[1], &app.theme);
             }
         }
@@ -551,13 +553,15 @@ pub fn draw(f: &mut Frame, app: &mut App) {
                     app.prd_explore_cursor,
                     &theme,
                 );
-            } else if let (Some(prd), Some(screen)) = (app.prd.as_ref(), app.prd_screen.as_ref()) {
+            } else if let (Some(prd), Some(screen)) =
+                (app.prd.as_ref(), app.screen_state.prd_screen.as_ref())
+            {
                 crate::tui::screens::prd::draw::draw(f, chunks[1], screen, prd, &theme);
             }
         }
         TuiMode::Roadmap => {
             crate::tui::screens::roadmap_dispatch::ensure_loaded(app);
-            if let Some(screen) = app.roadmap_screen.as_ref() {
+            if let Some(screen) = app.screen_state.roadmap_screen.as_ref() {
                 crate::tui::screens::roadmap::draw(f, chunks[1], screen, &theme);
             }
         }
@@ -573,7 +577,7 @@ pub fn draw(f: &mut Frame, app: &mut App) {
             f.render_widget(para, chunks[1]);
         }
         TuiMode::MilestoneHealth => {
-            if let Some(ref screen) = app.milestone_health_screen {
+            if let Some(ref screen) = app.screen_state.milestone_health_screen {
                 crate::tui::screens::milestone_health::draw::draw(
                     f,
                     chunks[1],
@@ -693,31 +697,86 @@ pub fn draw(f: &mut Frame, app: &mut App) {
 /// Resolve the active screen (if any) to extract keybindings and input mode.
 pub(super) fn active_screen(app: &App) -> Option<&dyn Screen> {
     match app.tui_mode {
-        TuiMode::Dashboard => app.home_screen.as_ref().map(|s| s as &dyn Screen),
-        TuiMode::Landing => app.landing_screen.as_ref().map(|s| s as &dyn Screen),
-        TuiMode::IssueBrowser => app.issue_browser_screen.as_ref().map(|s| s as &dyn Screen),
-        TuiMode::IssueWizard => app.issue_wizard_screen.as_ref().map(|s| s as &dyn Screen),
-        TuiMode::MilestoneView => app.milestone_screen.as_ref().map(|s| s as &dyn Screen),
+        TuiMode::Dashboard => app
+            .screen_state
+            .home_screen
+            .as_ref()
+            .map(|s| s as &dyn Screen),
+        TuiMode::Landing => app
+            .screen_state
+            .landing_screen
+            .as_ref()
+            .map(|s| s as &dyn Screen),
+        TuiMode::IssueBrowser => app
+            .screen_state
+            .issue_browser_screen
+            .as_ref()
+            .map(|s| s as &dyn Screen),
+        TuiMode::IssueWizard => app
+            .screen_state
+            .issue_wizard_screen
+            .as_ref()
+            .map(|s| s as &dyn Screen),
+        TuiMode::MilestoneView => app
+            .screen_state
+            .milestone_screen
+            .as_ref()
+            .map(|s| s as &dyn Screen),
         TuiMode::MilestoneWizard => app
+            .screen_state
             .milestone_wizard_screen
             .as_ref()
             .map(|s| s as &dyn Screen),
-        TuiMode::ProjectStats => app.project_stats_screen.as_ref().map(|s| s as &dyn Screen),
-        TuiMode::PromptInput => app.prompt_input_screen.as_ref().map(|s| s as &dyn Screen),
+        TuiMode::ProjectStats => app
+            .screen_state
+            .project_stats_screen
+            .as_ref()
+            .map(|s| s as &dyn Screen),
+        TuiMode::PromptInput => app
+            .screen_state
+            .prompt_input_screen
+            .as_ref()
+            .map(|s| s as &dyn Screen),
         TuiMode::QueueConfirmation => app
+            .screen_state
             .queue_confirmation_screen
             .as_ref()
             .map(|s| s as &dyn Screen),
-        TuiMode::Sanitize => app.sanitize_screen.as_ref().map(|s| s as &dyn Screen),
-        TuiMode::Settings => app.settings_screen.as_ref().map(|s| s as &dyn Screen),
-        TuiMode::PrReview => app.pr_review_screen.as_ref().map(|s| s as &dyn Screen),
-        TuiMode::HollowRetry => app.hollow_retry_screen.as_ref().map(|s| s as &dyn Screen),
+        TuiMode::Sanitize => app
+            .screen_state
+            .sanitize_screen
+            .as_ref()
+            .map(|s| s as &dyn Screen),
+        TuiMode::Settings => app
+            .screen_state
+            .settings_screen
+            .as_ref()
+            .map(|s| s as &dyn Screen),
+        TuiMode::PrReview => app
+            .screen_state
+            .pr_review_screen
+            .as_ref()
+            .map(|s| s as &dyn Screen),
+        TuiMode::HollowRetry => app
+            .screen_state
+            .hollow_retry_screen
+            .as_ref()
+            .map(|s| s as &dyn Screen),
         TuiMode::AdaptFollowUp => app
+            .screen_state
             .adapt_follow_up_screen
             .as_ref()
             .map(|s| s as &dyn Screen),
-        TuiMode::AdaptWizard => app.adapt_screen.as_ref().map(|s| s as &dyn Screen),
-        TuiMode::ReleaseNotes => app.release_notes_screen.as_ref().map(|s| s as &dyn Screen),
+        TuiMode::AdaptWizard => app
+            .screen_state
+            .adapt_screen
+            .as_ref()
+            .map(|s| s as &dyn Screen),
+        TuiMode::ReleaseNotes => app
+            .screen_state
+            .release_notes_screen
+            .as_ref()
+            .map(|s| s as &dyn Screen),
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary
- Adds `ScreenState` to group screen-owned TUI state off the top-level `App` struct.
- Adds `SessionConfig` for effective session defaults and limits, including config application.
- Updates TUI dispatch, rendering, input, and tests to use the grouped state without behavior changes.

Closes #395

## Test plan
- [x] cargo build
- [x] cargo test
- [x] cargo test -- --include-ignored
- [x] cargo clippy
- [ ] cargo clippy --all-targets --all-features (blocked by existing `clippy::approx_constant` in `src/turboquant/polar.rs` and unrelated existing warnings)