### PR TITLE
Fix TurboQuant dead handoff fields

### DIFF
--- a/src/turboquant/adapter.rs
+++ b/src/turboquant/adapter.rs
@@ -245,13 +245,9 @@ fn cosine(a: &[f32], b: &[f32]) -> f32 {
 
 /// Output of fork-handoff compression.
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // Reason: metrics surface exposed to the TUI activity log and tests
 pub struct CompressedHandoff {
     pub text: String,
     pub metrics: CompressionMetrics,
-    pub segments_total: usize,
-    pub segments_selected: usize,
-    pub truncated: bool,
 }
 
 impl TurboQuantAdapter {
@@ -274,15 +270,10 @@ impl TurboQuantAdapter {
                     compressed_tokens: 0,
                     compression_ratio: 1.0,
                 },
-                segments_total: 0,
-                segments_selected: 0,
-                truncated: false,
             };
         }
 
         let original_tokens = Self::estimate_tokens(history);
-        let segments: Vec<&str> = split_handoff_segments(history);
-        let segments_total = segments.len();
 
         if !self.enabled {
             return CompressedHandoff {
@@ -292,11 +283,10 @@ impl TurboQuantAdapter {
                     compressed_tokens: original_tokens,
                     compression_ratio: 1.0,
                 },
-                segments_total,
-                segments_selected: segments_total,
-                truncated: false,
             };
         }
+
+        let segments: Vec<&str> = split_handoff_segments(history);
 
         if token_budget == 0 {
             return CompressedHandoff {
@@ -310,16 +300,13 @@ impl TurboQuantAdapter {
                         original_tokens as f64
                     },
                 },
-                segments_total,
-                segments_selected: 0,
-                truncated: false,
             };
         }
 
         let ranked = self.rank_segments(&segments, task_prompt);
         let tb = crate::turboquant::budget::TokenBudget::new(token_budget as u64);
         let sel = tb.select(&ranked, |i| Self::estimate_tokens(segments[i]));
-        let mut kept = sel.indices.clone();
+        let mut kept = sel.indices;
         kept.sort_unstable();
         let text: String = kept
             .iter()
@@ -341,9 +328,6 @@ impl TurboQuantAdapter {
                 compressed_tokens,
                 compression_ratio,
             },
-            segments_total,
-            segments_selected: kept.len(),
-            truncated: sel.truncated_first,
         }
     }
 
@@ -912,8 +896,8 @@ mod tests {
         let a = ranker();
         let out = a.compress_handoff("", "any task", 4096);
         assert!(out.text.is_empty());
-        assert_eq!(out.segments_total, 0);
-        assert_eq!(out.segments_selected, 0);
+        assert_eq!(out.metrics.original_tokens, 0);
+        assert_eq!(out.metrics.compressed_tokens, 0);
     }
 
     #[test]
@@ -937,8 +921,8 @@ mod tests {
             ));
         }
         let out = a.compress_handoff(&history, "pick relevant work", 256);
-        assert!(out.text.len() / 4 <= 266);
-        assert!(out.segments_selected < out.segments_total);
+        assert!(out.metrics.compressed_tokens <= 256);
+        assert!(out.metrics.compressed_tokens < out.metrics.original_tokens);
     }
 
     #[test]
@@ -946,7 +930,7 @@ mod tests {
         let a = ranker();
         let out = a.compress_handoff("some history", "task", 0);
         assert!(out.text.is_empty());
-        assert_eq!(out.segments_selected, 0);
+        assert_eq!(out.metrics.compressed_tokens, 0);
     }
 
     #[test]
@@ -962,9 +946,7 @@ mod tests {
         let a = ranker();
         let history = "Tool: Bash\n$ echo hello";
         let out = a.compress_handoff(history, "run bash", 4096);
-        assert_eq!(out.segments_total, 1);
-        assert_eq!(out.segments_selected, 1);
-        assert!(out.text.contains("echo hello"));
+        assert_eq!(out.text, history);
     }
 
     #[test]
@@ -972,16 +954,18 @@ mod tests {
         let a = ranker();
         let history = "[Tool: Read]\nsrc/main.rs\n\n[Assistant]\nFile has 100 lines";
         let out = a.compress_handoff(history, "inspect file", 4096);
-        assert_eq!(out.segments_total, 2);
+        assert!(out.text.contains("[Tool: Read]"));
+        assert!(out.text.contains("[Assistant]"));
+        assert!(out.text.contains("\n\n"));
     }
 
     #[test]
