### PR TITLE
feat(azdo): implement work item tag labels

### DIFF
--- a/src/provider/azure_devops/mod.rs
+++ b/src/provider/azure_devops/mod.rs
@@ -5,6 +5,7 @@ use crate::provider::types::{
 use crate::util::{titles_equivalent, validate_body, validate_title};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
+use std::io::Write;
 use std::sync::Arc;
 
 mod issues;
@@ -44,11 +45,16 @@ impl AzDevOpsClient {
         }
     }
 
-    async fn run_az(&self, args: &[&str]) -> Result<String> {
+    async fn run_az_output(&self, args: &[&str]) -> Result<AzOutput> {
         let output =
             self.runner.run(args).await.context(
                 "Failed to run `az` CLI. Is it installed? Run `az login` to authenticate.",
             )?;
+        Ok(output)
+    }
+
+    async fn run_az(&self, args: &[&str]) -> Result<String> {
+        let output = self.run_az_output(args).await?;
 
         if !output.success {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -187,6 +193,43 @@ pub fn parse_work_items_json(json_str: &str) -> Result<Vec<Issue>> {
         });
     }
     Ok(issues)
+}
+
+/// Parse Azure DevOps tag dictionary JSON into provider-agnostic label names.
+pub fn parse_tags_json(json_str: &str) -> Result<Vec<String>> {
+    if json_str.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let raw: serde_json::Value =
+        serde_json::from_str(json_str).context("Failed to parse Azure DevOps tags JSON")?;
+    let tags = match &raw {
+        serde_json::Value::Array(items) => items.as_slice(),
+        serde_json::Value::Object(map) => map
+            .get("value")
+            .and_then(|value| value.as_array())
+            .map(Vec::as_slice)
+            .unwrap_or(&[]),
+        _ => &[],
+    };
+
+    Ok(tags
+        .iter()
+        .filter_map(|tag| match tag {
+            serde_json::Value::String(name) => Some(name.as_str()),
+            serde_json::Value::Object(map) => map.get("name").and_then(|name| name.as_str()),
+            _ => None,
+        })
+        .map(str::to_string)
+        .collect())
+}
+
+fn azure_tags_route_parameter(project: &str) -> String {
+    format!("project={project}")
+}
+
+fn duplicate_tag_error(stderr: &str) -> bool {
+    stderr.to_ascii_lowercase().contains("tag already exists")
 }
 
 #[async_trait]
@@ -593,11 +636,79 @@ impl RepoProvider for AzDevOpsClient {
     }
 
     async fn list_labels(&self) -> Result<Vec<String>> {
-        anyhow::bail!("list_labels is not supported for Azure DevOps")
+        let route_project = azure_tags_route_parameter(&self.project);
+        let json_str = self
+            .run_az(&[
+                "devops",
+                "invoke",
+                "--area",
+                "wit",
+                "--resource",
+                "tags",
+                "--route-parameters",
+                &route_project,
+                "--org",
+                &self.organization,
+                "-o",
+                "json",
+            ])
+            .await?;
+
+        parse_tags_json(&json_str)
     }
 
