### PR TITLE
feat(provider): expose CI and merge surfaces

### DIFF
--- a/src/config/github.rs
+++ b/src/config/github.rs
@@ -1,24 +1,7 @@
 use crate::provider::types::ProviderKind;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum MergeMethod {
-    Merge,
-    #[default]
-    Squash,
-    Rebase,
-}
-
-impl MergeMethod {
-    pub fn flag(&self) -> &'static str {
-        match self {
-            Self::Merge => "--merge",
-            Self::Squash => "--squash",
-            Self::Rebase => "--rebase",
-        }
-    }
-}
+pub use crate::provider::types::MergeMethod;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GithubConfig {

--- a/src/provider/azure_devops/mod.rs
+++ b/src/provider/azure_devops/mod.rs
@@ -1,5 +1,7 @@
 use crate::provider::github::client::RepoProvider;
-use crate::provider::types::{Issue, Milestone, PullRequest, ReviewEvent};
+use crate::provider::types::{
+    CheckRun, CiStatus, Issue, MergeMethod, Milestone, PullRequest, ReviewEvent,
+};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 
@@ -399,11 +401,32 @@ impl RepoProvider for AzDevOpsClient {
     ) -> Result<()> {
         anyhow::bail!("patch_milestone_description is not supported for Azure DevOps")
     }
+
+    async fn ci_status_for_branch(&self, _branch: &str) -> Result<CiStatus> {
+        anyhow::bail!("not yet implemented — tracked in v0.23.0 #B5")
+    }
+
+    async fn ci_status_for_pr(&self, _pr_number: u64) -> Result<CiStatus> {
+        anyhow::bail!("not yet implemented — tracked in v0.23.0 #B5")
+    }
+
+    async fn ci_check_runs_for_pr(&self, _pr_number: u64) -> Result<Vec<CheckRun>> {
+        anyhow::bail!("not yet implemented — tracked in v0.23.0 #B5")
+    }
+
+    async fn ci_logs_for_check(&self, _check_id: &str) -> Result<String> {
+        anyhow::bail!("not yet implemented — tracked in v0.23.0 #B5")
+    }
+
+    async fn merge_pr(&self, _pr_number: u64, _method: MergeMethod) -> Result<()> {
+        anyhow::bail!("not yet implemented — tracked in v0.23.0 #B5")
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::provider::github::client::RepoProvider;
 
     #[test]
     fn parse_work_items_json_valid_single_item() {
@@ -500,5 +523,21 @@ mod tests {
             issues[0].html_url,
             "https://dev.azure.com/MyOrg/MyProject/_apis/wit/workItems/42"
         );
+    }
+
+    #[tokio::test]
+    async fn merge_pr_stub_names_tracking_issue() {
+        let client = AzDevOpsClient::new(
+            "https://dev.azure.com/example".to_string(),
+            "Project".to_string(),
+        );
+
+        let err = client
+            .merge_pr(123, MergeMethod::Squash)
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("v0.23.0 #B5"));
     }
 }

--- a/src/provider/github/ci.rs
+++ b/src/provider/github/ci.rs
@@ -1,76 +1,10 @@
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
-/// CI check status for a pull request.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum CiStatus {
-    /// Checks are still running.
-    Pending,
-    /// All checks passed.
-    Passed,
-    /// One or more checks failed.
-    Failed { summary: String },
-    /// No CI checks configured on this repo/branch.
-    NoneConfigured,
-}
-
-/// Status of an individual CI check run.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub enum CheckStatus {
-    #[serde(alias = "QUEUED", alias = "queued")]
-    Queued,
-    #[serde(alias = "IN_PROGRESS", alias = "in_progress")]
-    InProgress,
-    #[serde(alias = "COMPLETED", alias = "completed")]
-    Completed,
-    #[serde(alias = "WAITING", alias = "waiting")]
-    Waiting,
-    #[serde(alias = "PENDING", alias = "pending")]
-    Pending,
-    #[serde(alias = "REQUESTED", alias = "requested")]
-    Requested,
-    #[serde(other)]
-    #[default]
-    Unknown,
-}
-
-/// Conclusion of a completed CI check run.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub enum CheckConclusion {
-    #[serde(alias = "SUCCESS", alias = "success")]
-    Success,
-    #[serde(alias = "FAILURE", alias = "failure")]
-    Failure,
-    #[serde(alias = "NEUTRAL", alias = "neutral")]
-    Neutral,
-    #[serde(alias = "CANCELLED", alias = "cancelled")]
-    Cancelled,
-    #[serde(alias = "TIMED_OUT", alias = "timed_out")]
-    TimedOut,
-    #[serde(alias = "ACTION_REQUIRED", alias = "action_required")]
-    ActionRequired,
-    #[serde(alias = "SKIPPED", alias = "skipped")]
-    Skipped,
-    #[serde(alias = "STALE", alias = "stale")]
-    Stale,
-    #[serde(alias = "STARTUP_FAILURE", alias = "startup_failure")]
-    StartupFailure,
-    /// Check not yet completed or unrecognized conclusion.
-    #[serde(other)]
-    #[default]
-    None,
-}
-
-/// Granular detail for a single CI check run.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CheckRunDetail {
-    pub name: String,
-    pub status: CheckStatus,
-    pub conclusion: CheckConclusion,
-    pub started_at: Option<DateTime<Utc>>,
-    pub elapsed_secs: Option<u64>,
-}
+pub use crate::provider::types::{
+    CheckConclusion, CheckRun as CheckRunDetail, CheckStatus, CiStatus,
+};
 
 /// Action to take after evaluating CI failure for auto-fix.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -98,6 +32,7 @@ pub struct PendingPrCheck {
 }
 
 /// Trait for CI status checking. Mockable for tests.
