### PR TITLE
fix(core): propagate state and queue errors

### DIFF
--- a/src/state/store.rs
+++ b/src/state/store.rs
@@ -73,8 +73,15 @@ mod tests {
     use crate::state::types::MaestroState;
     use std::sync::Arc;
 
+    fn must<T, E: std::fmt::Display>(result: std::result::Result<T, E>, context: &str) -> T {
+        match result {
+            Ok(value) => value,
+            Err(e) => panic!("{context}: {e}"),
+        }
+    }
+
     fn make_store() -> (tempfile::TempDir, StateStore) {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = must(tempfile::tempdir(), "tempdir should be created");
         let path = dir.path().join("test-state.json");
         (dir, StateStore::new(path))
     }
@@ -82,7 +89,7 @@ mod tests {
     #[test]
     fn load_returns_default_when_no_file() {
         let (_dir, store) = make_store();
-        let state = store.load().unwrap();
+        let state = must(store.load(), "missing state should load default");
         assert!(state.sessions.is_empty());
         assert_eq!(state.total_cost_usd, 0.0);
     }
@@ -90,11 +97,29 @@ mod tests {
     #[test]
     fn save_then_load_round_trips() {
         let (_dir, store) = make_store();
-        let mut state = MaestroState::default();
-        state.total_cost_usd = 42.5;
-        store.save(&state).unwrap();
-        let loaded = store.load().unwrap();
+        let state = MaestroState {
+            total_cost_usd: 42.5,
+            ..Default::default()
+        };
+        must(store.save(&state), "state should save");
+        let loaded = must(store.load(), "state should load");
         assert_eq!(loaded.total_cost_usd, 42.5);
+    }
+
+    #[test]
+    fn load_corrupt_json_returns_error() {
+        let (_dir, store) = make_store();
+        must(
+            std::fs::write(&store.path, b"{not valid json"),
+            "corrupt state should be written",
+        );
+
+        let err = match store.load() {
+            Ok(_) => panic!("corrupt state should return Err"),
+            Err(e) => e,
+        };
+
+        assert!(err.to_string().contains("parsing state"));
     }
 
     #[test]
@@ -116,9 +141,9 @@ mod tests {
         }
         state.sessions.push(s);
         let reports = state.compact(None);
-        store.save(&state).unwrap();
+        must(store.save(&state), "state should save");
         assert!(reports.is_empty());
-        let loaded = store.load().unwrap();
+        let loaded = must(store.load(), "state should load");
         assert_eq!(loaded.sessions[0].activity_log.len(), 5);
     }
 
@@ -146,9 +171,9 @@ mod tests {
 
         let adapter = TurboQuantAdapter::new(4);
         let reports = state.compact(Some(&adapter));
-        store.save(&state).unwrap();
+        must(store.save(&state), "state should save");
         assert_eq!(reports.len(), 1);
-        let loaded = store.load().unwrap();
+        let loaded = must(store.load(), "state should load");
         assert_eq!(loaded.sessions[0].activity_log.len(), 1);
         assert!(loaded.sessions[0].activity_log[0].message.contains("x12"));
     }
@@ -178,8 +203,11 @@ mod tests {
             "file_claims": {},
             "last_updated": null
         }"#;
-        std::fs::write(&store.path, legacy_json).unwrap();
-        let loaded = store.load().unwrap();
+        must(
+            std::fs::write(&store.path, legacy_json),
+            "legacy state should be written",
+        );
+        let loaded = must(store.load(), "legacy state should load");
         assert_eq!(loaded.sessions.len(), 1);
         assert!(loaded.sessions[0].tq_handoff_original_tokens.is_none());
         assert!(loaded.sessions[0].tq_handoff_compressed_tokens.is_none());
@@ -187,7 +215,7 @@ mod tests {
 
     #[test]
     fn concurrent_saves_do_not_corrupt() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = must(tempfile::tempdir(), "tempdir should be created");
         let path = dir.path().join("concurrent-state.json");
         let store = Arc::new(StateStore::new(path));
 
@@ -195,19 +223,23 @@ mod tests {
             .map(|i| {
                 let store = Arc::clone(&store);
                 std::thread::spawn(move || {
-                    let mut state = MaestroState::default();
-                    state.total_cost_usd = i as f64;
-                    store.save(&state).unwrap();
+                    let state = MaestroState {
+                        total_cost_usd: i as f64,
+                        ..Default::default()
+                    };
+                    must(store.save(&state), "concurrent save should succeed");
                 })
             })
             .collect();
 
         for h in handles {
-            h.join().unwrap();
+            if h.join().is_err() {
+                panic!("save thread should not panic");
+            }
         }
 
         // File must be valid JSON after all concurrent writes
-        let loaded = store.load().unwrap();
+        let loaded = must(store.load(), "state should load after concurrent saves");
         assert!(loaded.total_cost_usd >= 0.0);
     }
 }

--- a/src/tui/app/completion_summary.rs
+++ b/src/tui/app/completion_summary.rs
@@ -2,6 +2,7 @@ use super::App;
 use super::helpers::session_label;
 use super::types::{CompletionSessionLine, CompletionSummaryData, GateFailureInfo, TuiCommand};
 use crate::session::types::SessionStatus;
+use crate::tui::activity_log::LogLevel;
 use crate::util::truncate_with_ellipsis;
 
 impl App {
@@ -112,7 +113,19 @@ impl App {
         self.state.sessions = all.iter().copied().cloned().collect();
         self.state.update_total_cost();
         self.state.last_updated = Some(chrono::Utc::now());
-        let _ = self.store.save(&self.state);
+        if let Err(e) = self.store.save(&self.state) {
+            let message = e.to_string();
+            self.activity_log.push_simple(
+                "State".into(),
+                format!("Failed to save persisted state: {}", message),
+                LogLevel::Error,
+            );
+            self.notifications.notify(
+                crate::notifications::types::InterruptLevel::Critical,
+                "State save failed",
+                &message,
+            );
+        }
 
         // Build recent sessions for the home screen
         let recent: Vec<crate::tui::screens::home::SessionSummary> = all

--- a/src/tui/app/mod.rs
+++ b/src/tui/app/mod.rs
@@ -217,7 +217,10 @@ impl App {
     ) -> Self {
         let (event_tx, event_rx) = mpsc::unbounded_channel();
         let (data_tx, data_rx) = mpsc::unbounded_channel();
-        let state = store.load().unwrap_or_default();
+        let (state, state_load_error) = match store.load() {
+            Ok(state) => (state, None),
+            Err(e) => (MaestroState::default(), Some(e.to_string())),
+        };
         let mut pool = SessionPool::new(max_concurrent, worktree_mgr, event_tx);
         pool.set_permission_mode(permission_mode.clone());
         pool.set_allowed_tools(allowed_tools.clone());
@@ -334,6 +337,18 @@ impl App {
             home_dir_override: None,
             last_pr_marker_mtime: None,
         };
+        if let Some(error) = state_load_error {
+            app.activity_log.push_simple(
+                "State".into(),
+                format!("Failed to load persisted state: {}", error),
+                LogLevel::Error,
+            );
+            app.notifications.notify(
+                crate::notifications::types::InterruptLevel::Critical,
+                "State load failed",
+                &error,
+            );
+        }
         if pending_prs_truncated {
             app.activity_log.push_simple(
                 "#orphan-prs".into(),
@@ -640,7 +655,19 @@ impl App {
         // entries after a restart — without this the in-memory queue is
         // lost on shutdown.
         self.state.pending_prs = self.pending_prs.clone();
-        let _ = self.store.save(&self.state);
+        if let Err(e) = self.store.save(&self.state) {
+            let message = e.to_string();
+            self.activity_log.push_simple(
+                "State".into(),
+                format!("Failed to save persisted state: {}", message),
+                LogLevel::Error,
+            );
+            self.notifications.notify(
+                crate::notifications::types::InterruptLevel::Critical,
+                "State save failed",
+                &message,
+            );
+        }
     }
 }
 

--- a/src/tui/app/session_spawners.rs
+++ b/src/tui/app/session_spawners.rs
@@ -216,8 +216,21 @@ impl App {
                 None => return false,
             };
             match exec.advance() {
-                Some(item) => item.issue_number,
-                None => return false,
+                Ok(Some(item)) => item.issue_number,
+                Ok(None) => return false,
+                Err(e) => {
+                    self.activity_log.push_simple(
+                        "Queue".into(),
+                        format!("Queue advance failed: {}", e),
+                        LogLevel::Error,
+                    );
+                    self.notifications.notify(
+                        crate::notifications::types::InterruptLevel::Critical,
+                        "Queue advance failed",
+                        &e.to_string(),
+                    );
+                    return false;
+                }
             }
         };
 

--- a/src/tui/app/tests.rs
+++ b/src/tui/app/tests.rs
@@ -1980,6 +1980,21 @@ mod pending_prs_persistence {
         )
     }
 
+    fn build_app_with_raw_state(contents: &[u8]) -> App {
+        let path =
+            std::env::temp_dir().join(format!("state-load-error-{}.json", uuid::Uuid::new_v4()));
+        if let Err(e) = std::fs::write(&path, contents) {
+            panic!("raw state should be written: {e}");
+        }
+        App::new(
+            StateStore::new(path),
+            3,
+            Box::new(MockWorktreeManager::new()),
+            "bypassPermissions".into(),
+            vec![],
+        )
+    }
+
     #[test]
     fn app_new_rehydrates_pending_prs_from_persisted_state() {
         let mut seed = MaestroState::default();
@@ -2022,6 +2037,28 @@ mod pending_prs_persistence {
             "the warn must mention Shift+P so users know how to recover"
         );
         assert_eq!(warn.session_label, "#orphan-prs");
+    }
+
+    #[test]
+    fn app_new_notifies_when_state_load_fails() {
+        let app = build_app_with_raw_state(b"{not valid json");
+
+        let error_log = app.activity_log.entries().iter().any(|e| {
+            matches!(e.level, LogLevel::Error)
+                && e.session_label == "State"
+                && e.message.contains("Failed to load persisted state")
+        });
+        assert!(
+            error_log,
+            "state load failure must be visible in the TUI log"
+        );
+        assert!(
+            app.notifications
+                .active_banners()
+                .iter()
+                .any(|n| n.title == "State load failed"),
+            "state load failure must create a TUI notification banner"
+        );
     }
 
     #[test]

--- a/src/work/executor.rs
+++ b/src/work/executor.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)] // Reason: work executor for session orchestration — to be wired into main pipeline
 use super::queue::{QueuedItem, WorkQueue};
+use anyhow::{Result, bail};
 
 /// Execution state of a single queue item.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -91,9 +92,12 @@ impl QueueExecutor {
 
     /// Advance to the next pending item. Returns the QueuedItem to launch,
     /// or None if all items are done.
-    pub fn advance(&mut self) -> Option<&QueuedItem> {
+    pub fn advance(&mut self) -> Result<Option<&QueuedItem>> {
         if !matches!(self.phase, ExecutorPhase::Idle) {
-            return None;
+            bail!(
+                "cannot advance queue while executor is in {:?} phase",
+                self.phase
+            );
         }
 
         let next = self
@@ -105,11 +109,11 @@ impl QueueExecutor {
             Some(idx) => {
                 self.items[idx].state = QueueItemState::Running;
                 self.phase = ExecutorPhase::Running { current_index: idx };
-                Some(&self.items[idx].queued)
+                Ok(Some(&self.items[idx].queued))
             }
             None => {
                 self.phase = ExecutorPhase::Finished;
-                None
+                Ok(None)
             }
         }
     }
@@ -203,7 +207,17 @@ mod tests {
     fn make_queue(issues: &[u64]) -> WorkQueue {
         let items: Vec<WorkItem> = issues.iter().map(|&n| make_item(n)).collect();
         let graph = DependencyGraph::build(&items);
-        WorkQueue::validate_selection(issues, &graph).unwrap()
+        match WorkQueue::validate_selection(issues, &graph) {
+            Ok(queue) => queue,
+            Err(e) => panic!("test queue should validate: {e}"),
+        }
+    }
+
+    fn advance_ok(exec: &mut QueueExecutor) -> Option<&QueuedItem> {
+        match exec.advance() {
+            Ok(item) => item,
+            Err(e) => panic!("advance should succeed: {e}"),
+        }
     }
 
     #[test]
@@ -242,7 +256,7 @@ mod tests {
     fn advance_from_idle_moves_to_running_index_zero() {
         let queue = make_queue(&[1, 2]);
         let mut exec = QueueExecutor::new(&queue);
-        exec.advance();
+        advance_ok(&mut exec);
         assert_eq!(exec.phase(), ExecutorPhase::Running { current_index: 0 });
     }
 
@@ -250,7 +264,7 @@ mod tests {
     fn advance_sets_current_item_state_to_running() {
         let queue = make_queue(&[1, 2]);
         let mut exec = QueueExecutor::new(&queue);
-        exec.advance();
+        advance_ok(&mut exec);
         assert_eq!(exec.items()[0].state, QueueItemState::Running);
     }
 
@@ -258,7 +272,7 @@ mod tests {
     fn set_session_id_attaches_uuid_to_current_item() {
         let queue = make_queue(&[1]);
         let mut exec = QueueExecutor::new(&queue);
-        exec.advance();
+        advance_ok(&mut exec);
         let id = uuid::Uuid::new_v4();
         exec.set_session_id(id);
         assert_eq!(exec.items()[0].session_id, Some(id));
@@ -268,7 +282,7 @@ mod tests {
     fn mark_success_on_last_item_moves_to_finished() {
         let queue = make_queue(&[1]);
         let mut exec = QueueExecutor::new(&queue);
-        exec.advance();
+        advance_ok(&mut exec);
         exec.mark_success();
         assert_eq!(exec.phase(), ExecutorPhase::Finished);
     }
@@ -277,7 +291,7 @@ mod tests {
     fn mark_success_on_non_last_item_moves_to_idle() {
         let queue = make_queue(&[1, 2]);
         let mut exec = QueueExecutor::new(&queue);
-        exec.advance();
+        advance_ok(&mut exec);
         exec.mark_success();
         assert_eq!(exec.phase(), ExecutorPhase::Idle);
     }
@@ -286,7 +300,7 @@ mod tests {
     fn mark_success_sets_item_state_to_succeeded() {
         let queue = make_queue(&[1]);
         let mut exec = QueueExecutor::new(&queue);
-        exec.advance();
+        advance_ok(&mut exec);
         exec.mark_success();
         assert_eq!(exec.items()[0].state, QueueItemState::Succeeded);
     }
@@ -295,7 +309,7 @@ mod tests {
     fn completed_count_increments_after_mark_success() {
         let queue = make_queue(&[1, 2]);
         let mut exec = QueueExecutor::new(&queue);
-        exec.advance();
+        advance_ok(&mut exec);
         exec.mark_success();
         assert_eq!(exec.completed_count(), 1);
     }
@@ -304,7 +318,7 @@ mod tests {
     fn mark_failure_moves_to_awaiting_decision() {
         let queue = make_queue(&[1, 2]);
         let mut exec = QueueExecutor::new(&queue);
-        exec.advance();
+        advance_ok(&mut exec);
         exec.mark_failure();
         assert_eq!(
             exec.phase(),
@@ -316,7 +330,7 @@ mod tests {
     fn mark_failure_sets_item_state_to_failed() {
         let queue = make_queue(&[1]);
         let mut exec = QueueExecutor::new(&queue);
-        exec.advance();
+        advance_ok(&mut exec);
         exec.mark_failure();
         assert_eq!(exec.items()[0].state, QueueItemState::Failed);
     }
@@ -325,7 +339,7 @@ mod tests {
     fn apply_decision_retry_moves_to_idle() {
         let queue = make_queue(&[1, 2]);
         let mut exec = QueueExecutor::new(&queue);
-        exec.advance();
+        advance_ok(&mut exec);
         exec.mark_failure();
         exec.apply_decision(FailureAction::Retry);
         assert_eq!(exec.phase(), ExecutorPhase::Idle);
@@ -335,7 +349,7 @@ mod tests {
     fn apply_decision_retry_resets_item_state_to_pending() {
         let queue = make_queue(&[1]);
         let mut exec = QueueExecutor::new(&queue);
-        exec.advance();
+        advance_ok(&mut exec);
         exec.mark_failure();
         exec.apply_decision(FailureAction::Retry);
         assert_eq!(exec.items()[0].state, QueueItemState::Pending);
@@ -345,7 +359,7 @@ mod tests {
     fn apply_decision_skip_sets_item_state_to_skipped() {
         let queue = make_queue(&[1, 2]);
         let mut exec = QueueExecutor::new(&queue);
-        exec.advance();
+        advance_ok(&mut exec);
         exec.mark_failure();
         exec.apply_decision(FailureAction::Skip);
         assert_eq!(exec.items()[0].state, QueueItemState::Skipped);
@@ -355,7 +369,7 @@ mod tests {
     fn apply_decision_skip_on_last_item_moves_to_finished() {
         let queue = make_queue(&[1]);
         let mut exec = QueueExecutor::new(&queue);
-        exec.advance();
+        advance_ok(&mut exec);
         exec.mark_failure();
         exec.apply_decision(FailureAction::Skip);
         assert_eq!(exec.phase(), ExecutorPhase::Finished);
@@ -365,7 +379,7 @@ mod tests {
     fn apply_decision_skip_on_non_last_item_moves_to_idle() {
         let queue = make_queue(&[1, 2]);
         let mut exec = QueueExecutor::new(&queue);
-        exec.advance();
+        advance_ok(&mut exec);
         exec.mark_failure();
         exec.apply_decision(FailureAction::Skip);
         assert_eq!(exec.phase(), ExecutorPhase::Idle);
@@ -375,7 +389,7 @@ mod tests {
     fn apply_decision_abort_always_moves_to_finished() {
         let queue = make_queue(&[1, 2, 3]);
         let mut exec = QueueExecutor::new(&queue);
-        exec.advance();
+        advance_ok(&mut exec);
         exec.mark_failure();
         exec.apply_decision(FailureAction::Abort);
         assert_eq!(exec.phase(), ExecutorPhase::Finished);
@@ -392,7 +406,7 @@ mod tests {
     fn is_finished_returns_false_when_running() {
         let queue = make_queue(&[1]);
         let mut exec = QueueExecutor::new(&queue);
-        exec.advance();
+        advance_ok(&mut exec);
         assert!(!exec.is_finished());
     }
 
@@ -400,7 +414,7 @@ mod tests {
     fn is_finished_returns_false_when_awaiting_decision() {
         let queue = make_queue(&[1]);
         let mut exec = QueueExecutor::new(&queue);
-        exec.advance();
+        advance_ok(&mut exec);
         exec.mark_failure();
         assert!(!exec.is_finished());
     }
@@ -409,7 +423,7 @@ mod tests {
     fn is_finished_returns_true_when_finished() {
         let queue = make_queue(&[1]);
         let mut exec = QueueExecutor::new(&queue);
-        exec.advance();
+        advance_ok(&mut exec);
         exec.mark_success();
         assert!(exec.is_finished());
     }
@@ -419,11 +433,11 @@ mod tests {
         let queue = make_queue(&[1, 2]);
         let mut exec = QueueExecutor::new(&queue);
 
-        exec.advance();
+        advance_ok(&mut exec);
         exec.mark_success();
         assert_eq!(exec.completed_count(), 1);
 
-        exec.advance();
+        advance_ok(&mut exec);
         exec.mark_success();
         assert_eq!(exec.completed_count(), 2);
         assert!(exec.is_finished());
@@ -434,11 +448,11 @@ mod tests {
         let queue = make_queue(&[1]);
         let mut exec = QueueExecutor::new(&queue);
 
-        exec.advance();
+        advance_ok(&mut exec);
         exec.mark_failure();
         exec.apply_decision(FailureAction::Retry);
 
-        exec.advance();
+        advance_ok(&mut exec);
         exec.mark_success();
         assert!(exec.is_finished());
         assert_eq!(exec.completed_count(), 1);
@@ -449,7 +463,7 @@ mod tests {
         let queue = make_queue(&[1, 2, 3]);
         let mut exec = QueueExecutor::new(&queue);
 
-        exec.advance();
+        advance_ok(&mut exec);
         exec.mark_failure();
         exec.apply_decision(FailureAction::Abort);
 
@@ -471,7 +485,7 @@ mod tests {
         let queue = make_queue(&[1]);
         let mut exec = QueueExecutor::new(&queue);
         assert_eq!(exec.phase(), ExecutorPhase::Idle);
-        exec.advance();
+        advance_ok(&mut exec);
         assert!(matches!(exec.phase(), ExecutorPhase::Running { .. }));
     }
 
@@ -479,8 +493,22 @@ mod tests {
     fn advance_on_empty_queue_moves_directly_to_finished() {
         let queue = make_queue(&[]);
         let mut exec = QueueExecutor::new(&queue);
-        let result = exec.advance();
+        let result = advance_ok(&mut exec);
         assert!(result.is_none());
         assert_eq!(exec.phase(), ExecutorPhase::Finished);
+    }
+
+    #[test]
+    fn advance_while_running_returns_error() {
+        let queue = make_queue(&[1]);
+        let mut exec = QueueExecutor::new(&queue);
+        advance_ok(&mut exec);
+
+        let err = match exec.advance() {
+            Ok(_) => panic!("second advance while running should fail"),
+            Err(e) => e,
+        };
+
+        assert!(err.to_string().contains("cannot advance queue"));
     }
 }


### PR DESCRIPTION
## Summary
- propagate corrupt/unreadable state load errors instead of silently defaulting in the TUI
- surface state load/save and queue advance failures via activity log entries and critical notifications
- change QueueExecutor::advance to return Result<Option<_>> and cover invalid advance calls

Closes #397

## Verification
- cargo fmt -- --check
- cargo test state::store::tests
- cargo test work::executor::tests
- cargo test tui::app::tests::pending_prs_persistence
- cargo test
- cargo clippy -- -D warnings

Note: cargo clippy --all-targets --all-features currently fails on unrelated existing test-lint issues outside this change set, including clippy::approx_constant in src/turboquant/polar.rs and unwrap_err tests in src/commands/slash.rs.