-    async fn create_label(&self, _name: &str, _color: &str) -> Result<()> {
-        anyhow::bail!("create_label is not supported for Azure DevOps")
+    async fn create_label(&self, name: &str, color: &str) -> Result<()> {
+        tracing::debug!(
+            label = name,
+            color,
+            "Azure DevOps work-item tags do not support label colors; ignoring color"
+        );
+
+        let mut body_file =
+            tempfile::NamedTempFile::new().context("Failed to create Azure DevOps tag payload")?;
+        let body = serde_json::to_string(&serde_json::json!({ "name": name }))?;
+        body_file
+            .write_all(body.as_bytes())
+            .context("Failed to write Azure DevOps tag payload")?;
+        body_file
+            .flush()
+            .context("Failed to flush Azure DevOps tag payload")?;
+
+        let route_project = azure_tags_route_parameter(&self.project);
+        let body_path = body_file
+            .path()
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("Azure DevOps tag payload path is not UTF-8"))?;
+        let output = self
+            .run_az_output(&[
+                "devops",
+                "invoke",
+                "--area",
+                "wit",
+                "--resource",
+                "tags",
+                "--route-parameters",
+                &route_project,
+                "--http-method",
+                "PATCH",
+                "--in-file",
+                body_path,
+                "--org",
+                &self.organization,
+                "-o",
+                "json",
+            ])
+            .await?;
+
+        if !output.success {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if duplicate_tag_error(&stderr) {
+                return Ok(());
+            }
+            anyhow::bail!("az command failed: {}", stderr.trim());
+        }
+
+        Ok(())
     }
 
     async fn patch_milestone_description(

--- a/src/provider/azure_devops/tests.rs
+++ b/src/provider/azure_devops/tests.rs
@@ -5,6 +5,7 @@ use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
 mod iterations;
+mod tags;
 
 struct MockAzRunner {
     calls: Mutex<Vec<Vec<String>>>,
@@ -177,33 +178,6 @@ fn parse_work_items_json_captures_url() {
 }
 
 #[test]
-fn parse_tags_json_reads_value_names() {
-    let json = r#"{
-        "count": 2,
-        "value": [
-            {"id": "1", "name": "maestro:ready", "active": true},
-            {"id": "2", "name": "priority:P1", "active": true}
-        ]
-    }"#;
-
-    let tags = parse_tags_json(json).unwrap();
-
-    assert_eq!(tags, vec!["maestro:ready", "priority:P1"]);
-}
-
-#[test]
-fn parse_tags_json_empty_project_returns_empty_vec() {
-    let tags = parse_tags_json(r#"{"count":0,"value":[]}"#).unwrap();
-
-    assert!(tags.is_empty());
-}
-
-#[test]
-fn parse_tags_json_invalid_json_returns_err() {
-    assert!(parse_tags_json("{not json}").is_err());
-}
-
-#[test]
 fn azure_tags_field_joins_labels_with_semicolon_space() {
     let labels = vec!["maestro:ready".to_string(), "priority:P1".to_string()];
     assert_eq!(
@@ -365,76 +339,6 @@ async fn create_issue_rejects_overlong_title_before_api_call() {
 
     assert!(err.contains("issue title too long"));
     assert!(runner.calls().is_empty());
-}
-
-#[tokio::test]
-async fn list_labels_invokes_work_item_tags_endpoint() {
-    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success(
-        r#"{"count":1,"value":[{"name":"maestro:ready"}]}"#,
-    )]));
-    let client = test_client(runner.clone());
-
-    let labels = client.list_labels().await.unwrap();
-
-    assert_eq!(labels, vec!["maestro:ready"]);
-    assert_eq!(
-        runner.calls()[0],
-        vec![
-            "devops",
-            "invoke",
-            "--area",
-            "wit",
-            "--resource",
-            "tags",
-            "--route-parameters",
-            "project=Project",
-            "--org",
-            "https://dev.azure.com/example",
-            "-o",
-            "json",
-        ]
-    );
-}
-
-#[tokio::test]
-async fn create_label_patches_work_item_tags_endpoint() {
-    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success("{}")]));
-    let client = test_client(runner.clone());
-
-    client
-        .create_label("maestro:ready", "0E8A16")
-        .await
-        .unwrap();
-
-    let calls = runner.calls();
-    assert!(calls[0].windows(2).any(|w| w == ["--area", "wit"]));
-    assert!(calls[0].windows(2).any(|w| w == ["--resource", "tags"]));
-    assert!(
-        calls[0]
-            .windows(2)
-            .any(|w| w == ["--route-parameters", "project=Project"])
-    );
-    assert!(calls[0].windows(2).any(|w| w == ["--http-method", "PATCH"]));
-    assert!(calls[0].iter().any(|arg| arg == "--in-file"));
-    assert_eq!(
-        runner.in_file_contents(),
-        vec![r#"{"name":"maestro:ready"}"#]
-    );
-}
-
-#[tokio::test]
-async fn create_label_duplicate_tag_error_returns_ok() {
-    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::failure(
-        "TF401289: tag already exists",
-    )]));
-    let client = test_client(runner.clone());
-
-    client
-        .create_label("maestro:ready", "0E8A16")
-        .await
-        .unwrap();
-
-    assert_eq!(runner.calls().len(), 1);
 }
 
 #[tokio::test]

