### PR TITLE
fix(scripts): remove Cargo.lock from git add — it is gitignored

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -307,7 +307,7 @@ fi
 
 # ── Step 5: Commit ──────────────────────────────────────────────────────────────
 info "Staging files..."
-git add Cargo.toml Cargo.lock CHANGELOG.md
+git add Cargo.toml CHANGELOG.md
 
 # Stage known-drift snapshots if they were updated
 git add "${SNAPSHOTS_DIR}/maestro__tui__snapshot_tests__dashboard__home_screen_"*.snap 2>/dev/null || true


### PR DESCRIPTION
## Summary

- `Cargo.lock` is listed in `.gitignore` so staging it via `git add Cargo.lock` in the release script causes git to abort with an error, halting the release after the version bump has already been applied.
- Removed `Cargo.lock` from the `git add` line in Step 5.

## Test plan

- [x] Run `./scripts/release.sh --milestone "vX.Y.Z"` and confirm staging completes without the gitignore warning