### PR TITLE
feat(azdo): implement work item issue creation

### DIFF
--- a/src/provider/azure_devops/issues.rs
+++ b/src/provider/azure_devops/issues.rs
@@ -1,0 +1,51 @@
+use anyhow::{Context, Result};
+
+pub(super) fn azure_tags_field(labels: &[String]) -> Option<String> {
+    (!labels.is_empty()).then(|| format!("System.Tags={}", labels.join("; ")))
+}
+
+pub(super) fn build_create_work_item_args(
+    organization: &str,
+    project: &str,
+    title: &str,
+    body: &str,
+    labels: &[String],
+    iteration_path: Option<&str>,
+) -> Vec<String> {
+    let mut args = vec![
+        "boards".to_string(),
+        "work-item".to_string(),
+        "create".to_string(),
+        "--type".to_string(),
+        "User Story".to_string(),
+        "--title".to_string(),
+        title.to_string(),
+        "--description".to_string(),
+        body.to_string(),
+        "--org".to_string(),
+        organization.to_string(),
+        "--project".to_string(),
+        project.to_string(),
+    ];
+
+    if let Some(tags_field) = azure_tags_field(labels) {
+        args.push("--fields".to_string());
+        args.push(tags_field);
+    }
+
+    if let Some(iteration_path) = iteration_path.filter(|path| !path.is_empty()) {
+        args.push("--iteration".to_string());
+        args.push(iteration_path.to_string());
+    }
+
+    args.extend(["-o".to_string(), "json".to_string()]);
+    args
+}
+
+pub(super) fn parse_created_work_item_id(json_str: &str) -> Result<u64> {
+    let v: serde_json::Value =
+        serde_json::from_str(json_str).context("Failed to parse work item creation response")?;
+    v.get("id")
+        .and_then(|n| n.as_u64())
+        .ok_or_else(|| anyhow::anyhow!("Missing 'id' in work item creation response"))
+}

--- a/src/provider/azure_devops/mod.rs
+++ b/src/provider/azure_devops/mod.rs
@@ -1,14 +1,24 @@
-use crate::provider::github::client::RepoProvider;
+use crate::provider::github::client::{CreateOutcome, RepoProvider};
 use crate::provider::types::{
     CheckRun, CiStatus, Issue, MergeMethod, Milestone, PullRequest, ReviewEvent,
 };