--- a/src/provider/azure_devops/tests.rs
+++ b/src/provider/azure_devops/tests.rs
@@ -8,6 +8,7 @@ mod iterations;
 
 struct MockAzRunner {
     calls: Mutex<Vec<Vec<String>>>,
+    in_file_contents: Mutex<Vec<String>>,
     outputs: Mutex<VecDeque<AzOutput>>,
 }
 
@@ -15,6 +16,7 @@ impl MockAzRunner {
     fn new(outputs: Vec<AzOutput>) -> Self {
         Self {
             calls: Mutex::new(Vec::new()),
+            in_file_contents: Mutex::new(Vec::new()),
             outputs: Mutex::new(outputs.into()),
         }
     }
@@ -38,6 +40,10 @@ impl MockAzRunner {
     fn calls(&self) -> Vec<Vec<String>> {
         self.calls.lock().unwrap().clone()
     }
+
+    fn in_file_contents(&self) -> Vec<String> {
+        self.in_file_contents.lock().unwrap().clone()
+    }
 }
 
 #[async_trait]
@@ -48,6 +54,15 @@ impl AzRunner for MockAzRunner {
                 .map(|arg| (*arg).to_string())
                 .collect::<Vec<_>>(),
         );
+        if let Some(path) = args
+            .windows(2)
+            .find_map(|window| (window[0] == "--in-file").then_some(window[1]))
+        {
+            self.in_file_contents
+                .lock()
+                .unwrap()
+                .push(std::fs::read_to_string(path)?);
+        }
         self.outputs
             .lock()
             .unwrap()
@@ -159,6 +174,33 @@ fn parse_work_items_json_captures_url() {
         issues[0].html_url,
         "https://dev.azure.com/MyOrg/MyProject/_apis/wit/workItems/42"
     );
+}
+
+#[test]
+fn parse_tags_json_reads_value_names() {
+    let json = r#"{
+        "count": 2,
+        "value": [
+            {"id": "1", "name": "maestro:ready", "active": true},
+            {"id": "2", "name": "priority:P1", "active": true}
+        ]
+    }"#;
+
+    let tags = parse_tags_json(json).unwrap();
+
+    assert_eq!(tags, vec!["maestro:ready", "priority:P1"]);
+}
+
+#[test]
+fn parse_tags_json_empty_project_returns_empty_vec() {
+    let tags = parse_tags_json(r#"{"count":0,"value":[]}"#).unwrap();
+
+    assert!(tags.is_empty());
+}
+
+#[test]
+fn parse_tags_json_invalid_json_returns_err() {
+    assert!(parse_tags_json("{not json}").is_err());
 }
 
 #[test]
@@ -323,6 +365,76 @@ async fn create_issue_rejects_overlong_title_before_api_call() {
 
     assert!(err.contains("issue title too long"));
     assert!(runner.calls().is_empty());
+}
+
+#[tokio::test]
+async fn list_labels_invokes_work_item_tags_endpoint() {
+    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success(
+        r#"{"count":1,"value":[{"name":"maestro:ready"}]}"#,
+    )]));
+    let client = test_client(runner.clone());
+
+    let labels = client.list_labels().await.unwrap();
+
+    assert_eq!(labels, vec!["maestro:ready"]);
+    assert_eq!(
+        runner.calls()[0],
+        vec![
+            "devops",
+            "invoke",
+            "--area",
+            "wit",
+            "--resource",
+            "tags",
+            "--route-parameters",
+            "project=Project",
+            "--org",
+            "https://dev.azure.com/example",
+            "-o",
+            "json",
+        ]
+    );
+}
+
+#[tokio::test]
+async fn create_label_patches_work_item_tags_endpoint() {
+    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success("{}")]));
+    let client = test_client(runner.clone());
+
+    client
+        .create_label("maestro:ready", "0E8A16")
+        .await
+        .unwrap();
+
+    let calls = runner.calls();
+    assert!(calls[0].windows(2).any(|w| w == ["--area", "wit"]));
+    assert!(calls[0].windows(2).any(|w| w == ["--resource", "tags"]));
+    assert!(
+        calls[0]
+            .windows(2)
+            .any(|w| w == ["--route-parameters", "project=Project"])
+    );
+    assert!(calls[0].windows(2).any(|w| w == ["--http-method", "PATCH"]));
+    assert!(calls[0].iter().any(|arg| arg == "--in-file"));
+    assert_eq!(
+        runner.in_file_contents(),
+        vec![r#"{"name":"maestro:ready"}"#]
+    );
+}
+
+#[tokio::test]
+async fn create_label_duplicate_tag_error_returns_ok() {
+    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::failure(
+        "TF401289: tag already exists",
+    )]));
+    let client = test_client(runner.clone());
+
+    client
+        .create_label("maestro:ready", "0E8A16")
+        .await
+        .unwrap();
+
+    assert_eq!(runner.calls().len(), 1);
 }
 
 #[tokio::test]