+#[allow(dead_code)] // Reason: superseded by RepoProvider CI methods; kept for API compatibility.
 pub trait CiCheck {
     /// Check the rollup CI status for a PR (pass/fail/pending).
     fn check_pr_status(&self, pr_number: u64) -> Result<CiStatus>;
@@ -110,13 +45,14 @@ pub trait CiCheck {
 }
 
 /// Checks CI status for pull requests via `gh` CLI.
+#[allow(dead_code)] // Reason: superseded by GhCliClient's RepoProvider implementation.
 pub struct CiChecker;
 
 #[derive(Deserialize)]
 struct PrStatusJson {
     #[serde(default)]
     #[serde(rename = "statusCheckRollup")]
-    status_check_rollup: Vec<CheckRun>,
+    status_check_rollup: Vec<StatusCheckRollup>,
     #[serde(default)]
     #[serde(rename = "mergeStateStatus")]
     #[allow(dead_code)]
@@ -124,7 +60,7 @@ struct PrStatusJson {
 }
 
 #[derive(Deserialize)]
-struct CheckRun {
+struct StatusCheckRollup {
     #[serde(default)]
     name: String,
     #[serde(default)]
@@ -134,6 +70,7 @@ struct CheckRun {
 }
 
 impl CiChecker {
+    #[allow(dead_code)] // Reason: superseded by GhCliClient's RepoProvider implementation.
     pub fn new() -> Self {
         Self
     }

--- a/src/provider/github/transport.rs
+++ b/src/provider/github/transport.rs
@@ -1,7 +1,10 @@
-use crate::provider::types::{Issue, Milestone, PullRequest, ReviewEvent};
+use crate::provider::types::{
+    CheckRun, CiStatus, Issue, MergeMethod, Milestone, PullRequest, ReviewEvent,
+};
 use anyhow::Result;
 use async_trait::async_trait;
 
+mod ci_merge;
 mod cli;
 mod cli_impl;
 mod errors;
@@ -95,6 +98,12 @@ pub trait RepoProvider: Send + Sync {
         milestone_number: u64,
         description: &str,
     ) -> Result<()>;
+    #[allow(dead_code)] // Reason: branch-level CI is provider surface for upcoming AzDO work.
+    async fn ci_status_for_branch(&self, branch: &str) -> Result<CiStatus>;
+    async fn ci_status_for_pr(&self, pr_number: u64) -> Result<CiStatus>;
+    async fn ci_check_runs_for_pr(&self, pr_number: u64) -> Result<Vec<CheckRun>>;
+    async fn ci_logs_for_check(&self, check_id: &str) -> Result<String>;
+    async fn merge_pr(&self, pr_number: u64, method: MergeMethod) -> Result<()>;
 }
 
 /// Blanket impl: if T: RepoProvider, then &T is also a RepoProvider.
@@ -169,6 +178,21 @@ impl<T: RepoProvider + ?Sized> RepoProvider for &T {
             .patch_milestone_description(milestone_number, description)
             .await
     }
+    async fn ci_status_for_branch(&self, branch: &str) -> Result<CiStatus> {
+        (**self).ci_status_for_branch(branch).await
+    }
+    async fn ci_status_for_pr(&self, pr_number: u64) -> Result<CiStatus> {
+        (**self).ci_status_for_pr(pr_number).await
+    }
+    async fn ci_check_runs_for_pr(&self, pr_number: u64) -> Result<Vec<CheckRun>> {
+        (**self).ci_check_runs_for_pr(pr_number).await
+    }
+    async fn ci_logs_for_check(&self, check_id: &str) -> Result<String> {
+        (**self).ci_logs_for_check(check_id).await
+    }
+    async fn merge_pr(&self, pr_number: u64, method: MergeMethod) -> Result<()> {
+        (**self).merge_pr(pr_number, method).await
+    }
 }
 
 /// Blanket impl: if T: RepoProvider, then Box<T> is also a RepoProvider.
@@ -242,5 +266,20 @@ impl<T: RepoProvider + ?Sized> RepoProvider for Box<T> {
         (**self)
             .patch_milestone_description(milestone_number, description)
             .await
+    }
+    async fn ci_status_for_branch(&self, branch: &str) -> Result<CiStatus> {
+        (**self).ci_status_for_branch(branch).await
+    }
+    async fn ci_status_for_pr(&self, pr_number: u64) -> Result<CiStatus> {
+        (**self).ci_status_for_pr(pr_number).await
+    }
+    async fn ci_check_runs_for_pr(&self, pr_number: u64) -> Result<Vec<CheckRun>> {
+        (**self).ci_check_runs_for_pr(pr_number).await
+    }
+    async fn ci_logs_for_check(&self, check_id: &str) -> Result<String> {
+        (**self).ci_logs_for_check(check_id).await
+    }
+    async fn merge_pr(&self, pr_number: u64, method: MergeMethod) -> Result<()> {
+        (**self).merge_pr(pr_number, method).await
     }
 }

--- a/src/provider/github/transport/ci_merge.rs
+++ b/src/provider/github/transport/ci_merge.rs
@@ -1,0 +1,116 @@
+use super::{GhCliClient, argv_refs};
+use crate::provider::types::{CheckRun, CiStatus, MergeMethod};
+use crate::util::validate_gh_arg;
+use anyhow::Result;
+
+pub(super) async fn ci_status_for_branch(client: &GhCliClient, branch: &str) -> Result<CiStatus> {
+    validate_gh_arg(branch, "branch")?;
+    let mut argv = vec![
+        "pr".to_string(),
+        "view".to_string(),
+        branch.to_string(),
+        "--json".to_string(),
+        "statusCheckRollup,mergeStateStatus".to_string(),
+    ];
+    append_repo_arg(client, &mut argv);
+    let json_str = client.run_gh(&argv_refs(&argv)).await?;
+    crate::provider::github::ci::parse_ci_json(&json_str)
+}
+
+pub(super) async fn ci_status_for_pr(client: &GhCliClient, pr_number: u64) -> Result<CiStatus> {
+    let mut argv = vec![
+        "pr".to_string(),
+        "view".to_string(),
+        pr_number.to_string(),
+        "--json".to_string(),
+        "statusCheckRollup,mergeStateStatus".to_string(),
+    ];
+    append_repo_arg(client, &mut argv);
+    let json_str = client.run_gh(&argv_refs(&argv)).await?;
+    crate::provider::github::ci::parse_ci_json(&json_str)
+}
+
+pub(super) async fn ci_check_runs_for_pr(
+    client: &GhCliClient,
+    pr_number: u64,
+) -> Result<Vec<CheckRun>> {
+    let mut argv = vec![
+        "pr".to_string(),
+        "checks".to_string(),
+        pr_number.to_string(),
+        "--json".to_string(),
+        "name,status,conclusion,startedAt,completedAt".to_string(),
+    ];
+    append_repo_arg(client, &mut argv);
+    let json_str = client.run_gh(&argv_refs(&argv)).await?;
+    crate::provider::github::ci::parse_check_details(&json_str)
+}
+
+pub(super) async fn ci_logs_for_check(client: &GhCliClient, check_id: &str) -> Result<String> {
+    validate_gh_arg(check_id, "check_id")?;
+    if check_id.parse::<u64>().is_ok() {
+        let mut argv = vec![
+            "run".to_string(),
+            "view".to_string(),
+            check_id.to_string(),
+            "--log-failed".to_string(),
+        ];
+        append_repo_arg(client, &mut argv);
+        let full_log = client.run_gh(&argv_refs(&argv)).await?;
+        return Ok(crate::provider::github::ci::truncate_log(&full_log, 4000));
+    }
+
+    let mut list_argv = vec![
+        "run".to_string(),
+        "list".to_string(),
+        "--branch".to_string(),
+        check_id.to_string(),
+        "--status".to_string(),
+        "failure".to_string(),
+        "--limit".to_string(),
+        "1".to_string(),
+        "--json".to_string(),
+        "databaseId".to_string(),
+    ];
+    append_repo_arg(client, &mut list_argv);
+    let runs_json = client.run_gh(&argv_refs(&list_argv)).await?;
+    let runs: Vec<serde_json::Value> = serde_json::from_str(&runs_json)?;
+    let run_id = runs
+        .first()
+        .and_then(|r| r.get("databaseId"))
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| anyhow::anyhow!("No failed run found for {}", check_id))?;
+
+    let mut view_argv = vec![
+        "run".to_string(),
+        "view".to_string(),
+        run_id.to_string(),
+        "--log-failed".to_string(),
+    ];
+    append_repo_arg(client, &mut view_argv);
+    let full_log = client.run_gh(&argv_refs(&view_argv)).await?;
+    Ok(crate::provider::github::ci::truncate_log(&full_log, 4000))
+}
+
+pub(super) async fn merge_pr(
+    client: &GhCliClient,
+    pr_number: u64,
+    method: MergeMethod,
+) -> Result<()> {
+    let mut argv = vec![
+        "pr".to_string(),
+        "merge".to_string(),
+        pr_number.to_string(),
+        method.flag().to_string(),
+        "--delete-branch".to_string(),
+    ];
+    append_repo_arg(client, &mut argv);
+    client.run_gh(&argv_refs(&argv)).await?;
+    Ok(())
+}
+
+fn append_repo_arg(client: &GhCliClient, argv: &mut Vec<String>) {
+    if let Some(repo) = client.repo_arg() {
+        argv.extend(["--repo".to_string(), repo.to_string()]);
+    }
+}

--- a/src/provider/github/transport/cli_impl.rs
+++ b/src/provider/github/transport/cli_impl.rs
@@ -4,7 +4,9 @@ use super::{
     parse_pr_number_from_create_output, parse_prs_json,
 };
 use crate::provider::github::gh_argv;
-use crate::provider::types::{Issue, Milestone, PullRequest, ReviewEvent};
+use crate::provider::types::{
+    CheckRun, CiStatus, Issue, MergeMethod, Milestone, PullRequest, ReviewEvent,
+};
 use crate::util::{titles_equivalent, validate_body, validate_gh_arg, validate_title};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -319,5 +321,25 @@ impl RepoProvider for GhCliClient {
             .await
             .with_context(|| format!("patching milestone #{} description", milestone_number))?;
         Ok(())
+    }
+
+    async fn ci_status_for_branch(&self, branch: &str) -> Result<CiStatus> {
+        super::ci_merge::ci_status_for_branch(self, branch).await
+    }
+
+    async fn ci_status_for_pr(&self, pr_number: u64) -> Result<CiStatus> {
+        super::ci_merge::ci_status_for_pr(self, pr_number).await
+    }
+
+    async fn ci_check_runs_for_pr(&self, pr_number: u64) -> Result<Vec<CheckRun>> {
+        super::ci_merge::ci_check_runs_for_pr(self, pr_number).await
+    }
+
+    async fn ci_logs_for_check(&self, check_id: &str) -> Result<String> {
+        super::ci_merge::ci_logs_for_check(self, check_id).await
+    }
+
+    async fn merge_pr(&self, pr_number: u64, method: MergeMethod) -> Result<()> {
+        super::ci_merge::merge_pr(self, pr_number, method).await
     }
 }

