### PR TITLE
feat(azdo): map milestones to iterations

### DIFF
--- a/docs/api-contracts/README.md
+++ b/docs/api-contracts/README.md
@@ -13,4 +13,5 @@ JSON Schema files (Draft 2020-12) for every external data payload that crosses a
 
 | File | Payload | Added |
 |------|---------|-------|
+| `azure-devops-iterations.json` | Azure DevOps iteration classification nodes from `az boards iteration project list/create`; parsed into provider-neutral milestones | #463 |
 | `review-comment.json` | Structured JSON block embedded in `/review` slash-command PR comments; parsed by the TUI to render the concerns panel and drive the accept/reject flow | #327 |

--- a/docs/api-contracts/azure-devops-iterations.json
+++ b/docs/api-contracts/azure-devops-iterations.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/CarlosDanielDev/maestro/docs/api-contracts/azure-devops-iterations.json",
+  "title": "Azure DevOps Iteration Classification Nodes",
+  "description": "Payload returned by `az boards iteration project list` and the individual node returned by `az boards iteration project create`.",
+  "oneOf": [
+    {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/iterationNode"
+      }
+    },
+    {
+      "$ref": "#/$defs/iterationNode"
+    }
+  ],
+  "$defs": {
+    "iterationNode": {
+      "type": "object",
+      "required": ["name", "path"],
+      "additionalProperties": true,
+      "properties": {
+        "identifier": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "structureType": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "attributes": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "startDate": {
+              "type": "string"
+            },
+            "finishDate": {
+              "type": "string",
+              "pattern": "^(\\d{4}-\\d{2}-\\d{2}|\\d{4}-\\d{2}-\\d{2}T.*)$"
+            },
+            "description": {
+              "type": "string"
+            }
+          }
+        },
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/iterationNode"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -846,7 +846,7 @@ mod tests {
             az_project: Some("MyProject".into()),
             ..ProviderConfig::default()
         };