--- a/src/provider/azure_devops/tests/tags.rs
+++ b/src/provider/azure_devops/tests/tags.rs
@@ -1,0 +1,101 @@
+use super::{MockAzRunner, test_client};
+use crate::provider::azure_devops::parse_tags_json;
+use crate::provider::github::client::RepoProvider;
+use std::sync::Arc;
+
+#[test]
+fn parse_tags_json_reads_value_names() {
+    let json = r#"{
+        "count": 2,
+        "value": [
+            {"id": "1", "name": "maestro:ready", "active": true},
+            {"id": "2", "name": "priority:P1", "active": true}
+        ]
+    }"#;
+
+    let tags = parse_tags_json(json).unwrap();
+
+    assert_eq!(tags, vec!["maestro:ready", "priority:P1"]);
+}
+
+#[test]
+fn parse_tags_json_empty_project_returns_empty_vec() {
+    let tags = parse_tags_json(r#"{"count":0,"value":[]}"#).unwrap();
+
+    assert!(tags.is_empty());
+}
+
+#[test]
+fn parse_tags_json_invalid_json_returns_err() {
+    assert!(parse_tags_json("{not json}").is_err());
+}
+
+#[tokio::test]
+async fn list_labels_invokes_work_item_tags_endpoint() {
+    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success(
+        r#"{"count":1,"value":[{"name":"maestro:ready"}]}"#,
+    )]));
+    let client = test_client(runner.clone());
+
+    let labels = client.list_labels().await.unwrap();
+
+    assert_eq!(labels, vec!["maestro:ready"]);
+    assert_eq!(
+        runner.calls()[0],
+        vec![
+            "devops",
+            "invoke",
+            "--area",
+            "wit",
+            "--resource",
+            "tags",
+            "--route-parameters",
+            "project=Project",
+            "--org",
+            "https://dev.azure.com/example",
+            "-o",
+            "json",
+        ]
+    );
+}
+
+#[tokio::test]
+async fn create_label_patches_work_item_tags_endpoint() {
+    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success("{}")]));
+    let client = test_client(runner.clone());
+
+    client
+        .create_label("maestro:ready", "0E8A16")
+        .await
+        .unwrap();
+
+    let calls = runner.calls();
+    assert!(calls[0].windows(2).any(|w| w == ["--area", "wit"]));
+    assert!(calls[0].windows(2).any(|w| w == ["--resource", "tags"]));
+    assert!(
+        calls[0]
+            .windows(2)
+            .any(|w| w == ["--route-parameters", "project=Project"])
+    );
+    assert!(calls[0].windows(2).any(|w| w == ["--http-method", "PATCH"]));
+    assert!(calls[0].iter().any(|arg| arg == "--in-file"));
+    assert_eq!(
+        runner.in_file_contents(),
+        vec![r#"{"name":"maestro:ready"}"#]
+    );
+}
+
+#[tokio::test]
+async fn create_label_duplicate_tag_error_returns_ok() {
+    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::failure(
+        "TF401289: tag already exists",
+    )]));
+    let client = test_client(runner.clone());
+
+    client
+        .create_label("maestro:ready", "0E8A16")
+        .await
+        .unwrap();
+
+    assert_eq!(runner.calls().len(), 1);
+}


### PR DESCRIPTION
## Summary
- Implement Azure DevOps label listing via the work-item tags endpoint.
- Implement label creation with AzDO tag PATCH payloads and duplicate-tag idempotency.
- Add parser and CLI-call coverage for AzDO tag labels.

Closes #464

## Test plan
- [x] cargo fmt --check
- [x] cargo test provider::azure_devops
- [x] cargo test