### PR TITLE
refactor(provider): wire provider factory at call sites

### DIFF
--- a/src/adapt/mod.rs
+++ b/src/adapt/mod.rs
@@ -274,9 +274,11 @@ pub async fn cmd_adapt(config: AdaptConfig) -> anyhow::Result<()> {
 
     // Phase 4: Materialize
     eprintln!("Phase 4: Creating GitHub artifacts...");
-    let github = crate::provider::github::client::GhCliClient::from_config_repo(
-        project_cfg.as_ref().map(|c| c.project.repo.clone()),
-    );
+    let provider_config = project_cfg
+        .as_ref()
+        .map(|c| c.effective_provider_config())
+        .unwrap_or_default();
+    let github = crate::provider::create_provider(&provider_config)?;
     let materializer = GhMaterializer::new(github);
     let result = materializer.materialize(&plan, &report, false).await?;
 
@@ -354,9 +356,16 @@ pub async fn detect_milestone_hint(
         ));
     }
 
-    let github = crate::provider::github::client::GhCliClient::from_config_repo(
-        project_cfg.map(|c| c.project.repo.clone()),
-    );
+    let provider_config = project_cfg
+        .map(|c| c.effective_provider_config())
+        .unwrap_or_default();
+    let github = match crate::provider::create_provider(&provider_config) {
+        Ok(github) => github,
+        Err(e) => {
+            tracing::warn!("Failed to create provider for pattern detection: {e}");
+            return None;
+        }
+    };
     let mut titles: Vec<String> = Vec::new();
     for state in ["open", "closed"] {
         match crate::provider::github::client::RepoProvider::list_milestones(&github, state).await {

--- a/src/commands/dashboard.rs
+++ b/src/commands/dashboard.rs
@@ -1,6 +1,6 @@
 use crate::commands::setup::{DEFAULT_MAX_CONCURRENT, setup_app_from_config, startup_cleanup};
 use crate::config::Config;
-use crate::provider::github::client::GhCliClient;
+use crate::provider::create_provider;
 use crate::session::worktree::GitWorktreeManager;
 use crate::state::store::StateStore;
 use crate::tui::app::App;
@@ -35,7 +35,6 @@ pub async fn cmd_dashboard() -> anyhow::Result<()> {
         Err(e) => return Err(e),
     };
     let config = loaded.as_ref().map(|l| l.config.clone());
-    let github_repo = config.as_ref().map(|c| c.project.repo.clone());
 
     let repo_name = config
         .as_ref()
@@ -115,8 +114,9 @@ pub async fn cmd_dashboard() -> anyhow::Result<()> {
     let worktree_mgr = Box::new(GitWorktreeManager::new(repo_root));
 
     let mut app = if let Some(lc) = loaded {
+        let provider_config = lc.config.effective_provider_config();
         let mut app = setup_app_from_config(lc, store, worktree_mgr, None);
-        app.github_client = Some(Box::new(GhCliClient::from_config_repo(github_repo)));
+        app.github_client = Some(create_provider(&provider_config)?);
         app
     } else {
         App::new(

--- a/src/commands/queue.rs
+++ b/src/commands/queue.rs
@@ -1,11 +1,12 @@
 use crate::config::Config;
-use crate::provider::github::client::{GhCliClient, RepoProvider};
+use crate::provider::{create_provider, github::client::RepoProvider};
 use crate::work::assigner::WorkAssigner;
 use crate::work::types::WorkItem;
 
 pub async fn cmd_queue() -> anyhow::Result<()> {
     let config = Config::find_and_load()?;
-    let client = GhCliClient::from_config_repo(Some(config.project.repo.clone()));
+    let provider_config = config.effective_provider_config();
+    let client = create_provider(&provider_config)?;
     let label_refs: Vec<&str> = config
         .github
         .issue_filter_labels
@@ -75,8 +76,9 @@ pub async fn cmd_queue() -> anyhow::Result<()> {
 }
 
 pub async fn cmd_add(issue_number: u64) -> anyhow::Result<()> {
-    let repo = Config::find_and_load().ok().map(|c| c.project.repo);
-    let client = GhCliClient::from_config_repo(repo);
+    let config = Config::find_and_load()?;
+    let provider_config = config.effective_provider_config();
+    let client = create_provider(&provider_config)?;
     client.add_label(issue_number, "maestro:ready").await?;
     println!("Added 'maestro:ready' label to issue #{}", issue_number);
     Ok(())

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -1,13 +1,13 @@
 use crate::commands::setup::setup_app_from_config;
 use crate::config::Config;
-use crate::provider::github::client::GhCliClient;
+use crate::provider::create_provider;
 use crate::session::types::Session;
 use crate::session::worktree::GitWorktreeManager;
 use crate::state::store::StateStore;
 
 pub async fn cmd_resume(session_filter: Option<String>) -> anyhow::Result<()> {
     let loaded = Config::find_and_load_with_path()?;
-    let repo = Some(loaded.config.project.repo.clone());
+    let provider_config = loaded.config.effective_provider_config();
     let store = StateStore::new(StateStore::default_path());
     let state = store.load()?;
     let repo_root = std::env::current_dir()?;
@@ -61,7 +61,7 @@ pub async fn cmd_resume(session_filter: Option<String>) -> anyhow::Result<()> {
         app.add_session(new_session).await?;
     }
 
-    app.github_client = Some(Box::new(GhCliClient::from_config_repo(repo)));
+    app.github_client = Some(create_provider(&provider_config)?);
 
     crate::tui::run(app).await
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,6 +1,6 @@
 use crate::commands::setup::{setup_app_from_config_with_bypass, startup_cleanup};
 use crate::config::Config;
-use crate::provider::github::client::{GhCliClient, RepoProvider};
+use crate::provider::{create_provider, github::client::RepoProvider};
 use crate::session::types::Session;
 use crate::session::worktree::GitWorktreeManager;
 use crate::state::store::StateStore;
@@ -116,7 +116,8 @@ pub async fn cmd_run(
         .with_image_paths(images.clone());
         app.add_session(session).await?;
     } else if let Some(milestone_name) = milestone {
-        let client = GhCliClient::from_config_repo(Some(config.project.repo.clone()));
+        let provider_config = config.effective_provider_config();
+        let client = create_provider(&provider_config)?;
         let issues = client.list_issues_by_milestone(&milestone_name).await?;
         if issues.is_empty() {
             anyhow::bail!("No open issues found in milestone '{}'", milestone_name);
@@ -126,7 +127,7 @@ pub async fn cmd_run(
         let assigner = WorkAssigner::new(items);
 
         app.work_assignment_service = Some(WorkAssignmentService::new(assigner));
-        app.github_client = Some(Box::new(client));
+        app.github_client = Some(client);
 
         if continuous && app.flags.is_enabled(crate::flags::Flag::ContinuousMode) {
             app.continuous_mode = Some(crate::continuous::ContinuousModeState::new());
@@ -138,7 +139,8 @@ pub async fn cmd_run(
             tracing::info!("--continuous ignored: Flag::ContinuousMode is disabled");
         }
     } else if let Some(issue_str) = issue {
-        let client = GhCliClient::from_config_repo(Some(config.project.repo.clone()));
+        let provider_config = config.effective_provider_config();
+        let client = create_provider(&provider_config)?;
 
         for num_str in issue_str.split(',') {
             let num: u64 = num_str
@@ -166,9 +168,10 @@ pub async fn cmd_run(
             app.add_session(session).await?;
         }
 
-        app.github_client = Some(Box::new(client));
+        app.github_client = Some(client);
     } else {
-        let client = GhCliClient::from_config_repo(Some(config.project.repo.clone()));
+        let provider_config = config.effective_provider_config();
+        let client = create_provider(&provider_config)?;
         let label_refs: Vec<&str> = issue_filter_labels.iter().map(|s| s.as_str()).collect();
         let issues = client.list_issues(&label_refs).await?;
 
@@ -183,7 +186,7 @@ pub async fn cmd_run(
         let assigner = WorkAssigner::new(items);
 
         app.work_assignment_service = Some(WorkAssignmentService::new(assigner));
-        app.github_client = Some(Box::new(client));
+        app.github_client = Some(client);
     }
 
     app.once_mode = once;

--- a/src/config/github.rs
+++ b/src/config/github.rs
@@ -54,6 +54,9 @@ pub struct ProviderConfig {
     /// Provider type: "github" or "azure_devops". Default: github.
     #[serde(default)]
     pub kind: ProviderKind,
+    /// Optional repository slug (`owner/repo`) for providers that support it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
     /// Issue/work-item filter labels/tags.
     #[serde(default = "default_issue_labels")]
     pub issue_filter_labels: Vec<String>,
@@ -81,6 +84,7 @@ impl Default for ProviderConfig {
     fn default() -> Self {
         Self {
             kind: ProviderKind::default(),
+            repo: None,
             issue_filter_labels: default_issue_labels(),
             auto_pr: true,
             auto_merge: false,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -156,6 +156,16 @@ impl Config {
 
         Ok(())
     }
+
+    pub fn effective_provider_config(&self) -> ProviderConfig {
+        let mut provider = self.provider.clone();
+        if provider.repo.as_deref().unwrap_or("").trim().is_empty()
+            && !self.project.repo.trim().is_empty()
+        {
+            provider.repo = Some(self.project.repo.clone());
+        }
+        provider
+    }
 }
 
 /// A `Config` bundled with the filesystem path it was loaded from.

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -98,6 +98,9 @@ pub fn run_all_checks(config: Option<&Config>) -> DoctorReport {
             checks.push(check_az_identity());
         }
     }
+    if let Some(cfg) = config {
+        checks.push(check_provider_matches_remote(cfg.provider.kind));
+    }
 
     checks.push(check_claude_cli());
 
@@ -303,6 +306,38 @@ fn check_git_remote() -> CheckResult {
             "git remote",
             "no git remote found — are you in a git repo?",
             CheckSeverity::Required,
+        ),
+    }
+}
+
+fn check_provider_matches_remote(configured: ProviderKind) -> CheckResult {
+    match Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .output()
+    {
+        Ok(out) if out.status.success() => {
+            let url = String::from_utf8_lossy(&out.stdout);
+            let detected = crate::provider::detect_provider_from_remote(url.trim());
+            if detected == configured {
+                CheckResult::pass(
+                    "provider",
+                    format!("configured provider matches origin ({detected:?})"),
+                    CheckSeverity::Optional,
+                )
+            } else {
+                CheckResult::fail(
+                    "provider",
+                    format!(
+                        "configured provider is {configured:?}, but origin looks like {detected:?}"
+                    ),
+                    CheckSeverity::Optional,
+                )
+            }
+        }
+        _ => CheckResult::fail(
+            "provider",
+            "could not detect provider from origin remote",
+            CheckSeverity::Optional,
         ),
     }
 }

--- a/src/provider/github/transport.rs
+++ b/src/provider/github/transport.rs
@@ -170,3 +170,77 @@ impl<T: RepoProvider + ?Sized> RepoProvider for &T {
             .await
     }
 }
+
+/// Blanket impl: if T: RepoProvider, then Box<T> is also a RepoProvider.
+#[async_trait]
+impl<T: RepoProvider + ?Sized> RepoProvider for Box<T> {
+    async fn list_issues(&self, labels: &[&str]) -> Result<Vec<Issue>> {
+        (**self).list_issues(labels).await
+    }
+    async fn list_issues_by_milestone(&self, milestone: &str) -> Result<Vec<Issue>> {
+        (**self).list_issues_by_milestone(milestone).await
+    }
+    async fn list_milestones(&self, state: &str) -> Result<Vec<Milestone>> {
+        (**self).list_milestones(state).await
+    }
+    async fn get_issue(&self, number: u64) -> Result<Issue> {
+        (**self).get_issue(number).await
+    }
+    async fn add_label(&self, issue_number: u64, label: &str) -> Result<()> {
+        (**self).add_label(issue_number, label).await
+    }
+    async fn remove_label(&self, issue_number: u64, label: &str) -> Result<()> {
+        (**self).remove_label(issue_number, label).await
+    }
+    async fn create_pr(
+        &self,
+        issue_number: u64,
+        title: &str,
+        body: &str,
+        head_branch: &str,
+        base_branch: &str,
+    ) -> Result<u64> {
+        (**self)
+            .create_pr(issue_number, title, body, head_branch, base_branch)
+            .await
+    }
+    async fn list_prs_for_branch(&self, head_branch: &str) -> Result<Vec<u64>> {
+        (**self).list_prs_for_branch(head_branch).await
+    }
+    async fn create_milestone(&self, title: &str, description: &str) -> Result<CreateOutcome> {
+        (**self).create_milestone(title, description).await
+    }
+    async fn create_issue(
+        &self,
+        title: &str,
+        body: &str,
+        labels: &[String],
+        milestone: Option<u64>,
+    ) -> Result<CreateOutcome> {
+        (**self).create_issue(title, body, labels, milestone).await
+    }
+    async fn list_open_prs(&self) -> Result<Vec<PullRequest>> {
+        (**self).list_open_prs().await
+    }
+    async fn get_pr(&self, number: u64) -> Result<PullRequest> {
+        (**self).get_pr(number).await
+    }
+    async fn submit_pr_review(&self, pr_number: u64, event: ReviewEvent, body: &str) -> Result<()> {
+        (**self).submit_pr_review(pr_number, event, body).await
+    }
+    async fn list_labels(&self) -> Result<Vec<String>> {
+        (**self).list_labels().await
+    }
+    async fn create_label(&self, name: &str, color: &str) -> Result<()> {
+        (**self).create_label(name, color).await
+    }
+    async fn patch_milestone_description(
+        &self,
+        milestone_number: u64,
+        description: &str,
+    ) -> Result<()> {
+        (**self)
+            .patch_milestone_description(milestone_number, description)
+            .await
+    }
+}

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -1,4 +1,3 @@
-#[allow(dead_code)] // Reason: multi-provider support — planned feature
 pub mod azure_devops;
 pub mod github;
 pub mod types;
@@ -12,10 +11,9 @@ use types::ProviderKind;
 use self::github::client::GhCliClient;
 
 /// Create the appropriate provider client from config.
-#[allow(dead_code)] // to be wired when provider selection is exposed via CLI/config
 pub fn create_provider(config: &ProviderConfig) -> Result<Box<dyn RepoProvider>> {
     match config.kind {
-        ProviderKind::Github => Ok(Box::new(GhCliClient::new())),
+        ProviderKind::Github => Ok(Box::new(GhCliClient::from_config_repo(config.repo.clone()))),
         ProviderKind::AzureDevops => {
             let org = config.organization.clone().ok_or_else(|| {
                 anyhow::anyhow!("provider.organization required for azure_devops")
@@ -30,7 +28,6 @@ pub fn create_provider(config: &ProviderConfig) -> Result<Box<dyn RepoProvider>>
 }
 
 /// Detect provider from a git remote URL string.
-#[allow(dead_code)] // to be wired when provider auto-detection is exposed
 pub fn detect_provider_from_remote(url: &str) -> ProviderKind {
     if url.contains("dev.azure.com") || url.contains("visualstudio.com") {
         ProviderKind::AzureDevops

--- a/src/tui/app/completion_summary_core_tests.rs
+++ b/src/tui/app/completion_summary_core_tests.rs
@@ -195,13 +195,13 @@ fn suggestion_data_event_clears_loading_flag_on_home_screen() {
     if let Some(ref mut screen) = app.screen_state.home_screen {
         screen.loading_suggestions = true;
     }
-    app.handle_data_event(TuiDataEvent::SuggestionData(SuggestionDataPayload {
+    app.handle_data_event(TuiDataEvent::SuggestionData(Ok(SuggestionDataPayload {
         ready_issue_count: 0,
         failed_issue_count: 0,
         milestones: vec![],
         open_issue_count: 0,
         closed_issue_count: 0,
-    }));
+    })));
     assert!(
         !app.screen_state
             .home_screen

--- a/src/tui/app/data_handler.rs
+++ b/src/tui/app/data_handler.rs
@@ -147,7 +147,7 @@ impl App {
                     LogLevel::Error,
                 );
             }
-            TuiDataEvent::SuggestionData(payload) => {
+            TuiDataEvent::SuggestionData(Ok(payload)) => {
                 let active = self.pool.active_count();
                 let total = self.pool.total_count();
                 let suggestions = crate::tui::screens::home::Suggestion::build_suggestions(
@@ -175,6 +175,13 @@ impl App {
                     screen.set_suggestions(suggestions);
                     screen.set_stats(stats);
                 }
+            }
+            TuiDataEvent::SuggestionData(Err(e)) => {
+                self.activity_log.push_simple(
+                    "GitHub".into(),
+                    format!("Failed to fetch suggestion data: {}", e),
+                    LogLevel::Error,
+                );
             }
             TuiDataEvent::VersionCheckResult(Some(info)) => {
                 self.activity_log.push_simple(
@@ -427,10 +434,17 @@ impl App {
                     screen.finish_create_already_exists(number, state, title);
                 }
             }
-            TuiDataEvent::ProjectStats(data) => {
+            TuiDataEvent::ProjectStats(Ok(data)) => {
                 if let Some(ref mut screen) = self.screen_state.project_stats_screen {
                     screen.set_data(data);
                 }
+            }
+            TuiDataEvent::ProjectStats(Err(e)) => {
+                self.activity_log.push_simple(
+                    "GitHub".into(),
+                    format!("Failed to fetch project stats: {}", e),
+                    LogLevel::Error,
+                );
             }
             TuiDataEvent::AiPlanningResult(result) => {
                 if let Some(ref mut screen) = self.screen_state.milestone_wizard_screen {

--- a/src/tui/app/types.rs
+++ b/src/tui/app/types.rs
@@ -342,7 +342,7 @@ pub enum TuiDataEvent {
         title: String,
     },
     /// Aggregated stats for the Project Stats screen (#292).
-    ProjectStats(crate::tui::screens::project_stats::ProjectStatsData),
+    ProjectStats(anyhow::Result<crate::tui::screens::project_stats::ProjectStatsData>),
     /// AI planning result for the Milestone Wizard (#294). `Err(s)` is the
     /// human-readable failure reason rendered on the `Failed` step.
     AiPlanningResult(Result<crate::tui::screens::milestone_wizard::AiGeneratedPlan, String>),
@@ -361,7 +361,7 @@ pub enum TuiDataEvent {
     ),
     Milestones(anyhow::Result<Vec<(Milestone, Vec<Issue>)>>),
     Issue(anyhow::Result<Issue>, Option<String>),
-    SuggestionData(SuggestionDataPayload),
+    SuggestionData(anyhow::Result<SuggestionDataPayload>),
     VersionCheckResult(Option<crate::updater::ReleaseInfo>),
     UpgradeResult(Result<String, String>),
     AdaptScanResult(anyhow::Result<Box<ProjectProfile>>),

--- a/src/tui/background_tasks.rs
+++ b/src/tui/background_tasks.rs
@@ -1,18 +1,21 @@
 use super::app;
 use super::screens;
-use crate::provider::github::client::{GhCliClient, RepoProvider};
+use crate::config::ProviderConfig;
+use crate::provider::{create_provider, github::client::RepoProvider};
 
 pub(super) fn spawn_issue_fetch(
     tx: tokio::sync::mpsc::UnboundedSender<app::TuiDataEvent>,
     config: screens::SessionConfig,
-    repo: Option<String>,
+    provider_config: ProviderConfig,
 ) {
     let custom_prompt = config.custom_prompt.clone();
     match config.issue_number {
         Some(issue_number) => {
             tokio::spawn(async move {
-                let client = GhCliClient::from_config_repo(repo);
-                let result = client.get_issue(issue_number).await;
+                let result = match create_provider(&provider_config) {
+                    Ok(client) => client.get_issue(issue_number).await,
+                    Err(e) => Err(e),
+                };
                 let _ = tx.send(app::TuiDataEvent::Issue(result, custom_prompt));
             });
         }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -34,7 +34,8 @@ pub mod widgets;
 #[cfg(test)]
 mod snapshot_tests;
 
-use crate::provider::github::client::{GhCliClient, RepoProvider};
+use crate::config::ProviderConfig;
+use crate::provider::{create_provider, github::client::RepoProvider};
 use crate::tui::activity_log::LogLevel;
 use app::App;
 use background_tasks::{spawn_issue_fetch, spawn_version_check};
@@ -47,6 +48,7 @@ use crossterm::{
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use ratatui::{Terminal, backend::CrosstermBackend};
+use std::future::Future;
 use std::io;
 use std::time::Duration;
 use summary::print_summary;
@@ -61,8 +63,20 @@ async fn run_claude_print_for_wizard(prompt: &str) -> Result<String, String> {
         .map_err(|e| e.to_string())
 }
 
-fn github_repo_from_app(app: &App) -> Option<String> {
-    app.config.as_ref().map(|c| c.project.repo.clone())
+fn provider_config_from_app(app: &App) -> ProviderConfig {
+    app.config
+        .as_ref()
+        .map(|c| c.effective_provider_config())
+        .unwrap_or_default()
+}
+
+async fn with_provider<T, F, Fut>(provider_config: ProviderConfig, f: F) -> anyhow::Result<T>
+where
+    F: FnOnce(Box<dyn RepoProvider>) -> Fut,
+    Fut: Future<Output = anyhow::Result<T>>,
+{
+    let client = create_provider(&provider_config)?;
+    f(client).await
 }
 
 pub(crate) fn enter_tui_mode<W: io::Write>(out: &mut W) -> io::Result<()> {
@@ -188,111 +202,106 @@ async fn event_loop(
             match cmd {
                 app::TuiCommand::FetchIssues => {
                     let tx = app.data_tx.clone();
-                    let repo = github_repo_from_app(app);
+                    let provider_config = provider_config_from_app(app);
                     tokio::spawn(async move {
-                        let client = GhCliClient::from_config_repo(repo);
-                        let result = client.list_issues(&[]).await;
+                        let result = with_provider(provider_config, |client| async move {
+                            client.list_issues(&[]).await
+                        })
+                        .await;
                         let _ = tx.send(app::TuiDataEvent::Issues(result));
                     });
                 }
                 app::TuiCommand::FetchSuggestionData => {
                     let tx = app.data_tx.clone();
-                    let repo = github_repo_from_app(app);
+                    let provider_config = provider_config_from_app(app);
                     tokio::spawn(async move {
-                        let client = GhCliClient::from_config_repo(repo);
-                        let (ready_result, failed_result, milestones_result) = tokio::join!(
-                            client.list_issues(&["maestro:ready"]),
-                            client.list_issues(&["maestro:failed"]),
-                            client.list_milestones("open"),
-                        );
-                        let ready_count = ready_result.map(|v| v.len()).unwrap_or(0);
-                        let failed_count = failed_result.map(|v| v.len()).unwrap_or(0);
-                        let milestones_vec = milestones_result.unwrap_or_default();
-                        let open_issue_count: usize =
-                            milestones_vec.iter().map(|m| m.open_issues as usize).sum();
-                        let closed_issue_count: usize = milestones_vec
-                            .iter()
-                            .map(|m| m.closed_issues as usize)
-                            .sum();
-                        let milestones_data: Vec<_> = milestones_vec
-                            .iter()
-                            .map(|m| {
-                                let total = m.open_issues + m.closed_issues;
-                                (m.title.clone(), m.closed_issues, total)
-                            })
-                            .collect();
-                        let _ = tx.send(app::TuiDataEvent::SuggestionData(
-                            app::SuggestionDataPayload {
+                        let result = with_provider(provider_config, |client| async move {
+                            let (ready_result, failed_result, milestones_result) = tokio::join!(
+                                client.list_issues(&["maestro:ready"]),
+                                client.list_issues(&["maestro:failed"]),
+                                client.list_milestones("open"),
+                            );
+                            let ready_count = ready_result.map(|v| v.len()).unwrap_or(0);
+                            let failed_count = failed_result.map(|v| v.len()).unwrap_or(0);
+                            let milestones_vec = milestones_result.unwrap_or_default();
+                            let open_issue_count: usize =
+                                milestones_vec.iter().map(|m| m.open_issues as usize).sum();
+                            let closed_issue_count: usize = milestones_vec
+                                .iter()
+                                .map(|m| m.closed_issues as usize)
+                                .sum();
+                            let milestones_data: Vec<_> = milestones_vec
+                                .iter()
+                                .map(|m| {
+                                    let total = m.open_issues + m.closed_issues;
+                                    (m.title.clone(), m.closed_issues, total)
+                                })
+                                .collect();
+                            Ok(app::SuggestionDataPayload {
                                 ready_issue_count: ready_count,
                                 failed_issue_count: failed_count,
                                 milestones: milestones_data,
                                 open_issue_count,
                                 closed_issue_count,
-                            },
-                        ));
+                            })
+                        })
+                        .await;
+                        let _ = tx.send(app::TuiDataEvent::SuggestionData(result));
                     });
                 }
                 app::TuiCommand::FetchMilestones => {
                     let tx = app.data_tx.clone();
-                    let repo = github_repo_from_app(app);
+                    let provider_config = provider_config_from_app(app);
                     tokio::spawn(async move {
-                        let client = GhCliClient::from_config_repo(repo);
-                        match client.list_milestones("open").await {
-                            Ok(milestones) => {
-                                let futures: Vec<_> = milestones
-                                    .iter()
-                                    .map(|ms| client.list_issues_by_milestone(&ms.title))
-                                    .collect();
-                                let results = futures::future::join_all(futures).await;
-                                let entries = milestones
-                                    .into_iter()
-                                    .zip(results)
-                                    .map(|(ms, r)| (ms, r.unwrap_or_default()))
-                                    .collect();
-                                let _ = tx.send(app::TuiDataEvent::Milestones(Ok(entries)));
-                            }
-                            Err(e) => {
-                                let _ = tx.send(app::TuiDataEvent::Milestones(Err(e)));
-                            }
-                        }
+                        let result = with_provider(provider_config, |client| async move {
+                            let milestones = client.list_milestones("open").await?;
+                            let futures: Vec<_> = milestones
+                                .iter()
+                                .map(|ms| client.list_issues_by_milestone(&ms.title))
+                                .collect();
+                            let results = futures::future::join_all(futures).await;
+                            Ok(milestones
+                                .into_iter()
+                                .zip(results)
+                                .map(|(ms, r)| (ms, r.unwrap_or_default()))
+                                .collect())
+                        })
+                        .await;
+                        let _ = tx.send(app::TuiDataEvent::Milestones(result));
                     });
                 }
                 app::TuiCommand::LaunchSession(config) => {
-                    spawn_issue_fetch(app.data_tx.clone(), config, github_repo_from_app(app));
+                    spawn_issue_fetch(app.data_tx.clone(), config, provider_config_from_app(app));
                 }
                 app::TuiCommand::LaunchSessions(configs) => {
-                    let repo = github_repo_from_app(app);
+                    let provider_config = provider_config_from_app(app);
                     for config in configs {
-                        spawn_issue_fetch(app.data_tx.clone(), config, repo.clone());
+                        spawn_issue_fetch(app.data_tx.clone(), config, provider_config.clone());
                     }
                 }
                 app::TuiCommand::LaunchUnifiedSession(config) => {
                     let tx = app.data_tx.clone();
                     let issue_numbers: Vec<u64> = config.issues.iter().map(|(n, _)| *n).collect();
                     let custom_prompt = config.custom_prompt.clone();
-                    let repo = github_repo_from_app(app);
+                    let provider_config = provider_config_from_app(app);
                     tokio::spawn(async move {
-                        let client = GhCliClient::from_config_repo(repo);
-                        let futures: Vec<_> = issue_numbers
-                            .iter()
-                            .map(|num| client.get_issue(*num))
-                            .collect();
-                        let results = futures::future::join_all(futures).await;
-                        let mut issues = Vec::new();
-                        for result in results {
-                            match result {
-                                Ok(issue) => issues.push(issue),
-                                Err(e) => {
-                                    let _ = tx.send(app::TuiDataEvent::UnifiedIssues(
-                                        Err(e),
-                                        custom_prompt,
-                                    ));
-                                    return;
+                        let result = with_provider(provider_config, |client| async move {
+                            let futures: Vec<_> = issue_numbers
+                                .iter()
+                                .map(|num| client.get_issue(*num))
+                                .collect();
+                            let results = futures::future::join_all(futures).await;
+                            let mut issues = Vec::new();
+                            for result in results {
+                                match result {
+                                    Ok(issue) => issues.push(issue),
+                                    Err(e) => return Err(e),
                                 }
                             }
-                        }
-                        let _ =
-                            tx.send(app::TuiDataEvent::UnifiedIssues(Ok(issues), custom_prompt));
+                            Ok(issues)
+                        })
+                        .await;
+                        let _ = tx.send(app::TuiDataEvent::UnifiedIssues(result, custom_prompt));
                     });
                 }
                 app::TuiCommand::LaunchPromptSession(config) => {
@@ -330,10 +339,12 @@ async fn event_loop(
                 }
                 app::TuiCommand::FetchOpenPrs => {
                     let tx = app.data_tx.clone();
-                    let repo = github_repo_from_app(app);
+                    let provider_config = provider_config_from_app(app);
                     tokio::spawn(async move {
-                        let client = GhCliClient::from_config_repo(repo);
-                        let result = client.list_open_prs().await;
+                        let result = with_provider(provider_config, |client| async move {
+                            client.list_open_prs().await
+                        })
+                        .await;
                         let _ = tx.send(app::TuiDataEvent::PullRequests(result));
                     });
                 }
@@ -343,10 +354,12 @@ async fn event_loop(
                     body,
                 } => {
                     let tx = app.data_tx.clone();
-                    let repo = github_repo_from_app(app);
+                    let provider_config = provider_config_from_app(app);
                     tokio::spawn(async move {
-                        let client = GhCliClient::from_config_repo(repo);
-                        let result = client.submit_pr_review(pr_number, event, &body).await;
+                        let result = with_provider(provider_config, |client| async move {
+                            client.submit_pr_review(pr_number, event, &body).await
+                        })
+                        .await;
                         let _ = tx.send(app::TuiDataEvent::PrReviewSubmitted(result));
                     });
                 }
@@ -429,35 +442,41 @@ async fn event_loop(
                 }
                 app::TuiCommand::RunAdaptMaterialize(plan, report) => {
                     let tx = app.data_tx.clone();
-                    let repo = github_repo_from_app(app);
+                    let provider_config = provider_config_from_app(app);
                     tokio::spawn(async move {
                         use crate::adapt::materializer::{GhMaterializer, PlanMaterializer};
-                        let github =
-                            crate::provider::github::client::GhCliClient::from_config_repo(repo);
-                        let materializer = GhMaterializer::new(github);
-                        let result = materializer.materialize(&plan, &report, false).await;
+                        let result = with_provider(provider_config, |github| async move {
+                            let materializer = GhMaterializer::new(github);
+                            materializer.materialize(&plan, &report, false).await
+                        })
+                        .await;
                         let _ = tx.send(app::TuiDataEvent::AdaptMaterializeResult(result));
                     });
                 }
                 app::TuiCommand::CreateIssue(payload) => {
                     let tx = app.data_tx.clone();
-                    let repo = github_repo_from_app(app);
+                    let provider_config = provider_config_from_app(app);
                     tokio::spawn(async move {
                         use crate::provider::github::client::CreateOutcome;
                         let body =
                             crate::tui::screens::issue_wizard::render_body_markdown(&payload);
                         let labels = crate::tui::screens::issue_wizard::render_labels(&payload);
-                        let client = GhCliClient::from_config_repo(repo);
-                        let result = client
-                            .create_issue(&payload.title, &body, &labels, payload.milestone)
-                            .await;
+                        let title = payload.title.clone();
+                        let create_title = title.clone();
+                        let milestone = payload.milestone;
+                        let result = with_provider(provider_config, |client| async move {
+                            client
+                                .create_issue(&create_title, &body, &labels, milestone)
+                                .await
+                        })
+                        .await;
                         let evt = match result {
                             Ok(CreateOutcome::Created(n)) => app::TuiDataEvent::IssueCreated(Ok(n)),
                             Ok(CreateOutcome::Existed { number, state }) => {
                                 app::TuiDataEvent::IssueAlreadyExists {
                                     number,
                                     state,
-                                    title: payload.title.clone(),
+                                    title,
                                 }
                             }
                             Err(e) => app::TuiDataEvent::IssueCreated(Err(e)),
@@ -467,10 +486,12 @@ async fn event_loop(
                 }
                 app::TuiCommand::FetchWizardDependencies => {
                     let tx = app.data_tx.clone();
-                    let repo = github_repo_from_app(app);
+                    let provider_config = provider_config_from_app(app);
                     tokio::spawn(async move {
-                        let client = GhCliClient::from_config_repo(repo);
-                        let result = client.list_issues(&[]).await;
+                        let result = with_provider(provider_config, |client| async move {
+                            client.list_issues(&[]).await
+                        })
+                        .await;
                         let _ = tx.send(app::TuiDataEvent::WizardDependencyIssues(result));
                     });
                 }
@@ -500,11 +521,13 @@ async fn event_loop(
                 }
                 app::TuiCommand::CreateMilestoneWithIssues(plan) => {
                     let tx = app.data_tx.clone();
-                    let repo = github_repo_from_app(app);
+                    let provider_config = provider_config_from_app(app);
                     tokio::spawn(async move {
-                        let res =
-                            crate::tui::screens::milestone_wizard::materialize_plan(&plan, repo)
-                                .await;
+                        let res = crate::tui::screens::milestone_wizard::materialize_plan(
+                            &plan,
+                            provider_config,
+                        )
+                        .await;
                         let _ = tx.send(app::TuiDataEvent::MilestonePlanCreated(res));
                     });
                 }
@@ -524,54 +547,60 @@ async fn event_loop(
                     let tx = app.data_tx.clone();
                     let local_sessions: Vec<crate::session::types::Session> =
                         app.pool.all_sessions().into_iter().cloned().collect();
-                    let repo = github_repo_from_app(app);
+                    let provider_config = provider_config_from_app(app);
                     tokio::spawn(async move {
-                        let client = GhCliClient::from_config_repo(repo);
-                        let (
-                            open_result,
-                            closed_result,
-                            ready_result,
-                            failed_result,
-                            done_result,
-                            milestones_result,
-                        ) = tokio::join!(
-                            client.list_issues(&[]),
-                            client.list_issues(&["state:closed"]),
-                            client.list_issues(&["maestro:ready"]),
-                            client.list_issues(&["maestro:failed"]),
-                            client.list_issues(&["maestro:done"]),
-                            client.list_milestones("open"),
-                        );
-                        let data = crate::tui::screens::project_stats::aggregate(
-                            open_result.ok().map(|v| v.len() as u32).unwrap_or(0),
-                            closed_result.ok().map(|v| v.len() as u32).unwrap_or(0),
-                            ready_result.ok().map(|v| v.len() as u32).unwrap_or(0),
-                            failed_result.ok().map(|v| v.len() as u32).unwrap_or(0),
-                            done_result.ok().map(|v| v.len() as u32).unwrap_or(0),
-                            milestones_result.unwrap_or_default(),
-                            &local_sessions,
-                        );
-                        let _ = tx.send(app::TuiDataEvent::ProjectStats(data));
+                        let result = with_provider(provider_config, |client| async move {
+                            let (
+                                open_result,
+                                closed_result,
+                                ready_result,
+                                failed_result,
+                                done_result,
+                                milestones_result,
+                            ) = tokio::join!(
+                                client.list_issues(&[]),
+                                client.list_issues(&["state:closed"]),
+                                client.list_issues(&["maestro:ready"]),
+                                client.list_issues(&["maestro:failed"]),
+                                client.list_issues(&["maestro:done"]),
+                                client.list_milestones("open"),
+                            );
+                            Ok(crate::tui::screens::project_stats::aggregate(
+                                open_result.ok().map(|v| v.len() as u32).unwrap_or(0),
+                                closed_result.ok().map(|v| v.len() as u32).unwrap_or(0),
+                                ready_result.ok().map(|v| v.len() as u32).unwrap_or(0),
+                                failed_result.ok().map(|v| v.len() as u32).unwrap_or(0),
+                                done_result.ok().map(|v| v.len() as u32).unwrap_or(0),
+                                milestones_result.unwrap_or_default(),
+                                &local_sessions,
+                            ))
+                        })
+                        .await;
+                        let _ = tx.send(app::TuiDataEvent::ProjectStats(result));
                     });
                 }
                 app::TuiCommand::SyncPrd => {
                     let tx = app.data_tx.clone();
-                    let repo = github_repo_from_app(app);
+                    let provider_config = provider_config_from_app(app);
                     tokio::spawn(async move {
-                        let client = GhCliClient::from_config_repo(repo);
-                        let result = crate::prd::sync::GitHubPrdSyncer::new(Box::new(client))
-                            .fetch_current_state()
-                            .await;
+                        let result = with_provider(provider_config, |client| async move {
+                            crate::prd::sync::GitHubPrdSyncer::new(client)
+                                .fetch_current_state()
+                                .await
+                        })
+                        .await;
                         let _ = tx.send(app::TuiDataEvent::PrdSyncResult(result));
                     });
                 }
                 app::TuiCommand::SyncRoadmap => {
                     let tx = app.data_tx.clone();
-                    let repo = github_repo_from_app(app);
+                    let provider_config = provider_config_from_app(app);
                     tokio::spawn(async move {
-                        let client = GhCliClient::from_config_repo(repo);
-                        let result =
-                            crate::tui::screens::roadmap::loader::load_roadmap(&client).await;
+                        let result = with_provider(provider_config, |client| async move {
+                            crate::tui::screens::roadmap::loader::load_roadmap(client.as_ref())
+                                .await
+                        })
+                        .await;
                         let _ = tx.send(app::TuiDataEvent::RoadmapResult(result));
                     });
                 }
@@ -590,13 +619,15 @@ async fn event_loop(
                 }
                 app::TuiCommand::FetchMilestoneHealthIssues { milestone } => {
                     let tx = app.data_tx.clone();
-                    let repo = github_repo_from_app(app);
+                    let provider_config = provider_config_from_app(app);
                     tokio::spawn(async move {
-                        let client = GhCliClient::from_config_repo(repo);
-                        let result = client
-                            .list_issues_by_milestone(&milestone.title)
-                            .await
-                            .map(|issues| (milestone, issues));
+                        let result = with_provider(provider_config, |client| async move {
+                            client
+                                .list_issues_by_milestone(&milestone.title)
+                                .await
+                                .map(|issues| (milestone, issues))
+                        })
+                        .await;
                         let _ = tx.send(app::TuiDataEvent::MilestoneHealthIssuesFetched(result));
                     });
                 }
@@ -605,12 +636,14 @@ async fn event_loop(
                     description,
                 } => {
                     let tx = app.data_tx.clone();
-                    let repo = github_repo_from_app(app);
+                    let provider_config = provider_config_from_app(app);
                     tokio::spawn(async move {
-                        let client = GhCliClient::from_config_repo(repo);
-                        let result = client
-                            .patch_milestone_description(milestone_number, &description)
-                            .await;
+                        let result = with_provider(provider_config, |client| async move {
+                            client
+                                .patch_milestone_description(milestone_number, &description)
+                                .await
+                        })
+                        .await;
                         let _ = tx.send(app::TuiDataEvent::MilestoneHealthPatched(result));
                     });
                 }

--- a/src/tui/screens/milestone_wizard/mod.rs
+++ b/src/tui/screens/milestone_wizard/mod.rs
@@ -98,10 +98,9 @@ pub fn level_buckets(issues: &[AiProposedIssue]) -> Vec<Vec<usize>> {
 /// step's background task (#297, duplicate-aware via #455).
 pub async fn materialize_plan(
     plan: &AiGeneratedPlan,
-    repo: Option<String>,
+    provider_config: crate::config::ProviderConfig,
 ) -> Result<MilestoneCreationResult, String> {
-    use crate::provider::github::client::GhCliClient;
-    let client = GhCliClient::from_config_repo(repo);
+    let client = crate::provider::create_provider(&provider_config).map_err(|e| e.to_string())?;
     materialize_plan_with_client(plan, &client).await
 }
 


### PR DESCRIPTION
## Summary
- Route command and TUI provider usage through `create_provider(&config.provider)`.
- Carry configured repo slugs into `ProviderConfig` via `effective_provider_config()`.
- Surface provider factory failures through TUI data events instead of silently falling back.

Closes #459

## Test plan
- [x] cargo fmt --check
- [x] cargo test
- [x] cargo clippy -- -D warnings