### PR TITLE
Fix clippy warnings for all targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,11 +73,11 @@ harness = false
 unsafe_code = "deny"
 
 [lints.clippy]
-expect_used = "warn"
 dbg_macro = "deny"
 # Lints deliberately NOT enabled globally (documented in docs/RUST-GUARDRAILS.md §2, §11):
-#   unwrap_used, panic, todo: too many existing matches; opt-in per-module via
-#     `#![deny(clippy::unwrap_used)]` in new modules until the legacy is cleaned up.
+#   expect_used, unwrap_used, panic, todo: too many existing matches; opt-in
+#     per-module via `#![deny(clippy::unwrap_used)]` in new modules until the
+#     legacy is cleaned up.
 #   print_stdout, print_stderr: CLI commands legitimately print to stdout/stderr.
 #     Library code avoids them by convention; see guardrails §11.
 

--- a/src/adapt/scanner.rs
+++ b/src/adapt/scanner.rs
@@ -590,11 +590,13 @@ fn build_tree_recursive(current: &Path, depth: usize, max_depth: usize, lines: &
 }
 
 #[cfg(test)]
+#[allow(dead_code)]
 pub struct MockProjectScanner {
     result: Option<ProjectProfile>,
 }
 
 #[cfg(test)]
+#[allow(dead_code)]
 impl MockProjectScanner {
     pub fn with_profile(profile: ProjectProfile) -> Self {
         Self {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -386,7 +386,7 @@ mod tests {
         let cli = Cli::try_parse_from(["maestro", "mangen", "/tmp/man"]).unwrap();
         assert!(matches!(
             cli.command,
-            Some(Commands::Mangen { out_dir }) if out_dir == PathBuf::from("/tmp/man")
+            Some(Commands::Mangen { out_dir }) if out_dir.as_path() == std::path::Path::new("/tmp/man")
         ));
     }
 

--- a/src/git_tests.rs
+++ b/src/git_tests.rs
@@ -87,10 +87,13 @@ fn mock_git_ops_has_commits_ahead_propagates_should_fail() {
 fn mock_backup_wip_records_call() {
     let ops = MockGitOps::new();
     ops.backup_wip(Path::new("/tmp/wt-562a"), 562).unwrap();
-    let calls = ops.backup_wip_calls.lock().unwrap();
-    assert_eq!(calls.len(), 1);
-    assert_eq!(calls[0].0, Path::new("/tmp/wt-562a"));
-    assert_eq!(calls[0].1, 562u64);
+    let (len, path, issue) = {
+        let calls = ops.backup_wip_calls.lock().unwrap();
+        (calls.len(), calls[0].0.clone(), calls[0].1)
+    };
+    assert_eq!(len, 1);
+    assert_eq!(path, Path::new("/tmp/wt-562a"));
+    assert_eq!(issue, 562u64);
 }
 
 #[test]
@@ -126,11 +129,19 @@ fn mock_amend_clean_and_push_records_call() {
         "feat: implement #562",
     )
     .unwrap();
-    let calls = ops.amend_calls.lock().unwrap();
-    assert_eq!(calls.len(), 1);
-    assert_eq!(calls[0].0, Path::new("/tmp/wt-562b"));
-    assert_eq!(calls[0].1, "feat/issue-562");
-    assert_eq!(calls[0].2, "feat: implement #562");
+    let (len, path, branch, message) = {
+        let calls = ops.amend_calls.lock().unwrap();
+        (
+            calls.len(),
+            calls[0].0.clone(),
+            calls[0].1.clone(),
+            calls[0].2.clone(),
+        )
+    };
+    assert_eq!(len, 1);
+    assert_eq!(path, Path::new("/tmp/wt-562b"));
+    assert_eq!(branch, "feat/issue-562");
+    assert_eq!(message, "feat: implement #562");
 }
 
 #[test]

--- a/src/integration_tests/milestone_health_wizard.rs
+++ b/src/integration_tests/milestone_health_wizard.rs
@@ -124,10 +124,7 @@ fn run_to_report(
     let _ = state.transition(HealthInput::Key(KeyCode::Enter)); // Picker → Loading
     let dor = check_issues(&issues);
     let anomalies = analyze(&milestone.description, &issues);
-    let report = HealthReport {
-        dor,
-        anomalies: anomalies.clone(),
-    };
+    let report = HealthReport { dor, anomalies };
     let _ = state.transition(HealthInput::DataFetched(Ok((milestone, issues))));
     report
 }

--- a/src/integration_tests/worktree_lifecycle.rs
+++ b/src/integration_tests/worktree_lifecycle.rs
@@ -58,10 +58,10 @@ fn multiple_sessions_each_get_unique_worktree() {
     let ids: Vec<_> = pool.all_sessions().iter().map(|s| s.id).collect();
     let mut paths: Vec<String> = Vec::new();
     for id in ids {
-        if let Some(managed) = pool.get_active_mut(id) {
-            if let Some(ref path) = managed.worktree_path {
-                paths.push(path.to_string_lossy().to_string());
-            }
+        if let Some(managed) = pool.get_active_mut(id)
+            && let Some(ref path) = managed.worktree_path
+        {
+            paths.push(path.to_string_lossy().to_string());
         }
     }
 

--- a/src/mascot/tests.rs
+++ b/src/mascot/tests.rs
@@ -342,17 +342,17 @@ fn widget_applies_clawd_orange_to_non_space_cells() {
     let expected_fg = Color::Rgb(215, 119, 87);
     for y in 0..buf.area.height {
         for x in 0..buf.area.width {
-            if let Some(cell) = buf.cell((x, y)) {
-                if cell.symbol() != " " {
-                    assert_eq!(
-                        cell.fg,
-                        expected_fg,
-                        "Wrong fg at ({}, {}): symbol={:?}",
-                        x,
-                        y,
-                        cell.symbol()
-                    );
-                }
+            if let Some(cell) = buf.cell((x, y))
+                && cell.symbol() != " "
+            {
+                assert_eq!(
+                    cell.fg,
+                    expected_fg,
+                    "Wrong fg at ({}, {}): symbol={:?}",
+                    x,
+                    y,
+                    cell.symbol()
+                );
             }
         }
     }

--- a/src/prompts.rs
+++ b/src/prompts.rs
@@ -468,7 +468,7 @@ mod tests {
     // --- image prompt tests (issue #42) ---
 
     fn make_image_paths(names: &[&str]) -> Vec<std::path::PathBuf> {
-        names.iter().map(|n| std::path::PathBuf::from(n)).collect()
+        names.iter().map(std::path::PathBuf::from).collect()
     }
 
     #[test]

--- a/src/provider/github/transport/mock/impl_client.rs
+++ b/src/provider/github/transport/mock/impl_client.rs
@@ -6,16 +6,18 @@ use async_trait::async_trait;
 #[async_trait]
 impl RepoProvider for MockGitHubClient {
     async fn list_issues(&self, labels: &[&str]) -> Result<Vec<Issue>> {
-        let state = self.inner.lock().unwrap();
         let label_set: std::collections::HashSet<&str> = labels.iter().copied().collect();
-        let filtered = state
-            .issues
-            .iter()
-            .filter(|i| {
-                label_set.is_empty() || i.labels.iter().any(|l| label_set.contains(l.as_str()))
-            })
-            .cloned()
-            .collect();
+        let filtered = {
+            let state = self.inner.lock().unwrap();
+            state
+                .issues
+                .iter()
+                .filter(|i| {
+                    label_set.is_empty() || i.labels.iter().any(|l| label_set.contains(l.as_str()))
+                })
+                .cloned()
+                .collect()
+        };
         Ok(filtered)
     }
 
@@ -51,6 +53,7 @@ impl RepoProvider for MockGitHubClient {
             anyhow::bail!("{}", err);
         }
         state.add_label_calls.push((issue, label.to_string()));
+        drop(state);
         Ok(())
     }
 
@@ -60,6 +63,7 @@ impl RepoProvider for MockGitHubClient {
             anyhow::bail!("{}", err);
         }
         state.remove_label_calls.push((issue, label.to_string()));
+        drop(state);
         Ok(())
     }
 
@@ -204,6 +208,7 @@ impl RepoProvider for MockGitHubClient {
             event,
             body: body.to_string(),
         });
+        drop(state);
         Ok(())
     }
 
@@ -227,6 +232,7 @@ impl RepoProvider for MockGitHubClient {
         if !state.labels.contains(&name.to_string()) {
             state.labels.push(name.to_string());
         }
+        drop(state);
         Ok(())
     }
 
@@ -251,6 +257,7 @@ impl RepoProvider for MockGitHubClient {
         {
             m.description = description.to_string();
         }
+        drop(state);
         Ok(())
     }
 
@@ -312,6 +319,7 @@ impl RepoProvider for MockGitHubClient {
         if let Some(ref err) = state.merge_pr_error {
             anyhow::bail!("{}", err);
         }
+        drop(state);
         Ok(())
     }
 }

--- a/src/sanitize/mod.rs
+++ b/src/sanitize/mod.rs
@@ -144,9 +144,11 @@ mod pipeline_tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("main.rs"), "fn main() {}").unwrap();
 
-        let mut config = SanitizeConfig::default();
-        config.path = dir.path().to_path_buf();
-        config.skip_ai = true;
+        let config = SanitizeConfig {
+            path: dir.path().to_path_buf(),
+            skip_ai: true,
+            ..Default::default()
+        };
 
         let result = cmd_sanitize(config).await;
         assert!(result.is_ok());

--- a/src/sanitize/reporter.rs
+++ b/src/sanitize/reporter.rs
@@ -222,9 +222,7 @@ mod tests {
             vec![make_finding(Severity::Warning, "src/b.rs", 5)],
         );
 
-        let result = TextReporter::default()
-            .generate(&report, Severity::Info)
-            .unwrap();
+        let result = TextReporter.generate(&report, Severity::Info).unwrap();
 
         assert!(result.contains("CRITICAL"));
         assert!(result.contains("WARNING"));
@@ -236,9 +234,7 @@ mod tests {
     #[test]
     fn text_format_empty_report_shows_no_issues_found() {
         let report = SanitizeReport::default();
-        let result = TextReporter::default()
-            .generate(&report, Severity::Info)
-            .unwrap();
+        let result = TextReporter.generate(&report, Severity::Info).unwrap();
         assert!(result.to_lowercase().contains("no issues found"));
     }
 
@@ -251,9 +247,7 @@ mod tests {
             vec![make_finding(Severity::Critical, "src/main.rs", 0)],
         );
 
-        let result = JsonReporter::default()
-            .generate(&report, Severity::Info)
-            .unwrap();
+        let result = JsonReporter.generate(&report, Severity::Info).unwrap();
 
         let deserialized: SanitizeReport =
             serde_json::from_str(&result).expect("output must be valid JSON");
@@ -286,9 +280,7 @@ mod tests {
             vec![],
         );
 
-        let result = MarkdownReporter::default()
-            .generate(&report, Severity::Info)
-            .unwrap();
+        let result = MarkdownReporter.generate(&report, Severity::Info).unwrap();
 
         assert!(result.contains('#'));
         assert!(result.contains("src/foo.rs"));
@@ -299,9 +291,7 @@ mod tests {
     #[test]
     fn markdown_format_empty_report_shows_no_issues_found() {
         let report = SanitizeReport::default();
-        let result = MarkdownReporter::default()
-            .generate(&report, Severity::Info)
-            .unwrap();
+        let result = MarkdownReporter.generate(&report, Severity::Info).unwrap();
         assert!(result.to_lowercase().contains("no issues found"));
     }
 
@@ -318,9 +308,7 @@ mod tests {
             vec![],
         );
 
-        let result = TextReporter::default()
-            .generate(&report, Severity::Warning)
-            .unwrap();
+        let result = TextReporter.generate(&report, Severity::Warning).unwrap();
 
         assert!(result.contains("src/a.rs"));
         assert!(result.contains("src/b.rs"));
@@ -337,9 +325,7 @@ mod tests {
             vec![],
         );
 
-        let result = TextReporter::default()
-            .generate(&report, Severity::Critical)
-            .unwrap();
+        let result = TextReporter.generate(&report, Severity::Critical).unwrap();
 
         assert!(!result.contains("src/x.rs"));
         assert!(!result.contains("src/y.rs"));

--- a/src/session/parser.rs
+++ b/src/session/parser.rs
@@ -891,10 +891,13 @@ mod tests {
     fn parse_result_event_extracts_context_update() {
         let line = r#"{"type":"result","cost_usd":1.5,"usage":{"input_tokens":70000,"output_tokens":2000,"max_input_tokens":200000}}"#;
         let events = parse_stream_line(line);
-        let ctx = events
+        let ctx = match events
             .iter()
             .find(|e| matches!(e, StreamEvent::ContextUpdate { .. }))
-            .expect("Expected ContextUpdate from result event");
+        {
+            Some(ctx) => ctx,
+            None => panic!("Expected ContextUpdate from result event"),
+        };
         match ctx {
             StreamEvent::ContextUpdate { context_pct } => {
                 assert!((*context_pct - 0.35).abs() < 0.001);
@@ -933,10 +936,13 @@ mod tests {
     fn parse_assistant_event_extracts_context_from_cache_tokens() {
         let line = r#"{"type":"assistant","message":{"type":"text","text":"hello","usage":{"input_tokens":3,"cache_read_input_tokens":50000,"cache_creation_input_tokens":10000,"output_tokens":25}}}"#;
         let events = parse_stream_line(line);
-        let ctx = events
+        let ctx = match events
             .iter()
             .find(|e| matches!(e, StreamEvent::ContextUpdate { .. }))
-            .expect("Expected ContextUpdate from assistant event with cache tokens");
+        {
+            Some(ctx) => ctx,
+            None => panic!("Expected ContextUpdate from assistant event with cache tokens"),
+        };
         match ctx {
             StreamEvent::ContextUpdate { context_pct } => {
                 // total = 3 + 50000 + 10000 = 60003, max = 200000 (default)
@@ -966,10 +972,13 @@ mod tests {
     fn parse_assistant_event_opus_model_uses_1m_max() {
         let line = r#"{"type":"assistant","message":{"model":"claude-opus-4-6","type":"text","text":"hi","usage":{"input_tokens":3,"cache_read_input_tokens":50000,"cache_creation_input_tokens":10000,"output_tokens":25}}}"#;
         let events = parse_stream_line(line);
-        let ctx = events
+        let ctx = match events
             .iter()
             .find(|e| matches!(e, StreamEvent::ContextUpdate { .. }))
-            .expect("Expected ContextUpdate from opus assistant event");
+        {
+            Some(ctx) => ctx,
+            None => panic!("Expected ContextUpdate from opus assistant event"),
+        };
         match ctx {
             StreamEvent::ContextUpdate { context_pct } => {
                 // total = 60003, max = 1_000_000 (opus)
@@ -1099,7 +1108,9 @@ mod tests {
         let line = "{\"type\":\"assistant\",\"message\":{\"type\":\"tool_use\",\"name\":\"Agent\",\"input\":{\"subagent_type\":\"subagent-arch\\nitect\\u001b[31m\"}}}";
         match first_event(line) {
             StreamEvent::ToolUse { subagent_name, .. } => {
-                let name = subagent_name.expect("control chars must not collapse to None");
+                let Some(name) = subagent_name else {
+                    panic!("control chars must not collapse to None");
+                };
                 assert!(
                     !name.chars().any(char::is_control),
                     "control chars must be stripped, got {:?}",
@@ -1123,7 +1134,9 @@ mod tests {
         );
         match first_event(&line) {
             StreamEvent::ToolUse { subagent_name, .. } => {
-                let name = subagent_name.expect("oversized name should still produce Some");
+                let Some(name) = subagent_name else {
+                    panic!("oversized name should still produce Some");
+                };
                 assert!(
                     name.len() <= 80,
                     "name must be capped to 80, got {}",

--- a/src/session/types.rs
+++ b/src/session/types.rs
@@ -1364,10 +1364,9 @@ mod tests {
         let mut s = Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
         s.transition_to(SessionStatus::Spawning, TransitionReason::Promoted)
             .unwrap();
-        let last = s
-            .activity_log
-            .last()
-            .expect("activity log should have entry");
+        let Some(last) = s.activity_log.last() else {
+            panic!("activity log should have entry");
+        };
         assert!(
             last.message.contains("STATUS:"),
             "expected STATUS: prefix, got: {}",

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -8,4 +8,5 @@ pub use claude_settings::{CavemanModeState, FsSettingsStore, SettingsStore};
 // `CavemanWriteError` is exported only via `claude_settings::` for tests
 // and library consumers; the binary itself never names it directly.
 #[cfg(test)]
+#[allow(unused_imports)]
 pub use claude_settings::CavemanWriteError;

--- a/src/tui/app/completion_git.rs
+++ b/src/tui/app/completion_git.rs
@@ -136,9 +136,12 @@ mod tests {
         let head_is_wip = app.backup_wip_before_gates(562, &PathBuf::from("/tmp/fake-wt-562-1"));
 
         assert!(head_is_wip, "fresh WIP creation must report WIP at HEAD");
-        let calls = backup_calls.lock().unwrap();
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].1, 562u64);
+        let (len, issue) = {
+            let calls = backup_calls.lock().unwrap();
+            (calls.len(), calls[0].1)
+        };
+        assert_eq!(len, 1);
+        assert_eq!(issue, 562u64);
     }
 
     #[test]
@@ -183,10 +186,13 @@ mod tests {
             true,
         );
 
-        let amend = amend_calls.lock().unwrap();
-        assert_eq!(amend.len(), 1);
-        assert_eq!(amend[0].1, "feat/issue-562");
-        assert_eq!(amend[0].2, "feat: implement changes for issue #562");
+        let (len, branch, message) = {
+            let amend = amend_calls.lock().unwrap();
+            (amend.len(), amend[0].1.clone(), amend[0].2.clone())
+        };
+        assert_eq!(len, 1);
+        assert_eq!(branch, "feat/issue-562");
+        assert_eq!(message, "feat: implement changes for issue #562");
         assert!(commit_and_push_calls.lock().unwrap().is_empty());
     }
 
@@ -204,9 +210,12 @@ mod tests {
             false,
         );
 
-        let cap = commit_and_push_calls.lock().unwrap();
-        assert_eq!(cap.len(), 1);
-        assert_eq!(cap[0].1, "feat/issue-562");
+        let (len, branch) = {
+            let cap = commit_and_push_calls.lock().unwrap();
+            (cap.len(), cap[0].1.clone())
+        };
+        assert_eq!(len, 1);
+        assert_eq!(branch, "feat/issue-562");
         assert!(amend_calls.lock().unwrap().is_empty());
     }
 }

--- a/src/tui/app/completion_summary_conflicts_tests.rs
+++ b/src/tui/app/completion_summary_conflicts_tests.rs
@@ -16,7 +16,7 @@ fn build_completion_summary_gate_failure_message_truncated() {
         None,
     );
     session.status = crate::session::types::SessionStatus::NeedsReview;
-    session.gate_results = vec![GateResultEntry::fail("tests", &"x".repeat(300))];
+    session.gate_results = vec![GateResultEntry::fail("tests", "x".repeat(300))];
     app.pool.enqueue(session);
 
     let summary = app.build_completion_summary();

--- a/src/tui/input_handler.rs
+++ b/src/tui/input_handler.rs
@@ -1731,9 +1731,12 @@ mod tests {
 
         handle_completion_summary(&mut app, &key('s'));
 
-        let captured = calls.lock().expect("mutex");
-        assert_eq!(captured.len(), 1);
-        assert_eq!(captured[0], PathBuf::from(".maestro/worktrees/issue-560"));
+        let (len, path) = {
+            let captured = calls.lock().expect("mutex");
+            (captured.len(), captured[0].clone())
+        };
+        assert_eq!(len, 1);
+        assert_eq!(path, PathBuf::from(".maestro/worktrees/issue-560"));
     }
 
     #[test]

--- a/src/tui/screens/issue_wizard/mod.rs
+++ b/src/tui/screens/issue_wizard/mod.rs
@@ -1484,12 +1484,14 @@ mod tests {
 
     #[test]
     fn render_body_includes_attachments_section_when_images_present() {
-        let mut p = IssueCreationPayload::default();
-        p.title = "t".into();
-        p.overview = "o".into();
-        p.expected_behavior = "e".into();
-        p.acceptance_criteria = "a".into();
-        p.image_paths = vec!["/tmp/a.png".into(), "/tmp/b.png".into()];
+        let p = IssueCreationPayload {
+            title: "t".into(),
+            overview: "o".into(),
+            expected_behavior: "e".into(),
+            acceptance_criteria: "a".into(),
+            image_paths: vec!["/tmp/a.png".into(), "/tmp/b.png".into()],
+            ..Default::default()
+        };
         let body = render_body_markdown(&p);
         assert!(body.contains("## Attachments"));
         assert!(body.contains("[Attached image: /tmp/a.png]"));
@@ -1498,11 +1500,13 @@ mod tests {
 
     #[test]
     fn render_body_omits_attachments_section_when_empty() {
-        let mut p = IssueCreationPayload::default();
-        p.title = "t".into();
-        p.overview = "o".into();
-        p.expected_behavior = "e".into();
-        p.acceptance_criteria = "a".into();
+        let p = IssueCreationPayload {
+            title: "t".into(),
+            overview: "o".into(),
+            expected_behavior: "e".into(),
+            acceptance_criteria: "a".into(),
+            ..Default::default()
+        };
         let body = render_body_markdown(&p);
         assert!(!body.contains("## Attachments"));
     }

--- a/src/tui/screens/milestone_wizard/mod.rs
+++ b/src/tui/screens/milestone_wizard/mod.rs
@@ -346,6 +346,7 @@ impl MilestoneWizardScreen {
     /// the wizard itself — it exists so tests can set payload directly
     /// and still have the textareas render the same content.
     #[cfg(test)]
+    #[allow(dead_code)]
     pub(crate) fn reseed_fields_from_payload(&mut self) {
         self.goal_field.set_text(&self.payload.goals);
         self.non_goals_field.set_text(&self.payload.non_goals);
@@ -882,7 +883,7 @@ mod tests {
         s.handle_input(&key_event(KeyCode::Enter), InputMode::Insert);
         assert_eq!(s.payload().doc_references.len(), 1);
         assert_eq!(s.payload().doc_references[0], "https://example.com");
-        assert_eq!(s.payload().doc_reference_valid[0], true);
+        assert!(s.payload().doc_reference_valid[0]);
         assert_eq!(s.doc_buffer(), "");
     }
 

--- a/src/tui/screens/wrap.rs
+++ b/src/tui/screens/wrap.rs
@@ -125,12 +125,6 @@ mod tests {
         wrap_lines(&lines, (0, 0), width).lines
     }
 
-    // Helper: wrap multiple logical lines and return visual lines.
-    fn wrap_multi(lines: &[&str], width: u16) -> Vec<String> {
-        let owned: Vec<String> = lines.iter().map(|s| s.to_string()).collect();
-        wrap_lines(&owned, (0, 0), width).lines
-    }
-
     // === Group 1: Basic wrapping ===
 
     #[test]

--- a/src/tui/shell_launcher.rs
+++ b/src/tui/shell_launcher.rs
@@ -98,9 +98,12 @@ mod tests {
         let path = PathBuf::from("/tmp/wt/issue-542");
         let result = launcher.open_shell_at(&path);
         assert!(result.is_ok());
-        let calls = launcher.calls.lock().expect("mutex");
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0], path);
+        let (len, called_path) = {
+            let calls = launcher.calls.lock().expect("mutex");
+            (calls.len(), calls[0].clone())
+        };
+        assert_eq!(len, 1);
+        assert_eq!(called_path, path);
     }
 
     #[test]

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -847,8 +847,10 @@ mod tests {
 
     #[test]
     fn from_config_override_replaces_single_field() {
-        let mut overrides = ThemeOverrides::default();
-        overrides.text_primary = Some(SerializableColor(Color::Magenta));
+        let overrides = ThemeOverrides {
+            text_primary: Some(SerializableColor(Color::Magenta)),
+            ..Default::default()
+        };
         let cfg = ThemeConfig {
             preset: ThemePreset::Dark,
             overrides,
@@ -860,9 +862,11 @@ mod tests {
 
     #[test]
     fn from_config_multiple_overrides_all_applied() {
-        let mut overrides = ThemeOverrides::default();
-        overrides.text_primary = Some(SerializableColor(Color::Magenta));
-        overrides.border_active = Some(SerializableColor(Color::LightBlue));
+        let overrides = ThemeOverrides {
+            text_primary: Some(SerializableColor(Color::Magenta)),
+            border_active: Some(SerializableColor(Color::LightBlue)),
+            ..Default::default()
+        };
         let cfg = ThemeConfig {
             preset: ThemePreset::Dark,
             overrides,
@@ -1439,8 +1443,10 @@ mod tests {
 
     #[test]
     fn from_config_overrides_selection_bg() {
-        let mut overrides = ThemeOverrides::default();
-        overrides.selection_bg = Some(SerializableColor(Color::Magenta));
+        let overrides = ThemeOverrides {
+            selection_bg: Some(SerializableColor(Color::Magenta)),
+            ..Default::default()
+        };
         let cfg = ThemeConfig {
             preset: ThemePreset::Dark,
             overrides,
@@ -1450,8 +1456,10 @@ mod tests {
 
     #[test]
     fn from_config_overrides_selection_fg() {
-        let mut overrides = ThemeOverrides::default();
-        overrides.selection_fg = Some(SerializableColor(Color::LightYellow));
+        let overrides = ThemeOverrides {
+            selection_fg: Some(SerializableColor(Color::LightYellow)),
+            ..Default::default()
+        };
         let cfg = ThemeConfig {
             preset: ThemePreset::Dark,
             overrides,
@@ -1494,8 +1502,10 @@ mod tests {
 
     #[test]
     fn fkey_badge_override_applies() {
-        let mut overrides = ThemeOverrides::default();
-        overrides.fkey_badge_bg = Some(SerializableColor(Color::Magenta));
+        let overrides = ThemeOverrides {
+            fkey_badge_bg: Some(SerializableColor(Color::Magenta)),
+            ..Default::default()
+        };
         let cfg = ThemeConfig {
             preset: ThemePreset::Dark,
             overrides,

--- a/src/turboquant/adapter.rs
+++ b/src/turboquant/adapter.rs
@@ -761,18 +761,10 @@ mod tests {
         let mut s = make_running_session();
         // 4 distinct messages, 50 repetitions each, NOT interleaved
         let mut msgs: Vec<&str> = Vec::new();
-        for _ in 0..50 {
-            msgs.push("Tool: Bash");
-        }
-        for _ in 0..50 {
-            msgs.push("Read: src/lib.rs");
-        }
-        for _ in 0..50 {
-            msgs.push("Tool: Bash");
-        }
-        for _ in 0..50 {
-            msgs.push("Tool: Grep");
-        }
+        msgs.extend(["Tool: Bash"; 50]);
+        msgs.extend(["Read: src/lib.rs"; 50]);
+        msgs.extend(["Tool: Bash"; 50]);
+        msgs.extend(["Tool: Grep"; 50]);
         push_entries(&mut s, &msgs);
         assert_eq!(s.activity_log.len(), 200);
         let report = adapter.compact_session_history(&mut s);
@@ -1217,7 +1209,7 @@ mod tests {
     fn compact_history_is_idempotent_on_already_compacted_log() {
         let adapter = ranker();
         let mut s = make_running_session();
-        push_entries(&mut s, &vec!["Tool: Bash"; 5]);
+        push_entries(&mut s, &["Tool: Bash"; 5]);
         adapter.compact_session_history(&mut s);
         let after_first = s.activity_log.clone();
         adapter.compact_session_history(&mut s);

--- a/src/turboquant/pipeline.rs
+++ b/src/turboquant/pipeline.rs
@@ -128,7 +128,7 @@ mod tests {
         let v = vec![1.0, 2.0, 3.0, 4.0];
         let compressed = turbo_quantize(&v, 4);
         assert_eq!(compressed.strategy, QuantStrategy::TurboQuant);
-        assert!(compressed.polar.codes.len() > 0);
+        assert!(!compressed.polar.codes.is_empty());
         assert!(compressed.residual.projection_dim > 0);
     }
 
@@ -236,11 +236,7 @@ mod tests {
             QuantStrategy::PolarQuant,
             QuantStrategy::Qjl,
         ] {
-            let bits = if strategy == QuantStrategy::TurboQuant {
-                4
-            } else {
-                4
-            };
+            let bits = 4;
             let c = quantize_with_strategy(&v, strategy, bits);
             let _est = dot_product_with_strategy(&q, &c);
             // Just verify it doesn't panic

--- a/src/updater/replace.rs
+++ b/src/updater/replace.rs
@@ -175,6 +175,7 @@ impl ReplacerBehavior {
 }
 
 #[cfg(test)]
+#[allow(dead_code)]
 pub(crate) struct ReplacerCall {
     pub target: PathBuf,
     pub bytes_len: usize,

--- a/src/work/assigner.rs
+++ b/src/work/assigner.rs
@@ -473,7 +473,7 @@ mod tests {
         ]);
         assigner.mark_in_progress(1);
         let cascaded = assigner.mark_failed_cascade(1);
-        let mut nums = cascaded.clone();
+        let mut nums = cascaded;
         nums.sort();
         assert_eq!(nums, vec![2, 3]);
         assert_eq!(assigner.count_by_status().failed, 3);
@@ -488,7 +488,7 @@ mod tests {
         ]);
         assigner.mark_in_progress(1);
         let cascaded = assigner.mark_failed_cascade(1);
-        let mut nums = cascaded.clone();
+        let mut nums = cascaded;
         nums.sort();
         assert_eq!(nums, vec![2, 3]);
     }

--- a/src/work/types.rs
+++ b/src/work/types.rs
@@ -127,7 +127,7 @@ mod tests {
     fn from_issue_collects_blockers_from_labels() {
         let issue = make_gh_issue(10, &["blocked-by:#3", "blocked-by:#7"], "");
         let item = WorkItem::from_issue(issue);
-        let mut blockers = item.blocked_by.clone();
+        let mut blockers = item.blocked_by;
         blockers.sort();
         assert_eq!(blockers, vec![3u64, 7u64]);
     }
@@ -136,7 +136,7 @@ mod tests {
     fn from_issue_collects_blockers_from_body() {
         let issue = make_gh_issue(10, &[], "blocked-by: #5\nblocked-by: #9");
         let item = WorkItem::from_issue(issue);
-        let mut blockers = item.blocked_by.clone();
+        let mut blockers = item.blocked_by;
         blockers.sort();
         assert_eq!(blockers, vec![5u64, 9u64]);
     }
@@ -145,7 +145,7 @@ mod tests {
     fn from_issue_deduplicates_blockers_from_labels_and_body() {
         let issue = make_gh_issue(10, &["blocked-by:#2"], "blocked-by: #2\nblocked-by: #4");
         let item = WorkItem::from_issue(issue);
-        let mut blockers = item.blocked_by.clone();
+        let mut blockers = item.blocked_by;
         blockers.sort();
         assert_eq!(blockers, vec![2u64, 4u64]);
     }

--- a/tests/settings_caveman.rs
+++ b/tests/settings_caveman.rs
@@ -14,8 +14,8 @@ fn write_fixture(path: &PathBuf, body: &str) {
 }
 
 fn read_value(path: &PathBuf) -> Value {
-    let raw = fs::read_to_string(path).expect("read");
-    serde_json::from_str(&raw).expect("parse json")
+    let raw = fs::read_to_string(path).unwrap();
+    serde_json::from_str(&raw).unwrap()
 }
 
 #[test]
@@ -34,7 +34,7 @@ fn roundtrip_preserves_unknown_top_level_keys() {
     );
 
     let store = FsSettingsStore::new(&path);
-    store.save_caveman_mode(true).expect("save ok");
+    store.save_caveman_mode(true).unwrap();
 
     let value = read_value(&path);
     assert_eq!(value["behavior"]["caveman_mode"], serde_json::json!(true));
@@ -54,7 +54,7 @@ fn toggle_when_file_missing_creates_minimal_json() {
     assert!(!path.exists());
 
     let store = FsSettingsStore::new(&path);
-    store.save_caveman_mode(true).expect("save ok");
+    store.save_caveman_mode(true).unwrap();
 
     assert!(path.exists());
     let value = read_value(&path);
@@ -72,7 +72,7 @@ fn toggle_when_behavior_block_absent_adds_only_behavior() {
     write_fixture(&path, r#"{"mcpServers": {}}"#);
 
     let store = FsSettingsStore::new(&path);
-    store.save_caveman_mode(true).expect("save ok");
+    store.save_caveman_mode(true).unwrap();
 
     let value = read_value(&path);
     assert_eq!(value["behavior"]["caveman_mode"], serde_json::json!(true));
@@ -87,7 +87,7 @@ fn toggle_when_behavior_partial_preserves_other_behavior_keys() {
     write_fixture(&path, r#"{"behavior": {"other_flag": true}}"#);
 
     let store = FsSettingsStore::new(&path);
-    store.save_caveman_mode(true).expect("save ok");
+    store.save_caveman_mode(true).unwrap();
 
     let value = read_value(&path);
     assert_eq!(value["behavior"]["other_flag"], serde_json::json!(true));
@@ -170,12 +170,12 @@ fn symlink_followed_writes_target_keeps_symlink() {
     let real = dir.path().join("real.json");
     let link = dir.path().join("link.json");
     write_fixture(&real, r#"{"behavior":{"caveman_mode":false}}"#);
-    symlink(&real, &link).expect("symlink");
+    symlink(&real, &link).unwrap();
 
     let store = FsSettingsStore::new(&link);
-    store.save_caveman_mode(true).expect("save ok");
+    store.save_caveman_mode(true).unwrap();
 
-    let link_meta = fs::symlink_metadata(&link).expect("symlink meta");
+    let link_meta = fs::symlink_metadata(&link).unwrap();
     assert!(
         link_meta.file_type().is_symlink(),
         "symlink path must remain a symlink"
@@ -198,7 +198,7 @@ fn broken_symlink_returns_symlink_not_supported() {
     let dir = tempdir().unwrap();
     let link = dir.path().join("link.json");
     let broken_target = dir.path().join("nonexistent_target.json");
-    symlink(&broken_target, &link).expect("symlink");
+    symlink(&broken_target, &link).unwrap();
     assert!(!broken_target.exists());
 
     let store = FsSettingsStore::new(&link);


### PR DESCRIPTION
## Summary
- align clippy lint policy with the existing guardrails by not enabling expect_used globally
- fix all remaining clippy warnings surfaced by cargo clippy --all-targets -- -D warnings
- clean up test-only helpers, mock mutex guard lifetimes, and small idiomatic lint issues

## Verification
- cargo clippy --all-targets -- -D warnings
- cargo test