+use crate::util::validate_title;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
+use std::sync::Arc;
+
+mod issues;
+
+use issues::{build_create_work_item_args, parse_created_work_item_id};
+
+#[cfg(test)]
+mod tests;
 
 /// Azure DevOps client using `az` CLI.
 pub struct AzDevOpsClient {
     organization: String,
     project: String,
+    runner: Arc<dyn AzRunner>,
 }
 
 impl AzDevOpsClient {
@@ -16,21 +26,59 @@ impl AzDevOpsClient {
         Self {
             organization,
             project,
+            runner: Arc::new(AzCliRunner),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_runner(organization: String, project: String, runner: Arc<dyn AzRunner>) -> Self {
+        Self {
+            organization,
+            project,
+            runner,
         }
     }
 
     async fn run_az(&self, args: &[&str]) -> Result<String> {
-        let output = tokio::process::Command::new("az")
-            .args(args)
-            .output()
-            .await
-            .context("Failed to run `az` CLI. Is it installed? Run `az login` to authenticate.")?;
+        let output =
+            self.runner.run(args).await.context(
+                "Failed to run `az` CLI. Is it installed? Run `az login` to authenticate.",
+            )?;
 
-        if !output.status.success() {
+        if !output.success {
             let stderr = String::from_utf8_lossy(&output.stderr);
             anyhow::bail!("az command failed: {}", stderr.trim());
         }
         Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    }
+}
+
+struct AzOutput {
+    success: bool,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+}
+
+#[async_trait]
+trait AzRunner: Send + Sync {
+    async fn run(&self, args: &[&str]) -> Result<AzOutput>;
+}
+
+struct AzCliRunner;
+
+#[async_trait]
+impl AzRunner for AzCliRunner {
+    async fn run(&self, args: &[&str]) -> Result<AzOutput> {
+        let output = tokio::process::Command::new("az")
+            .args(args)
+            .output()
+            .await?;
+
+        Ok(AzOutput {
+            success: output.status.success(),
+            stdout: output.stdout,
+            stderr: output.stderr,
+        })
     }
 }
 
@@ -351,22 +399,39 @@ impl RepoProvider for AzDevOpsClient {
             .collect())
     }
 
-    async fn create_milestone(
-        &self,
-        _title: &str,
-        _description: &str,
-    ) -> Result<crate::provider::github::client::CreateOutcome> {
+    async fn create_milestone(&self, _title: &str, _description: &str) -> Result<CreateOutcome> {
         anyhow::bail!("create_milestone is not supported for Azure DevOps")
     }
 
     async fn create_issue(
         &self,
-        _title: &str,
-        _body: &str,
-        _labels: &[String],
-        _milestone: Option<u64>,
-    ) -> Result<crate::provider::github::client::CreateOutcome> {
-        anyhow::bail!("create_issue is not supported for Azure DevOps")
+        title: &str,
+        body: &str,
+        labels: &[String],
+        milestone: Option<u64>,
+    ) -> Result<CreateOutcome> {
+        let normalized_title = validate_title(title, "issue title")?;
+        let iteration_path = if let Some(milestone_number) = milestone {
+            self.list_milestones("open")
+                .await?
+                .into_iter()
+                .find(|m| m.number == milestone_number)
+                .map(|m| m.title)
+        } else {
+            None
+        };
+        let args = build_create_work_item_args(
+            &self.organization,
+            &self.project,
+            &normalized_title,
+            body,
+            labels,
+            iteration_path.as_deref(),
+        );
+        let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+        let json_str = self.run_az(&arg_refs).await?;
+        let id = parse_created_work_item_id(&json_str)?;
+        Ok(CreateOutcome::Created(id))
     }
 
     async fn list_open_prs(&self) -> Result<Vec<PullRequest>> {
@@ -420,124 +485,5 @@ impl RepoProvider for AzDevOpsClient {
 
     async fn merge_pr(&self, _pr_number: u64, _method: MergeMethod) -> Result<()> {
         anyhow::bail!("not yet implemented — tracked in v0.23.0 #B5")
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::provider::github::client::RepoProvider;
-
-    #[test]
-    fn parse_work_items_json_valid_single_item() {
-        let json = r#"[{
-            "id": 101,
-            "fields": {
-                "System.Title": "Fix login bug",
-                "System.Description": "Detailed description",
-                "System.State": "Active",
-                "System.Tags": "maestro:ready; priority:P1"
-            },
-            "url": "https://dev.azure.com/MyOrg/MyProject/_apis/wit/workItems/101"
-        }]"#;
-        let issues = parse_work_items_json(json).unwrap();
-        assert_eq!(issues.len(), 1);
-        assert_eq!(issues[0].number, 101);
-        assert_eq!(issues[0].title, "Fix login bug");
-        assert_eq!(issues[0].state, "open");
-    }
-
-    #[test]
-    fn parse_work_items_json_maps_labels_from_tags() {
-        let json = r#"[{
-            "id": 1,
-            "fields": {
-                "System.Title": "T",
-                "System.State": "Active",
-                "System.Tags": "maestro:ready; priority:P1"
-            },
-            "url": ""
-        }]"#;
-        let issues = parse_work_items_json(json).unwrap();
-        assert_eq!(issues[0].labels, vec!["maestro:ready", "priority:P1"]);
-    }
-
-    #[test]
-    fn parse_work_items_json_empty_tags_produces_empty_labels() {
-        let json = r#"[{
-            "id": 1,
-            "fields": {"System.Title": "T", "System.State": "Active", "System.Tags": ""},
-            "url": ""
-        }]"#;
-        let issues = parse_work_items_json(json).unwrap();
-        assert!(issues[0].labels.is_empty());
-    }
-
-    #[test]
-    fn parse_work_items_json_active_state_maps_to_open() {
-        let json = r#"[{"id":1,"fields":{"System.Title":"T","System.State":"Active"},"url":""}]"#;
-        let issues = parse_work_items_json(json).unwrap();
-        assert_eq!(issues[0].state, "open");
-    }
-
-    #[test]
-    fn parse_work_items_json_closed_state_maps_to_closed() {
-        let json = r#"[{"id":1,"fields":{"System.Title":"T","System.State":"Closed"},"url":""}]"#;
-        let issues = parse_work_items_json(json).unwrap();
-        assert_eq!(issues[0].state, "closed");
-    }
-
-    #[test]
-    fn parse_work_items_json_resolved_state_maps_to_closed() {
-        let json = r#"[{"id":1,"fields":{"System.Title":"T","System.State":"Resolved"},"url":""}]"#;
-        let issues = parse_work_items_json(json).unwrap();
-        assert_eq!(issues[0].state, "closed");
-    }
-
-    #[test]
-    fn parse_work_items_json_empty_array() {
-        let issues = parse_work_items_json("[]").unwrap();
-        assert!(issues.is_empty());
-    }
-
-    #[test]
-    fn parse_work_items_json_invalid_json_returns_err() {
-        assert!(parse_work_items_json("{not json}").is_err());
-    }
-
-    #[test]
-    fn parse_work_items_json_missing_id_returns_err() {
-        let json = r#"[{"fields":{"System.Title":"T","System.State":"Active"},"url":""}]"#;
-        assert!(parse_work_items_json(json).is_err());
-    }
-
-    #[test]
-    fn parse_work_items_json_captures_url() {
-        let json = r#"[{
-            "id": 42,
-            "fields": {"System.Title": "T", "System.State": "Active"},
-            "url": "https://dev.azure.com/MyOrg/MyProject/_apis/wit/workItems/42"
-        }]"#;
-        let issues = parse_work_items_json(json).unwrap();
-        assert_eq!(
-            issues[0].html_url,
-            "https://dev.azure.com/MyOrg/MyProject/_apis/wit/workItems/42"
-        );
-    }
-
-    #[tokio::test]
-    async fn merge_pr_stub_names_tracking_issue() {
-        let client = AzDevOpsClient::new(
-            "https://dev.azure.com/example".to_string(),
-            "Project".to_string(),
-        );
-
-        let err = client
-            .merge_pr(123, MergeMethod::Squash)
-            .await
-            .unwrap_err()
-            .to_string();
-
-        assert!(err.contains("v0.23.0 #B5"));
     }
 }