-        let checks = vec![
+        let checks = [
             build_az_cli_result(true, CheckSeverity::Required),
             build_az_identity_result(true, Some("user@example.com"), CheckSeverity::Required),
             build_azdo_config_result(&provider),

--- a/src/provider/azure_devops/iterations.rs
+++ b/src/provider/azure_devops/iterations.rs
@@ -1,0 +1,173 @@
+use crate::provider::types::Milestone;
+use anyhow::{Context, Result};
+use chrono::{DateTime, NaiveDate, Utc};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct AzureIteration {
+    pub(super) number: u64,
+    pub(super) title: String,
+    pub(super) path: String,
+    pub(super) description: String,
+    pub(super) finish_date: Option<NaiveDate>,
+}
+
+pub(super) fn stable_iteration_number(path: &str) -> u64 {
+    let mut hasher = Sha256::new();
+    hasher.update(path.trim().as_bytes());
+    let digest = hasher.finalize();
+    let mut bytes = [0_u8; 8];
+    bytes.copy_from_slice(&digest[..8]);
+    // Reason: Azure iteration identifiers are UUID strings, not provider-compatible
+    // u64s; hashing the stable iteration path gives create/list round-trip behavior
+    // without adding provider-specific state storage.
+    u64::from_be_bytes(bytes)
+}
+
+pub(super) fn parse_iterations_json(json_str: &str) -> Result<Vec<AzureIteration>> {
+    let raw: Vec<Value> =
+        serde_json::from_str(json_str).context("Failed to parse Azure DevOps iterations JSON")?;
+    parse_iteration_nodes(&raw)
+}
+
+pub(super) fn parse_iteration_json(json_str: &str) -> Result<AzureIteration> {
+    let raw: Value =
+        serde_json::from_str(json_str).context("Failed to parse Azure DevOps iteration JSON")?;
+    parse_iteration_value(&raw)
+}
+
+pub(super) fn filter_iterations_by_state(
+    iterations: Vec<AzureIteration>,
+    state: &str,
+    today: NaiveDate,
+) -> Result<Vec<AzureIteration>> {
+    match state {
+        "all" => Ok(iterations),
+        "open" => Ok(iterations
+            .into_iter()
+            .filter(|iteration| {
+                iteration
+                    .finish_date
+                    .is_none_or(|finish_date| finish_date >= today)
+            })
+            .collect()),
+        "closed" => Ok(iterations
+            .into_iter()
+            .filter(|iteration| {
+                iteration
+                    .finish_date
+                    .is_some_and(|finish_date| finish_date < today)
+            })
+            .collect()),
+        _ => anyhow::bail!(
+            "Invalid milestone state: {:?}. Must be open, closed, or all",
+            state
+        ),
+    }
+}
+
+pub(super) fn iterations_to_milestones(
+    iterations: Vec<AzureIteration>,
+    today: NaiveDate,
+) -> Vec<Milestone> {
+    iterations
+        .into_iter()
+        .map(|iteration| iteration_to_milestone(iteration, today))
+        .collect()
+}
+
+pub(super) fn iteration_path_for_milestone_number(
+    iterations: &[AzureIteration],
+    number: u64,
+) -> Option<String> {
+    iterations
+        .iter()
+        .find(|iteration| iteration.number == number)
+        .map(|iteration| iteration.path.clone())
+}
+
+pub(super) fn iteration_state(iteration: &AzureIteration, today: NaiveDate) -> String {
+    if iteration
+        .finish_date
+        .is_some_and(|finish_date| finish_date < today)
+    {
+        "closed".to_string()
+    } else {
+        "open".to_string()
+    }
+}
+
+fn parse_iteration_nodes(nodes: &[Value]) -> Result<Vec<AzureIteration>> {
+    let mut iterations = Vec::new();
+    for node in nodes {
+        flatten_iteration_node(node, &mut iterations)?;
+    }
+    Ok(iterations)
+}
+
+fn flatten_iteration_node(node: &Value, iterations: &mut Vec<AzureIteration>) -> Result<()> {
+    iterations.push(parse_iteration_value(node)?);
+    if let Some(children) = node.get("children").and_then(Value::as_array) {
+        for child in children {
+            flatten_iteration_node(child, iterations)?;
+        }
+    }
+    Ok(())
+}
+
+fn parse_iteration_value(value: &Value) -> Result<AzureIteration> {
+    let title = value
+        .get("name")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow::anyhow!("Missing 'name' field in Azure DevOps iteration JSON"))?
+        .to_string();
+    let path = value
+        .get("path")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow::anyhow!("Missing 'path' field in Azure DevOps iteration JSON"))?
+        .to_string();
+    let description = value
+        .get("description")
+        .or_else(|| value.pointer("/attributes/description"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let finish_date = value
+        .pointer("/attributes/finishDate")
+        .and_then(Value::as_str)
+        .map(parse_finish_date)
+        .transpose()?;
+
+    Ok(AzureIteration {
+        number: stable_iteration_number(&path),
+        title,
+        path,
+        description,
+        finish_date,
+    })
+}
+
+fn parse_finish_date(raw: &str) -> Result<NaiveDate> {
+    if let Ok(date_time) = DateTime::parse_from_rfc3339(raw) {
+        return Ok(date_time.date_naive());
+    }
+    NaiveDate::parse_from_str(raw, "%Y-%m-%d")
+        .with_context(|| format!("Failed to parse Azure DevOps iteration finishDate {raw:?}"))
+}
+
+fn iteration_to_milestone(iteration: AzureIteration, today: NaiveDate) -> Milestone {
+    let state = iteration_state(&iteration, today);
+    Milestone {
+        number: iteration.number,
+        title: iteration.title,
+        description: iteration.description,
+        state,
+        open_issues: 0,
+        closed_issues: 0,
+    }
+}
+
+pub(super) fn today_utc() -> NaiveDate {
+    Utc::now().date_naive()
+}

--- a/src/provider/azure_devops/mod.rs
+++ b/src/provider/azure_devops/mod.rs
@@ -2,14 +2,19 @@ use crate::provider::github::client::{CreateOutcome, RepoProvider};
 use crate::provider::types::{
     CheckRun, CiStatus, Issue, MergeMethod, Milestone, PullRequest, ReviewEvent,
 };
-use crate::util::validate_title;
+use crate::util::{titles_equivalent, validate_body, validate_title};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use std::sync::Arc;
 
 mod issues;
+mod iterations;
 
 use issues::{build_create_work_item_args, parse_created_work_item_id};
+use iterations::{
+    filter_iterations_by_state, iteration_path_for_milestone_number, iteration_state,
+    iterations_to_milestones, parse_iteration_json, parse_iterations_json, today_utc,
+};
 
 #[cfg(test)]
 mod tests;
@@ -51,6 +56,37 @@ impl AzDevOpsClient {
         }
         Ok(String::from_utf8_lossy(&output.stdout).to_string())
     }
+
+    async fn resolve_iteration_path_by_title_or_path(
+        &self,
+        milestone: &str,
+    ) -> Result<Option<String>> {
+        let json_str = self
+            .run_az(&[
+                "boards",
+                "iteration",
+                "project",
+                "list",
+                "--org",
+                &self.organization,
+                "--project",
+                &self.project,
+                "-o",
+                "json",
+            ])
+            .await?;
+        let iterations = parse_iterations_json(&json_str)?;
+        Ok(iterations
+            .into_iter()
+            .find(|iteration| {
+                titles_equivalent(&iteration.title, milestone) || iteration.path == milestone
+            })
+            .map(|iteration| iteration.path))
+    }
+}
+
+fn escape_wiql_string_literal(value: &str) -> String {
+    value.replace('\'', "''")
 }
 
 struct AzOutput {
@@ -213,10 +249,15 @@ impl RepoProvider for AzDevOpsClient {
     }
 
     async fn list_issues_by_milestone(&self, milestone: &str) -> Result<Vec<Issue>> {
+        let iteration_path = self
+            .resolve_iteration_path_by_title_or_path(milestone)
+            .await?
+            .unwrap_or_else(|| milestone.to_string());
+        let escaped_iteration_path = escape_wiql_string_literal(&iteration_path);
         let wiql = format!(
             "SELECT [System.Id] FROM WorkItems WHERE [System.IterationPath] UNDER '{}' \
              AND [System.State] <> 'Closed' AND [System.State] <> 'Removed'",
-            milestone
+            escaped_iteration_path
         );
 
         let json_str = self
@@ -266,9 +307,25 @@ impl RepoProvider for AzDevOpsClient {
         parse_work_items_json(&details_str)
     }
 
-    async fn list_milestones(&self, _state: &str) -> Result<Vec<Milestone>> {
-        // Azure DevOps uses iterations rather than milestones; not yet implemented.
-        Ok(vec![])
+    async fn list_milestones(&self, state: &str) -> Result<Vec<Milestone>> {
+        let today = today_utc();
+        let json_str = self
+            .run_az(&[
+                "boards",
+                "iteration",
+                "project",
+                "list",
+                "--org",
+                &self.organization,
+                "--project",
+                &self.project,
+                "-o",
+                "json",
+            ])
+            .await?;
+        let iterations = parse_iterations_json(&json_str)?;
+        let filtered = filter_iterations_by_state(iterations, state, today)?;
+        Ok(iterations_to_milestones(filtered, today))
     }
 
     async fn get_issue(&self, number: u64) -> Result<Issue> {
@@ -399,8 +456,73 @@ impl RepoProvider for AzDevOpsClient {
             .collect())
     }
 
-    async fn create_milestone(&self, _title: &str, _description: &str) -> Result<CreateOutcome> {
-        anyhow::bail!("create_milestone is not supported for Azure DevOps")
+    async fn create_milestone(&self, title: &str, description: &str) -> Result<CreateOutcome> {
+        let normalized = validate_title(title, "milestone title")?;
+        validate_body(description, "milestone description")?;
+        let today = today_utc();
+        let existing_json = self
+            .run_az(&[
+                "boards",
+                "iteration",
+                "project",
+                "list",
+                "--org",
+                &self.organization,
+                "--project",
+                &self.project,
+                "-o",
+                "json",
+            ])
+            .await?;
+        let existing = parse_iterations_json(&existing_json)?;
+
+        if let Some(iteration) = existing
+            .iter()
+            .find(|iteration| titles_equivalent(&iteration.title, &normalized))
+        {
+            return Ok(CreateOutcome::Existed {
+                number: iteration.number,
+                state: iteration_state(iteration, today),
+            });
+        }
+
+        let created_json = self
+            .run_az(&[
+                "boards",
+                "iteration",
+                "project",
+                "create",
+                "--name",
+                &normalized,
+                "--org",
+                &self.organization,
+                "--project",
+                &self.project,
+                "-o",
+                "json",
+            ])
+            .await?;
+        let created = parse_iteration_json(&created_json)?;
+
+        self.run_az(&[
+            "boards",
+            "iteration",
+            "project",
+            "update",
+            "--path",
+            &created.path,
+            "--description",
+            description,
+            "--org",
+            &self.organization,
+            "--project",
+            &self.project,
+            "-o",
+            "json",
+        ])
+        .await?;
+
+        Ok(CreateOutcome::Created(created.number))
     }
 
     async fn create_issue(
@@ -412,11 +534,30 @@ impl RepoProvider for AzDevOpsClient {
     ) -> Result<CreateOutcome> {
         let normalized_title = validate_title(title, "issue title")?;
         let iteration_path = if let Some(milestone_number) = milestone {
-            self.list_milestones("open")
-                .await?
-                .into_iter()
-                .find(|m| m.number == milestone_number)
-                .map(|m| m.title)
+            let json_str = self
+                .run_az(&[
+                    "boards",
+                    "iteration",
+                    "project",
+                    "list",
+                    "--org",
+                    &self.organization,
+                    "--project",
+                    &self.project,
+                    "-o",
+                    "json",
+                ])
+                .await?;
+            let iterations = parse_iterations_json(&json_str)?;
+            Some(
+                iteration_path_for_milestone_number(&iterations, milestone_number).ok_or_else(
+                    || {
+                        anyhow::anyhow!(
+                            "Azure DevOps iteration for milestone id {milestone_number} not found"
+                        )
+                    },
+                )?,
+            )
         } else {
             None
         };

--- a/src/provider/azure_devops/tests.rs
+++ b/src/provider/azure_devops/tests.rs
@@ -4,6 +4,8 @@ use crate::provider::github::client::RepoProvider;
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
+mod iterations;
+
 struct MockAzRunner {
     calls: Mutex<Vec<Vec<String>>>,
     outputs: Mutex<VecDeque<AzOutput>>,
@@ -262,18 +264,18 @@ async fn create_issue_sends_semicolon_joined_labels() {
 }
 
 #[tokio::test]
-async fn create_issue_omits_iteration_when_milestone_is_missing() {
-    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success(
-        r#"{"id":125}"#,
-    )]));
+async fn create_issue_errors_when_requested_milestone_is_missing() {
+    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success("[]")]));
     let client = test_client(runner.clone());
 
-    client
+    let err = client
         .create_issue("Title", "Body", &[], Some(99))
         .await
-        .unwrap();
+        .unwrap_err()
+        .to_string();
 
-    assert!(!runner.calls()[0].iter().any(|arg| arg == "--iteration"));
+    assert!(err.contains("Azure DevOps iteration for milestone id 99 not found"));
+    assert_eq!(runner.calls().len(), 1);
 }
 
 #[tokio::test]

--- a/src/provider/azure_devops/tests/iterations.rs
+++ b/src/provider/azure_devops/tests/iterations.rs
@@ -1,0 +1,386 @@
+use super::{MockAzRunner, test_client};
+use crate::provider::azure_devops::iterations::{
+    filter_iterations_by_state, iteration_path_for_milestone_number, iterations_to_milestones,
+    parse_iterations_json, stable_iteration_number,
+};
+use crate::provider::github::client::{CreateOutcome, RepoProvider};
+use chrono::NaiveDate;
+use std::sync::Arc;
+
+fn iterations_fixture() -> &'static str {
+    r#"[
+        {
+            "identifier": "11111111-1111-1111-1111-111111111111",
+            "name": "Backlog",
+            "path": "Project\\Backlog",
+            "structureType": "iteration",
+            "attributes": {},
+            "url": "https://dev.azure.com/example/Project/_apis/wit/classificationNodes/Iterations/Backlog"
+        },
+        {
+            "identifier": "22222222-2222-2222-2222-222222222222",
+            "name": "Sprint Past",
+            "path": "Project\\Sprint Past",
+            "structureType": "iteration",
+            "attributes": { "finishDate": "2026-05-03T00:00:00Z" },
+            "url": "https://dev.azure.com/example/Project/_apis/wit/classificationNodes/Iterations/Sprint%20Past"
+        },
+        {
+            "identifier": "33333333-3333-3333-3333-333333333333",
+            "name": "Sprint Future",
+            "path": "Project\\Sprint Future",
+            "structureType": "iteration",
+            "attributes": { "finishDate": "2026-06-04T00:00:00Z" },
+            "url": "https://dev.azure.com/example/Project/_apis/wit/classificationNodes/Iterations/Sprint%20Future"
+        }
+    ]"#
+}
+
+fn work_item_details() -> &'static str {
+    r#"[{
+        "id": 10,
+        "fields": {
+            "System.Title": "Scoped story",
+            "System.State": "Active"
+        },
+        "url": "https://dev.azure.com/example/Project/_apis/wit/workItems/10"
+    }]"#
+}
+
+#[test]
+fn parse_iterations_json_maps_nodes_to_milestones() {
+    let iterations = parse_iterations_json(iterations_fixture()).unwrap();
+
+    assert_eq!(iterations.len(), 3);
+    assert_eq!(iterations[2].title, "Sprint Future");
+    assert_eq!(iterations[2].path, "Project\\Sprint Future");
+    assert_eq!(
+        iterations[2].finish_date,
+        Some(NaiveDate::from_ymd_opt(2026, 6, 4).unwrap())
+    );
+
+    let milestones =
+        iterations_to_milestones(iterations, NaiveDate::from_ymd_opt(2026, 5, 4).unwrap());
+    assert_eq!(milestones[0].title, "Backlog");
+    assert_eq!(milestones[0].description, "");
+    assert_eq!(milestones[0].state, "open");
+    assert_eq!(milestones[0].open_issues, 0);
+    assert_eq!(milestones[0].closed_issues, 0);
+    assert_eq!(
+        milestones[2].number,
+        stable_iteration_number("Project\\Sprint Future")
+    );
+}
+
+#[test]
+fn parse_iterations_json_flattens_children() {
+    let json = r#"[{
+        "name": "Parent",
+        "path": "Project\\Parent",
+        "attributes": {},
+        "children": [{
+            "name": "Child",
+            "path": "Project\\Parent\\Child",
+            "attributes": { "finishDate": "2026-06-04T00:00:00Z" }
+        }]
+    }]"#;
+
+    let iterations = parse_iterations_json(json).unwrap();
+
+    assert_eq!(iterations.len(), 2);
+    assert_eq!(iterations[1].title, "Child");
+    assert_eq!(iterations[1].path, "Project\\Parent\\Child");
+}
+
+#[test]
+fn filter_iterations_by_state_open_keeps_future_and_unset_finish_dates() {
+    let today = NaiveDate::from_ymd_opt(2026, 5, 4).unwrap();
+    let iterations = parse_iterations_json(iterations_fixture()).unwrap();
+
+    let filtered = filter_iterations_by_state(iterations, "open", today).unwrap();
+
+    assert_eq!(
+        filtered
+            .iter()
+            .map(|iteration| iteration.title.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Backlog", "Sprint Future"]
+    );
+}
+
+#[test]
+fn filter_iterations_by_state_closed_keeps_past_finish_dates() {
+    let today = NaiveDate::from_ymd_opt(2026, 5, 4).unwrap();
+    let iterations = parse_iterations_json(iterations_fixture()).unwrap();
+
+    let filtered = filter_iterations_by_state(iterations, "closed", today).unwrap();
+
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(filtered[0].title, "Sprint Past");
+}
+
+#[test]
+fn filter_iterations_by_state_all_bypasses_filter() {
+    let today = NaiveDate::from_ymd_opt(2026, 5, 4).unwrap();
+    let iterations = parse_iterations_json(iterations_fixture()).unwrap();
+
+    let filtered = filter_iterations_by_state(iterations, "all", today).unwrap();
+
+    assert_eq!(filtered.len(), 3);
+}
+
+#[test]
+fn parse_iterations_json_empty_array() {
+    let iterations = parse_iterations_json("[]").unwrap();
+
+    assert!(iterations.is_empty());
+}
+
+#[test]
+fn parse_iterations_json_malformed_az_output_returns_err() {
+    let err = parse_iterations_json("{not json}").unwrap_err().to_string();
+
+    assert!(err.contains("Failed to parse Azure DevOps iterations JSON"));
+}
+
+#[tokio::test]
+async fn create_issue_resolves_milestone_number_to_iteration_path() {
+    let iteration_number = stable_iteration_number("Project\\Sprint Future");
+    let runner = Arc::new(MockAzRunner::new(vec![
+        MockAzRunner::success(iterations_fixture()),
+        MockAzRunner::success(r#"{"id":126}"#),
+    ]));
+    let client = test_client(runner.clone());
+
+    client
+        .create_issue("Title", "Body", &[], Some(iteration_number))
+        .await
+        .unwrap();
+
+    let calls = runner.calls();
+    assert_eq!(calls.len(), 2);
+    assert!(
+        calls[0]
+            .windows(4)
+            .any(|w| { w == ["boards", "iteration", "project", "list"] })
+    );
+    assert!(
+        calls[1]
+            .windows(2)
+            .any(|w| w == ["--iteration", "Project\\Sprint Future"])
+    );
+}
+
+#[tokio::test]
+async fn list_issues_by_milestone_resolves_iteration_title_to_path() {
+    let runner = Arc::new(MockAzRunner::new(vec![
+        MockAzRunner::success(iterations_fixture()),
+        MockAzRunner::success(r#"[{"id":10}]"#),
+        MockAzRunner::success(work_item_details()),
+    ]));
+    let client = test_client(runner.clone());
+
+    let issues = client
+        .list_issues_by_milestone("Sprint Future")
+        .await
+        .unwrap();
+
+    assert_eq!(issues.len(), 1);
+    let calls = runner.calls();
+    assert_eq!(calls.len(), 3);
+    assert!(
+        calls[1]
+            .windows(2)
+            .any(|w| w == ["--wiql", "SELECT [System.Id] FROM WorkItems WHERE [System.IterationPath] UNDER 'Project\\Sprint Future' AND [System.State] <> 'Closed' AND [System.State] <> 'Removed'"])
+    );
+}
+
+#[tokio::test]
+async fn list_issues_by_milestone_escapes_iteration_path_for_wiql() {
+    let runner = Arc::new(MockAzRunner::new(vec![
+        MockAzRunner::success(
+            r#"[{
+                "name": "Bob's Sprint",
+                "path": "Project\\Bob's Sprint",
+                "attributes": {}
+            }]"#,
+        ),
+        MockAzRunner::success("[]"),
+    ]));
+    let client = test_client(runner.clone());
+
+    let issues = client
+        .list_issues_by_milestone("Bob's Sprint")
+        .await
+        .unwrap();
+
+    assert!(issues.is_empty());
+    assert!(
+        runner.calls()[1]
+            .windows(2)
+            .any(|w| w == ["--wiql", "SELECT [System.Id] FROM WorkItems WHERE [System.IterationPath] UNDER 'Project\\Bob''s Sprint' AND [System.State] <> 'Closed' AND [System.State] <> 'Removed'"])
+    );
+}
+
+#[tokio::test]
+async fn list_milestones_all_calls_az_and_returns_all_iterations() {
+    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success(
+        iterations_fixture(),
+    )]));
+    let client = test_client(runner.clone());
+
+    let milestones = client.list_milestones("all").await.unwrap();
+
+    assert_eq!(milestones.len(), 3);
+    assert_eq!(milestones[0].title, "Backlog");
+    assert_eq!(milestones[1].state, "closed");
+    assert_eq!(milestones[2].state, "open");
+    assert_eq!(
+        runner.calls()[0],
+        vec![
+            "boards",
+            "iteration",
+            "project",
+            "list",
+            "--org",
+            "https://dev.azure.com/example",
+            "--project",
+            "Project",
+            "-o",
+            "json",
+        ]
+    );
+}
+
+#[tokio::test]
+async fn list_milestones_open_filters_past_iterations() {
+    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success(
+        iterations_fixture(),
+    )]));
+    let client = test_client(runner);
+
+    let milestones = client.list_milestones("open").await.unwrap();
+
+    assert_eq!(
+        milestones
+            .iter()
+            .map(|milestone| milestone.title.as_str())
+            .collect::<Vec<_>>(),
+        vec!["Backlog", "Sprint Future"]
+    );
+}
+
+#[tokio::test]
+async fn list_milestones_closed_filters_future_and_unset_iterations() {
+    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success(
+        iterations_fixture(),
+    )]));
+    let client = test_client(runner);
+
+    let milestones = client.list_milestones("closed").await.unwrap();
+
+    assert_eq!(milestones.len(), 1);
+    assert_eq!(milestones[0].title, "Sprint Past");
+}
+
+#[tokio::test]
+async fn list_milestones_empty_list_returns_empty() {
+    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success("[]")]));
+    let client = test_client(runner);
+
+    let milestones = client.list_milestones("all").await.unwrap();
+
+    assert!(milestones.is_empty());
+}
+
+#[tokio::test]
+async fn list_milestones_malformed_az_output_returns_err() {
+    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success("{not json}")]));
+    let client = test_client(runner);
+
+    let err = client.list_milestones("all").await.unwrap_err().to_string();
+
+    assert!(err.contains("Failed to parse Azure DevOps iterations JSON"));
+}
+
+#[tokio::test]
+async fn create_milestone_duplicate_title_returns_existed_without_create() {
+    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success(
+        r#"[{
+            "name": "Sprint 2",
+            "path": "Project\\Sprint 2",
+            "attributes": { "finishDate": "2026-06-04T00:00:00Z" }
+        }]"#,
+    )]));
+    let client = test_client(runner.clone());
+
+    let outcome = client
+        .create_milestone("  sprint   2  ", "desc")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        outcome,
+        CreateOutcome::Existed {
+            number: stable_iteration_number("Project\\Sprint 2"),
+            state: "open".to_string()
+        }
+    );
+    assert_eq!(runner.calls().len(), 1);
+    assert!(!runner.calls().iter().flatten().any(|arg| arg == "create"));
+}
+
+#[tokio::test]
+async fn create_milestone_creates_iteration_updates_description_and_returns_stable_id() {
+    let runner = Arc::new(MockAzRunner::new(vec![
+        MockAzRunner::success("[]"),
+        MockAzRunner::success(
+            r#"{
+                "name": "Sprint 2",
+                "path": "Project\\Sprint 2",
+                "attributes": { "finishDate": "2026-06-04T00:00:00Z" }
+            }"#,
+        ),
+        MockAzRunner::success(
+            r#"{
+                "name": "Sprint 2",
+                "path": "Project\\Sprint 2",
+                "attributes": { "finishDate": "2026-06-04T00:00:00Z" }
+            }"#,
+        ),
+    ]));
+    let client = test_client(runner.clone());
+
+    let outcome = client
+        .create_milestone("  Sprint   2  ", "desc")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        outcome,
+        CreateOutcome::Created(stable_iteration_number("Project\\Sprint 2"))
+    );
+    let calls = runner.calls();
+    assert_eq!(calls.len(), 3);
+    assert_eq!(calls[0][0..4], ["boards", "iteration", "project", "list"]);
+    assert_eq!(calls[1][0..4], ["boards", "iteration", "project", "create"]);
+    assert!(calls[1].windows(2).any(|w| w == ["--name", "Sprint 2"]));
+    assert_eq!(calls[2][0..4], ["boards", "iteration", "project", "update"]);
+    assert!(
+        calls[2]
+            .windows(2)
+            .any(|w| w == ["--path", "Project\\Sprint 2"])
+    );
+    assert!(calls[2].windows(2).any(|w| w == ["--description", "desc"]));
+}
+
+#[test]
+fn iteration_path_for_milestone_number_round_trips_listed_hash() {
+    let iterations = parse_iterations_json(iterations_fixture()).unwrap();
+    let number = stable_iteration_number("Project\\Sprint Future");
+
+    assert_eq!(
+        iteration_path_for_milestone_number(&iterations, number).as_deref(),
+        Some("Project\\Sprint Future")
+    );
+}


### PR DESCRIPTION
## Summary
- Map Azure DevOps milestone listing/creation to project iterations
- Add stable hash-backed iteration IDs and duplicate-title detection
- Resolve milestone IDs to iteration paths for AzDO issue creation and milestone issue listing
- Document the Azure DevOps iteration payload schema

## Tests
- cargo fmt -- --check
- cargo clippy --all-targets -- -D warnings
- cargo test provider::azure_devops --all-targets
- cargo test --all-targets

Closes #463