--- a/src/provider/github/transport/mock.rs
+++ b/src/provider/github/transport/mock.rs
@@ -1,5 +1,7 @@
 use super::CreateOutcome;
-use crate::provider::types::{Issue, Milestone, PullRequest, ReviewEvent};
+use crate::provider::types::{
+    CheckRun, CiStatus, Issue, MergeMethod, Milestone, PullRequest, ReviewEvent,
+};
 use std::sync::{Arc, Mutex};
 
 mod impl_client;
@@ -53,6 +55,19 @@ struct MockState {
     list_issues_by_milestone_error: Option<String>,
     patch_milestone_error: Option<String>,
     patch_milestone_calls: Vec<(u64, String)>,
+
+    // CI and merge provider surface fields (#460)
+    ci_status_for_branch_calls: Vec<String>,
+    ci_status_for_pr_calls: Vec<u64>,
+    ci_check_runs_for_pr_calls: Vec<u64>,
+    ci_logs_for_check_calls: Vec<String>,
+    merge_pr_calls: Vec<(u64, MergeMethod)>,
+    ci_status_for_branch_responses: std::collections::HashMap<String, CiStatus>,
+    ci_status_for_pr_responses: std::collections::HashMap<u64, CiStatus>,
+    ci_check_runs_for_pr_responses: std::collections::HashMap<u64, Vec<CheckRun>>,
+    ci_logs_for_check_responses: std::collections::HashMap<String, String>,
+    ci_error: Option<String>,
+    merge_pr_error: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -220,5 +235,64 @@ impl MockGitHubClient {
 
     pub fn patch_milestone_calls(&self) -> Vec<(u64, String)> {
         self.inner.lock().unwrap().patch_milestone_calls.clone()
+    }
+
+    pub fn set_ci_status_for_pr(&self, pr_number: u64, status: CiStatus) {
+        self.inner
+            .lock()
+            .unwrap()
+            .ci_status_for_pr_responses
+            .insert(pr_number, status);
+    }
+
+    #[allow(dead_code)] // Reason: helper for provider CI tests that do not need PR numbers.
+    pub fn set_ci_status_for_branch(&self, branch: &str, status: CiStatus) {
+        self.inner
+            .lock()
+            .unwrap()
+            .ci_status_for_branch_responses
+            .insert(branch.to_string(), status);
+    }
+
+    #[allow(dead_code)] // Reason: helper for tests that exercise CI detail rendering.
+    pub fn set_ci_check_runs_for_pr(&self, pr_number: u64, runs: Vec<CheckRun>) {
+        self.inner
+            .lock()
+            .unwrap()
+            .ci_check_runs_for_pr_responses
+            .insert(pr_number, runs);
+    }
+
+    #[allow(dead_code)] // Reason: helper for tests that exercise CI auto-fix log retrieval.
+    pub fn set_ci_logs_for_check(&self, check_id: &str, log: &str) {
+        self.inner
+            .lock()
+            .unwrap()
+            .ci_logs_for_check_responses
+            .insert(check_id.to_string(), log.to_string());
+    }
+
+    #[allow(dead_code)] // Reason: helper for tests that exercise provider CI failures.
+    pub fn set_ci_error(&self, msg: &str) {
+        self.inner.lock().unwrap().ci_error = Some(msg.to_string());
+    }
+
+    #[allow(dead_code)] // Reason: helper for tests that exercise auto-merge failures.
+    pub fn set_merge_pr_error(&self, msg: &str) {
+        self.inner.lock().unwrap().merge_pr_error = Some(msg.to_string());
+    }
+
+    pub fn ci_status_for_pr_calls(&self) -> Vec<u64> {
+        self.inner.lock().unwrap().ci_status_for_pr_calls.clone()
+    }
+
+    #[allow(dead_code)] // Reason: helper for tests that assert CI log lookup routing.
+    pub fn ci_logs_for_check_calls(&self) -> Vec<String> {
+        self.inner.lock().unwrap().ci_logs_for_check_calls.clone()
+    }
+
+    #[allow(dead_code)] // Reason: helper for tests that assert auto-merge routing.
+    pub fn merge_pr_calls(&self) -> Vec<(u64, MergeMethod)> {
+        self.inner.lock().unwrap().merge_pr_calls.clone()
     }
 }

--- a/src/provider/github/transport/mock/impl_client.rs
+++ b/src/provider/github/transport/mock/impl_client.rs
@@ -253,4 +253,65 @@ impl RepoProvider for MockGitHubClient {
         }
         Ok(())
     }