-    fn compress_handoff_truncated_flag_set_when_first_segment_exceeds_budget() {
+    fn compress_handoff_keeps_single_oversized_segment() {
         let a = ranker();
         let big = "y".repeat(4000);
         let out = a.compress_handoff(&big, "task", 100);
-        assert!(out.truncated);
-        assert_eq!(out.segments_selected, 1);
+        assert_eq!(out.text, big);
+        assert_eq!(out.metrics.compressed_tokens, out.metrics.original_tokens);
     }
 
     #[test]
@@ -990,7 +974,6 @@ mod tests {
         let history = "I made a cup of tea today and read a book.\n\n\
                        cargo test suite ran with 200 tests passing in 3 seconds.";
         let out = a.compress_handoff(history, "cargo test suite results", 20);
-        assert!(out.segments_selected >= 1);
         assert!(out.text.contains("cargo") || out.text.contains("tests"));
     }
 

--- a/src/turboquant/budget.rs
+++ b/src/turboquant/budget.rs
@@ -13,9 +13,6 @@ pub struct TokenBudget {
 #[derive(Debug, Clone)]
 pub struct BudgetSelection {
     pub indices: Vec<usize>,
-    #[allow(dead_code)] // Reason: surfaced by metrics callers and tests
-    pub tokens_used: u64,
-    pub truncated_first: bool,
 }
 
 impl TokenBudget {
@@ -30,13 +27,10 @@ impl TokenBudget {
     ) -> BudgetSelection {
         let mut picked = Vec::new();
         let mut used = 0u64;
-        let mut truncated_first = false;
         for &(i, _) in ranked {
             let c = token_cost(i);
             if picked.is_empty() && c > self.limit {
                 picked.push(i);
-                used = c;
-                truncated_first = true;
                 break;
             }
             if used + c > self.limit {
@@ -45,11 +39,7 @@ impl TokenBudget {
             picked.push(i);
             used += c;
         }
-        BudgetSelection {
-            indices: picked,
-            tokens_used: used,
-            truncated_first,
-        }
+        BudgetSelection { indices: picked }
     }
 }
 
@@ -62,18 +52,14 @@ mod tests {
         let budget = TokenBudget::new(100);
         let sel = budget.select(&[], |_| 10);
         assert!(sel.indices.is_empty());
-        assert_eq!(sel.tokens_used, 0);
-        assert!(!sel.truncated_first);
     }
 
     #[test]
-    fn single_oversized_segment_kept_with_truncated_flag() {
+    fn single_oversized_segment_is_kept() {
         let budget = TokenBudget::new(100);
         let ranked = vec![(0, 0.9), (1, 0.5)];
         let sel = budget.select(&ranked, |i| if i == 0 { 500 } else { 50 });
         assert_eq!(sel.indices, vec![0]);
-        assert_eq!(sel.tokens_used, 500);
-        assert!(sel.truncated_first);
     }
 
     #[test]
@@ -82,8 +68,6 @@ mod tests {
         let ranked = vec![(0, 0.9), (1, 0.8), (2, 0.7)];
         let sel = budget.select(&ranked, |_| 40);
         assert_eq!(sel.indices, vec![0, 1]);
-        assert_eq!(sel.tokens_used, 80);
-        assert!(!sel.truncated_first);
     }
 
     #[test]
@@ -92,7 +76,6 @@ mod tests {
         let ranked = vec![(0, 0.9), (1, 0.8), (2, 0.7)];
         let sel = budget.select(&ranked, |_| 30);
         assert_eq!(sel.indices, vec![0, 1, 2]);
-        assert_eq!(sel.tokens_used, 90);
     }
 
     #[test]


### PR DESCRIPTION
Closes #403

## Summary
- remove dead diagnostic fields from TurboQuant handoff compression results
- remove stale budget selection diagnostics that no production caller consumes
- update TurboQuant tests to assert behavior through retained text and metrics

## Verification
- cargo fmt --check
- cargo test turboquant --lib
- cargo clippy -- -W dead_code
- cargo test
- cargo test snapshot

Note: `cargo clippy -- -W clippy::dead_code` exits successfully on this toolchain but emits an unknown-lint warning because `dead_code` is a rustc lint, not a clippy lint.