### PR TITLE
refactor(provider): rename repo provider types

### DIFF
--- a/src/adapt/materializer.rs
+++ b/src/adapt/materializer.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use async_trait::async_trait;
 
 use super::types::*;
-use crate::provider::github::client::{CreateOutcome, GitHubClient};
+use crate::provider::github::client::{CreateOutcome, RepoProvider};
 
 const DEFAULT_LABEL_COLOR: &str = "EDEDED";
 
@@ -46,11 +46,11 @@ pub trait PlanMaterializer: Send + Sync {
     ) -> anyhow::Result<MaterializeResult>;
 }
 
-pub struct GhMaterializer<G: GitHubClient> {
+pub struct GhMaterializer<G: RepoProvider> {
     github: G,
 }
 
-impl<G: GitHubClient> GhMaterializer<G> {
+impl<G: RepoProvider> GhMaterializer<G> {
     pub fn new(github: G) -> Self {
         Self { github }
     }
@@ -93,7 +93,7 @@ impl<G: GitHubClient> GhMaterializer<G> {
 }
 
 #[async_trait]
-impl<G: GitHubClient> PlanMaterializer for GhMaterializer<G> {
+impl<G: RepoProvider> PlanMaterializer for GhMaterializer<G> {
     async fn materialize(
         &self,
         plan: &AdaptPlan,
@@ -783,12 +783,8 @@ mod tests {
 
     // ── Issue #454: reused/skipped outcomes ────────────────────────────
 
-    fn make_milestone(
-        number: u64,
-        title: &str,
-        state: &str,
-    ) -> crate::provider::github::types::GhMilestone {
-        crate::provider::github::types::GhMilestone {
+    fn make_milestone(number: u64, title: &str, state: &str) -> crate::provider::types::Milestone {
+        crate::provider::types::Milestone {
             number,
             title: title.to_string(),
             description: String::new(),
@@ -798,12 +794,8 @@ mod tests {
         }
     }
 
-    fn make_seeded_issue(
-        number: u64,
-        title: &str,
-        state: &str,
-    ) -> crate::provider::github::types::GhIssue {
-        crate::provider::github::types::GhIssue {
+    fn make_seeded_issue(number: u64, title: &str, state: &str) -> crate::provider::types::Issue {
+        crate::provider::types::Issue {
             number,
             title: title.to_string(),
             body: String::new(),

--- a/src/adapt/mod.rs
+++ b/src/adapt/mod.rs
@@ -359,7 +359,7 @@ pub async fn detect_milestone_hint(
     );
     let mut titles: Vec<String> = Vec::new();
     for state in ["open", "closed"] {
-        match crate::provider::github::client::GitHubClient::list_milestones(&github, state).await {
+        match crate::provider::github::client::RepoProvider::list_milestones(&github, state).await {
             Ok(ms) => titles.extend(ms.into_iter().map(|m| m.title)),
             Err(e) => {
                 tracing::warn!("Failed to list {state} milestones for pattern detection: {e}");

--- a/src/commands/queue.rs
+++ b/src/commands/queue.rs
@@ -1,5 +1,5 @@
 use crate::config::Config;
-use crate::provider::github::client::{GhCliClient, GitHubClient};
+use crate::provider::github::client::{GhCliClient, RepoProvider};
 use crate::work::assigner::WorkAssigner;
 use crate::work::types::WorkItem;
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,6 +1,6 @@
 use crate::commands::setup::{setup_app_from_config_with_bypass, startup_cleanup};
 use crate::config::Config;
-use crate::provider::github::client::{GhCliClient, GitHubClient};
+use crate::provider::github::client::{GhCliClient, RepoProvider};
 use crate::session::types::Session;
 use crate::session::worktree::GitWorktreeManager;
 use crate::state::store::StateStore;

--- a/src/integration_tests/completion_pipeline.rs
+++ b/src/integration_tests/completion_pipeline.rs
@@ -1,5 +1,5 @@
 use crate::integration_tests::helpers::*;
-use crate::provider::github::client::GitHubClient;
+use crate::provider::github::client::RepoProvider;
 use crate::provider::github::client::mock::MockGitHubClient;
 use crate::provider::github::labels::LabelManager;
 use crate::provider::github::pr::{PrCreator, build_pr_body};

--- a/src/integration_tests/milestone_health_wizard.rs
+++ b/src/integration_tests/milestone_health_wizard.rs
@@ -11,15 +11,15 @@ use crossterm::event::KeyCode;
 
 use crate::milestone_health::report::HealthReport;
 use crate::milestone_health::{analyze, check_issues};
-use crate::provider::github::client::GitHubClient;
+use crate::provider::github::client::RepoProvider;
 use crate::provider::github::client::mock::MockGitHubClient;
-use crate::provider::github::types::{GhIssue, GhMilestone};
+use crate::provider::types::{Issue, Milestone};
 use crate::tui::screens::milestone_health::state::{
     HealthInput, HealthScreenState, HealthSideEffect, HealthStep, PatchOutcome,
 };
 
-fn ms(n: u64, title: &str, desc: &str) -> GhMilestone {
-    GhMilestone {
+fn ms(n: u64, title: &str, desc: &str) -> Milestone {
+    Milestone {
         number: n,
         title: title.to_string(),
         description: desc.to_string(),
@@ -83,8 +83,8 @@ fn missing_section_body(missing: &str) -> String {
     s
 }
 
-fn make_issue(number: u64, body: String) -> GhIssue {
-    GhIssue {
+fn make_issue(number: u64, body: String) -> Issue {
+    Issue {
         number,
         title: format!("Issue #{}", number),
         body,
@@ -116,8 +116,8 @@ fn graph_with_all_at_level_zero(numbers: &[u64]) -> String {
 
 fn run_to_report(
     state: &mut HealthScreenState,
-    milestone: GhMilestone,
-    issues: Vec<GhIssue>,
+    milestone: Milestone,
+    issues: Vec<Issue>,
 ) -> HealthReport {
     // Walk Picker → Loading via the public reducer.
     let _ = state.transition(HealthInput::MilestonesLoaded(Ok(vec![milestone.clone()])));
@@ -368,7 +368,7 @@ async fn empty_milestone_zero_issues_goes_to_empty_no_patch() {
 #[tokio::test]
 async fn fifty_issues_analysis_completes_dor_len_is_50() {
     let mock = MockGitHubClient::new();
-    let issues: Vec<GhIssue> = (1..=50)
+    let issues: Vec<Issue> = (1..=50)
         .map(|n| make_issue(n, full_feature_body(&[])))
         .collect();
     mock.set_issues(issues.clone());

--- a/src/integration_tests/mod.rs
+++ b/src/integration_tests/mod.rs
@@ -31,7 +31,7 @@ mod worktree_lifecycle;
 mod helpers {
     use tokio::sync::mpsc;
 
-    use crate::provider::github::types::GhIssue;
+    use crate::provider::types::Issue;
     use crate::session::pool::SessionPool;
     use crate::session::types::Session;
     use crate::session::worktree::MockWorktreeManager;
@@ -82,8 +82,8 @@ mod helpers {
         s
     }
 
-    pub fn make_gh_issue(number: u64) -> GhIssue {
-        GhIssue {
+    pub fn make_gh_issue(number: u64) -> Issue {
+        Issue {
             number,
             title: format!("Implement feature #{}", number),
             body: String::new(),

--- a/src/milestone_health/dor.rs
+++ b/src/milestone_health/dor.rs
@@ -1,7 +1,7 @@
 //! DOR (Definition of Ready) checker for one issue (#500).
 
 use crate::milestone_health::types::{BlockedBySection, DorResult, IssueType, MissingField};
-use crate::provider::github::types::GhIssue;
+use crate::provider::types::Issue;
 
 const FEATURE_SECTIONS: &[&str] = &[
     "Overview",
@@ -30,7 +30,7 @@ pub fn required_sections(t: IssueType) -> &'static [&'static str] {
     }
 }
 
-pub fn detect_issue_type(issue: &GhIssue) -> IssueType {
+pub fn detect_issue_type(issue: &Issue) -> IssueType {
     if issue.labels.iter().any(|l| l == "type:bug") {
         return IssueType::Bug;
     }
@@ -43,7 +43,7 @@ pub fn detect_issue_type(issue: &GhIssue) -> IssueType {
     IssueType::Feature
 }
 
-pub fn check_issue(issue: &GhIssue) -> DorResult {
+pub fn check_issue(issue: &Issue) -> DorResult {
     let issue_type = detect_issue_type(issue);
     let mut missing: Vec<MissingField> = Vec::new();
 
@@ -70,7 +70,7 @@ pub fn check_issue(issue: &GhIssue) -> DorResult {
     }
 }
 
-pub fn check_issues(issues: &[GhIssue]) -> Vec<DorResult> {
+pub fn check_issues(issues: &[Issue]) -> Vec<DorResult> {
     issues.iter().map(check_issue).collect()
 }
 

--- a/src/milestone_health/dor/tests.rs
+++ b/src/milestone_health/dor/tests.rs
@@ -1,10 +1,10 @@
 //! Tests for the DOR (Definition of Ready) checker (#500).
 
 use super::*;
-use crate::provider::github::types::GhIssue;
+use crate::provider::types::Issue;
 
-fn raw_issue(number: u64, labels: &[&str], body: &str) -> GhIssue {
-    GhIssue {
+fn raw_issue(number: u64, labels: &[&str], body: &str) -> Issue {
+    Issue {
         number,
         title: format!("Issue #{}", number),
         body: body.to_string(),
@@ -29,7 +29,7 @@ fn body_with(sections: &[&str]) -> String {
     out
 }
 
-pub(crate) fn make_feature_issue(number: u64, missing: &[&str]) -> GhIssue {
+pub(crate) fn make_feature_issue(number: u64, missing: &[&str]) -> Issue {
     let kept: Vec<&str> = FEATURE_SECTIONS
         .iter()
         .copied()
@@ -38,7 +38,7 @@ pub(crate) fn make_feature_issue(number: u64, missing: &[&str]) -> GhIssue {
     raw_issue(number, &["type:feature"], &body_with(&kept))
 }
 
-pub(crate) fn make_bug_issue(number: u64, missing: &[&str]) -> GhIssue {
+pub(crate) fn make_bug_issue(number: u64, missing: &[&str]) -> Issue {
     let kept: Vec<&str> = BUG_SECTIONS
         .iter()
         .copied()

--- a/src/milestone_health/graph.rs
+++ b/src/milestone_health/graph.rs
@@ -4,12 +4,12 @@ use std::collections::{HashMap, HashSet};
 
 use crate::milestone_health::dor::parse_blocked_by_section;
 use crate::milestone_health::types::{BlockedBySection, GraphAnomaly, GraphLevel, ParsedGraph};
-use crate::provider::github::types::GhIssue;
+use crate::provider::types::Issue;
 
 /// Gather all blocker issue numbers for an issue: union of labels,
 /// inline `blocked-by:` references, and the structured `## Blocked By`
 /// section. Deduplicated and sorted.
-pub fn gather_blockers(issue: &GhIssue) -> Vec<u64> {
+pub fn gather_blockers(issue: &Issue) -> Vec<u64> {
     let mut all = issue.all_blockers();
     if let Some(BlockedBySection::Issues(nums)) = parse_blocked_by_section(&issue.body) {
         all.extend(nums);
@@ -115,7 +115,7 @@ fn parse_issue_bullet(line: &str) -> Option<(u64, bool)> {
 /// inline body refs, and the structured `## Blocked By` section). Computing
 /// this once and reusing it across `detect_cycles` and `compute_levels`
 /// avoids re-parsing each issue body O(N) times per `analyze` call.
-fn build_blockers_map(issues: &[GhIssue]) -> HashMap<u64, Vec<u64>> {
+fn build_blockers_map(issues: &[Issue]) -> HashMap<u64, Vec<u64>> {
     issues
         .iter()
         .map(|i| (i.number, gather_blockers(i)))
@@ -127,7 +127,7 @@ fn build_blockers_map(issues: &[GhIssue]) -> HashMap<u64, Vec<u64>> {
 /// `CrossMilestoneBlockedBy` anomalies, not level shifts). Cycle members
 /// get `None`.
 pub fn compute_levels(
-    issues: &[GhIssue],
+    issues: &[Issue],
     milestone_set: &HashSet<u64>,
 ) -> HashMap<u64, Option<usize>> {
     let blockers_map = build_blockers_map(issues);
@@ -136,7 +136,7 @@ pub fn compute_levels(
 }
 
 fn compute_levels_with(
-    issues: &[GhIssue],
+    issues: &[Issue],
     milestone_set: &HashSet<u64>,
     blockers_map: &HashMap<u64, Vec<u64>>,
     cycles: &[Vec<u64>],
@@ -198,13 +198,13 @@ fn compute_levels_with(
 /// SCCs are sorted by minimum issue number; within an SCC, members are
 /// sorted ascending.
 #[allow(dead_code)] // Reason: public ergonomic wrapper; production uses detect_cycles_with_blockers, tests call this directly
-pub fn detect_cycles(issues: &[GhIssue]) -> Vec<Vec<u64>> {
+pub fn detect_cycles(issues: &[Issue]) -> Vec<Vec<u64>> {
     let blockers_map = build_blockers_map(issues);
     detect_cycles_with_blockers(issues, &blockers_map)
 }
 
 fn detect_cycles_with_blockers(
-    issues: &[GhIssue],
+    issues: &[Issue],
     blockers_map: &HashMap<u64, Vec<u64>>,
 ) -> Vec<Vec<u64>> {
     let nodes: Vec<u64> = issues.iter().map(|i| i.number).collect();
@@ -324,7 +324,7 @@ fn strongconnect(
 /// Builds the blockers map, cycle set, and computed levels exactly once
 /// internally — earlier revisions ran detect_cycles three times and
 /// compute_levels twice on the same inputs.
-pub fn analyze(description: &str, issues: &[GhIssue]) -> Vec<GraphAnomaly> {
+pub fn analyze(description: &str, issues: &[Issue]) -> Vec<GraphAnomaly> {
     let mut out: Vec<GraphAnomaly> = Vec::new();
     let parsed = parse_graph(description);
     let milestone_set: HashSet<u64> = issues.iter().map(|i| i.number).collect();
@@ -361,7 +361,7 @@ pub fn analyze(description: &str, issues: &[GhIssue]) -> Vec<GraphAnomaly> {
         let levels_map = parsed.issue_to_level();
         let computed = compute_levels_with(issues, &milestone_set, &blockers_map, &cycles);
 
-        let mut sorted_issues: Vec<&GhIssue> = issues.iter().collect();
+        let mut sorted_issues: Vec<&Issue> = issues.iter().collect();
         sorted_issues.sort_by_key(|i| i.number);
         for issue in sorted_issues {
             if cycle_members.contains(&issue.number) {

--- a/src/milestone_health/graph/tests.rs
+++ b/src/milestone_health/graph/tests.rs
@@ -2,9 +2,9 @@
 //! detector, and analyzer (#500).
 
 use super::*;
-use crate::provider::github::types::GhIssue;
+use crate::provider::types::Issue;
 
-fn issue_blocked_by(number: u64, blockers: &[u64], milestone: Option<u64>) -> GhIssue {
+fn issue_blocked_by(number: u64, blockers: &[u64], milestone: Option<u64>) -> Issue {
     let body = if blockers.is_empty() {
         "## Blocked By\n\n- None\n".to_string()
     } else {
@@ -14,7 +14,7 @@ fn issue_blocked_by(number: u64, blockers: &[u64], milestone: Option<u64>) -> Gh
         }
         s
     };
-    GhIssue {
+    Issue {
         number,
         title: format!("Issue #{}", number),
         body,

--- a/src/milestone_health/patch.rs
+++ b/src/milestone_health/patch.rs
@@ -9,7 +9,7 @@ use std::collections::{BTreeMap, HashSet};
 
 use crate::milestone_health::graph::{compute_levels, parse_graph};
 use crate::milestone_health::types::GraphAnomaly;
-use crate::provider::github::types::{GhIssue, GhMilestone};
+use crate::provider::types::{Issue, Milestone};
 
 const GRAPH_HEADING: &str = "## Dependency Graph (Implementation Order)";
 
@@ -25,8 +25,8 @@ const GRAPH_HEADING: &str = "## Dependency Graph (Implementation Order)";
 /// - Annotates cycle members with a `(cycle)` warning suffix — they cannot
 ///   be placed at a deterministic level until the cycle is broken.
 pub fn generate_patch(
-    milestone: &GhMilestone,
-    issues: &[GhIssue],
+    milestone: &Milestone,
+    issues: &[Issue],
     anomalies: &[GraphAnomaly],
 ) -> String {
     let preamble = preamble_text(&milestone.description);
@@ -142,10 +142,10 @@ fn preamble_text(description: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::provider::github::types::{GhIssue, GhMilestone};
+    use crate::provider::types::{Issue, Milestone};
 
-    fn ms(description: &str) -> GhMilestone {
-        GhMilestone {
+    fn ms(description: &str) -> Milestone {
+        Milestone {
             number: 1,
             title: "v1.0".to_string(),
             description: description.to_string(),
@@ -155,7 +155,7 @@ mod tests {
         }
     }
 
-    fn issue(number: u64, title: &str, blockers: &[u64]) -> GhIssue {
+    fn issue(number: u64, title: &str, blockers: &[u64]) -> Issue {
         let mut body = format!("## Overview\n\n{}\n\n## Blocked By\n\n", title);
         if blockers.is_empty() {
             body.push_str("- None\n");
@@ -164,7 +164,7 @@ mod tests {
                 body.push_str(&format!("- #{} placeholder\n", b));
             }
         }
-        GhIssue {
+        Issue {
             number,
             title: title.to_string(),
             body,

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::provider::github::types::GhIssue;
+use crate::provider::types::Issue;
 
 /// Routes issues to specific models based on label-matching rules.
 pub struct ModelRouter {
@@ -23,7 +23,7 @@ impl ModelRouter {
     /// Resolve which model to use for a given issue.
     /// Checks issue labels against routing rules. First match wins.
     /// Rules are patterns like "priority:P0" or "type:docs".
-    pub fn resolve(&self, issue: &GhIssue) -> &str {
+    pub fn resolve(&self, issue: &Issue) -> &str {
         for (pattern, model) in &self.rules {
             if issue.labels.iter().any(|l| l == pattern) {
                 return model;
@@ -37,8 +37,8 @@ impl ModelRouter {
 mod tests {
     use super::*;
 
-    fn make_issue(labels: &[&str]) -> GhIssue {
-        GhIssue {
+    fn make_issue(labels: &[&str]) -> Issue {
+        Issue {
             number: 1,
             title: "Test".into(),
             body: String::new(),

--- a/src/prd/sync.rs
+++ b/src/prd/sync.rs
@@ -10,8 +10,8 @@
 use crate::prd::discover::{DiscoveredPrd, discover_all};
 use crate::prd::ingest::{IngestedPrd, parse_markdown};
 use crate::prd::model::{CurrentState, TimelineMilestone, TimelineStatus};
-use crate::provider::github::client::GitHubClient;
-use crate::provider::github::types::GhIssue;
+use crate::provider::github::client::RepoProvider;
+use crate::provider::types::Issue;
 use anyhow::Result;
 use async_trait::async_trait;
 
@@ -44,11 +44,11 @@ pub trait PrdSyncer: Send + Sync {
 }
 
 pub struct GitHubPrdSyncer {
-    client: Box<dyn GitHubClient>,
+    client: Box<dyn RepoProvider>,
 }
 
 impl GitHubPrdSyncer {
-    pub fn new(client: Box<dyn GitHubClient>) -> Self {
+    pub fn new(client: Box<dyn RepoProvider>) -> Self {
         Self { client }
     }
 
@@ -135,7 +135,7 @@ impl PrdSyncer for GitHubPrdSyncer {
 
 /// Pure aggregation — used by the syncer and exposed for direct testing.
 pub fn aggregate(
-    open_issues: &[GhIssue],
+    open_issues: &[Issue],
     closed_issues: u32,
     open_milestones: u32,
     closed_milestones: u32,
@@ -164,10 +164,10 @@ pub fn aggregate(
 /// Build a timeline from the open + closed milestones combined. Sorted
 /// by milestone number ascending (creation order).
 pub fn compute_timeline(
-    open_milestones: &[crate::provider::github::types::GhMilestone],
-    closed_milestones: &[crate::provider::github::types::GhMilestone],
+    open_milestones: &[crate::provider::types::Milestone],
+    closed_milestones: &[crate::provider::types::Milestone],
 ) -> Vec<TimelineMilestone> {
-    let mut combined: Vec<&crate::provider::github::types::GhMilestone> = open_milestones
+    let mut combined: Vec<&crate::provider::types::Milestone> = open_milestones
         .iter()
         .chain(closed_milestones.iter())
         .collect();
@@ -200,9 +200,9 @@ pub fn compute_timeline(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::provider::github::types::{GhIssue, GhMilestone};
+    use crate::provider::types::{Issue, Milestone};
 
-    fn issue(number: u64, blockers: &[u64]) -> GhIssue {
+    fn issue(number: u64, blockers: &[u64]) -> Issue {
         // Use the format the existing `blocked_by_from_body` regex parses:
         // `blocked-by: #N` (case-insensitive). The `## Blocked By` prose
         // section in real issues is parsed elsewhere; here we exercise the
@@ -216,7 +216,7 @@ mod tests {
                 .collect();
             lines.join("\n")
         };
-        GhIssue {
+        Issue {
             number,
             title: format!("Issue {number}"),
             body,
@@ -228,8 +228,8 @@ mod tests {
         }
     }
 
-    fn milestone(num: u64, title: &str, open: u32, closed: u32, state: &str) -> GhMilestone {
-        GhMilestone {
+    fn milestone(num: u64, title: &str, open: u32, closed: u32, state: &str) -> Milestone {
+        Milestone {
             number: num,
             title: title.into(),
             description: String::new(),

--- a/src/prompts.rs
+++ b/src/prompts.rs
@@ -1,5 +1,5 @@
 use crate::config::Config;
-use crate::provider::github::types::GhIssue;
+use crate::provider::types::Issue;
 use crate::session::image::image_section_for_prompt;
 use std::path::{Path, PathBuf};
 
@@ -85,7 +85,7 @@ pub struct PromptBuilder;
 impl PromptBuilder {
     /// Build a structured prompt for an issue-based session with optional image references.
     pub fn build_issue_prompt_with_images(
-        issue: &GhIssue,
+        issue: &Issue,
         config: &Config,
         image_relative_paths: &[PathBuf],
     ) -> String {
@@ -97,7 +97,7 @@ impl PromptBuilder {
     }
 
     /// Build a structured prompt for an issue-based session.
-    pub fn build_issue_prompt(issue: &GhIssue, config: &Config) -> String {
+    pub fn build_issue_prompt(issue: &Issue, config: &Config) -> String {
         let task_type = Self::detect_task_type(issue);
         let phase_instructions = Self::phase_instructions(&task_type);
         let safety_guards = Self::safety_guards();
@@ -134,7 +134,7 @@ impl PromptBuilder {
     }
 
     /// Detect the task type from issue labels.
-    fn detect_task_type(issue: &GhIssue) -> String {
+    fn detect_task_type(issue: &Issue) -> String {
         for label in &issue.labels {
             match label.as_str() {
                 "type:docs" | "documentation" => return "Documentation".into(),
@@ -208,8 +208,8 @@ impl PromptBuilder {
 mod tests {
     use super::*;
 
-    fn make_issue(labels: &[&str]) -> GhIssue {
-        GhIssue {
+    fn make_issue(labels: &[&str]) -> Issue {
+        Issue {
             number: 42,
             title: "Test issue".into(),
             body: "Fix the thing".into(),

--- a/src/provider/azure_devops/mod.rs
+++ b/src/provider/azure_devops/mod.rs
@@ -1,6 +1,5 @@
-use super::types::Issue;
-use crate::provider::github::client::GitHubClient;
-use crate::provider::github::types::GhMilestone;
+use crate::provider::github::client::RepoProvider;
+use crate::provider::types::{Issue, Milestone, PullRequest, ReviewEvent};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 
@@ -105,7 +104,7 @@ pub fn parse_work_items_json(json_str: &str) -> Result<Vec<Issue>> {
 }
 
 #[async_trait]
-impl GitHubClient for AzDevOpsClient {
+impl RepoProvider for AzDevOpsClient {
     async fn list_issues(&self, labels: &[&str]) -> Result<Vec<Issue>> {
         let mut wiql = String::from(
             "SELECT [System.Id] FROM WorkItems WHERE [System.State] <> 'Closed' \
@@ -217,7 +216,7 @@ impl GitHubClient for AzDevOpsClient {
         parse_work_items_json(&details_str)
     }
 
-    async fn list_milestones(&self, _state: &str) -> Result<Vec<GhMilestone>> {
+    async fn list_milestones(&self, _state: &str) -> Result<Vec<Milestone>> {
         // Azure DevOps uses iterations rather than milestones; not yet implemented.
         Ok(vec![])
     }
@@ -368,18 +367,18 @@ impl GitHubClient for AzDevOpsClient {
         anyhow::bail!("create_issue is not supported for Azure DevOps")
     }
 
-    async fn list_open_prs(&self) -> Result<Vec<crate::provider::github::types::GhPullRequest>> {
+    async fn list_open_prs(&self) -> Result<Vec<PullRequest>> {
         anyhow::bail!("list_open_prs is not supported for Azure DevOps")
     }
 
-    async fn get_pr(&self, _number: u64) -> Result<crate::provider::github::types::GhPullRequest> {
+    async fn get_pr(&self, _number: u64) -> Result<PullRequest> {
         anyhow::bail!("get_pr is not supported for Azure DevOps")
     }
 
     async fn submit_pr_review(
         &self,
         _pr_number: u64,
-        _event: crate::provider::github::types::PrReviewEvent,
+        _event: ReviewEvent,
         _body: &str,
     ) -> Result<()> {
         anyhow::bail!("submit_pr_review is not supported for Azure DevOps")

--- a/src/provider/github/client.rs
+++ b/src/provider/github/client.rs
@@ -8,7 +8,7 @@
 pub(crate) use super::transport::parse_pr_number_from_create_output;
 #[allow(unused_imports)]
 pub use super::transport::{
-    CreateOutcome, GhCliClient, GitHubClient, is_auth_error, is_gh_auth_error, parse_issues_json,
+    CreateOutcome, GhCliClient, RepoProvider, is_auth_error, is_gh_auth_error, parse_issues_json,
     parse_milestones_json, parse_prs_json, redact_secrets,
 };
 

--- a/src/provider/github/gh_argv.rs
+++ b/src/provider/github/gh_argv.rs
@@ -13,7 +13,7 @@
 //! - Tests live in `#[cfg(test)] mod tests` at the bottom; one snapshot
 //!   per builder using literal `Vec<&str>` for readability.
 
-use crate::provider::github::types::PrReviewEvent;
+use crate::provider::types::ReviewEvent;
 
 /// Append `--repo {owner}/{repo}` to `argv` when `repo` is set. No-op
 /// otherwise. Centralizes the rollout so individual builders stay tidy.
@@ -109,7 +109,7 @@ pub(crate) fn build_remove_label_argv(
 
 pub(crate) fn build_submit_pr_review_argv(
     pr_number: u64,
-    event: PrReviewEvent,
+    event: ReviewEvent,
     body: &str,
 ) -> Vec<String> {
     let mut argv = vec![
@@ -366,21 +366,21 @@ mod tests {
     #[test]
     fn submit_pr_review_argv_with_body() {
         assert_eq!(
-            build_submit_pr_review_argv(99, PrReviewEvent::Approve, "LGTM"),
+            build_submit_pr_review_argv(99, ReviewEvent::Approve, "LGTM"),
             s(&["pr", "review", "99", "--approve", "--body", "LGTM",])
         );
     }
 
     #[test]
     fn submit_pr_review_argv_omits_body_when_empty() {
-        let argv = build_submit_pr_review_argv(99, PrReviewEvent::Comment, "");
+        let argv = build_submit_pr_review_argv(99, ReviewEvent::Comment, "");
         assert_eq!(argv, s(&["pr", "review", "99", "--comment"]));
         assert!(!argv.contains(&"--body".to_string()));
     }
 
     #[test]
     fn submit_pr_review_argv_request_changes() {
-        let argv = build_submit_pr_review_argv(99, PrReviewEvent::RequestChanges, "see comments");
+        let argv = build_submit_pr_review_argv(99, ReviewEvent::RequestChanges, "see comments");
         assert_eq!(
             argv,
             s(&[
@@ -805,8 +805,8 @@ mod wire_tests {
         if !integration_enabled() {
             return;
         }
-        use crate::provider::github::types::PrReviewEvent;
-        let argv = build_submit_pr_review_argv(1, PrReviewEvent::Approve, "LGTM");
+        use crate::provider::types::ReviewEvent;
+        let argv = build_submit_pr_review_argv(1, ReviewEvent::Approve, "LGTM");
         let flags = gh_help_flags(&["pr", "review"]);
         assert_all_recognized(&argv, &flags, "build_submit_pr_review_argv");
     }

--- a/src/provider/github/labels.rs
+++ b/src/provider/github/labels.rs
@@ -1,13 +1,13 @@
-use super::transport::GitHubClient;
-use super::types::MaestroLabel;
+use super::transport::RepoProvider;
+use crate::provider::types::MaestroLabel;
 use anyhow::Result;
 
 /// Manages the maestro label lifecycle on GitHub issues.
-pub struct LabelManager<C: GitHubClient> {
+pub struct LabelManager<C: RepoProvider> {
     client: C,
 }
 
-impl<C: GitHubClient> LabelManager<C> {
+impl<C: RepoProvider> LabelManager<C> {
     pub fn new(client: C) -> Self {
         Self { client }
     }

--- a/src/provider/github/pr.rs
+++ b/src/provider/github/pr.rs
@@ -1,5 +1,5 @@
-use super::transport::GitHubClient;
-use super::types::GhIssue;
+use super::transport::RepoProvider;
+use crate::provider::types::Issue;
 use anyhow::Result;
 use std::time::Duration;
 
@@ -19,7 +19,7 @@ fn append_pr_footer(body: &mut String, files_touched: &[&str], cost_usd: f64) {
 }
 
 /// Build the PR body for an issue.
-pub fn build_pr_body(issue: &GhIssue, files_touched: &[&str], cost_usd: f64) -> String {
+pub fn build_pr_body(issue: &Issue, files_touched: &[&str], cost_usd: f64) -> String {
     let mut body = String::new();
     body.push_str(&format!("Closes #{}\n\n", issue.number));
     body.push_str("## Summary\n\n");
@@ -32,7 +32,7 @@ pub fn build_pr_body(issue: &GhIssue, files_touched: &[&str], cost_usd: f64) -> 
 }
 
 /// Build a PR body that closes multiple issues (unified PR).
-pub fn build_unified_pr_body(issues: &[&GhIssue], files_touched: &[&str], cost_usd: f64) -> String {
+pub fn build_unified_pr_body(issues: &[&Issue], files_touched: &[&str], cost_usd: f64) -> String {
     let mut body = String::new();
 
     for issue in issues {
@@ -60,12 +60,12 @@ pub fn unified_branch_name(issue_numbers: &[u64]) -> String {
     format!("maestro/unified-{}", joined.join("-"))
 }
 
-pub struct PrCreator<C: GitHubClient> {
+pub struct PrCreator<C: RepoProvider> {
     client: C,
     base_branch: String,
 }
 
-impl<C: GitHubClient> PrCreator<C> {
+impl<C: RepoProvider> PrCreator<C> {
     pub fn new(client: C, base_branch: String) -> Self {
         Self {
             client,
@@ -76,7 +76,7 @@ impl<C: GitHubClient> PrCreator<C> {
     /// Create a PR for a completed issue session.
     pub async fn create_for_issue(
         &self,
-        issue: &GhIssue,
+        issue: &Issue,
         head_branch: &str,
         files_touched: &[&str],
         cost_usd: f64,
@@ -151,8 +151,8 @@ mod tests {
     use super::*;
     use crate::provider::github::transport::mock::MockGitHubClient;
 
-    fn make_issue(number: u64) -> GhIssue {
-        GhIssue {
+    fn make_issue(number: u64) -> Issue {
+        Issue {
             number,
             title: format!("Implement feature #{}", number),
             body: String::new(),

--- a/src/provider/github/transport.rs
+++ b/src/provider/github/transport.rs
@@ -1,4 +1,4 @@
-use super::types::{GhIssue, GhMilestone, GhPullRequest, PrReviewEvent};
+use crate::provider::types::{Issue, Milestone, PullRequest, ReviewEvent};
 use anyhow::Result;
 use async_trait::async_trait;
 
@@ -57,13 +57,13 @@ impl CreateOutcome {
     }
 }
 
-/// Trait for GitHub API operations. Mockable for testing.
+/// Trait for repository provider operations. Mockable for testing.
 #[async_trait]
-pub trait GitHubClient: Send + Sync {
-    async fn list_issues(&self, labels: &[&str]) -> Result<Vec<GhIssue>>;
-    async fn list_issues_by_milestone(&self, milestone: &str) -> Result<Vec<GhIssue>>;
-    async fn list_milestones(&self, state: &str) -> Result<Vec<GhMilestone>>;
-    async fn get_issue(&self, number: u64) -> Result<GhIssue>;
+pub trait RepoProvider: Send + Sync {
+    async fn list_issues(&self, labels: &[&str]) -> Result<Vec<Issue>>;
+    async fn list_issues_by_milestone(&self, milestone: &str) -> Result<Vec<Issue>>;
+    async fn list_milestones(&self, state: &str) -> Result<Vec<Milestone>>;
+    async fn get_issue(&self, number: u64) -> Result<Issue>;
     async fn add_label(&self, issue_number: u64, label: &str) -> Result<()>;
     async fn remove_label(&self, issue_number: u64, label: &str) -> Result<()>;
     async fn create_pr(
@@ -84,15 +84,10 @@ pub trait GitHubClient: Send + Sync {
         labels: &[String],
         milestone: Option<u64>,
     ) -> Result<CreateOutcome>;
-    async fn list_open_prs(&self) -> Result<Vec<GhPullRequest>>;
+    async fn list_open_prs(&self) -> Result<Vec<PullRequest>>;
     #[allow(dead_code)] // Reason: PR detail view — currently PR data comes from list
-    async fn get_pr(&self, number: u64) -> Result<GhPullRequest>;
-    async fn submit_pr_review(
-        &self,
-        pr_number: u64,
-        event: PrReviewEvent,
-        body: &str,
-    ) -> Result<()>;
+    async fn get_pr(&self, number: u64) -> Result<PullRequest>;
+    async fn submit_pr_review(&self, pr_number: u64, event: ReviewEvent, body: &str) -> Result<()>;
     async fn list_labels(&self) -> Result<Vec<String>>;
     async fn create_label(&self, name: &str, color: &str) -> Result<()>;
     async fn patch_milestone_description(
@@ -102,19 +97,19 @@ pub trait GitHubClient: Send + Sync {
     ) -> Result<()>;
 }
 
-/// Blanket impl: if T: GitHubClient, then &T is also a GitHubClient.
+/// Blanket impl: if T: RepoProvider, then &T is also a RepoProvider.
 #[async_trait]
-impl<T: GitHubClient + ?Sized> GitHubClient for &T {
-    async fn list_issues(&self, labels: &[&str]) -> Result<Vec<GhIssue>> {
+impl<T: RepoProvider + ?Sized> RepoProvider for &T {
+    async fn list_issues(&self, labels: &[&str]) -> Result<Vec<Issue>> {
         (**self).list_issues(labels).await
     }
-    async fn list_issues_by_milestone(&self, milestone: &str) -> Result<Vec<GhIssue>> {
+    async fn list_issues_by_milestone(&self, milestone: &str) -> Result<Vec<Issue>> {
         (**self).list_issues_by_milestone(milestone).await
     }
-    async fn list_milestones(&self, state: &str) -> Result<Vec<GhMilestone>> {
+    async fn list_milestones(&self, state: &str) -> Result<Vec<Milestone>> {
         (**self).list_milestones(state).await
     }
-    async fn get_issue(&self, number: u64) -> Result<GhIssue> {
+    async fn get_issue(&self, number: u64) -> Result<Issue> {
         (**self).get_issue(number).await
     }
     async fn add_label(&self, issue_number: u64, label: &str) -> Result<()> {
@@ -150,18 +145,13 @@ impl<T: GitHubClient + ?Sized> GitHubClient for &T {
     ) -> Result<CreateOutcome> {
         (**self).create_issue(title, body, labels, milestone).await
     }
-    async fn list_open_prs(&self) -> Result<Vec<GhPullRequest>> {
+    async fn list_open_prs(&self) -> Result<Vec<PullRequest>> {
         (**self).list_open_prs().await
     }
-    async fn get_pr(&self, number: u64) -> Result<GhPullRequest> {
+    async fn get_pr(&self, number: u64) -> Result<PullRequest> {
         (**self).get_pr(number).await
     }
-    async fn submit_pr_review(
-        &self,
-        pr_number: u64,
-        event: PrReviewEvent,
-        body: &str,
-    ) -> Result<()> {
+    async fn submit_pr_review(&self, pr_number: u64, event: ReviewEvent, body: &str) -> Result<()> {
         (**self).submit_pr_review(pr_number, event, body).await
     }
     async fn list_labels(&self) -> Result<Vec<String>> {

--- a/src/provider/github/transport/cli_impl.rs
+++ b/src/provider/github/transport/cli_impl.rs
@@ -1,17 +1,17 @@
 use super::{
-    CreateOutcome, GhCliClient, GitHubClient, PR_JSON_FIELDS, argv_refs, is_label_not_found_error,
+    CreateOutcome, GhCliClient, PR_JSON_FIELDS, RepoProvider, argv_refs, is_label_not_found_error,
     normalize_paginated_json_arrays, parse_issues_json, parse_milestones_json,
     parse_pr_number_from_create_output, parse_prs_json,
 };
 use crate::provider::github::gh_argv;
-use crate::provider::github::types::{GhIssue, GhMilestone, GhPullRequest, PrReviewEvent};
+use crate::provider::types::{Issue, Milestone, PullRequest, ReviewEvent};
 use crate::util::{titles_equivalent, validate_body, validate_gh_arg, validate_title};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 
 #[async_trait]
-impl GitHubClient for GhCliClient {
-    async fn list_issues(&self, labels: &[&str]) -> Result<Vec<GhIssue>> {
+impl RepoProvider for GhCliClient {
+    async fn list_issues(&self, labels: &[&str]) -> Result<Vec<Issue>> {
         for label in labels {
             validate_gh_arg(label, "label")?;
         }
@@ -26,14 +26,14 @@ impl GitHubClient for GhCliClient {
         parse_issues_json(&json_str)
     }
 
-    async fn list_issues_by_milestone(&self, milestone: &str) -> Result<Vec<GhIssue>> {
+    async fn list_issues_by_milestone(&self, milestone: &str) -> Result<Vec<Issue>> {
         validate_gh_arg(milestone, "milestone")?;
         let argv = gh_argv::build_list_issues_by_milestone_argv(milestone, self.repo_arg());
         let json_str = self.run_gh(&argv_refs(&argv)).await?;
         parse_issues_json(&json_str)
     }
 
-    async fn list_milestones(&self, state: &str) -> Result<Vec<GhMilestone>> {
+    async fn list_milestones(&self, state: &str) -> Result<Vec<Milestone>> {
         match state {
             "open" | "closed" | "all" => {}
             _ => anyhow::bail!(
@@ -47,7 +47,7 @@ impl GitHubClient for GhCliClient {
         parse_milestones_json(&normalized)
     }
 
-    async fn get_issue(&self, number: u64) -> Result<GhIssue> {
+    async fn get_issue(&self, number: u64) -> Result<Issue> {
         let argv = gh_argv::build_get_issue_argv(number, self.repo_arg());
         let json_str = self.run_gh(&argv_refs(&argv)).await?;
         // gh issue view returns a single object, wrap it in array for parsing
@@ -260,13 +260,13 @@ impl GitHubClient for GhCliClient {
         Ok(CreateOutcome::Created(number))
     }
 
-    async fn list_open_prs(&self) -> Result<Vec<GhPullRequest>> {
+    async fn list_open_prs(&self) -> Result<Vec<PullRequest>> {
         let argv = gh_argv::build_list_open_prs_argv(PR_JSON_FIELDS, self.repo_arg());
         let json_str = self.run_gh(&argv_refs(&argv)).await?;
         parse_prs_json(&json_str)
     }
 
-    async fn get_pr(&self, number: u64) -> Result<GhPullRequest> {
+    async fn get_pr(&self, number: u64) -> Result<PullRequest> {
         let argv = gh_argv::build_get_pr_argv(number, PR_JSON_FIELDS, self.repo_arg());
         let json_str = self.run_gh(&argv_refs(&argv)).await?;
         let prs = parse_prs_json(&format!("[{}]", json_str))?;
@@ -275,12 +275,7 @@ impl GitHubClient for GhCliClient {
             .ok_or_else(|| anyhow::anyhow!("PR #{} not found", number))
     }
 
-    async fn submit_pr_review(
-        &self,
-        pr_number: u64,
-        event: PrReviewEvent,
-        body: &str,
-    ) -> Result<()> {
+    async fn submit_pr_review(&self, pr_number: u64, event: ReviewEvent, body: &str) -> Result<()> {
         // Parity with create_pr / create_issue / create_milestone — every
         // user-facing body that ships to GitHub is bounded at the same cap.
         validate_body(body, "PR review body")?;

--- a/src/provider/github/transport/mock.rs
+++ b/src/provider/github/transport/mock.rs
@@ -1,5 +1,5 @@
-use super::{CreateOutcome, GhIssue, GhMilestone};
-use crate::provider::github::types::{GhPullRequest, PrReviewEvent};
+use super::CreateOutcome;
+use crate::provider::types::{Issue, Milestone, PullRequest, ReviewEvent};
 use std::sync::{Arc, Mutex};
 
 mod impl_client;
@@ -17,8 +17,8 @@ pub struct MockGitHubClient {
 
 #[derive(Default)]
 struct MockState {
-    issues: Vec<GhIssue>,
-    milestones: Vec<GhMilestone>,
+    issues: Vec<Issue>,
+    milestones: Vec<Milestone>,
     add_label_error: Option<String>,
     remove_label_error: Option<String>,
     create_pr_response: Option<u64>,
@@ -43,7 +43,7 @@ struct MockState {
     create_label_error: Option<String>,
 
     // PR review fields
-    pull_requests: Vec<GhPullRequest>,
+    pull_requests: Vec<PullRequest>,
     list_open_prs_error: Option<String>,
     get_pr_errors: std::collections::HashMap<u64, String>,
     submit_pr_review_error: Option<String>,
@@ -58,7 +58,7 @@ struct MockState {
 #[derive(Debug, Clone)]
 pub struct SubmitPrReviewCallRecord {
     pub pr_number: u64,
-    pub event: PrReviewEvent,
+    pub event: ReviewEvent,
     pub body: String,
 }
 
@@ -84,14 +84,14 @@ impl MockGitHubClient {
         Self::default()
     }
 
-    pub fn set_issues(&self, issues: Vec<GhIssue>) {
+    pub fn set_issues(&self, issues: Vec<Issue>) {
         let mut guard = self.inner.lock().unwrap();
         let max = issues.iter().map(|i| i.number).max().unwrap_or(0);
         guard.create_issue_counter = guard.create_issue_counter.max(max);
         guard.issues = issues;
     }
 
-    pub fn set_milestones(&self, milestones: Vec<GhMilestone>) {
+    pub fn set_milestones(&self, milestones: Vec<Milestone>) {
         let mut guard = self.inner.lock().unwrap();
         let max = milestones.iter().map(|m| m.number).max().unwrap_or(0);
         guard.create_milestone_counter = guard.create_milestone_counter.max(max);
@@ -99,12 +99,12 @@ impl MockGitHubClient {
     }
 
     /// Alias of `set_milestones` matching the naming requested in #453.
-    pub fn set_existing_milestones(&self, milestones: Vec<GhMilestone>) {
+    pub fn set_existing_milestones(&self, milestones: Vec<Milestone>) {
         self.set_milestones(milestones);
     }
 
     /// Alias of `set_issues` matching the naming requested in #453.
-    pub fn set_existing_issues(&self, issues: Vec<GhIssue>) {
+    pub fn set_existing_issues(&self, issues: Vec<Issue>) {
         self.set_issues(issues);
     }
 
@@ -180,7 +180,7 @@ impl MockGitHubClient {
         self.inner.lock().unwrap().create_label_calls.clone()
     }
 
-    pub fn set_pull_requests(&self, prs: Vec<GhPullRequest>) {
+    pub fn set_pull_requests(&self, prs: Vec<PullRequest>) {
         self.inner.lock().unwrap().pull_requests = prs;
     }
 

--- a/src/provider/github/transport/mock/impl_client.rs
+++ b/src/provider/github/transport/mock/impl_client.rs
@@ -1,11 +1,11 @@
 use super::*;
-use crate::provider::github::transport::GitHubClient;
+use crate::provider::github::transport::RepoProvider;
 use anyhow::Result;
 use async_trait::async_trait;
 
 #[async_trait]
-impl GitHubClient for MockGitHubClient {
-    async fn list_issues(&self, labels: &[&str]) -> Result<Vec<GhIssue>> {
+impl RepoProvider for MockGitHubClient {
+    async fn list_issues(&self, labels: &[&str]) -> Result<Vec<Issue>> {
         let state = self.inner.lock().unwrap();
         let label_set: std::collections::HashSet<&str> = labels.iter().copied().collect();
         let filtered = state
@@ -19,7 +19,7 @@ impl GitHubClient for MockGitHubClient {
         Ok(filtered)
     }
 
-    async fn list_issues_by_milestone(&self, _milestone: &str) -> Result<Vec<GhIssue>> {
+    async fn list_issues_by_milestone(&self, _milestone: &str) -> Result<Vec<Issue>> {
         let state = self.inner.lock().unwrap();
         if let Some(ref err) = state.list_issues_by_milestone_error {
             anyhow::bail!("{}", err);
@@ -27,12 +27,12 @@ impl GitHubClient for MockGitHubClient {
         Ok(state.issues.clone())
     }
 
-    async fn list_milestones(&self, _state: &str) -> Result<Vec<GhMilestone>> {
+    async fn list_milestones(&self, _state: &str) -> Result<Vec<Milestone>> {
         let state = self.inner.lock().unwrap();
         Ok(state.milestones.clone())
     }
 
-    async fn get_issue(&self, number: u64) -> Result<GhIssue> {
+    async fn get_issue(&self, number: u64) -> Result<Issue> {
         let state = self.inner.lock().unwrap();
         if let Some(err_msg) = state.get_issue_errors.get(&number) {
             anyhow::bail!("{}", err_msg);
@@ -114,7 +114,7 @@ impl GitHubClient for MockGitHubClient {
             state
                 .create_milestone_calls
                 .push((normalized.clone(), description.to_string()));
-            state.milestones.push(GhMilestone {
+            state.milestones.push(Milestone {
                 number,
                 title: normalized,
                 description: description.to_string(),
@@ -157,7 +157,7 @@ impl GitHubClient for MockGitHubClient {
                 labels: labels.to_vec(),
                 milestone,
             });
-            state.issues.push(GhIssue {
+            state.issues.push(Issue {
                 number,
                 title: normalized,
                 body: body.to_string(),
@@ -173,7 +173,7 @@ impl GitHubClient for MockGitHubClient {
         Ok(outcome)
     }
 
-    async fn list_open_prs(&self) -> Result<Vec<GhPullRequest>> {
+    async fn list_open_prs(&self) -> Result<Vec<PullRequest>> {
         let state = self.inner.lock().unwrap();
         if let Some(ref err) = state.list_open_prs_error {
             anyhow::bail!("{}", err);
@@ -181,7 +181,7 @@ impl GitHubClient for MockGitHubClient {
         Ok(state.pull_requests.clone())
     }
 
-    async fn get_pr(&self, number: u64) -> Result<GhPullRequest> {
+    async fn get_pr(&self, number: u64) -> Result<PullRequest> {
         let state = self.inner.lock().unwrap();
         if let Some(err_msg) = state.get_pr_errors.get(&number) {
             anyhow::bail!("{}", err_msg);
@@ -194,12 +194,7 @@ impl GitHubClient for MockGitHubClient {
             .ok_or_else(|| anyhow::anyhow!("mock: PR #{} not found", number))
     }
 
-    async fn submit_pr_review(
-        &self,
-        pr_number: u64,
-        event: PrReviewEvent,
-        body: &str,
-    ) -> Result<()> {
+    async fn submit_pr_review(&self, pr_number: u64, event: ReviewEvent, body: &str) -> Result<()> {
         let mut state = self.inner.lock().unwrap();
         if let Some(ref err) = state.submit_pr_review_error {
             anyhow::bail!("{}", err);

--- a/src/provider/github/transport/mock/tests_create.rs
+++ b/src/provider/github/transport/mock/tests_create.rs
@@ -1,11 +1,11 @@
 use super::*;
-use crate::provider::github::transport::GitHubClient;
-use crate::provider::github::types::{GhIssue, GhMilestone};
+use crate::provider::github::transport::RepoProvider;
+use crate::provider::types::{Issue, Milestone};
 
 // -- Issue #453: CreateOutcome proactive pre-check --
 
-fn gh_issue(number: u64, title: &str, state: &str) -> GhIssue {
-    GhIssue {
+fn gh_issue(number: u64, title: &str, state: &str) -> Issue {
+    Issue {
         number,
         title: title.to_string(),
         body: String::new(),
@@ -17,8 +17,8 @@ fn gh_issue(number: u64, title: &str, state: &str) -> GhIssue {
     }
 }
 
-fn gh_milestone(number: u64, title: &str, state: &str) -> GhMilestone {
-    GhMilestone {
+fn gh_milestone(number: u64, title: &str, state: &str) -> Milestone {
+    Milestone {
         number,
         title: title.to_string(),
         description: String::new(),

--- a/src/provider/github/transport/mock/tests_issue.rs
+++ b/src/provider/github/transport/mock/tests_issue.rs
@@ -1,9 +1,9 @@
 use super::*;
-use crate::provider::github::transport::GitHubClient;
-use crate::provider::github::types::{GhIssue, GhMilestone};
+use crate::provider::github::transport::RepoProvider;
+use crate::provider::types::{Issue, Milestone};
 
-fn make_issue(number: u64, labels: &[&str]) -> GhIssue {
-    GhIssue {
+fn make_issue(number: u64, labels: &[&str]) -> Issue {
+    Issue {
         number,
         title: format!("Issue #{}", number),
         body: String::new(),
@@ -139,7 +139,7 @@ async fn mock_create_pr_propagates_configured_error() {
 async fn mock_list_milestones_returns_stored_milestones() {
     let client = MockGitHubClient::new();
     client.set_milestones(vec![
-        GhMilestone {
+        Milestone {
             number: 1,
             title: "v1.0".to_string(),
             description: String::new(),
@@ -147,7 +147,7 @@ async fn mock_list_milestones_returns_stored_milestones() {
             open_issues: 2,
             closed_issues: 3,
         },
-        GhMilestone {
+        Milestone {
             number: 2,
             title: "v2.0".to_string(),
             description: String::new(),

--- a/src/provider/github/transport/mock/tests_pr.rs
+++ b/src/provider/github/transport/mock/tests_pr.rs
@@ -1,9 +1,9 @@
 use super::*;
-use crate::provider::github::transport::GitHubClient;
-use crate::provider::github::types::GhPullRequest;
+use crate::provider::github::transport::RepoProvider;
+use crate::provider::types::PullRequest;
 
-fn make_pr(number: u64) -> GhPullRequest {
-    GhPullRequest {
+fn make_pr(number: u64) -> PullRequest {
+    PullRequest {
         number,
         title: format!("PR #{}", number),
         body: String::new(),
@@ -79,49 +79,49 @@ async fn mock_get_pr_propagates_configured_error() {
 
 #[tokio::test]
 async fn mock_submit_pr_review_records_approve_call() {
-    use crate::provider::github::types::PrReviewEvent;
+    use crate::provider::types::ReviewEvent;
     let client = MockGitHubClient::new();
     client
-        .submit_pr_review(7, PrReviewEvent::Approve, "LGTM")
+        .submit_pr_review(7, ReviewEvent::Approve, "LGTM")
         .await
         .unwrap();
     let calls = client.submit_pr_review_calls();
     assert_eq!(calls.len(), 1);
     assert_eq!(calls[0].pr_number, 7);
-    assert_eq!(calls[0].event, PrReviewEvent::Approve);
+    assert_eq!(calls[0].event, ReviewEvent::Approve);
     assert_eq!(calls[0].body, "LGTM");
 }
 
 #[tokio::test]
 async fn mock_submit_pr_review_records_request_changes_call() {
-    use crate::provider::github::types::PrReviewEvent;
+    use crate::provider::types::ReviewEvent;
     let client = MockGitHubClient::new();
     client
-        .submit_pr_review(3, PrReviewEvent::RequestChanges, "needs work")
+        .submit_pr_review(3, ReviewEvent::RequestChanges, "needs work")
         .await
         .unwrap();
     let calls = client.submit_pr_review_calls();
-    assert_eq!(calls[0].event, PrReviewEvent::RequestChanges);
+    assert_eq!(calls[0].event, ReviewEvent::RequestChanges);
 }
 
 #[tokio::test]
 async fn mock_submit_pr_review_records_comment_call() {
-    use crate::provider::github::types::PrReviewEvent;
+    use crate::provider::types::ReviewEvent;
     let client = MockGitHubClient::new();
     client
-        .submit_pr_review(1, PrReviewEvent::Comment, "nice")
+        .submit_pr_review(1, ReviewEvent::Comment, "nice")
         .await
         .unwrap();
     let calls = client.submit_pr_review_calls();
-    assert_eq!(calls[0].event, PrReviewEvent::Comment);
+    assert_eq!(calls[0].event, ReviewEvent::Comment);
 }
 
 #[tokio::test]
 async fn mock_submit_pr_review_propagates_configured_error() {
-    use crate::provider::github::types::PrReviewEvent;
+    use crate::provider::types::ReviewEvent;
     let client = MockGitHubClient::new();
     client.set_submit_pr_review_error("forbidden");
-    let result = client.submit_pr_review(1, PrReviewEvent::Approve, "").await;
+    let result = client.submit_pr_review(1, ReviewEvent::Approve, "").await;
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("forbidden"));
 }

--- a/src/provider/github/transport/parsing.rs
+++ b/src/provider/github/transport/parsing.rs
@@ -1,5 +1,4 @@
-use super::GhIssue;
-use crate::provider::github::types::GhMilestone;
+use crate::provider::types::{Issue, Milestone, PullRequest};
 use anyhow::{Context, Result};
 
 /// Extract label names from a JSON value containing `{"labels": [{"name": "..."}, ...]}`.
@@ -19,7 +18,7 @@ pub(super) fn extract_label_names(v: &serde_json::Value) -> Vec<String> {
 }
 
 /// Parse JSON output from `gh issue list --json ...`.
-pub fn parse_issues_json(json_str: &str) -> Result<Vec<GhIssue>> {
+pub fn parse_issues_json(json_str: &str) -> Result<Vec<Issue>> {
     let raw: Vec<serde_json::Value> =
         serde_json::from_str(json_str).context("Failed to parse GitHub issues JSON")?;
     let mut issues = Vec::new();
@@ -51,7 +50,7 @@ pub fn parse_issues_json(json_str: &str) -> Result<Vec<GhIssue>> {
             })
             .unwrap_or_default();
 
-        issues.push(GhIssue {
+        issues.push(Issue {
             number: v
                 .get("number")
                 .and_then(|n| n.as_u64())
@@ -86,14 +85,12 @@ pub fn parse_issues_json(json_str: &str) -> Result<Vec<GhIssue>> {
 }
 
 /// Parse JSON output from `gh api repos/{owner}/{repo}/milestones`.
-pub fn parse_milestones_json(json_str: &str) -> Result<Vec<GhMilestone>> {
+pub fn parse_milestones_json(json_str: &str) -> Result<Vec<Milestone>> {
     serde_json::from_str(json_str).context("Failed to parse milestones JSON")
 }
 
 /// Parse JSON output from `gh pr list --json ...`.
-pub fn parse_prs_json(
-    json_str: &str,
-) -> Result<Vec<crate::provider::github::types::GhPullRequest>> {
+pub fn parse_prs_json(json_str: &str) -> Result<Vec<PullRequest>> {
     let raw: Vec<serde_json::Value> =
         serde_json::from_str(json_str).context("Failed to parse GitHub PRs JSON")?;
     let mut prs = Vec::new();
@@ -113,7 +110,7 @@ pub fn parse_prs_json(
             })
             .unwrap_or_default();
 
-        prs.push(crate::provider::github::types::GhPullRequest {
+        prs.push(PullRequest {
             number: v
                 .get("number")
                 .and_then(|n| n.as_u64())

--- a/src/provider/github/types.rs
+++ b/src/provider/github/types.rs
@@ -1,245 +1,11 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
-use std::sync::OnceLock;
 
-static BLOCKED_BY_RE: OnceLock<regex::Regex> = OnceLock::new();
-
-fn blocked_by_regex() -> &'static regex::Regex {
-    BLOCKED_BY_RE.get_or_init(|| regex::Regex::new(r"(?i)blocked-by:\s*#(\d+)").unwrap())
-}
-
-#[derive(
-    Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
-)]
-pub enum Priority {
-    P0 = 0,
-    P1 = 1,
-    #[default]
-    P2 = 2,
-}
-
-impl Priority {
-    pub fn from_label(label: &str) -> Option<Self> {
-        match label {
-            "priority:P0" => Some(Self::P0),
-            "priority:P1" => Some(Self::P1),
-            "priority:P2" => Some(Self::P2),
-            _ => None,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum MaestroLabel {
-    Ready,
-    InProgress,
-    Done,
-    Failed,
-}
-
-impl MaestroLabel {
-    #[allow(dead_code)]
-    pub fn from_str(s: &str) -> Option<Self> {
-        match s {
-            "maestro:ready" => Some(Self::Ready),
-            "maestro:in-progress" => Some(Self::InProgress),
-            "maestro:done" => Some(Self::Done),
-            "maestro:failed" => Some(Self::Failed),
-            _ => None,
-        }
-    }
-
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::Ready => "maestro:ready",
-            Self::InProgress => "maestro:in-progress",
-            Self::Done => "maestro:done",
-            Self::Failed => "maestro:failed",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum SessionMode {
-    Orchestrator,
-    Vibe,
-}
-
-impl SessionMode {
-    pub fn from_label(label: &str) -> Option<Self> {
-        match label {
-            "mode:orchestrator" => Some(Self::Orchestrator),
-            "mode:vibe" => Some(Self::Vibe),
-            _ => None,
-        }
-    }
-
-    pub fn as_config_str(&self) -> &'static str {
-        match self {
-            Self::Orchestrator => "orchestrator",
-            Self::Vibe => "vibe",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GhIssue {
-    pub number: u64,
-    pub title: String,
-    pub body: String,
-    pub labels: Vec<String>,
-    pub state: String,
-    pub html_url: String,
-    #[serde(default)]
-    pub milestone: Option<u64>,
-    #[serde(default)]
-    pub assignees: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GhMilestone {
-    pub number: u64,
-    pub title: String,
-    #[serde(default)]
-    pub description: String,
-    pub state: String,
-    #[serde(default)]
-    pub open_issues: u32,
-    #[serde(default)]
-    pub closed_issues: u32,
-}
-
-impl GhIssue {
-    /// Extract the priority from labels. Defaults to P2.
-    pub fn priority(&self) -> Priority {
-        self.labels
-            .iter()
-            .find_map(|l| Priority::from_label(l))
-            .unwrap_or_default()
-    }
-
-    /// Extract the maestro session mode from labels.
-    pub fn session_mode(&self) -> Option<SessionMode> {
-        self.labels.iter().find_map(|l| SessionMode::from_label(l))
-    }
-
-    /// Extract `blocked-by:#N` dependencies from labels.
-    pub fn blocked_by_from_labels(&self) -> Vec<u64> {
-        self.labels
-            .iter()
-            .filter_map(|l| {
-                l.strip_prefix("blocked-by:#")
-                    .and_then(|n| n.parse::<u64>().ok())
-            })
-            .collect()
-    }
-
-    /// Extract `blocked-by: #N` from issue body text (case-insensitive).
-    pub fn blocked_by_from_body(&self) -> Vec<u64> {
-        blocked_by_regex()
-            .captures_iter(&self.body)
-            .filter_map(|cap| cap[1].parse::<u64>().ok())
-            .collect()
-    }
-
-    /// All blocking issue numbers (union of labels + body, deduplicated).
-    pub fn all_blockers(&self) -> Vec<u64> {
-        let mut blockers = self.blocked_by_from_labels();
-        blockers.extend(self.blocked_by_from_body());
-        blockers.sort_unstable();
-        blockers.dedup();
-        blockers
-    }
-
-    #[allow(dead_code)]
-    pub fn has_maestro_label(&self, label: MaestroLabel) -> bool {
-        self.labels.iter().any(|l| l == label.as_str())
-    }
-
-    /// Build a prompt for an unattended Claude session working on this issue.
-    pub fn unattended_prompt(&self) -> String {
-        format!(
-            "Work on GitHub issue #{}.\n\nTitle: {}\n\nDescription:\n{}\n\n\
-             IMPORTANT: You are running in unattended mode (no human at the terminal). \
-             Do NOT use AskUserQuestion or ask for clarification — make your best judgment \
-             and proceed autonomously. Read relevant source files first, then implement \
-             the required changes.",
-            self.number, self.title, self.body
-        )
-    }
-}
-
-/// A pull request from the GitHub API.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GhPullRequest {
-    pub number: u64,
-    pub title: String,
-    pub body: String,
-    pub state: String,
-    pub html_url: String,
-    pub head_branch: String,
-    pub base_branch: String,
-    pub author: String,
-    #[serde(default)]
-    pub labels: Vec<String>,
-    #[serde(default)]
-    pub draft: bool,
-    #[serde(default)]
-    pub mergeable: bool,
-    #[serde(default)]
-    pub additions: u64,
-    #[serde(default)]
-    pub deletions: u64,
-    #[serde(default)]
-    pub changed_files: u64,
-}
-
-/// The type of review action to submit on a pull request.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum PrReviewEvent {
-    Approve,
-    RequestChanges,
-    #[default]
-    Comment,
-}
-
-impl PrReviewEvent {
-    pub fn as_gh_arg(&self) -> &'static str {
-        match self {
-            Self::Approve => "approve",
-            Self::RequestChanges => "request-changes",
-            Self::Comment => "comment",
-        }
-    }
-
-    #[allow(dead_code)] // Reason: used by PR review screen rendering
-    pub fn label(&self) -> &'static str {
-        match self {
-            Self::Approve => "Approve",
-            Self::RequestChanges => "Request Changes",
-            Self::Comment => "Comment",
-        }
-    }
-
-    pub fn next(&self) -> Self {
-        match self {
-            Self::Comment => Self::Approve,
-            Self::Approve => Self::RequestChanges,
-            Self::RequestChanges => Self::Comment,
-        }
-    }
-
-    pub fn prev(&self) -> Self {
-        match self {
-            Self::Comment => Self::RequestChanges,
-            Self::Approve => Self::Comment,
-            Self::RequestChanges => Self::Approve,
-        }
-    }
-}
+#[cfg(test)]
+use crate::provider::types::{
+    Issue, MaestroLabel, Priority, PullRequest, ReviewEvent, SessionMode,
+};
 
 /// Most recent error messages a PendingPr will retain for correlation.
 ///
@@ -419,8 +185,8 @@ pub(crate) fn awaiting_pending_pr(issue_number: u64) -> PendingPr {
 mod tests {
     use super::*;
 
-    fn make_issue(number: u64, labels: &[&str], body: &str) -> GhIssue {
-        GhIssue {
+    fn make_issue(number: u64, labels: &[&str], body: &str) -> Issue {
+        Issue {
             number,
             title: format!("Issue #{}", number),
             body: body.to_string(),
@@ -725,7 +491,7 @@ mod tests {
         assert_eq!(SessionMode::from_label("bug"), None);
     }
 
-    // GhIssue::priority
+    // Issue::priority
 
     #[test]
     fn issue_priority_p0_from_labels() {
@@ -751,7 +517,7 @@ mod tests {
         assert_eq!(issue.priority(), Priority::P2);
     }
 
-    // GhIssue::session_mode
+    // Issue::session_mode
 
     #[test]
     fn issue_session_mode_orchestrator() {
@@ -771,7 +537,7 @@ mod tests {
         assert_eq!(issue.session_mode(), None);
     }
 
-    // GhIssue::blocked_by_from_labels
+    // Issue::blocked_by_from_labels
 
     #[test]
     fn blocked_by_from_labels_single() {
@@ -799,7 +565,7 @@ mod tests {
         assert!(issue.blocked_by_from_labels().is_empty());
     }
 
-    // GhIssue::blocked_by_from_body
+    // Issue::blocked_by_from_body
 
     #[test]
     fn blocked_by_from_body_single_reference() {
@@ -833,7 +599,7 @@ mod tests {
         assert_eq!(issue.blocked_by_from_body(), vec![99u64]);
     }
 
-    // GhIssue::all_blockers
+    // Issue::all_blockers
 
     #[test]
     fn all_blockers_union_of_labels_and_body() {
@@ -856,7 +622,7 @@ mod tests {
         assert_eq!(result[0], 7u64);
     }
 
-    // GhIssue::has_maestro_label
+    // Issue::has_maestro_label
 
     #[test]
     fn has_maestro_label_returns_true_when_present() {
@@ -876,62 +642,62 @@ mod tests {
         assert!(!issue.has_maestro_label(MaestroLabel::Done));
     }
 
-    // --- PrReviewEvent ---
+    // --- ReviewEvent ---
 
     #[test]
     fn pr_review_event_default_is_comment() {
-        assert_eq!(PrReviewEvent::default(), PrReviewEvent::Comment);
+        assert_eq!(ReviewEvent::default(), ReviewEvent::Comment);
     }
 
     #[test]
     fn pr_review_event_approve_as_gh_arg() {
-        assert_eq!(PrReviewEvent::Approve.as_gh_arg(), "approve");
+        assert_eq!(ReviewEvent::Approve.as_gh_arg(), "approve");
     }
 
     #[test]
     fn pr_review_event_request_changes_as_gh_arg() {
-        assert_eq!(PrReviewEvent::RequestChanges.as_gh_arg(), "request-changes");
+        assert_eq!(ReviewEvent::RequestChanges.as_gh_arg(), "request-changes");
     }
 
     #[test]
     fn pr_review_event_comment_as_gh_arg() {
-        assert_eq!(PrReviewEvent::Comment.as_gh_arg(), "comment");
+        assert_eq!(ReviewEvent::Comment.as_gh_arg(), "comment");
     }
 
     #[test]
     fn pr_review_event_label_approve() {
-        assert_eq!(PrReviewEvent::Approve.label(), "Approve");
+        assert_eq!(ReviewEvent::Approve.label(), "Approve");
     }
 
     #[test]
     fn pr_review_event_label_request_changes() {
-        assert_eq!(PrReviewEvent::RequestChanges.label(), "Request Changes");
+        assert_eq!(ReviewEvent::RequestChanges.label(), "Request Changes");
     }
 
     #[test]
     fn pr_review_event_label_comment() {
-        assert_eq!(PrReviewEvent::Comment.label(), "Comment");
+        assert_eq!(ReviewEvent::Comment.label(), "Comment");
     }
 
     #[test]
     fn pr_review_event_next_cycles_forward() {
-        assert_eq!(PrReviewEvent::Comment.next(), PrReviewEvent::Approve);
-        assert_eq!(PrReviewEvent::Approve.next(), PrReviewEvent::RequestChanges);
-        assert_eq!(PrReviewEvent::RequestChanges.next(), PrReviewEvent::Comment);
+        assert_eq!(ReviewEvent::Comment.next(), ReviewEvent::Approve);
+        assert_eq!(ReviewEvent::Approve.next(), ReviewEvent::RequestChanges);
+        assert_eq!(ReviewEvent::RequestChanges.next(), ReviewEvent::Comment);
     }
 
     #[test]
     fn pr_review_event_prev_cycles_backward() {
-        assert_eq!(PrReviewEvent::Comment.prev(), PrReviewEvent::RequestChanges);
-        assert_eq!(PrReviewEvent::Approve.prev(), PrReviewEvent::Comment);
-        assert_eq!(PrReviewEvent::RequestChanges.prev(), PrReviewEvent::Approve);
+        assert_eq!(ReviewEvent::Comment.prev(), ReviewEvent::RequestChanges);
+        assert_eq!(ReviewEvent::Approve.prev(), ReviewEvent::Comment);
+        assert_eq!(ReviewEvent::RequestChanges.prev(), ReviewEvent::Approve);
     }
 
-    // --- GhPullRequest ---
+    // --- PullRequest ---
 
     #[test]
     fn gh_pull_request_round_trips_via_serde() {
-        let pr = GhPullRequest {
+        let pr = PullRequest {
             number: 42,
             title: "Fix bug".to_string(),
             body: "## Summary\nFixes issue".to_string(),
@@ -948,7 +714,7 @@ mod tests {
             changed_files: 3,
         };
         let json = serde_json::to_string(&pr).unwrap();
-        let rt: GhPullRequest = serde_json::from_str(&json).unwrap();
+        let rt: PullRequest = serde_json::from_str(&json).unwrap();
         assert_eq!(rt.number, 42);
         assert_eq!(rt.title, "Fix bug");
         assert_eq!(rt.head_branch, "fix/bug");

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -3,7 +3,7 @@ pub mod azure_devops;
 pub mod github;
 pub mod types;
 
-use self::github::client::GitHubClient;
+use self::github::client::RepoProvider;
 use crate::config::ProviderConfig;
 use anyhow::Result;
 use types::ProviderKind;
@@ -13,7 +13,7 @@ use self::github::client::GhCliClient;
 
 /// Create the appropriate provider client from config.
 #[allow(dead_code)] // to be wired when provider selection is exposed via CLI/config
-pub fn create_provider(config: &ProviderConfig) -> Result<Box<dyn GitHubClient>> {
+pub fn create_provider(config: &ProviderConfig) -> Result<Box<dyn RepoProvider>> {
     match config.kind {
         ProviderKind::Github => Ok(Box::new(GhCliClient::new())),
         ProviderKind::AzureDevops => {
@@ -104,6 +104,11 @@ mod tests {
     fn create_provider_github() {
         let cfg = ProviderConfig::default();
         let _client = create_provider(&cfg).unwrap();
+    }
+
+    #[test]
+    fn gh_cli_client_is_repo_provider_trait_object() {
+        let _: Box<dyn RepoProvider> = Box::new(GhCliClient::new());
     }
 
     #[test]

--- a/src/provider/types.rs
+++ b/src/provider/types.rs
@@ -1,4 +1,11 @@
 use serde::{Deserialize, Serialize};
+use std::sync::OnceLock;
+
+static BLOCKED_BY_RE: OnceLock<regex::Regex> = OnceLock::new();
+
+fn blocked_by_regex() -> &'static regex::Regex {
+    BLOCKED_BY_RE.get_or_init(|| regex::Regex::new(r"(?i)blocked-by:\s*#(\d+)").unwrap())
+}
 
 /// Which code hosting provider is configured.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -10,15 +17,237 @@ pub enum ProviderKind {
     AzureDevops,
 }
 
-// Re-export all types from github::types under provider-agnostic names.
-// Re-export GitHub types under provider-agnostic names.
-// These are used by consumers that import from provider::types.
-#[allow(unused_imports)]
-pub use crate::provider::github::types::GhIssue as Issue;
-#[allow(unused_imports)]
-pub use crate::provider::github::types::GhMilestone as Milestone;
-#[allow(unused_imports)]
-pub use crate::provider::github::types::{MaestroLabel, Priority, SessionMode};
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+pub enum Priority {
+    P0 = 0,
+    P1 = 1,
+    #[default]
+    P2 = 2,
+}
+
+impl Priority {
+    pub fn from_label(label: &str) -> Option<Self> {
+        match label {
+            "priority:P0" => Some(Self::P0),
+            "priority:P1" => Some(Self::P1),
+            "priority:P2" => Some(Self::P2),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MaestroLabel {
+    Ready,
+    InProgress,
+    Done,
+    Failed,
+}
+
+impl MaestroLabel {
+    #[allow(dead_code)]
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "maestro:ready" => Some(Self::Ready),
+            "maestro:in-progress" => Some(Self::InProgress),
+            "maestro:done" => Some(Self::Done),
+            "maestro:failed" => Some(Self::Failed),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Ready => "maestro:ready",
+            Self::InProgress => "maestro:in-progress",
+            Self::Done => "maestro:done",
+            Self::Failed => "maestro:failed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionMode {
+    Orchestrator,
+    Vibe,
+}
+
+impl SessionMode {
+    pub fn from_label(label: &str) -> Option<Self> {
+        match label {
+            "mode:orchestrator" => Some(Self::Orchestrator),
+            "mode:vibe" => Some(Self::Vibe),
+            _ => None,
+        }
+    }
+
+    pub fn as_config_str(&self) -> &'static str {
+        match self {
+            Self::Orchestrator => "orchestrator",
+            Self::Vibe => "vibe",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Issue {
+    pub number: u64,
+    pub title: String,
+    pub body: String,
+    pub labels: Vec<String>,
+    pub state: String,
+    pub html_url: String,
+    #[serde(default)]
+    pub milestone: Option<u64>,
+    #[serde(default)]
+    pub assignees: Vec<String>,
+}
+
+impl Issue {
+    /// Extract the priority from labels. Defaults to P2.
+    pub fn priority(&self) -> Priority {
+        self.labels
+            .iter()
+            .find_map(|l| Priority::from_label(l))
+            .unwrap_or_default()
+    }
+
+    /// Extract the maestro session mode from labels.
+    pub fn session_mode(&self) -> Option<SessionMode> {
+        self.labels.iter().find_map(|l| SessionMode::from_label(l))
+    }
+
+    /// Extract `blocked-by:#N` dependencies from labels.
+    pub fn blocked_by_from_labels(&self) -> Vec<u64> {
+        self.labels
+            .iter()
+            .filter_map(|l| {
+                l.strip_prefix("blocked-by:#")
+                    .and_then(|n| n.parse::<u64>().ok())
+            })
+            .collect()
+    }
+
+    /// Extract `blocked-by: #N` from issue body text (case-insensitive).
+    pub fn blocked_by_from_body(&self) -> Vec<u64> {
+        blocked_by_regex()
+            .captures_iter(&self.body)
+            .filter_map(|cap| cap[1].parse::<u64>().ok())
+            .collect()
+    }
+
+    /// All blocking issue numbers (union of labels + body, deduplicated).
+    pub fn all_blockers(&self) -> Vec<u64> {
+        let mut blockers = self.blocked_by_from_labels();
+        blockers.extend(self.blocked_by_from_body());
+        blockers.sort_unstable();
+        blockers.dedup();
+        blockers
+    }
+
+    #[allow(dead_code)]
+    pub fn has_maestro_label(&self, label: MaestroLabel) -> bool {
+        self.labels.iter().any(|l| l == label.as_str())
+    }
+
+    /// Build a prompt for an unattended Claude session working on this issue.
+    pub fn unattended_prompt(&self) -> String {
+        format!(
+            "Work on GitHub issue #{}.\n\nTitle: {}\n\nDescription:\n{}\n\n\
+             IMPORTANT: You are running in unattended mode (no human at the terminal). \
+             Do NOT use AskUserQuestion or ask for clarification — make your best judgment \
+             and proceed autonomously. Read relevant source files first, then implement \
+             the required changes.",
+            self.number, self.title, self.body
+        )
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Milestone {
+    pub number: u64,
+    pub title: String,
+    #[serde(default)]
+    pub description: String,
+    pub state: String,
+    #[serde(default)]
+    pub open_issues: u32,
+    #[serde(default)]
+    pub closed_issues: u32,
+}
+
+/// A pull request from a repository provider.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PullRequest {
+    pub number: u64,
+    pub title: String,
+    pub body: String,
+    pub state: String,
+    pub html_url: String,
+    pub head_branch: String,
+    pub base_branch: String,
+    pub author: String,
+    #[serde(default)]
+    pub labels: Vec<String>,
+    #[serde(default)]
+    pub draft: bool,
+    #[serde(default)]
+    pub mergeable: bool,
+    #[serde(default)]
+    pub additions: u64,
+    #[serde(default)]
+    pub deletions: u64,
+    #[serde(default)]
+    pub changed_files: u64,
+}
+
+/// The type of review action to submit on a pull request.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ReviewEvent {
+    Approve,
+    RequestChanges,
+    #[default]
+    Comment,
+}
+
+impl ReviewEvent {
+    pub fn as_gh_arg(&self) -> &'static str {
+        match self {
+            Self::Approve => "approve",
+            Self::RequestChanges => "request-changes",
+            Self::Comment => "comment",
+        }
+    }
+
+    #[allow(dead_code)] // Reason: used by PR review screen rendering
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Approve => "Approve",
+            Self::RequestChanges => "Request Changes",
+            Self::Comment => "Comment",
+        }
+    }
+
+    pub fn next(&self) -> Self {
+        match self {
+            Self::Comment => Self::Approve,
+            Self::Approve => Self::RequestChanges,
+            Self::RequestChanges => Self::Comment,
+        }
+    }
+
+    pub fn prev(&self) -> Self {
+        match self {
+            Self::Comment => Self::RequestChanges,
+            Self::Approve => Self::Comment,
+            Self::RequestChanges => Self::Approve,
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/state/types.rs
+++ b/src/state/types.rs
@@ -1,4 +1,5 @@
-use crate::provider::github::types::{GhIssue, PendingPr};
+use crate::provider::github::types::PendingPr;
+use crate::provider::types::Issue;
 use crate::session::types::Session;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -35,7 +36,7 @@ pub struct MaestroState {
     pub last_updated: Option<DateTime<Utc>>,
     /// Cached GitHub issue data to avoid repeated API calls.
     #[serde(default)]
-    pub issue_cache: HashMap<u64, GhIssue>,
+    pub issue_cache: HashMap<u64, Issue>,
     /// Fork lineage: maps child session ID to parent session ID.
     #[serde(default)]
     pub fork_lineage: HashMap<uuid::Uuid, uuid::Uuid>,

--- a/src/tui/app/auto_pr.rs
+++ b/src/tui/app/auto_pr.rs
@@ -162,7 +162,7 @@ impl App {
         }
 
         let cached_issue = self.state.issue_cache.get(&issue_number).cloned();
-        let primary_issue: Option<crate::provider::github::types::GhIssue> = match cached_issue {
+        let primary_issue: Option<crate::provider::types::Issue> = match cached_issue {
             Some(cached) => Some(cached),
             None => match self
                 .github_client
@@ -204,7 +204,7 @@ impl App {
         let pr_creator = PrCreator::new(client.as_ref(), base_branch.clone());
 
         let pr_result = if is_unified {
-            let unified_issues: Vec<&crate::provider::github::types::GhIssue> = issue_numbers
+            let unified_issues: Vec<&crate::provider::types::Issue> = issue_numbers
                 .iter()
                 .filter_map(|n| self.state.issue_cache.get(n))
                 .collect();

--- a/src/tui/app/auto_pr_tests.rs
+++ b/src/tui/app/auto_pr_tests.rs
@@ -7,13 +7,13 @@
 
 use super::App;
 use crate::provider::github::client::mock::MockGitHubClient;
-use crate::provider::github::types::{GhIssue, GhPullRequest};
+use crate::provider::types::{Issue, PullRequest};
 use crate::session::worktree::MockWorktreeManager;
 use crate::state::store::StateStore;
 use crate::tui::activity_log::LogLevel;
 
-fn make_issue(number: u64) -> GhIssue {
-    GhIssue {
+fn make_issue(number: u64) -> Issue {
+    Issue {
         number,
         title: format!("Test issue #{}", number),
         body: String::new(),
@@ -60,8 +60,8 @@ fn make_app_with_mock(mock: MockGitHubClient) -> App {
     app
 }
 
-fn make_pr(number: u64, head_branch: &str) -> GhPullRequest {
-    GhPullRequest {
+fn make_pr(number: u64, head_branch: &str) -> PullRequest {
+    PullRequest {
         number,
         title: format!("Existing PR #{}", number),
         body: String::new(),

--- a/src/tui/app/data_handler.rs
+++ b/src/tui/app/data_handler.rs
@@ -63,7 +63,7 @@ impl App {
     /// Build a prompt from issue + optional custom instructions.
     fn build_issue_prompt_with_custom(
         &self,
-        gh_issue: &crate::provider::github::types::GhIssue,
+        gh_issue: &crate::provider::types::Issue,
         custom_prompt: &Option<String>,
     ) -> String {
         let base = self
@@ -580,10 +580,10 @@ impl App {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::provider::github::types::GhIssue;
+    use crate::provider::types::Issue;
 
-    fn issue_with_labels(labels: &[&str]) -> GhIssue {
-        GhIssue {
+    fn issue_with_labels(labels: &[&str]) -> Issue {
+        Issue {
             number: 402,
             title: "Wire mode resolver".to_string(),
             body: String::new(),

--- a/src/tui/app/issue_completion_tests.rs
+++ b/src/tui/app/issue_completion_tests.rs
@@ -5,13 +5,13 @@
 
 use super::App;
 use crate::provider::github::client::mock::MockGitHubClient;
-use crate::provider::github::types::GhIssue;
+use crate::provider::types::Issue;
 use crate::session::worktree::MockWorktreeManager;
 use crate::state::store::StateStore;
 use crate::tui::activity_log::LogLevel;
 
-fn make_issue(number: u64) -> GhIssue {
-    GhIssue {
+fn make_issue(number: u64) -> Issue {
+    Issue {
         number,
         title: format!("Test issue #{}", number),
         body: String::new(),

--- a/src/tui/app/mod.rs
+++ b/src/tui/app/mod.rs
@@ -33,7 +33,7 @@ use crate::models::ModelRouter;
 use crate::notifications::desktop::{DesktopNotifier, OsascriptNotifier};
 use crate::notifications::dispatcher::NotificationDispatcher;
 use crate::plugins::runner::PluginRunner;
-use crate::provider::github::client::GitHubClient;
+use crate::provider::github::client::RepoProvider;
 use crate::session::context_monitor::{ContextMonitor, ProductionContextMonitor};
 use crate::session::fork::ForkPolicy;
 use crate::session::health::{HealthCheck, HealthMonitor};
@@ -72,7 +72,7 @@ pub struct App {
     pub start_time: chrono::DateTime<chrono::Utc>,
     pub event_rx: mpsc::UnboundedReceiver<SessionEvent>,
     pub work_assignment_service: Option<WorkAssignmentService>,
-    pub github_client: Option<Box<dyn GitHubClient>>,
+    pub github_client: Option<Box<dyn RepoProvider>>,
     pub config: Option<Config>,
     pub config_path: Option<std::path::PathBuf>,
     pub(crate) pending_issue_completions: Vec<PendingIssueCompletion>,

--- a/src/tui/app/types.rs
+++ b/src/tui/app/types.rs
@@ -4,7 +4,7 @@ use crate::adapt::types::{
 };
 use crate::config::SessionsConfig;
 use crate::plugins::hooks::{HookContext, HookPoint};
-use crate::provider::github::types::{GhIssue, GhMilestone};
+use crate::provider::types::{Issue, Milestone};
 use crate::session::types::SessionStatus;
 use crate::tui::screens::{
     PromptSessionConfig, SessionConfig as ScreenSessionConfig, UnifiedSessionConfig,
@@ -300,7 +300,7 @@ pub enum TuiCommand {
     FetchOpenPrs,
     SubmitPrReview {
         pr_number: u64,
-        event: crate::provider::github::types::PrReviewEvent,
+        event: crate::provider::types::ReviewEvent,
         body: String,
     },
     /// Sync the live PRD's `current_state` from GitHub (#321).
@@ -314,10 +314,10 @@ pub enum TuiCommand {
         repo: String,
     },
     /// Fetch open issues for a selected milestone (#500). The full
-    /// `GhMilestone` is passed through so the background task does not need
+    /// `Milestone` is passed through so the background task does not need
     /// to re-fetch the milestone list to find it by number.
     FetchMilestoneHealthIssues {
-        milestone: GhMilestone,
+        milestone: Milestone,
     },
     /// Patch a milestone description via gh api PATCH (#500). The wizard
     /// dispatches this only after explicit user confirmation.
@@ -329,7 +329,7 @@ pub enum TuiCommand {
 
 /// Data events delivered from background fetch tasks.
 pub enum TuiDataEvent {
-    Issues(anyhow::Result<Vec<GhIssue>>),
+    Issues(anyhow::Result<Vec<Issue>>),
     /// Result of creating a GitHub issue via the Issue Wizard (#291+#298).
     /// Only emitted for `CreateOutcome::Created` — `Existed` surfaces as
     /// `IssueAlreadyExists` so the wizard can show a blocking modal (#455).
@@ -347,7 +347,7 @@ pub enum TuiDataEvent {
     /// human-readable failure reason rendered on the `Failed` step.
     AiPlanningResult(Result<crate::tui::screens::milestone_wizard::AiGeneratedPlan, String>),
     /// Open issues fetched for the Issue Wizard's Dependencies step (#295).
-    WizardDependencyIssues(anyhow::Result<Vec<GhIssue>>),
+    WizardDependencyIssues(anyhow::Result<Vec<Issue>>),
     /// AI review companion result (#296). Carries the raw response text
     /// or a human-readable failure reason.
     AiReviewResult(Result<String, String>),
@@ -359,8 +359,8 @@ pub enum TuiDataEvent {
     MilestonePlanCreated(
         Result<crate::tui::screens::milestone_wizard::MilestoneCreationResult, String>,
     ),
-    Milestones(anyhow::Result<Vec<(GhMilestone, Vec<GhIssue>)>>),
-    Issue(anyhow::Result<GhIssue>, Option<String>),
+    Milestones(anyhow::Result<Vec<(Milestone, Vec<Issue>)>>),
+    Issue(anyhow::Result<Issue>, Option<String>),
     SuggestionData(SuggestionDataPayload),
     VersionCheckResult(Option<crate::updater::ReleaseInfo>),
     UpgradeResult(Result<String, String>),
@@ -370,8 +370,8 @@ pub enum TuiDataEvent {
     AdaptPlanResult(anyhow::Result<AdaptPlan>),
     AdaptScaffoldResult(anyhow::Result<ScaffoldResult>),
     AdaptMaterializeResult(anyhow::Result<MaterializeResult>),
-    UnifiedIssues(anyhow::Result<Vec<GhIssue>>, Option<String>),
-    PullRequests(anyhow::Result<Vec<crate::provider::github::types::GhPullRequest>>),
+    UnifiedIssues(anyhow::Result<Vec<Issue>>, Option<String>),
+    PullRequests(anyhow::Result<Vec<crate::provider::types::PullRequest>>),
     PrReviewSubmitted(anyhow::Result<()>),
     /// Result of `SyncPrd` (#321) — fold into the live PRD's current_state.
     PrdSyncResult(anyhow::Result<crate::prd::sync::PrdSyncResult>),
@@ -383,7 +383,7 @@ pub enum TuiDataEvent {
         result: anyhow::Result<crate::review::types::ReviewReport>,
     },
     /// Result of `FetchMilestoneHealthIssues` (#500).
-    MilestoneHealthIssuesFetched(anyhow::Result<(GhMilestone, Vec<GhIssue>)>),
+    MilestoneHealthIssuesFetched(anyhow::Result<(Milestone, Vec<Issue>)>),
     /// Result of `PatchMilestoneDescription` (#500).
     MilestoneHealthPatched(anyhow::Result<()>),
 }

--- a/src/tui/app/work_assigner_tests.rs
+++ b/src/tui/app/work_assigner_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::config::Config;
 use crate::models::ModelRouter;
-use crate::provider::github::types::GhIssue;
+use crate::provider::types::Issue;
 use crate::work::assigner::WorkAssigner;
 use crate::work::types::{WorkItem, WorkStatus};
 use std::collections::HashMap;
@@ -46,7 +46,7 @@ fn make_config_with_heavy(labels: &[&str], limit: usize) -> Config {
 }
 
 fn make_work_item(number: u64, labels: &[&str]) -> WorkItem {
-    WorkItem::from_issue(GhIssue {
+    WorkItem::from_issue(Issue {
         number,
         title: format!("Issue #{}", number),
         body: String::new(),

--- a/src/tui/background_tasks.rs
+++ b/src/tui/background_tasks.rs
@@ -1,6 +1,6 @@
 use super::app;
 use super::screens;
-use crate::provider::github::client::{GhCliClient, GitHubClient};
+use crate::provider::github::client::{GhCliClient, RepoProvider};
 
 pub(super) fn spawn_issue_fetch(
     tx: tokio::sync::mpsc::UnboundedSender<app::TuiDataEvent>,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -34,7 +34,7 @@ pub mod widgets;
 #[cfg(test)]
 mod snapshot_tests;
 
-use crate::provider::github::client::{GhCliClient, GitHubClient};
+use crate::provider::github::client::{GhCliClient, RepoProvider};
 use crate::tui::activity_log::LogLevel;
 use app::App;
 use background_tasks::{spawn_issue_fetch, spawn_version_check};
@@ -791,15 +791,15 @@ mod handle_screen_action_tests {
         assert!(app.pending_commands.is_empty());
     }
 
-    use crate::provider::github::types::GhIssue;
+    use crate::provider::types::Issue;
     use crate::tui::screens::milestone::MilestoneEntry;
 
-    fn make_issue(number: u64, milestone: Option<u64>) -> GhIssue {
+    fn make_issue(number: u64, milestone: Option<u64>) -> Issue {
         make_issue_with_state(number, milestone, "open")
     }
 
-    fn make_issue_with_state(number: u64, milestone: Option<u64>, state: &str) -> GhIssue {
-        GhIssue {
+    fn make_issue_with_state(number: u64, milestone: Option<u64>, state: &str) -> Issue {
+        Issue {
             number,
             title: format!("Issue #{number}"),
             body: String::new(),

--- a/src/tui/screen_dispatch.rs
+++ b/src/tui/screen_dispatch.rs
@@ -1,6 +1,6 @@
 use super::app;
 use super::screens::{self, Screen, ScreenAction};
-use crate::provider::github::types::GhIssue;
+use crate::provider::types::Issue;
 use crate::session::transition::TransitionReason;
 use crossterm::event::Event;
 
@@ -207,13 +207,13 @@ pub(super) fn dispatch_paste_to_active_screen(app: &mut app::App, text: &str) {
 }
 
 /// Returns milestone issues only when navigating from `MilestoneView`.
-fn milestone_issues_if_applicable(app: &app::App) -> Option<Vec<GhIssue>> {
+fn milestone_issues_if_applicable(app: &app::App) -> Option<Vec<Issue>> {
     if app.tui_mode != app::TuiMode::MilestoneView {
         return None;
     }
     app.screen_state.milestone_screen.as_ref().and_then(|ms| {
         ms.selected_milestone().and_then(|entry| {
-            let open_issues: Vec<GhIssue> = entry
+            let open_issues: Vec<Issue> = entry
                 .issues
                 .iter()
                 .filter(|i| i.state == "open")
@@ -800,7 +800,7 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
                 .iter()
                 .filter_map(|c| {
                     c.issue_number.map(|n| {
-                        WorkItem::from_issue(crate::provider::github::types::GhIssue {
+                        WorkItem::from_issue(crate::provider::types::Issue {
                             number: n,
                             title: c.title.clone(),
                             body: String::new(),

--- a/src/tui/screens/issue_browser/mod.rs
+++ b/src/tui/screens/issue_browser/mod.rs
@@ -1,6 +1,6 @@
 mod draw;
 use super::{Screen, ScreenAction, SessionConfig, sanitize_for_terminal};
-use crate::provider::github::types::GhIssue;
+use crate::provider::types::Issue;
 use crate::tui::marquee::MarqueeState;
 use crate::tui::navigation::InputMode;
 use crate::tui::navigation::keymap::{KeyBinding, KeyBindingGroup, KeymapProvider};
@@ -93,7 +93,7 @@ pub enum FilterMode {
 }
 
 pub struct IssueBrowserScreen {
-    pub(crate) issues: Vec<GhIssue>,
+    pub(crate) issues: Vec<Issue>,
     pub(crate) filtered_indices: Vec<usize>,
     pub(crate) selected: usize,
     scroll_offset: usize,
@@ -117,7 +117,7 @@ pub struct IssueBrowserScreen {
 }
 
 impl IssueBrowserScreen {
-    pub fn new(issues: Vec<GhIssue>) -> Self {
+    pub fn new(issues: Vec<Issue>) -> Self {
         let filtered_indices: Vec<usize> = (0..issues.len()).collect();
         Self {
             issues,
@@ -143,7 +143,7 @@ impl IssueBrowserScreen {
         self
     }
 
-    pub fn set_issues(&mut self, issues: Vec<GhIssue>) {
+    pub fn set_issues(&mut self, issues: Vec<Issue>) {
         self.issues = issues;
         self.selected = 0;
         self.scroll_offset = 0;
@@ -344,8 +344,8 @@ mod tests {
     use crate::tui::screens::test_helpers::{key_event, key_event_with_modifiers};
     use crossterm::event::{KeyCode, KeyModifiers};
 
-    fn make_issue(number: u64, title: &str) -> GhIssue {
-        GhIssue {
+    fn make_issue(number: u64, title: &str) -> Issue {
+        Issue {
             number,
             title: title.to_string(),
             body: String::new(),
@@ -357,8 +357,8 @@ mod tests {
         }
     }
 
-    fn make_issue_with_milestone(number: u64, milestone_number: u64) -> GhIssue {
-        GhIssue {
+    fn make_issue_with_milestone(number: u64, milestone_number: u64) -> Issue {
+        Issue {
             number,
             title: format!("Issue #{}", number),
             body: String::new(),
@@ -370,7 +370,7 @@ mod tests {
         }
     }
 
-    fn make_three_issues() -> Vec<GhIssue> {
+    fn make_three_issues() -> Vec<Issue> {
         vec![
             make_issue(1, "Add login"),
             make_issue(2, "Fix crash"),
@@ -699,7 +699,7 @@ mod tests {
     fn milestone_filter_mode_typed_number_matches_by_milestone_not_title() {
         // All issues share the same title so a title-match bug would return all 3.
         let issues = vec![
-            GhIssue {
+            Issue {
                 number: 1,
                 title: "Same title".to_string(),
                 body: String::new(),
@@ -709,7 +709,7 @@ mod tests {
                 milestone: Some(42),
                 assignees: vec![],
             },
-            GhIssue {
+            Issue {
                 number: 2,
                 title: "Same title".to_string(),
                 body: String::new(),
@@ -719,7 +719,7 @@ mod tests {
                 milestone: Some(42),
                 assignees: vec![],
             },
-            GhIssue {
+            Issue {
                 number: 3,
                 title: "Same title".to_string(),
                 body: String::new(),

--- a/src/tui/screens/issue_wizard/mod.rs
+++ b/src/tui/screens/issue_wizard/mod.rs
@@ -92,7 +92,7 @@ pub struct IssueWizardScreen {
     /// owns its 4 or 6 textareas, and non-text steps hold `empty()`.
     pub(super) fields: WizardFields,
     /// #295 Dependencies step state.
-    pub(super) dep_issues: Option<Vec<crate::provider::github::types::GhIssue>>,
+    pub(super) dep_issues: Option<Vec<crate::provider::types::Issue>>,
     pub(super) dep_loading: bool,
     pub(super) dep_selected: usize,
     pub(super) dep_checked: std::collections::BTreeSet<u64>,
@@ -563,7 +563,7 @@ impl IssueWizardScreen {
     }
 
     /// #295: apply the result of a `FetchIssues` background task.
-    pub fn apply_dep_issues(&mut self, issues: Vec<crate::provider::github::types::GhIssue>) {
+    pub fn apply_dep_issues(&mut self, issues: Vec<crate::provider::types::Issue>) {
         // Filter to open issues only — closed issues can't block anything.
         let open: Vec<_> = issues.into_iter().filter(|i| i.state == "open").collect();
         self.dep_selected = self.dep_selected.min(open.len().saturating_sub(1));
@@ -571,7 +571,7 @@ impl IssueWizardScreen {
         self.dep_loading = false;
     }
 
-    pub fn dep_issues(&self) -> Option<&[crate::provider::github::types::GhIssue]> {
+    pub fn dep_issues(&self) -> Option<&[crate::provider::types::Issue]> {
         self.dep_issues.as_deref()
     }
 
@@ -1509,8 +1509,8 @@ mod tests {
 
     // ---- #295 Dependencies step ----
 
-    fn make_open_issue(number: u64) -> crate::provider::github::types::GhIssue {
-        crate::provider::github::types::GhIssue {
+    fn make_open_issue(number: u64) -> crate::provider::types::Issue {
+        crate::provider::types::Issue {
             number,
             title: format!("Issue #{}", number),
             body: String::new(),

--- a/src/tui/screens/milestone.rs
+++ b/src/tui/screens/milestone.rs
@@ -1,5 +1,5 @@
 use super::{Screen, ScreenAction, SessionConfig, draw_keybinds_bar, sanitize_for_terminal};
-use crate::provider::github::types::{GhIssue, GhMilestone};
+use crate::provider::types::{Issue, Milestone};
 use crate::tui::app::TuiMode;
 use crate::tui::icons::{self, IconId};
 use crate::tui::navigation::InputMode;
@@ -24,11 +24,11 @@ pub struct MilestoneEntry {
     pub state: String,
     pub open_issues: u32,
     pub closed_issues: u32,
-    pub issues: Vec<GhIssue>,
+    pub issues: Vec<Issue>,
 }
 
-impl From<(GhMilestone, Vec<GhIssue>)> for MilestoneEntry {
-    fn from((ms, issues): (GhMilestone, Vec<GhIssue>)) -> Self {
+impl From<(Milestone, Vec<Issue>)> for MilestoneEntry {
+    fn from((ms, issues): (Milestone, Vec<Issue>)) -> Self {
         Self {
             number: ms.number,
             title: ms.title,
@@ -114,11 +114,11 @@ impl MilestoneScreen {
     /// `#NNN` references inside their `## Blocked By` section. Issues with
     /// no parsed dependencies sort first (Level 0). Ties break on issue
     /// number ascending.
-    pub fn sorted_issues(&self) -> Vec<&GhIssue> {
+    pub fn sorted_issues(&self) -> Vec<&Issue> {
         let Some(entry) = self.milestones.get(self.selected) else {
             return Vec::new();
         };
-        let mut with_levels: Vec<(usize, &GhIssue)> = entry
+        let mut with_levels: Vec<(usize, &Issue)> = entry
             .issues
             .iter()
             .map(|i| (count_blocked_by(&i.body), i))
@@ -464,8 +464,8 @@ impl MilestoneScreen {
 /// milestone. Picks the open issues at the deepest existing dependency
 /// level — typically a leaf of the current chain — so a new "next step"
 /// issue is wired up correctly without manual graph editing.
-pub fn suggest_blocked_by_for_new_issue(issues: &[GhIssue]) -> Vec<u64> {
-    let open: Vec<&GhIssue> = issues.iter().filter(|i| i.state == "open").collect();
+pub fn suggest_blocked_by_for_new_issue(issues: &[Issue]) -> Vec<u64> {
+    let open: Vec<&Issue> = issues.iter().filter(|i| i.state == "open").collect();
     if open.is_empty() {
         return Vec::new();
     }
@@ -751,8 +751,8 @@ mod tests {
     use crate::tui::screens::test_helpers::key_event;
     use crossterm::event::KeyCode;
 
-    fn make_issue(number: u64) -> GhIssue {
-        GhIssue {
+    fn make_issue(number: u64) -> Issue {
+        Issue {
             number,
             title: format!("Issue #{}", number),
             body: String::new(),
@@ -776,7 +776,7 @@ mod tests {
         }
     }
 
-    fn make_entry_with_issues(number: u64, issues: Vec<GhIssue>) -> MilestoneEntry {
+    fn make_entry_with_issues(number: u64, issues: Vec<Issue>) -> MilestoneEntry {
         let open = issues.len() as u32;
         MilestoneEntry {
             number,
@@ -791,7 +791,7 @@ mod tests {
 
     // ---- #325 compact view: tab switching and dependency sorting ----
 
-    fn make_issue_with_body(number: u64, body: &str) -> GhIssue {
+    fn make_issue_with_body(number: u64, body: &str) -> Issue {
         let mut i = make_issue(number);
         i.body = body.to_string();
         i

--- a/src/tui/screens/milestone_health/draw.rs
+++ b/src/tui/screens/milestone_health/draw.rs
@@ -94,7 +94,7 @@ fn draw_picker(
     f: &mut Frame,
     area: Rect,
     theme: &Theme,
-    milestones: &[crate::provider::github::types::GhMilestone],
+    milestones: &[crate::provider::types::Milestone],
     selected: usize,
 ) {
     let items: Vec<ListItem> = milestones
@@ -163,7 +163,7 @@ fn draw_report(
     f: &mut Frame,
     area: Rect,
     theme: &Theme,
-    milestone: &crate::provider::github::types::GhMilestone,
+    milestone: &crate::provider::types::Milestone,
     screen: &MilestoneHealthScreen,
 ) {
     let mut lines: Vec<Line> = Vec::new();
@@ -220,7 +220,7 @@ fn draw_patch(
     f: &mut Frame,
     area: Rect,
     theme: &Theme,
-    milestone: &crate::provider::github::types::GhMilestone,
+    milestone: &crate::provider::types::Milestone,
     diff: &[DiffLine],
     scroll: u16,
 ) {
@@ -264,7 +264,7 @@ fn draw_confirm(
     f: &mut Frame,
     area: Rect,
     theme: &Theme,
-    milestone: &crate::provider::github::types::GhMilestone,
+    milestone: &crate::provider::types::Milestone,
 ) {
     let lines = vec![
         Line::from(Span::styled(
@@ -295,7 +295,7 @@ fn draw_result(
     f: &mut Frame,
     area: Rect,
     theme: &Theme,
-    milestone: &crate::provider::github::types::GhMilestone,
+    milestone: &crate::provider::types::Milestone,
     outcome: &PatchOutcome,
 ) {
     let (title, lines) = match outcome {

--- a/src/tui/screens/milestone_health/mod.rs
+++ b/src/tui/screens/milestone_health/mod.rs
@@ -14,7 +14,7 @@ pub use state::{HealthInput, HealthScreenState, HealthSideEffect, HealthStep};
 use crossterm::event::{Event, KeyCode, KeyEvent};
 use ratatui::{Frame, layout::Rect};
 
-use crate::provider::github::types::{GhIssue, GhMilestone};
+use crate::provider::types::{Issue, Milestone};
 use crate::tui::app::TuiCommand;
 use crate::tui::navigation::InputMode;
 use crate::tui::navigation::keymap::{KeyBindingGroup, KeymapProvider};
@@ -87,7 +87,7 @@ impl MilestoneHealthScreen {
 
     pub fn apply_milestones_loaded(
         &mut self,
-        result: anyhow::Result<Vec<GhMilestone>>,
+        result: anyhow::Result<Vec<Milestone>>,
     ) -> Option<TuiCommand> {
         let _ = self.state.transition(HealthInput::MilestonesLoaded(result));
         self.pending_command.take()
@@ -95,7 +95,7 @@ impl MilestoneHealthScreen {
 
     pub fn apply_issues_fetched(
         &mut self,
-        result: anyhow::Result<(GhMilestone, Vec<GhIssue>)>,
+        result: anyhow::Result<(Milestone, Vec<Issue>)>,
     ) -> Option<TuiCommand> {
         let _ = self.state.transition(HealthInput::DataFetched(result));
         self.pending_command.take()

--- a/src/tui/screens/milestone_health/state.rs
+++ b/src/tui/screens/milestone_health/state.rs
@@ -7,13 +7,13 @@ use crossterm::event::KeyCode;
 
 use crate::milestone_health::report::HealthReport;
 use crate::milestone_health::{analyze, check_issues, generate_patch};
-use crate::provider::github::types::{GhIssue, GhMilestone};
+use crate::provider::types::{Issue, Milestone};
 use crate::tui::screens::milestone_health::diff::{DiffLine, diff_lines};
 
 #[derive(Debug, Clone)]
 pub enum HealthStep {
     Picker {
-        milestones: Vec<GhMilestone>,
+        milestones: Vec<Milestone>,
         selected: usize,
     },
     Loading {
@@ -22,35 +22,35 @@ pub enum HealthStep {
         /// the picker — caches the user's selection so the dispatch layer
         /// can embed it in the `TuiCommand` instead of re-fetching the
         /// milestone list. `None` when loading the milestone list itself.
-        milestone: Option<GhMilestone>,
+        milestone: Option<Milestone>,
     },
     Empty {
-        milestone: GhMilestone,
+        milestone: Milestone,
     },
     Healthy {
-        milestone: GhMilestone,
+        milestone: Milestone,
     },
     Report {
-        milestone: GhMilestone,
-        issues: Vec<GhIssue>,
+        milestone: Milestone,
+        issues: Vec<Issue>,
     },
     Patch {
-        milestone: GhMilestone,
+        milestone: Milestone,
         proposed: String,
         /// Precomputed before/after diff so `draw_patch` doesn't recompute
         /// the LCS on every render frame.
         diff: Vec<DiffLine>,
     },
     Confirm {
-        milestone: GhMilestone,
+        milestone: Milestone,
         proposed: String,
     },
     Writing {
-        milestone: GhMilestone,
+        milestone: Milestone,
         last_proposed: String,
     },
     Result {
-        milestone: GhMilestone,
+        milestone: Milestone,
         outcome: PatchOutcome,
     },
     /// Terminal state for fetch-side errors (no milestone selected yet).
@@ -89,8 +89,8 @@ impl Default for HealthStep {
 #[derive(Debug)]
 pub enum HealthInput {
     Key(KeyCode),
-    MilestonesLoaded(anyhow::Result<Vec<GhMilestone>>),
-    DataFetched(anyhow::Result<(GhMilestone, Vec<GhIssue>)>),
+    MilestonesLoaded(anyhow::Result<Vec<Milestone>>),
+    DataFetched(anyhow::Result<(Milestone, Vec<Issue>)>),
     DataPatched(anyhow::Result<()>),
 }
 

--- a/src/tui/screens/milestone_health/state/tests/mod.rs
+++ b/src/tui/screens/milestone_health/state/tests/mod.rs
@@ -2,8 +2,8 @@
 
 use super::*;
 
-fn ms(n: u64, title: &str) -> GhMilestone {
-    GhMilestone {
+fn ms(n: u64, title: &str) -> Milestone {
+    Milestone {
         number: n,
         title: title.to_string(),
         description: String::new(),
@@ -13,8 +13,8 @@ fn ms(n: u64, title: &str) -> GhMilestone {
     }
 }
 
-fn issue(number: u64, body: &str) -> GhIssue {
-    GhIssue {
+fn issue(number: u64, body: &str) -> Issue {
+    Issue {
         number,
         title: format!("Issue #{}", number),
         body: body.to_string(),
@@ -56,7 +56,7 @@ fn full_feature_body(blockers: &[u64]) -> String {
     s
 }
 
-fn picker_with(milestones: Vec<GhMilestone>) -> HealthScreenState {
+fn picker_with(milestones: Vec<Milestone>) -> HealthScreenState {
     HealthScreenState {
         step: HealthStep::Picker {
             milestones,
@@ -136,7 +136,7 @@ fn loading_data_fetched_zero_issues_goes_to_empty() {
 #[test]
 fn loading_data_fetched_healthy_goes_to_healthy() {
     let mut s = loading();
-    let m = GhMilestone {
+    let m = Milestone {
         number: 1,
         title: "v1.0".to_string(),
         description: "Header.\n\n## Dependency Graph (Implementation Order)\n\nLevel 0 — no dependencies:\n• #1 first\n\nLevel 1 — depends on Level 0:\n• #2 second\n\nSequence: #1 → #2\n".to_string(),
@@ -390,7 +390,7 @@ fn full_happy_path_dispatches_patch_exactly_once() {
 #[test]
 fn healthy_path_never_reaches_patch_or_confirm() {
     let mut s = loading();
-    let m = GhMilestone {
+    let m = Milestone {
         number: 1,
         title: "v1.0".to_string(),
         description: "Header.\n\n## Dependency Graph (Implementation Order)\n\nLevel 0 — no dependencies:\n• #1 a\n\nSequence: #1\n".to_string(),

--- a/src/tui/screens/milestone_wizard/mod.rs
+++ b/src/tui/screens/milestone_wizard/mod.rs
@@ -105,9 +105,9 @@ pub async fn materialize_plan(
     materialize_plan_with_client(plan, &client).await
 }
 
-/// Inner impl parameterized over any `GitHubClient`. Exposed so tests
+/// Inner impl parameterized over any `RepoProvider`. Exposed so tests
 /// can drive a mock through the same logic as production.
-pub async fn materialize_plan_with_client<G: crate::provider::github::client::GitHubClient>(
+pub async fn materialize_plan_with_client<G: crate::provider::github::client::RepoProvider>(
     plan: &AiGeneratedPlan,
     client: &G,
 ) -> Result<MilestoneCreationResult, String> {
@@ -1067,10 +1067,10 @@ mod tests {
     #[tokio::test]
     async fn materialize_plan_returns_reused_when_milestone_exists() {
         use crate::provider::github::client::mock::MockGitHubClient;
-        use crate::provider::github::types::GhMilestone;
+        use crate::provider::types::Milestone;
 
         let client = MockGitHubClient::new();
-        client.set_existing_milestones(vec![GhMilestone {
+        client.set_existing_milestones(vec![Milestone {
             number: 42,
             title: "M0: Foundation".into(),
             description: String::new(),
@@ -1099,10 +1099,10 @@ mod tests {
     #[tokio::test]
     async fn materialize_plan_skips_duplicate_issues_within_reused_milestone() {
         use crate::provider::github::client::mock::MockGitHubClient;
-        use crate::provider::github::types::{GhIssue, GhMilestone};
+        use crate::provider::types::{Issue, Milestone};
 
         let client = MockGitHubClient::new();
-        client.set_existing_milestones(vec![GhMilestone {
+        client.set_existing_milestones(vec![Milestone {
             number: 42,
             title: "M0: Foundation".into(),
             description: String::new(),
@@ -1110,7 +1110,7 @@ mod tests {
             open_issues: 0,
             closed_issues: 0,
         }]);
-        client.set_existing_issues(vec![GhIssue {
+        client.set_existing_issues(vec![Issue {
             number: 99,
             title: "feat: login page".into(),
             body: String::new(),

--- a/src/tui/screens/mod.rs
+++ b/src/tui/screens/mod.rs
@@ -152,7 +152,7 @@ pub enum ScreenAction {
     /// Submit a PR review.
     SubmitPrReview {
         pr_number: u64,
-        event: crate::provider::github::types::PrReviewEvent,
+        event: crate::provider::types::ReviewEvent,
         body: String,
     },
     /// Open the Issue Wizard with the milestone pre-selected (#326).

--- a/src/tui/screens/pr_review/draw.rs
+++ b/src/tui/screens/pr_review/draw.rs
@@ -277,9 +277,9 @@ fn draw_submit_review(screen: &PrReviewScreen, f: &mut Frame, area: Rect, theme:
     f.render_widget(block, area);
 
     let events = [
-        crate::provider::github::types::PrReviewEvent::Comment,
-        crate::provider::github::types::PrReviewEvent::Approve,
-        crate::provider::github::types::PrReviewEvent::RequestChanges,
+        crate::provider::types::ReviewEvent::Comment,
+        crate::provider::types::ReviewEvent::Approve,
+        crate::provider::types::ReviewEvent::RequestChanges,
     ];
 
     let mut lines = vec![

--- a/src/tui/screens/pr_review/mod.rs
+++ b/src/tui/screens/pr_review/mod.rs
@@ -5,7 +5,7 @@ pub mod types;
 
 pub use types::*;
 
-use crate::provider::github::types::GhPullRequest;
+use crate::provider::types::PullRequest;
 use crate::tui::navigation::InputMode;
 use crate::tui::navigation::keymap::{KeyBinding, KeyBindingGroup, KeymapProvider};
 use crate::tui::theme::Theme;
@@ -16,10 +16,10 @@ use super::{Screen, ScreenAction};
 
 pub struct PrReviewScreen {
     pub step: PrReviewStep,
-    pub prs: Vec<GhPullRequest>,
+    pub prs: Vec<PullRequest>,
     pub selected: usize,
     pub scroll_offset: u16,
-    pub current_pr: Option<GhPullRequest>,
+    pub current_pr: Option<PullRequest>,
     pub form: ReviewForm,
     pub error: Option<String>,
     pub spinner_tick: usize,
@@ -43,18 +43,18 @@ impl PrReviewScreen {
         self.spinner_tick = self.spinner_tick.wrapping_add(1);
     }
 
-    pub fn set_prs(&mut self, prs: Vec<GhPullRequest>) {
+    pub fn set_prs(&mut self, prs: Vec<PullRequest>) {
         self.prs = prs;
         self.selected = 0;
         self.error = None;
         self.step = PrReviewStep::PrList;
     }
 
-    pub fn find_pr(&self, number: u64) -> Option<GhPullRequest> {
+    pub fn find_pr(&self, number: u64) -> Option<PullRequest> {
         self.prs.iter().find(|p| p.number == number).cloned()
     }
 
-    pub fn set_pr_detail(&mut self, pr: GhPullRequest) {
+    pub fn set_pr_detail(&mut self, pr: PullRequest) {
         self.current_pr = Some(pr);
         self.scroll_offset = 0;
         self.step = PrReviewStep::PrDetail;
@@ -286,12 +286,12 @@ impl Screen for PrReviewScreen {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::provider::github::types::PrReviewEvent;
+    use crate::provider::types::ReviewEvent;
     use crate::tui::screens::test_helpers::key_event;
     use crossterm::event::KeyCode;
 
-    fn make_pr(number: u64) -> GhPullRequest {
-        GhPullRequest {
+    fn make_pr(number: u64) -> PullRequest {
+        PullRequest {
             number,
             title: format!("PR #{}: Fix something", number),
             body: format!("## Summary\n\nFixes issue #{}", number),
@@ -309,7 +309,7 @@ mod tests {
         }
     }
 
-    fn make_three_prs() -> Vec<GhPullRequest> {
+    fn make_three_prs() -> Vec<PullRequest> {
         vec![make_pr(1), make_pr(2), make_pr(3)]
     }
 
@@ -543,25 +543,25 @@ mod tests {
     #[test]
     fn submit_review_default_event_is_comment() {
         let screen = screen_at_submit_review();
-        assert_eq!(screen.form.event, PrReviewEvent::Comment);
+        assert_eq!(screen.form.event, ReviewEvent::Comment);
     }
 
     #[test]
     fn submit_review_tab_cycles_event_type_forward() {
         let mut screen = screen_at_submit_review();
         screen.handle_input(&key_event(KeyCode::Tab), InputMode::Insert);
-        assert_eq!(screen.form.event, PrReviewEvent::Approve);
+        assert_eq!(screen.form.event, ReviewEvent::Approve);
         screen.handle_input(&key_event(KeyCode::Tab), InputMode::Insert);
-        assert_eq!(screen.form.event, PrReviewEvent::RequestChanges);
+        assert_eq!(screen.form.event, ReviewEvent::RequestChanges);
         screen.handle_input(&key_event(KeyCode::Tab), InputMode::Insert);
-        assert_eq!(screen.form.event, PrReviewEvent::Comment);
+        assert_eq!(screen.form.event, ReviewEvent::Comment);
     }
 
     #[test]
     fn submit_review_backtab_cycles_event_type_backward() {
         let mut screen = screen_at_submit_review();
         screen.handle_input(&key_event(KeyCode::BackTab), InputMode::Insert);
-        assert_eq!(screen.form.event, PrReviewEvent::RequestChanges);
+        assert_eq!(screen.form.event, ReviewEvent::RequestChanges);
     }
 
     #[test]
@@ -590,14 +590,14 @@ mod tests {
     #[test]
     fn submit_review_enter_returns_submit_action() {
         let mut screen = screen_at_submit_review();
-        screen.form.event = PrReviewEvent::Approve;
+        screen.form.event = ReviewEvent::Approve;
         screen.form.body = "LGTM".to_string();
         let action = screen.handle_input(&key_event(KeyCode::Enter), InputMode::Insert);
         assert_eq!(
             action,
             ScreenAction::SubmitPrReview {
                 pr_number: 1,
-                event: PrReviewEvent::Approve,
+                event: ReviewEvent::Approve,
                 body: "LGTM".to_string(),
             }
         );
@@ -606,13 +606,13 @@ mod tests {
     #[test]
     fn submit_review_enter_with_empty_body_still_returns_submit_action() {
         let mut screen = screen_at_submit_review();
-        screen.form.event = PrReviewEvent::Approve;
+        screen.form.event = ReviewEvent::Approve;
         let action = screen.handle_input(&key_event(KeyCode::Enter), InputMode::Insert);
         assert_eq!(
             action,
             ScreenAction::SubmitPrReview {
                 pr_number: 1,
-                event: PrReviewEvent::Approve,
+                event: ReviewEvent::Approve,
                 body: String::new(),
             }
         );

--- a/src/tui/screens/pr_review/types.rs
+++ b/src/tui/screens/pr_review/types.rs
@@ -1,4 +1,4 @@
-use crate::provider::github::types::PrReviewEvent;
+use crate::provider::types::ReviewEvent;
 
 /// State machine for the PR review screen.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -21,14 +21,14 @@ impl PrReviewStep {
 /// Form state for composing a PR review submission.
 #[derive(Debug, Clone)]
 pub struct ReviewForm {
-    pub event: PrReviewEvent,
+    pub event: ReviewEvent,
     pub body: String,
 }
 
 impl Default for ReviewForm {
     fn default() -> Self {
         Self {
-            event: PrReviewEvent::Comment,
+            event: ReviewEvent::Comment,
             body: String::new(),
         }
     }
@@ -62,7 +62,7 @@ mod tests {
     #[test]
     fn review_form_default_event_is_comment() {
         let form = ReviewForm::default();
-        assert_eq!(form.event, PrReviewEvent::Comment);
+        assert_eq!(form.event, ReviewEvent::Comment);
     }
 
     #[test]

--- a/src/tui/screens/project_stats/mod.rs
+++ b/src/tui/screens/project_stats/mod.rs
@@ -5,7 +5,7 @@ pub use types::{
     IssueCounts, MilestoneProgress, ProjectStatsData, RecentActivityRow, SessionMetrics,
 };
 
-use crate::provider::github::types::GhMilestone;
+use crate::provider::types::Milestone;
 use crate::session::types::{Session, SessionStatus};
 
 use super::{Screen, ScreenAction};
@@ -56,7 +56,7 @@ pub fn aggregate(
     ready_count: u32,
     failed_count: u32,
     done_count: u32,
-    milestones: Vec<GhMilestone>,
+    milestones: Vec<Milestone>,
     local_sessions: &[Session],
 ) -> ProjectStatsData {
     let milestone_progress = milestones

--- a/src/tui/screens/roadmap/loader.rs
+++ b/src/tui/screens/roadmap/loader.rs
@@ -3,15 +3,15 @@
 #![deny(clippy::unwrap_used)]
 #![allow(dead_code)]
 
-use crate::provider::github::client::GitHubClient;
-use crate::provider::github::types::GhIssue;
+use crate::provider::github::client::RepoProvider;
+use crate::provider::types::Issue;
 use crate::tui::screens::roadmap::types::{RoadmapEntry, SemVer};
 use anyhow::Result;
 
 /// Concurrent fetch: first list all open + closed milestones, then for
 /// each pull its issues. Returns entries unsorted; the screen state sorts
 /// them by descending semver on `set_entries`.
-pub async fn load_roadmap(client: &dyn GitHubClient) -> Result<Vec<RoadmapEntry>> {
+pub async fn load_roadmap(client: &dyn RepoProvider) -> Result<Vec<RoadmapEntry>> {
     let (open_ms, closed_ms) = tokio::join!(
         client.list_milestones("open"),
         client.list_milestones("closed"),
@@ -21,7 +21,7 @@ pub async fn load_roadmap(client: &dyn GitHubClient) -> Result<Vec<RoadmapEntry>
 
     let mut entries = Vec::with_capacity(milestones.len());
     for m in milestones {
-        let issues: Vec<GhIssue> = client
+        let issues: Vec<Issue> = client
             .list_issues_by_milestone(&m.title)
             .await
             .unwrap_or_default();
@@ -36,24 +36,23 @@ pub async fn load_roadmap(client: &dyn GitHubClient) -> Result<Vec<RoadmapEntry>
 }
 
 // Tests for `load_roadmap` are exercised through the integration tests
-// that drive the App pipeline; the GitHubClient trait surface is too large
+// that drive the App pipeline; the RepoProvider trait surface is too large
 // to duplicate here as a hand-written fake.
 #[cfg(any())]
 mod tests {
     use super::*;
-    use crate::provider::github::client::GitHubClient;
-    use crate::provider::github::types::{
-        CreateOutcome, GhMilestone, GhPr, PendingPr, PrReviewEvent,
-    };
+    use crate::provider::github::client::{CreateOutcome, RepoProvider};
+    use crate::provider::github::types::PendingPr;
+    use crate::provider::types::{Milestone, PullRequest, ReviewEvent};
     use anyhow::Result;
     use async_trait::async_trait;
     use std::sync::Mutex;
 
     /// Minimal fake — only the methods we exercise here are non-trivial.
     struct FakeClient {
-        open_milestones: Vec<GhMilestone>,
-        closed_milestones: Vec<GhMilestone>,
-        issues_by_milestone: std::collections::HashMap<String, Vec<GhIssue>>,
+        open_milestones: Vec<Milestone>,
+        closed_milestones: Vec<Milestone>,
+        issues_by_milestone: std::collections::HashMap<String, Vec<Issue>>,
         calls: Mutex<Vec<String>>,
     }
 
@@ -69,12 +68,12 @@ mod tests {
     }
 
     #[async_trait]
-    impl GitHubClient for FakeClient {
-        async fn list_issues(&self, _labels: &[&str]) -> Result<Vec<GhIssue>> {
+    impl RepoProvider for FakeClient {
+        async fn list_issues(&self, _labels: &[&str]) -> Result<Vec<Issue>> {
             self.calls.lock().expect("lock").push("list_issues".into());
             Ok(Vec::new())
         }
-        async fn list_issues_by_milestone(&self, milestone: &str) -> Result<Vec<GhIssue>> {
+        async fn list_issues_by_milestone(&self, milestone: &str) -> Result<Vec<Issue>> {
             self.calls
                 .lock()
                 .expect("lock")
@@ -85,7 +84,7 @@ mod tests {
                 .cloned()
                 .unwrap_or_default())
         }
-        async fn list_milestones(&self, state: &str) -> Result<Vec<GhMilestone>> {
+        async fn list_milestones(&self, state: &str) -> Result<Vec<Milestone>> {
             self.calls
                 .lock()
                 .expect("lock")
@@ -111,7 +110,7 @@ mod tests {
         async fn list_open_prs(&self) -> Result<Vec<PendingPr>> {
             unimplemented!()
         }
-        async fn list_pr_details(&self) -> Result<Vec<GhPr>> {
+        async fn list_pr_details(&self) -> Result<Vec<PullRequest>> {
             unimplemented!()
         }
         async fn add_label(&self, _number: u64, _label: &str) -> Result<()> {
@@ -129,15 +128,15 @@ mod tests {
         async fn submit_pr_review(
             &self,
             _pr_number: u64,
-            _event: PrReviewEvent,
+            _event: ReviewEvent,
             _body: &str,
         ) -> Result<()> {
             unimplemented!()
         }
     }
 
-    fn ms(num: u64, title: &str, state: &str) -> GhMilestone {
-        GhMilestone {
+    fn ms(num: u64, title: &str, state: &str) -> Milestone {
+        Milestone {
             number: num,
             title: title.into(),
             description: String::new(),

--- a/src/tui/screens/roadmap/state.rs
+++ b/src/tui/screens/roadmap/state.rs
@@ -91,11 +91,11 @@ impl RoadmapScreen {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::provider::github::types::GhMilestone;
+    use crate::provider::types::Milestone;
 
     fn entry(num: u64, semver: SemVer) -> RoadmapEntry {
         RoadmapEntry {
-            milestone: GhMilestone {
+            milestone: Milestone {
                 number: num,
                 title: format!("v{}.{}.{}", semver.major, semver.minor, semver.patch),
                 description: String::new(),

--- a/src/tui/screens/roadmap/types.rs
+++ b/src/tui/screens/roadmap/types.rs
@@ -3,15 +3,15 @@
 #![deny(clippy::unwrap_used)]
 #![allow(dead_code)]
 
-use crate::provider::github::types::{GhIssue, GhMilestone};
+use crate::provider::types::{Issue, Milestone};
 
 /// One milestone row in the roadmap, with its issues already
 /// dependency-level-sorted (by `dep_levels::dep_levels`).
 #[derive(Debug, Clone)]
 pub struct RoadmapEntry {
-    pub milestone: GhMilestone,
+    pub milestone: Milestone,
     pub semver: SemVer,
-    pub issues: Vec<GhIssue>,
+    pub issues: Vec<Issue>,
 }
 
 /// Lightweight semver triple parsed from a milestone title like `v0.16.0`.
@@ -76,7 +76,7 @@ impl Filters {
             && matches!(self.status, StatusFilter::Any)
     }
 
-    pub fn matches(&self, issue: &GhIssue) -> bool {
+    pub fn matches(&self, issue: &Issue) -> bool {
         if !self.label.is_empty() {
             let needle = self.label.to_lowercase();
             if !issue
@@ -109,8 +109,8 @@ impl Filters {
 mod tests {
     use super::*;
 
-    fn gh_issue(state: &str, labels: &[&str], assignees: &[&str]) -> GhIssue {
-        GhIssue {
+    fn gh_issue(state: &str, labels: &[&str], assignees: &[&str]) -> Issue {
+        Issue {
             number: 1,
             title: "x".into(),
             body: String::new(),

--- a/src/tui/snapshot_tests/mod.rs
+++ b/src/tui/snapshot_tests/mod.rs
@@ -96,8 +96,8 @@ pub fn make_activity(offset_secs: i64, message: &str) -> ActivityEntry {
     }
 }
 
-pub fn make_gh_issue(number: u64, title: &str) -> crate::provider::github::types::GhIssue {
-    crate::provider::github::types::GhIssue {
+pub fn make_gh_issue(number: u64, title: &str) -> crate::provider::types::Issue {
+    crate::provider::types::Issue {
         number,
         title: title.to_string(),
         body: String::new(),

--- a/src/work/assigner.rs
+++ b/src/work/assigner.rs
@@ -262,7 +262,7 @@ impl WorkAssigner {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::provider::github::types::{GhIssue, Priority};
+    use crate::provider::types::{Issue, Priority};
 
     fn make_item(number: u64, priority: Priority, blocked_by: &[u64]) -> WorkItem {
         let mut labels: Vec<String> = blocked_by
@@ -271,7 +271,7 @@ mod tests {
             .collect();
         // Encode priority as a label
         labels.push(format!("priority:{:?}", priority));
-        WorkItem::from_issue(GhIssue {
+        WorkItem::from_issue(Issue {
             number,
             title: format!("Issue #{}", number),
             body: String::new(),

--- a/src/work/dependencies.rs
+++ b/src/work/dependencies.rs
@@ -108,12 +108,12 @@ mod tests {
     use super::*;
 
     fn make_item(number: u64, blocked_by: &[u64]) -> WorkItem {
-        use crate::provider::github::types::GhIssue;
+        use crate::provider::types::Issue;
         let labels: Vec<String> = blocked_by
             .iter()
             .map(|b| format!("blocked-by:#{}", b))
             .collect();
-        WorkItem::from_issue(GhIssue {
+        WorkItem::from_issue(Issue {
             number,
             title: format!("Issue #{}", number),
             body: String::new(),

--- a/src/work/executor.rs
+++ b/src/work/executor.rs
@@ -187,12 +187,12 @@ impl QueueExecutor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::provider::github::types::GhIssue;
+    use crate::provider::types::Issue;
     use crate::work::dependencies::DependencyGraph;
     use crate::work::types::WorkItem;
 
     fn make_item(number: u64) -> WorkItem {
-        WorkItem::from_issue(GhIssue {
+        WorkItem::from_issue(Issue {
             number,
             title: format!("Issue #{}", number),
             body: String::new(),

--- a/src/work/queue.rs
+++ b/src/work/queue.rs
@@ -156,7 +156,7 @@ fn transitive_dependents(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::provider::github::types::GhIssue;
+    use crate::provider::types::Issue;
     use crate::work::types::WorkItem;
 
     fn make_item(number: u64, blocked_by: &[u64]) -> WorkItem {
@@ -164,7 +164,7 @@ mod tests {
             .iter()
             .map(|b| format!("blocked-by:#{}", b))
             .collect();
-        WorkItem::from_issue(GhIssue {
+        WorkItem::from_issue(Issue {
             number,
             title: format!("Issue #{}", number),
             body: String::new(),

--- a/src/work/types.rs
+++ b/src/work/types.rs
@@ -1,4 +1,4 @@
-use crate::provider::github::types::{GhIssue, Priority, SessionMode};
+use crate::provider::types::{Issue, Priority, SessionMode};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
@@ -20,11 +20,11 @@ pub struct WorkItem {
     /// Cached blockers (computed once from issue labels + body).
     pub blocked_by: Vec<u64>,
     /// The original issue data.
-    pub issue: GhIssue,
+    pub issue: Issue,
 }
 
 impl WorkItem {
-    pub fn from_issue(issue: GhIssue) -> Self {
+    pub fn from_issue(issue: Issue) -> Self {
         let priority = issue.priority();
         let mode = issue.session_mode();
         let blocked_by = issue.all_blockers();
@@ -58,8 +58,8 @@ impl WorkItem {
 mod tests {
     use super::*;
 
-    fn make_gh_issue(number: u64, labels: &[&str], body: &str) -> GhIssue {
-        GhIssue {
+    fn make_gh_issue(number: u64, labels: &[&str], body: &str) -> Issue {
+        Issue {
             number,
             title: format!("Issue #{}", number),
             body: body.to_string(),


### PR DESCRIPTION
## Summary
- Rename the provider trait from `GitHubClient` to `RepoProvider`.
- Move shared issue, milestone, PR, priority, mode, and review models into `provider::types`.
- Update GitHub, Azure DevOps, TUI, commands, work queue, and tests to use neutral provider names.

Closes #458

## Test plan
- [x] cargo fmt --check
- [x] cargo build
- [x] cargo test
- [x] cargo clippy -- -D warnings