+
+    async fn ci_status_for_branch(&self, branch: &str) -> Result<CiStatus> {
+        let mut state = self.inner.lock().unwrap();
+        state.ci_status_for_branch_calls.push(branch.to_string());
+        if let Some(ref err) = state.ci_error {
+            anyhow::bail!("{}", err);
+        }
+        Ok(state
+            .ci_status_for_branch_responses
+            .get(branch)
+            .cloned()
+            .unwrap_or(CiStatus::NoneConfigured))
+    }
+
+    async fn ci_status_for_pr(&self, pr_number: u64) -> Result<CiStatus> {
+        let mut state = self.inner.lock().unwrap();
+        state.ci_status_for_pr_calls.push(pr_number);
+        if let Some(ref err) = state.ci_error {
+            anyhow::bail!("{}", err);
+        }
+        Ok(state
+            .ci_status_for_pr_responses
+            .get(&pr_number)
+            .cloned()
+            .unwrap_or(CiStatus::NoneConfigured))
+    }
+
+    async fn ci_check_runs_for_pr(&self, pr_number: u64) -> Result<Vec<CheckRun>> {
+        let mut state = self.inner.lock().unwrap();
+        state.ci_check_runs_for_pr_calls.push(pr_number);
+        if let Some(ref err) = state.ci_error {
+            anyhow::bail!("{}", err);
+        }
+        Ok(state
+            .ci_check_runs_for_pr_responses
+            .get(&pr_number)
+            .cloned()
+            .unwrap_or_default())
+    }
+
+    async fn ci_logs_for_check(&self, check_id: &str) -> Result<String> {
+        let mut state = self.inner.lock().unwrap();
+        state.ci_logs_for_check_calls.push(check_id.to_string());
+        if let Some(ref err) = state.ci_error {
+            anyhow::bail!("{}", err);
+        }
+        state
+            .ci_logs_for_check_responses
+            .get(check_id)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("mock: CI log {} not found", check_id))
+    }
+
+    async fn merge_pr(&self, pr_number: u64, method: MergeMethod) -> Result<()> {
+        let mut state = self.inner.lock().unwrap();
+        state.merge_pr_calls.push((pr_number, method));
+        if let Some(ref err) = state.merge_pr_error {
+            anyhow::bail!("{}", err);
+        }
+        Ok(())
+    }
 }