--- a/src/provider/azure_devops/tests.rs
+++ b/src/provider/azure_devops/tests.rs
@@ -1,0 +1,340 @@
+use super::issues::{azure_tags_field, build_create_work_item_args, parse_created_work_item_id};
+use super::*;
+use crate::provider::github::client::RepoProvider;
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+struct MockAzRunner {
+    calls: Mutex<Vec<Vec<String>>>,
+    outputs: Mutex<VecDeque<AzOutput>>,
+}
+
+impl MockAzRunner {
+    fn new(outputs: Vec<AzOutput>) -> Self {
+        Self {
+            calls: Mutex::new(Vec::new()),
+            outputs: Mutex::new(outputs.into()),
+        }
+    }
+
+    fn success(stdout: &str) -> AzOutput {
+        AzOutput {
+            success: true,
+            stdout: stdout.as_bytes().to_vec(),
+            stderr: Vec::new(),
+        }
+    }
+
+    fn failure(stderr: &str) -> AzOutput {
+        AzOutput {
+            success: false,
+            stdout: Vec::new(),
+            stderr: stderr.as_bytes().to_vec(),
+        }
+    }
+
+    fn calls(&self) -> Vec<Vec<String>> {
+        self.calls.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl AzRunner for MockAzRunner {
+    async fn run(&self, args: &[&str]) -> Result<AzOutput> {
+        self.calls.lock().unwrap().push(
+            args.iter()
+                .map(|arg| (*arg).to_string())
+                .collect::<Vec<_>>(),
+        );
+        self.outputs
+            .lock()
+            .unwrap()
+            .pop_front()
+            .ok_or_else(|| anyhow::anyhow!("no mock az output queued"))
+    }
+}
+
+fn test_client(runner: Arc<dyn AzRunner>) -> AzDevOpsClient {
+    AzDevOpsClient::with_runner(
+        "https://dev.azure.com/example".to_string(),
+        "Project".to_string(),
+        runner,
+    )
+}
+
+#[test]
+fn parse_work_items_json_valid_single_item() {
+    let json = r#"[{
+        "id": 101,
+        "fields": {
+            "System.Title": "Fix login bug",
+            "System.Description": "Detailed description",
+            "System.State": "Active",
+            "System.Tags": "maestro:ready; priority:P1"
+        },
+        "url": "https://dev.azure.com/MyOrg/MyProject/_apis/wit/workItems/101"
+    }]"#;
+    let issues = parse_work_items_json(json).unwrap();
+    assert_eq!(issues.len(), 1);
+    assert_eq!(issues[0].number, 101);
+    assert_eq!(issues[0].title, "Fix login bug");
+    assert_eq!(issues[0].state, "open");
+}
+
+#[test]
+fn parse_work_items_json_maps_labels_from_tags() {
+    let json = r#"[{
+        "id": 1,
+        "fields": {
+            "System.Title": "T",
+            "System.State": "Active",
+            "System.Tags": "maestro:ready; priority:P1"
+        },
+        "url": ""
+    }]"#;
+    let issues = parse_work_items_json(json).unwrap();
+    assert_eq!(issues[0].labels, vec!["maestro:ready", "priority:P1"]);
+}
+
+#[test]
+fn parse_work_items_json_empty_tags_produces_empty_labels() {
+    let json = r#"[{
+        "id": 1,
+        "fields": {"System.Title": "T", "System.State": "Active", "System.Tags": ""},
+        "url": ""
+    }]"#;
+    let issues = parse_work_items_json(json).unwrap();
+    assert!(issues[0].labels.is_empty());
+}
+
+#[test]
+fn parse_work_items_json_active_state_maps_to_open() {
+    let json = r#"[{"id":1,"fields":{"System.Title":"T","System.State":"Active"},"url":""}]"#;
+    let issues = parse_work_items_json(json).unwrap();
+    assert_eq!(issues[0].state, "open");
+}
+
+#[test]
+fn parse_work_items_json_closed_state_maps_to_closed() {
+    let json = r#"[{"id":1,"fields":{"System.Title":"T","System.State":"Closed"},"url":""}]"#;
+    let issues = parse_work_items_json(json).unwrap();
+    assert_eq!(issues[0].state, "closed");
+}
+
+#[test]
+fn parse_work_items_json_resolved_state_maps_to_closed() {
+    let json = r#"[{"id":1,"fields":{"System.Title":"T","System.State":"Resolved"},"url":""}]"#;
+    let issues = parse_work_items_json(json).unwrap();
+    assert_eq!(issues[0].state, "closed");
+}
+
+#[test]
+fn parse_work_items_json_empty_array() {
+    let issues = parse_work_items_json("[]").unwrap();
+    assert!(issues.is_empty());
+}
+
+#[test]
+fn parse_work_items_json_invalid_json_returns_err() {
+    assert!(parse_work_items_json("{not json}").is_err());
+}
+
+#[test]
+fn parse_work_items_json_missing_id_returns_err() {
+    let json = r#"[{"fields":{"System.Title":"T","System.State":"Active"},"url":""}]"#;
+    assert!(parse_work_items_json(json).is_err());
+}
+
+#[test]
+fn parse_work_items_json_captures_url() {
+    let json = r#"[{
+        "id": 42,
+        "fields": {"System.Title": "T", "System.State": "Active"},
+        "url": "https://dev.azure.com/MyOrg/MyProject/_apis/wit/workItems/42"
+    }]"#;
+    let issues = parse_work_items_json(json).unwrap();
+    assert_eq!(
+        issues[0].html_url,
+        "https://dev.azure.com/MyOrg/MyProject/_apis/wit/workItems/42"
+    );
+}
+
+#[test]
+fn azure_tags_field_joins_labels_with_semicolon_space() {
+    let labels = vec!["maestro:ready".to_string(), "priority:P1".to_string()];
+    assert_eq!(
+        azure_tags_field(&labels).unwrap(),
+        "System.Tags=maestro:ready; priority:P1"
+    );
+}
+
+#[test]
+fn azure_tags_field_omits_empty_labels() {
+    assert!(azure_tags_field(&[]).is_none());
+}
+
+#[test]
+fn build_create_work_item_args_includes_iteration_path() {
+    let labels = vec!["a".to_string(), "b".to_string()];
+    let args = build_create_work_item_args(
+        "https://dev.azure.com/example",
+        "Project",
+        "Title",
+        "Body",
+        &labels,
+        Some("Project\\Sprint 1"),
+    );
+
+    assert!(
+        args.windows(2)
+            .any(|w| w == ["--iteration", "Project\\Sprint 1"])
+    );
+    assert!(
+        args.windows(2)
+            .any(|w| w == ["--fields", "System.Tags=a; b"])
+    );
+}
+
+#[test]
+fn build_create_work_item_args_omits_iteration_when_none() {
+    let args = build_create_work_item_args(
+        "https://dev.azure.com/example",
+        "Project",
+        "Title",
+        "Body",
+        &[],
+        None,
+    );
+
+    assert!(!args.iter().any(|arg| arg == "--iteration"));
+    assert!(!args.iter().any(|arg| arg == "--fields"));
+}
+
+#[test]
+fn parse_created_work_item_id_reads_id() {
+    assert_eq!(parse_created_work_item_id(r#"{"id":321}"#).unwrap(), 321);
+}
+
+#[tokio::test]
+async fn create_issue_happy_path_returns_created_id() {
+    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success(
+        r#"{"id":123}"#,
+    )]));
+    let client = test_client(runner.clone());
+
+    let outcome = client
+        .create_issue("  New   story  ", "Body", &[], None)
+        .await
+        .unwrap();
+
+    assert_eq!(outcome, CreateOutcome::Created(123));
+    let calls = runner.calls();
+    assert_eq!(calls.len(), 1);
+    assert!(calls[0].windows(2).any(|w| w == ["--title", "New story"]));
+    assert!(calls[0].windows(2).any(|w| w == ["--description", "Body"]));
+    assert!(calls[0].windows(2).any(|w| w == ["--type", "User Story"]));
+    assert!(
+        calls[0]
+            .windows(2)
+            .any(|w| w == ["--org", "https://dev.azure.com/example"])
+    );
+    assert!(calls[0].windows(2).any(|w| w == ["--project", "Project"]));
+}
+
+#[tokio::test]
+async fn create_issue_sends_semicolon_joined_labels() {
+    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success(
+        r#"{"id":124}"#,
+    )]));
+    let client = test_client(runner.clone());
+    let labels = vec!["maestro:ready".to_string(), "priority:P1".to_string()];
+
+    client
+        .create_issue("Title", "Body", &labels, None)
+        .await
+        .unwrap();
+
+    assert!(
+        runner.calls()[0]
+            .windows(2)
+            .any(|w| w == ["--fields", "System.Tags=maestro:ready; priority:P1"])
+    );
+}
+
+#[tokio::test]
+async fn create_issue_omits_iteration_when_milestone_is_missing() {
+    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success(
+        r#"{"id":125}"#,
+    )]));
+    let client = test_client(runner.clone());
+
+    client
+        .create_issue("Title", "Body", &[], Some(99))
+        .await
+        .unwrap();
+
+    assert!(!runner.calls()[0].iter().any(|arg| arg == "--iteration"));
+}
+
+#[tokio::test]
+async fn create_issue_propagates_az_stderr() {
+    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::failure(
+        "VS403474: malformed field value",
+    )]));
+    let client = test_client(runner);
+
+    let err = client
+        .create_issue("Title", "Body", &[], None)
+        .await
+        .unwrap_err()
+        .to_string();
+
+    assert!(err.contains("VS403474: malformed field value"));
+}
+
+#[tokio::test]
+async fn create_issue_rejects_invalid_title_before_api_call() {
+    let runner = Arc::new(MockAzRunner::new(Vec::new()));
+    let client = test_client(runner.clone());
+
+    let err = client
+        .create_issue("   ", "Body", &[], None)
+        .await
+        .unwrap_err()
+        .to_string();
+
+    assert!(err.contains("issue title must not be empty"));
+    assert!(runner.calls().is_empty());
+}
+
+#[tokio::test]
+async fn create_issue_rejects_overlong_title_before_api_call() {
+    let runner = Arc::new(MockAzRunner::new(Vec::new()));
+    let client = test_client(runner.clone());
+    let title = "x".repeat(257);
+
+    let err = client
+        .create_issue(&title, "Body", &[], None)
+        .await
+        .unwrap_err()
+        .to_string();
+
+    assert!(err.contains("issue title too long"));
+    assert!(runner.calls().is_empty());
+}
+
+#[tokio::test]
+async fn merge_pr_stub_names_tracking_issue() {
+    let client = AzDevOpsClient::new(
+        "https://dev.azure.com/example".to_string(),
+        "Project".to_string(),
+    );
+
+    let err = client
+        .merge_pr(123, MergeMethod::Squash)
+        .await
+        .unwrap_err()
+        .to_string();
+
+    assert!(err.contains("v0.23.0 #B5"));
+}


### PR DESCRIPTION
## Summary
- Implement Azure DevOps issue creation through `az boards work-item create`.
- Map labels to Azure work-item tags and milestone numbers to iteration paths when available.
- Add focused tests for argument construction, response parsing, validation, and CLI failures.

Closes #462

## Test plan
- [x] cargo fmt --check
- [x] cargo test azure_devops --all-targets