### PR TITLE
fix(session): propagate spawn errors

### DIFF
--- a/src/session/manager.rs
+++ b/src/session/manager.rs
@@ -28,6 +28,7 @@ pub struct ManagedSession {
     pub permission_mode: Option<String>,
     /// Allowed tools whitelist.
     pub allowed_tools: Vec<String>,
+    claude_binary: String,
     last_tool_start: Option<std::time::Instant>,
     thinking_start: Option<std::time::Instant>,
 }
@@ -43,6 +44,7 @@ impl ManagedSession {
             system_prompt_appendix: None,
             permission_mode: None,
             allowed_tools: Vec::new(),
+            claude_binary: "claude".to_string(),
             last_tool_start: None,
             thinking_start: None,
         }
@@ -63,9 +65,15 @@ impl ManagedSession {
             system_prompt_appendix,
             permission_mode: None,
             allowed_tools: Vec::new(),
+            claude_binary: "claude".to_string(),
             last_tool_start: None,
             thinking_start: None,
         }
+    }
+
+    #[cfg(test)]
+    fn set_claude_binary_for_test(&mut self, binary: impl Into<String>) {
+        self.claude_binary = binary.into();
     }
 
     /// Build the CLI arguments for spawning the Claude process.
@@ -117,7 +125,7 @@ impl ManagedSession {
             .transition_to(SessionStatus::Spawning, TransitionReason::Promoted);
         self.session.started_at = Some(Utc::now());
 
-        let mut cmd = Command::new("claude");
+        let mut cmd = Command::new(&self.claude_binary);
         cmd.args(self.build_args());
 
         // Set working directory to worktree if available
@@ -129,7 +137,21 @@ impl ManagedSession {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
-        let mut child = cmd.spawn().context("Failed to spawn claude CLI")?;
+        let mut child = match cmd.spawn().with_context(|| {
+            format!(
+                "Failed to spawn Claude CLI using binary '{}'",
+                self.claude_binary
+            )
+        }) {
+            Ok(child) => child,
+            Err(err) => {
+                let _ = self
+                    .session
+                    .transition_to(SessionStatus::Errored, TransitionReason::StreamError);
+                self.session.log_activity(format!("Spawn failed: {err}"));
+                return Err(err);
+            }
+        };
 
         let pid = child.id().unwrap_or(0);
         self.session.pid = Some(pid);
@@ -487,6 +509,25 @@ mod tests {
         assert!(
             !args.iter().any(|a| a == "--permission-mode"),
             "permission_mode=default must not emit --permission-mode flag"
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_invalid_binary_returns_error_without_panic() {
+        let mut ms = make_managed("test");
+        ms.set_claude_binary_for_test("/definitely/not/a/claude/binary");
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        let result = ms.spawn(tx).await;
+
+        assert!(result.is_err());
+        assert_eq!(ms.session.status, SessionStatus::Errored);
+        assert!(
+            ms.session
+                .activity_log
+                .iter()
+                .any(|entry| entry.message.contains("Spawn failed")),
+            "spawn failure should be recorded in the session activity log"
         );
     }
 

--- a/src/session/pool.rs
+++ b/src/session/pool.rs
@@ -464,6 +464,27 @@ mod tests {
         )
     }
 
+    fn must_get_active_mut(pool: &mut SessionPool, id: Uuid) -> &mut ManagedSession {
+        match pool.get_active_mut(id) {
+            Some(managed) => managed,
+            None => panic!("expected active session {id}"),
+        }
+    }
+
+    fn must_get_session(pool: &SessionPool, id: Uuid) -> &Session {
+        match pool.get_session(id) {
+            Some(session) => session,
+            None => panic!("expected session {id} in pool"),
+        }
+    }
+
+    fn must_get_appendix(managed: &ManagedSession) -> &str {
+        match managed.system_prompt_appendix.as_deref() {
+            Some(appendix) => appendix,
+            None => panic!("expected system prompt appendix"),
+        }
+    }
+
     #[test]
     fn enqueue_adds_to_queue() {
         let mut pool = make_pool(2);
@@ -684,14 +705,11 @@ mod tests {
         // Verify worktree_path was set on the active session
         let managed = &pool.active[0];
         assert!(managed.worktree_path.is_some());
-        assert!(
-            managed
-                .worktree_path
-                .as_ref()
-                .unwrap()
-                .to_string_lossy()
-                .contains("issue-42")
-        );
+        let path = match managed.worktree_path.as_ref() {
+            Some(path) => path,
+            None => panic!("expected worktree path for issue session"),
+        };
+        assert!(path.to_string_lossy().contains("issue-42"));
     }
 
     #[test]
@@ -782,12 +800,11 @@ mod tests {
         let id = session.id;
         pool.enqueue(session);
         pool.try_promote();
-        pool.get_active_mut(id)
-            .unwrap()
+        must_get_active_mut(&mut pool, id)
             .session
             .transition_flash_remaining = 3;
         pool.tick_flash_counters();
-        assert_eq!(pool.get_session(id).unwrap().transition_flash_remaining, 2);
+        assert_eq!(must_get_session(&pool, id).transition_flash_remaining, 2);
     }
 
     #[test]
@@ -797,9 +814,9 @@ mod tests {
         let id = session.id;
         pool.enqueue(session);
         pool.try_promote();
-        assert_eq!(pool.get_session(id).unwrap().transition_flash_remaining, 0);
+        assert_eq!(must_get_session(&pool, id).transition_flash_remaining, 0);
         pool.tick_flash_counters();
-        assert_eq!(pool.get_session(id).unwrap().transition_flash_remaining, 0);
+        assert_eq!(must_get_session(&pool, id).transition_flash_remaining, 0);
     }
 
     #[test]
@@ -812,17 +829,15 @@ mod tests {
         pool.enqueue(s1);
         pool.enqueue(s2);
         pool.try_promote();
-        pool.get_active_mut(id1)
-            .unwrap()
+        must_get_active_mut(&mut pool, id1)
             .session
             .transition_flash_remaining = 4;
-        pool.get_active_mut(id2)
-            .unwrap()
+        must_get_active_mut(&mut pool, id2)
             .session
             .transition_flash_remaining = 2;
         pool.tick_flash_counters();
-        assert_eq!(pool.get_session(id1).unwrap().transition_flash_remaining, 3);
-        assert_eq!(pool.get_session(id2).unwrap().transition_flash_remaining, 1);
+        assert_eq!(must_get_session(&pool, id1).transition_flash_remaining, 3);
+        assert_eq!(must_get_session(&pool, id2).transition_flash_remaining, 1);
     }
 
     // --- Issue #344: TurboQuant system-prompt compaction integration ---
@@ -854,7 +869,7 @@ mod tests {
         pool.enqueue(make_session("work"));
         pool.try_promote();
         let managed = &pool.active[0];
-        let appendix = managed.system_prompt_appendix.as_ref().unwrap();
+        let appendix = must_get_appendix(managed);
         assert!(appendix.contains("GUARDRAIL"));
     }
 
@@ -870,7 +885,7 @@ mod tests {
         pool.enqueue(make_session("work"));
         pool.try_promote();
         let managed = &pool.active[0];
-        let appendix = managed.system_prompt_appendix.as_ref().unwrap();
+        let appendix = must_get_appendix(managed);
         assert!(appendix.contains("GUARDRAIL: X"));
     }
 
@@ -881,13 +896,12 @@ mod tests {
         let id = s.id;
         pool.enqueue(s);
         pool.try_promote();
-        pool.get_active_mut(id)
-            .unwrap()
+        must_get_active_mut(&mut pool, id)
             .session
             .transition_flash_remaining = 3;
         pool.finalize_and_teardown(id);
         pool.tick_flash_counters();
-        assert_eq!(pool.get_session(id).unwrap().transition_flash_remaining, 2);
+        assert_eq!(must_get_session(&pool, id).transition_flash_remaining, 2);
     }
 
     // --- Issue #558: finalize_retain_worktree (gate-failure recovery path) ---


### PR DESCRIPTION
## Summary
- Propagate Claude CLI spawn failures as structured `anyhow` errors instead of leaving the session in a spawning state.
- Mark failed spawns as `Errored` and record a session activity-log entry.
- Remove remaining bare `unwrap()` calls from the targeted session files and add spawn-failure coverage.

Closes #396

## Test plan
- [x] `rg -n "unwrap\\(\\)" src/session/manager.rs src/session/pool.rs src/session/health.rs` returns no matches
- [x] `cargo fmt --check`
- [x] `cargo test`
- [ ] `cargo clippy --all-targets --all-features` (fails on existing repo-wide lints outside this PR, e.g. `src/turboquant/polar.rs` approx constants and `src/commands/slash.rs` denied `unwrap_err()` in tests)