--- a/src/provider/types.rs
+++ b/src/provider/types.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::sync::OnceLock;
 
@@ -203,6 +204,96 @@ pub struct PullRequest {
     pub deletions: u64,
     #[serde(default)]
     pub changed_files: u64,
+}
+
+/// CI check status for a pull request or branch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CiStatus {
+    /// Checks are still running.
+    Pending,
+    /// All checks passed.
+    Passed,
+    /// One or more checks failed.
+    Failed { summary: String },
+    /// No CI checks configured on this repo/branch.
+    NoneConfigured,
+}
+
+/// Status of an individual CI check run.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CheckStatus {
+    #[serde(alias = "QUEUED", alias = "queued")]
+    Queued,
+    #[serde(alias = "IN_PROGRESS", alias = "in_progress")]
+    InProgress,
+    #[serde(alias = "COMPLETED", alias = "completed")]
+    Completed,
+    #[serde(alias = "WAITING", alias = "waiting")]
+    Waiting,
+    #[serde(alias = "PENDING", alias = "pending")]
+    Pending,
+    #[serde(alias = "REQUESTED", alias = "requested")]
+    Requested,
+    #[serde(other)]
+    #[default]
+    Unknown,
+}
+
+/// Conclusion of a completed CI check run.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CheckConclusion {
+    #[serde(alias = "SUCCESS", alias = "success")]
+    Success,
+    #[serde(alias = "FAILURE", alias = "failure")]
+    Failure,
+    #[serde(alias = "NEUTRAL", alias = "neutral")]
+    Neutral,
+    #[serde(alias = "CANCELLED", alias = "cancelled")]
+    Cancelled,
+    #[serde(alias = "TIMED_OUT", alias = "timed_out")]
+    TimedOut,
+    #[serde(alias = "ACTION_REQUIRED", alias = "action_required")]
+    ActionRequired,
+    #[serde(alias = "SKIPPED", alias = "skipped")]
+    Skipped,
+    #[serde(alias = "STALE", alias = "stale")]
+    Stale,
+    #[serde(alias = "STARTUP_FAILURE", alias = "startup_failure")]
+    StartupFailure,
+    /// Check not yet completed or unrecognized conclusion.
+    #[serde(other)]
+    #[default]
+    None,
+}
+
+/// Granular detail for a single CI check run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckRun {
+    pub name: String,
+    pub status: CheckStatus,
+    pub conclusion: CheckConclusion,
+    pub started_at: Option<DateTime<Utc>>,
+    pub elapsed_secs: Option<u64>,
+}
+
+/// Pull request merge strategy.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MergeMethod {
+    Merge,
+    #[default]
+    Squash,
+    Rebase,
+}
+
+impl MergeMethod {
+    pub fn flag(&self) -> &'static str {
+        match self {
+            Self::Merge => "--merge",
+            Self::Squash => "--squash",
+            Self::Rebase => "--rebase",
+        }
+    }
 }
 
 /// The type of review action to submit on a pull request.

--- a/src/tui/app/ci_polling.rs
+++ b/src/tui/app/ci_polling.rs
@@ -1,5 +1,6 @@
 use super::App;
-use crate::provider::github::ci::{CiCheck, CiChecker, CiStatus, PendingPrCheck};
+use crate::provider::github::ci::PendingPrCheck;
+use crate::provider::types::{CheckRun, CiStatus};
 use crate::tui::activity_log::LogLevel;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
@@ -12,7 +13,7 @@ use std::time::{Duration, Instant};
 pub struct CiPoller {
     pub pending_pr_checks: Vec<PendingPrCheck>,
     pub last_ci_poll: Instant,
-    pub ci_check_details: HashMap<u64, Vec<crate::provider::github::ci::CheckRunDetail>>,
+    pub ci_check_details: HashMap<u64, Vec<CheckRun>>,
 }
 
 impl Default for CiPoller {
@@ -121,7 +122,7 @@ mod tests {
 }
 
 impl App {
-    pub(super) fn poll_ci_status(&mut self) {
+    pub(super) async fn poll_ci_status(&mut self) {
         let ci_poll_interval = self
             .config
             .as_ref()
@@ -132,6 +133,15 @@ impl App {
             return;
         }
         self.ci_poller.mark_polled();
+
+        let Some(provider) = self.github_client.take() else {
+            self.activity_log.push_simple(
+                "CI".into(),
+                "CI polling skipped: no repository provider configured".into(),
+                LogLevel::Error,
+            );
+            return;
+        };
 
         let ci_max_wait = self
             .config
@@ -146,12 +156,10 @@ impl App {
             .map(|c| c.gates.ci_auto_fix.max_retries)
             .unwrap_or(3);
 
-        let checker = CiChecker::new();
         let mut completed_indices = Vec::new();
         // Collect fix requests to process after the loop (avoids borrow conflict)
         let mut fix_requests: Vec<crate::provider::github::ci::CiFixRequest> = Vec::new();
-        let mut detail_updates: Vec<(u64, Vec<crate::provider::github::ci::CheckRunDetail>)> =
-            Vec::new();
+        let mut detail_updates: Vec<(u64, Vec<CheckRun>)> = Vec::new();
 
         for (i, check) in self.ci_poller.pending_pr_checks.iter_mut().enumerate() {
             check.check_count += 1;
@@ -172,7 +180,8 @@ impl App {
 
             // If awaiting a fix session's CI re-run, handle separately
             if check.awaiting_fix_ci {
-                match checker.check_pr_status(check.pr_number) {
+                let status = provider.ci_status_for_pr(check.pr_number).await;
+                match status {
                     Ok(CiStatus::Pending) => {
                         // Fix was pushed, CI is re-running. Reset flag.
                         check.awaiting_fix_ci = false;
@@ -199,7 +208,8 @@ impl App {
                 continue;
             }
 
-            match checker.check_pr_status(check.pr_number) {
+            let status = provider.ci_status_for_pr(check.pr_number).await;
+            match status {
                 Ok(CiStatus::Passed) => {
                     self.activity_log.push_simple(
                         format!("PR #{}", check.pr_number),
@@ -217,31 +227,21 @@ impl App {
                     if let Some(ref config) = self.config
                         && config.github.auto_merge
                     {
-                        let method_flag = config.github.merge_method.flag();
-                        let pr_str = check.pr_number.to_string();
-                        let result = std::process::Command::new("gh")
-                            .args(["pr", "merge", &pr_str, method_flag, "--delete-branch"])
-                            .output();
+                        let result = provider
+                            .merge_pr(check.pr_number, config.github.merge_method.clone())
+                            .await;
                         match result {
-                            Ok(output) if output.status.success() => {
+                            Ok(()) => {
                                 self.activity_log.push_simple(
                                     format!("PR #{}", check.pr_number),
                                     "Auto-merged".into(),
                                     LogLevel::Info,
                                 );
                             }
-                            Ok(output) => {
-                                let stderr = String::from_utf8_lossy(&output.stderr);
-                                self.activity_log.push_simple(
-                                    format!("PR #{}", check.pr_number),
-                                    format!("Auto-merge failed: {}", stderr.trim()),
-                                    LogLevel::Error,
-                                );
-                            }
                             Err(e) => {
                                 self.activity_log.push_simple(
                                     format!("PR #{}", check.pr_number),
-                                    format!("Auto-merge error: {}", e),
+                                    format!("Auto-merge failed: {}", e),
                                     LogLevel::Error,
                                 );
                             }
@@ -252,7 +252,7 @@ impl App {
                     use crate::provider::github::ci::{
                         CiFixRequest, CiPollAction, decide_ci_action,
                     };
-                    if let Ok(details) = checker.check_pr_details(check.pr_number) {
+                    if let Ok(details) = provider.ci_check_runs_for_pr(check.pr_number).await {
                         detail_updates.push((check.pr_number, details));
                     }
 
@@ -264,7 +264,7 @@ impl App {
 
                     match action {
                         CiPollAction::SpawnFix { .. } => {
-                            match checker.fetch_failure_log(check.pr_number, &check.branch) {
+                            match provider.ci_logs_for_check(&check.branch).await {
                                 Ok(failure_log) => {
                                     self.activity_log.push_simple(
                                         format!("PR #{}", check.pr_number),
@@ -327,7 +327,7 @@ impl App {
                     completed_indices.push(i);
                 }
                 Ok(CiStatus::Pending) => {
-                    if let Ok(details) = checker.check_pr_details(check.pr_number) {
+                    if let Ok(details) = provider.ci_check_runs_for_pr(check.pr_number).await {
                         detail_updates.push((check.pr_number, details));
                     }
                 }
@@ -361,6 +361,7 @@ impl App {
         // Remove completed checks
         completed_indices.sort_unstable();
         self.ci_poller.remove_completed(&completed_indices);
+        self.github_client = Some(provider);
     }
 }
 

--- a/src/tui/app/ci_polling_app_tests.rs
+++ b/src/tui/app/ci_polling_app_tests.rs
@@ -11,8 +11,8 @@ fn make_app_with_flags(flags: crate::flags::store::FeatureFlags) -> crate::tui::
     app
 }
 
-#[test]
-fn poll_ci_status_skips_fix_when_ci_auto_fix_flag_disabled() {
+#[tokio::test]
+async fn poll_ci_status_skips_fix_when_ci_auto_fix_flag_disabled() {
     use crate::provider::github::ci::PendingPrCheck;
     let flags = crate::flags::store::FeatureFlags::new(
         std::collections::HashMap::new(),
@@ -37,11 +37,42 @@ fn poll_ci_status_skips_fix_when_ci_auto_fix_flag_disabled() {
     // poll_ci_status with Flag::CiAutoFix disabled — no fix sessions spawned.
     // The checker will fail (no gh in tests), but auto_fix_enabled is false so
     // CiPollAction::Abandon is chosen — no fix session enqueued.
-    app.poll_ci_status();
+    app.poll_ci_status().await;
     assert!(
         app.pending_session_launches.is_empty(),
         "poll_ci_status must not spawn fix session when Flag::CiAutoFix is disabled"
     );
+}
+
+#[tokio::test]
+async fn poll_ci_status_uses_provider_ci_status_once_per_tick() {
+    use crate::provider::github::ci::PendingPrCheck;
+    use crate::provider::github::client::mock::MockGitHubClient;
+    use crate::provider::types::CiStatus;
+
+    let mock = MockGitHubClient::new();
+    mock.set_ci_status_for_pr(123, CiStatus::Pending);
+
+    let mut app = make_app();
+    app.github_client = Some(Box::new(mock.clone()));
+    app.ci_poller.add_check(PendingPrCheck {
+        pr_number: 123,
+        issue_number: 42,
+        branch: "feat/test".to_string(),
+        fix_attempt: 0,
+        check_count: 0,
+        awaiting_fix_ci: false,
+        created_at: Instant::now()
+            .checked_sub(Duration::from_secs(120))
+            .unwrap_or_else(Instant::now),
+    });
+    app.ci_poller.last_ci_poll = Instant::now()
+        .checked_sub(Duration::from_secs(120))
+        .unwrap_or_else(Instant::now);
+
+    app.poll_ci_status().await;
+
+    assert_eq!(mock.ci_status_for_pr_calls(), vec![123]);
 }
 
 // --- Issue #125: CI check details field ---
@@ -55,10 +86,10 @@ fn app_ci_check_details_field_defaults_to_empty() {
 #[test]
 fn ci_check_details_can_be_populated_and_read() {
     let mut app = make_app();
-    let detail = crate::provider::github::ci::CheckRunDetail {
+    let detail = crate::provider::types::CheckRun {
         name: "build".into(),
-        status: crate::provider::github::ci::CheckStatus::Completed,
-        conclusion: crate::provider::github::ci::CheckConclusion::Success,
+        status: crate::provider::types::CheckStatus::Completed,
+        conclusion: crate::provider::types::CheckConclusion::Success,
         started_at: None,
         elapsed_secs: Some(42),
     };
@@ -70,10 +101,10 @@ fn ci_check_details_can_be_populated_and_read() {
 #[test]
 fn ci_check_details_keyed_by_pr_number() {
     let mut app = make_app();
-    let detail = crate::provider::github::ci::CheckRunDetail {
+    let detail = crate::provider::types::CheckRun {
         name: "test".into(),
-        status: crate::provider::github::ci::CheckStatus::InProgress,
-        conclusion: crate::provider::github::ci::CheckConclusion::None,
+        status: crate::provider::types::CheckStatus::InProgress,
+        conclusion: crate::provider::types::CheckConclusion::None,
         started_at: None,
         elapsed_secs: None,
     };

--- a/src/tui/app/completion_pipeline.rs
+++ b/src/tui/app/completion_pipeline.rs
@@ -411,7 +411,7 @@ impl App {
         }
 
         // Slow tier: CI status polling (every ~30s)
-        self.poll_ci_status();
+        self.poll_ci_status().await;
 
         // Try to promote queued sessions
         let promoted_ids = self.pool.try_promote();

--- a/src/tui/widgets/ci_monitor.rs
+++ b/src/tui/widgets/ci_monitor.rs
@@ -6,7 +6,7 @@ use ratatui::{
     widgets::{Paragraph, Widget},
 };
 
-use crate::provider::github::ci::{CheckConclusion, CheckRunDetail, CheckStatus};
+use crate::provider::types::{CheckConclusion, CheckRun as CheckRunDetail, CheckStatus};
 use crate::tui::icons::{self, IconId};
 use crate::tui::theme::Theme;
 


### PR DESCRIPTION
## Summary
- Add provider-agnostic CI status, check-run, and merge method types.
- Extend RepoProvider with CI and merge methods, including GitHub gh-backed implementations and AzDO fail-fast stubs.
- Route TUI CI polling and auto-merge through the provider trait, with mock coverage for polling and AzDO stub behavior.

Closes #460

## Test plan
- [x] cargo test --all-targets
- [ ] cargo clippy --all-targets -- -D warnings (currently blocked by pre-existing unrelated warnings/lints)