### PR TITLE
feat(azdo): implement PR review surface

### DIFF
--- a/src/provider/azure_devops/mod.rs
+++ b/src/provider/azure_devops/mod.rs
@@ -10,12 +10,14 @@ use std::sync::Arc;
 
 mod issues;
 mod iterations;
+mod pr;
 
 use issues::{build_create_work_item_args, parse_created_work_item_id};
 use iterations::{
     filter_iterations_by_state, iteration_path_for_milestone_number, iteration_state,
     iterations_to_milestones, parse_iteration_json, parse_iterations_json, today_utc,
 };
+use pr::{parse_pr_json, parse_prs_json};
 
 #[cfg(test)]
 mod tests;
@@ -619,20 +621,82 @@ impl RepoProvider for AzDevOpsClient {
     }
 
     async fn list_open_prs(&self) -> Result<Vec<PullRequest>> {
-        anyhow::bail!("list_open_prs is not supported for Azure DevOps")
+        let json_str = self
+            .run_az(&[
+                "repos",
+                "pr",
+                "list",
+                "--status",
+                "active",
+                "--org",
+                &self.organization,
+                "--project",
+                &self.project,
+                "-o",
+                "json",
+            ])
+            .await?;
+
+        parse_prs_json(&json_str)
     }
 
-    async fn get_pr(&self, _number: u64) -> Result<PullRequest> {
-        anyhow::bail!("get_pr is not supported for Azure DevOps")
+    async fn get_pr(&self, number: u64) -> Result<PullRequest> {
+        let number_str = number.to_string();
+        let json_str = self
+            .run_az(&[
+                "repos",
+                "pr",
+                "show",
+                "--id",
+                &number_str,
+                "--org",
+                &self.organization,
+                "-o",
+                "json",
+            ])
+            .await?;
+
+        parse_pr_json(&json_str)
     }
 
-    async fn submit_pr_review(
-        &self,
-        _pr_number: u64,
-        _event: ReviewEvent,
-        _body: &str,
-    ) -> Result<()> {
-        anyhow::bail!("submit_pr_review is not supported for Azure DevOps")
+    async fn submit_pr_review(&self, pr_number: u64, event: ReviewEvent, body: &str) -> Result<()> {
+        validate_body(body, "PR review body")?;
+        let pr_number_str = pr_number.to_string();
+
+        if let Some(vote) = pr::review_event_vote(event) {
+            self.run_az(&[
+                "repos",
+                "pr",
+                "set-vote",
+                "--id",
+                &pr_number_str,
+                "--vote",
+                vote,
+                "--org",
+                &self.organization,
+                "--project",
+                &self.project,
+            ])
+            .await?;
+        }
+
+        self.run_az(&[
+            "repos",
+            "pr",
+            "comment",
+            "add",
+            "--id",
+            &pr_number_str,
+            "--content",
+            body,
+            "--org",
+            &self.organization,
+            "--project",
+            &self.project,
+        ])
+        .await?;
+
+        Ok(())
     }
 
     async fn list_labels(&self) -> Result<Vec<String>> {

--- a/src/provider/azure_devops/pr.rs
+++ b/src/provider/azure_devops/pr.rs
@@ -1,0 +1,56 @@
+use crate::provider::types::{PullRequest, ReviewEvent};
+use anyhow::{Context, Result};
+
+pub(super) fn parse_prs_json(json_str: &str) -> Result<Vec<PullRequest>> {
+    let raw: Vec<serde_json::Value> =
+        serde_json::from_str(json_str).context("Failed to parse Azure DevOps PRs JSON")?;
+    Ok(raw.iter().map(parse_pr_value).collect())
+}
+
+pub(super) fn parse_pr_json(json_str: &str) -> Result<PullRequest> {
+    let raw: serde_json::Value =
+        serde_json::from_str(json_str).context("Failed to parse Azure DevOps PR JSON")?;
+    Ok(parse_pr_value(&raw))
+}
+
+pub(super) fn review_event_vote(event: ReviewEvent) -> Option<&'static str> {
+    match event {
+        ReviewEvent::Approve => Some("approve"),
+        ReviewEvent::RequestChanges => Some("reject"),
+        ReviewEvent::Comment => None,
+    }
+}
+
+fn parse_pr_value(v: &serde_json::Value) -> PullRequest {
+    PullRequest {
+        number: v
+            .get("pullRequestId")
+            .and_then(|number| number.as_u64())
+            .unwrap_or(0),
+        title: string_field(v, "title"),
+        body: string_field(v, "description"),
+        state: string_field(v, "status").to_lowercase(),
+        html_url: string_field(v, "url"),
+        head_branch: string_field(v, "sourceRefName"),
+        base_branch: string_field(v, "targetRefName"),
+        author: v
+            .get("createdBy")
+            .and_then(|created_by| created_by.get("uniqueName"))
+            .and_then(|unique_name| unique_name.as_str())
+            .unwrap_or("")
+            .to_string(),
+        labels: Vec::new(),
+        draft: false,
+        mergeable: false,
+        additions: 0,
+        deletions: 0,
+        changed_files: 0,
+    }
+}
+
+fn string_field(v: &serde_json::Value, key: &str) -> String {
+    v.get(key)
+        .and_then(|value| value.as_str())
+        .unwrap_or("")
+        .to_string()
+}

--- a/src/provider/azure_devops/tests.rs
+++ b/src/provider/azure_devops/tests.rs
@@ -1,11 +1,11 @@
 use super::issues::{azure_tags_field, build_create_work_item_args, parse_created_work_item_id};
-use super::pr::{parse_pr_json, parse_prs_json};
 use super::*;
 use crate::provider::github::client::RepoProvider;
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
 mod iterations;
+mod pull_requests;
 mod tags;
 
 struct MockAzRunner {
@@ -234,58 +234,6 @@ fn parse_created_work_item_id_reads_id() {
     assert_eq!(parse_created_work_item_id(r#"{"id":321}"#).unwrap(), 321);
 }
 
-#[test]
-fn parse_prs_json_maps_azure_devops_fields() {
-    let prs = parse_prs_json(
-        r#"[{
-            "pullRequestId": 42,
-            "title": "Add login",
-            "description": "Implements login",
-            "sourceRefName": "refs/heads/feature/login",
-            "targetRefName": "refs/heads/main",
-            "createdBy": {"uniqueName": "dev@example.com"},
-            "status": "active",
-            "url": "https://dev.azure.com/example/Project/_git/repo/pullrequest/42"
-        }]"#,
-    )
-    .unwrap();
-
-    assert_eq!(prs.len(), 1);
-    assert_eq!(prs[0].number, 42);
-    assert_eq!(prs[0].title, "Add login");
-    assert_eq!(prs[0].body, "Implements login");
-    assert_eq!(prs[0].head_branch, "refs/heads/feature/login");
-    assert_eq!(prs[0].base_branch, "refs/heads/main");
-    assert_eq!(prs[0].author, "dev@example.com");
-    assert_eq!(prs[0].state, "active");
-    assert_eq!(
-        prs[0].html_url,
-        "https://dev.azure.com/example/Project/_git/repo/pullrequest/42"
-    );
-}
-
-#[test]
-fn parse_pr_json_defaults_missing_fields() {
-    let pr = parse_pr_json(r#"{"pullRequestId":7}"#).unwrap();
-
-    assert_eq!(pr.number, 7);
-    assert_eq!(pr.title, "");
-    assert_eq!(pr.body, "");
-    assert_eq!(pr.head_branch, "");
-    assert_eq!(pr.base_branch, "");
-    assert_eq!(pr.author, "");
-    assert_eq!(pr.state, "");
-    assert_eq!(pr.html_url, "");
-    assert!(pr.labels.is_empty());
-    assert!(!pr.draft);
-    assert!(!pr.mergeable);
-}
-
-#[test]
-fn parse_prs_json_invalid_json_returns_err() {
-    assert!(parse_prs_json("{not json}").is_err());
-}
-
 #[tokio::test]
 async fn create_issue_happy_path_returns_created_id() {
     let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success(
@@ -392,182 +340,6 @@ async fn create_issue_rejects_overlong_title_before_api_call() {
 
     assert!(err.contains("issue title too long"));
     assert!(runner.calls().is_empty());
-}
-
-#[tokio::test]
-async fn list_open_prs_calls_az_and_parses_results() {
-    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success(
-        r#"[{
-            "pullRequestId": 11,
-            "title": "Title",
-            "description": "Body",
-            "sourceRefName": "refs/heads/feature",
-            "targetRefName": "refs/heads/main",
-            "createdBy": {"uniqueName": "author@example.com"},
-            "status": "active",
-            "url": "https://dev.azure.com/example/Project/_git/repo/pullrequest/11"
-        }]"#,
-    )]));
-    let client = test_client(runner.clone());
-
-    let prs = client.list_open_prs().await.unwrap();
-
-    assert_eq!(prs.len(), 1);
-    assert_eq!(prs[0].number, 11);
-    let calls = runner.calls();
-    assert_eq!(calls.len(), 1);
-    assert_eq!(
-        calls[0],
-        vec![
-            "repos",
-            "pr",
-            "list",
-            "--status",
-            "active",
-            "--org",
-            "https://dev.azure.com/example",
-            "--project",
-            "Project",
-            "-o",
-            "json"
-        ]
-    );
-}
-
-#[tokio::test]
-async fn get_pr_calls_az_show_and_parses_result() {
-    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success(
-        r#"{
-            "pullRequestId": 12,
-            "title": "Title",
-            "description": "Body",
-            "sourceRefName": "refs/heads/feature",
-            "targetRefName": "refs/heads/main",
-            "createdBy": {"uniqueName": "author@example.com"},
-            "status": "active",
-            "url": "https://dev.azure.com/example/Project/_git/repo/pullrequest/12"
-        }"#,
-    )]));
-    let client = test_client(runner.clone());
-
-    let pr = client.get_pr(12).await.unwrap();
-
-    assert_eq!(pr.number, 12);
-    let calls = runner.calls();
-    assert_eq!(calls.len(), 1);
-    assert_eq!(
-        calls[0],
-        vec![
-            "repos",
-            "pr",
-            "show",
-            "--id",
-            "12",
-            "--org",
-            "https://dev.azure.com/example",
-            "-o",
-            "json"
-        ]
-    );
-}
-
-#[tokio::test]
-async fn submit_pr_review_comment_posts_comment_without_vote() {
-    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success("")]));
-    let client = test_client(runner.clone());
-
-    client
-        .submit_pr_review(13, ReviewEvent::Comment, "Looks good")
-        .await
-        .unwrap();
-
-    assert_eq!(
-        runner.calls(),
-        vec![vec![
-            "repos",
-            "pr",
-            "comment",
-            "add",
-            "--id",
-            "13",
-            "--content",
-            "Looks good",
-            "--org",
-            "https://dev.azure.com/example",
-            "--project",
-            "Project"
-        ]]
-    );
-}
-
-#[tokio::test]
-async fn submit_pr_review_approve_votes_then_comments() {
-    let runner = Arc::new(MockAzRunner::new(vec![
-        MockAzRunner::success(""),
-        MockAzRunner::success(""),
-    ]));
-    let client = test_client(runner.clone());
-
-    client
-        .submit_pr_review(14, ReviewEvent::Approve, "Approved")
-        .await
-        .unwrap();
-
-    assert_eq!(
-        runner.calls(),
-        vec![
-            vec![
-                "repos",
-                "pr",
-                "set-vote",
-                "--id",
-                "14",
-                "--vote",
-                "approve",
-                "--org",
-                "https://dev.azure.com/example",
-                "--project",
-                "Project"
-            ],
-            vec![
-                "repos",
-                "pr",
-                "comment",
-                "add",
-                "--id",
-                "14",
-                "--content",
-                "Approved",
-                "--org",
-                "https://dev.azure.com/example",
-                "--project",
-                "Project"
-            ]
-        ]
-    );
-}
-
-#[tokio::test]
-async fn submit_pr_review_request_changes_votes_reject_then_comments() {
-    let runner = Arc::new(MockAzRunner::new(vec![
-        MockAzRunner::success(""),
-        MockAzRunner::success(""),
-    ]));
-    let client = test_client(runner.clone());
-
-    client
-        .submit_pr_review(15, ReviewEvent::RequestChanges, "Needs changes")
-        .await
-        .unwrap();
-
-    let calls = runner.calls();
-    assert_eq!(calls.len(), 2);
-    assert!(calls[0].windows(2).any(|w| w == ["--vote", "reject"]));
-    assert!(
-        calls[1]
-            .windows(2)
-            .any(|w| w == ["--content", "Needs changes"])
-    );
 }
 
 #[tokio::test]

--- a/src/provider/azure_devops/tests.rs
+++ b/src/provider/azure_devops/tests.rs
@@ -1,4 +1,5 @@
 use super::issues::{azure_tags_field, build_create_work_item_args, parse_created_work_item_id};
+use super::pr::{parse_pr_json, parse_prs_json};
 use super::*;
 use crate::provider::github::client::RepoProvider;
 use std::collections::VecDeque;
@@ -233,6 +234,58 @@ fn parse_created_work_item_id_reads_id() {
     assert_eq!(parse_created_work_item_id(r#"{"id":321}"#).unwrap(), 321);
 }
 
+#[test]
+fn parse_prs_json_maps_azure_devops_fields() {
+    let prs = parse_prs_json(
+        r#"[{
+            "pullRequestId": 42,
+            "title": "Add login",
+            "description": "Implements login",
+            "sourceRefName": "refs/heads/feature/login",
+            "targetRefName": "refs/heads/main",
+            "createdBy": {"uniqueName": "dev@example.com"},
+            "status": "active",
+            "url": "https://dev.azure.com/example/Project/_git/repo/pullrequest/42"
+        }]"#,
+    )
+    .unwrap();
+
+    assert_eq!(prs.len(), 1);
+    assert_eq!(prs[0].number, 42);
+    assert_eq!(prs[0].title, "Add login");
+    assert_eq!(prs[0].body, "Implements login");
+    assert_eq!(prs[0].head_branch, "refs/heads/feature/login");
+    assert_eq!(prs[0].base_branch, "refs/heads/main");
+    assert_eq!(prs[0].author, "dev@example.com");
+    assert_eq!(prs[0].state, "active");
+    assert_eq!(
+        prs[0].html_url,
+        "https://dev.azure.com/example/Project/_git/repo/pullrequest/42"
+    );
+}
+
+#[test]
+fn parse_pr_json_defaults_missing_fields() {
+    let pr = parse_pr_json(r#"{"pullRequestId":7}"#).unwrap();
+
+    assert_eq!(pr.number, 7);
+    assert_eq!(pr.title, "");
+    assert_eq!(pr.body, "");
+    assert_eq!(pr.head_branch, "");
+    assert_eq!(pr.base_branch, "");
+    assert_eq!(pr.author, "");
+    assert_eq!(pr.state, "");
+    assert_eq!(pr.html_url, "");
+    assert!(pr.labels.is_empty());
+    assert!(!pr.draft);
+    assert!(!pr.mergeable);
+}
+
+#[test]
+fn parse_prs_json_invalid_json_returns_err() {
+    assert!(parse_prs_json("{not json}").is_err());
+}
+
 #[tokio::test]
 async fn create_issue_happy_path_returns_created_id() {
     let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success(
@@ -339,6 +392,182 @@ async fn create_issue_rejects_overlong_title_before_api_call() {
 
     assert!(err.contains("issue title too long"));
     assert!(runner.calls().is_empty());
+}
+
+#[tokio::test]
+async fn list_open_prs_calls_az_and_parses_results() {
+    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success(
+        r#"[{
+            "pullRequestId": 11,
+            "title": "Title",
+            "description": "Body",
+            "sourceRefName": "refs/heads/feature",
+            "targetRefName": "refs/heads/main",
+            "createdBy": {"uniqueName": "author@example.com"},
+            "status": "active",
+            "url": "https://dev.azure.com/example/Project/_git/repo/pullrequest/11"
+        }]"#,
+    )]));
+    let client = test_client(runner.clone());
+
+    let prs = client.list_open_prs().await.unwrap();
+
+    assert_eq!(prs.len(), 1);
+    assert_eq!(prs[0].number, 11);
+    let calls = runner.calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(
+        calls[0],
+        vec![
+            "repos",
+            "pr",
+            "list",
+            "--status",
+            "active",
+            "--org",
+            "https://dev.azure.com/example",
+            "--project",
+            "Project",
+            "-o",
+            "json"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn get_pr_calls_az_show_and_parses_result() {
+    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success(
+        r#"{
+            "pullRequestId": 12,
+            "title": "Title",
+            "description": "Body",
+            "sourceRefName": "refs/heads/feature",
+            "targetRefName": "refs/heads/main",
+            "createdBy": {"uniqueName": "author@example.com"},
+            "status": "active",
+            "url": "https://dev.azure.com/example/Project/_git/repo/pullrequest/12"
+        }"#,
+    )]));
+    let client = test_client(runner.clone());
+
+    let pr = client.get_pr(12).await.unwrap();
+
+    assert_eq!(pr.number, 12);
+    let calls = runner.calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(
+        calls[0],
+        vec![
+            "repos",
+            "pr",
+            "show",
+            "--id",
+            "12",
+            "--org",
+            "https://dev.azure.com/example",
+            "-o",
+            "json"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn submit_pr_review_comment_posts_comment_without_vote() {
+    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success("")]));
+    let client = test_client(runner.clone());
+
+    client
+        .submit_pr_review(13, ReviewEvent::Comment, "Looks good")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        runner.calls(),
+        vec![vec![
+            "repos",
+            "pr",
+            "comment",
+            "add",
+            "--id",
+            "13",
+            "--content",
+            "Looks good",
+            "--org",
+            "https://dev.azure.com/example",
+            "--project",
+            "Project"
+        ]]
+    );
+}
+
+#[tokio::test]
+async fn submit_pr_review_approve_votes_then_comments() {
+    let runner = Arc::new(MockAzRunner::new(vec![
+        MockAzRunner::success(""),
+        MockAzRunner::success(""),
+    ]));
+    let client = test_client(runner.clone());
+
+    client
+        .submit_pr_review(14, ReviewEvent::Approve, "Approved")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        runner.calls(),
+        vec![
+            vec![
+                "repos",
+                "pr",
+                "set-vote",
+                "--id",
+                "14",
+                "--vote",
+                "approve",
+                "--org",
+                "https://dev.azure.com/example",
+                "--project",
+                "Project"
+            ],
+            vec![
+                "repos",
+                "pr",
+                "comment",
+                "add",
+                "--id",
+                "14",
+                "--content",
+                "Approved",
+                "--org",
+                "https://dev.azure.com/example",
+                "--project",
+                "Project"
+            ]
+        ]
+    );
+}
+
+#[tokio::test]
+async fn submit_pr_review_request_changes_votes_reject_then_comments() {
+    let runner = Arc::new(MockAzRunner::new(vec![
+        MockAzRunner::success(""),
+        MockAzRunner::success(""),
+    ]));
+    let client = test_client(runner.clone());
+
+    client
+        .submit_pr_review(15, ReviewEvent::RequestChanges, "Needs changes")
+        .await
+        .unwrap();
+
+    let calls = runner.calls();
+    assert_eq!(calls.len(), 2);
+    assert!(calls[0].windows(2).any(|w| w == ["--vote", "reject"]));
+    assert!(
+        calls[1]
+            .windows(2)
+            .any(|w| w == ["--content", "Needs changes"])
+    );
 }
 
 #[tokio::test]

--- a/src/provider/azure_devops/tests/pull_requests.rs
+++ b/src/provider/azure_devops/tests/pull_requests.rs
@@ -1,0 +1,233 @@
+use super::super::pr::{parse_pr_json, parse_prs_json};
+use super::{MockAzRunner, test_client};
+use crate::provider::github::client::RepoProvider;
+use crate::provider::types::ReviewEvent;
+use std::sync::Arc;
+
+#[test]
+fn parse_prs_json_maps_azure_devops_fields() {
+    let prs = parse_prs_json(
+        r#"[{
+            "pullRequestId": 42,
+            "title": "Add login",
+            "description": "Implements login",
+            "sourceRefName": "refs/heads/feature/login",
+            "targetRefName": "refs/heads/main",
+            "createdBy": {"uniqueName": "dev@example.com"},
+            "status": "active",
+            "url": "https://dev.azure.com/example/Project/_git/repo/pullrequest/42"
+        }]"#,
+    )
+    .unwrap();
+
+    assert_eq!(prs.len(), 1);
+    assert_eq!(prs[0].number, 42);
+    assert_eq!(prs[0].title, "Add login");
+    assert_eq!(prs[0].body, "Implements login");
+    assert_eq!(prs[0].head_branch, "refs/heads/feature/login");
+    assert_eq!(prs[0].base_branch, "refs/heads/main");
+    assert_eq!(prs[0].author, "dev@example.com");
+    assert_eq!(prs[0].state, "active");
+    assert_eq!(
+        prs[0].html_url,
+        "https://dev.azure.com/example/Project/_git/repo/pullrequest/42"
+    );
+}
+
+#[test]
+fn parse_pr_json_defaults_missing_fields() {
+    let pr = parse_pr_json(r#"{"pullRequestId":7}"#).unwrap();
+
+    assert_eq!(pr.number, 7);
+    assert_eq!(pr.title, "");
+    assert_eq!(pr.body, "");
+    assert_eq!(pr.head_branch, "");
+    assert_eq!(pr.base_branch, "");
+    assert_eq!(pr.author, "");
+    assert_eq!(pr.state, "");
+    assert_eq!(pr.html_url, "");
+    assert!(pr.labels.is_empty());
+    assert!(!pr.draft);
+    assert!(!pr.mergeable);
+}
+
+#[test]
+fn parse_prs_json_invalid_json_returns_err() {
+    assert!(parse_prs_json("{not json}").is_err());
+}
+
+#[tokio::test]
+async fn list_open_prs_calls_az_and_parses_results() {
+    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success(
+        r#"[{
+            "pullRequestId": 11,
+            "title": "Title",
+            "description": "Body",
+            "sourceRefName": "refs/heads/feature",
+            "targetRefName": "refs/heads/main",
+            "createdBy": {"uniqueName": "author@example.com"},
+            "status": "active",
+            "url": "https://dev.azure.com/example/Project/_git/repo/pullrequest/11"
+        }]"#,
+    )]));
+    let client = test_client(runner.clone());
+
+    let prs = client.list_open_prs().await.unwrap();
+
+    assert_eq!(prs.len(), 1);
+    assert_eq!(prs[0].number, 11);
+    let calls = runner.calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(
+        calls[0],
+        vec![
+            "repos",
+            "pr",
+            "list",
+            "--status",
+            "active",
+            "--org",
+            "https://dev.azure.com/example",
+            "--project",
+            "Project",
+            "-o",
+            "json"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn get_pr_calls_az_show_and_parses_result() {
+    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success(
+        r#"{
+            "pullRequestId": 12,
+            "title": "Title",
+            "description": "Body",
+            "sourceRefName": "refs/heads/feature",
+            "targetRefName": "refs/heads/main",
+            "createdBy": {"uniqueName": "author@example.com"},
+            "status": "active",
+            "url": "https://dev.azure.com/example/Project/_git/repo/pullrequest/12"
+        }"#,
+    )]));
+    let client = test_client(runner.clone());
+
+    let pr = client.get_pr(12).await.unwrap();
+
+    assert_eq!(pr.number, 12);
+    let calls = runner.calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(
+        calls[0],
+        vec![
+            "repos",
+            "pr",
+            "show",
+            "--id",
+            "12",
+            "--org",
+            "https://dev.azure.com/example",
+            "-o",
+            "json"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn submit_pr_review_comment_posts_comment_without_vote() {
+    let runner = Arc::new(MockAzRunner::new(vec![MockAzRunner::success("")]));
+    let client = test_client(runner.clone());
+
+    client
+        .submit_pr_review(13, ReviewEvent::Comment, "Looks good")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        runner.calls(),
+        vec![vec![
+            "repos",
+            "pr",
+            "comment",
+            "add",
+            "--id",
+            "13",
+            "--content",
+            "Looks good",
+            "--org",
+            "https://dev.azure.com/example",
+            "--project",
+            "Project"
+        ]]
+    );
+}
+
+#[tokio::test]
+async fn submit_pr_review_approve_votes_then_comments() {
+    let runner = Arc::new(MockAzRunner::new(vec![
+        MockAzRunner::success(""),
+        MockAzRunner::success(""),
+    ]));
+    let client = test_client(runner.clone());
+
+    client
+        .submit_pr_review(14, ReviewEvent::Approve, "Approved")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        runner.calls(),
+        vec![
+            vec![
+                "repos",
+                "pr",
+                "set-vote",
+                "--id",
+                "14",
+                "--vote",
+                "approve",
+                "--org",
+                "https://dev.azure.com/example",
+                "--project",
+                "Project"
+            ],
+            vec![
+                "repos",
+                "pr",
+                "comment",
+                "add",
+                "--id",
+                "14",
+                "--content",
+                "Approved",
+                "--org",
+                "https://dev.azure.com/example",
+                "--project",
+                "Project"
+            ]
+        ]
+    );
+}
+
+#[tokio::test]
+async fn submit_pr_review_request_changes_votes_reject_then_comments() {
+    let runner = Arc::new(MockAzRunner::new(vec![
+        MockAzRunner::success(""),
+        MockAzRunner::success(""),
+    ]));
+    let client = test_client(runner.clone());
+
+    client
+        .submit_pr_review(15, ReviewEvent::RequestChanges, "Needs changes")
+        .await
+        .unwrap();
+
+    let calls = runner.calls();
+    assert_eq!(calls.len(), 2);
+    assert!(calls[0].windows(2).any(|w| w == ["--vote", "reject"]));
+    assert!(
+        calls[1]
+            .windows(2)
+            .any(|w| w == ["--content", "Needs changes"])
+    );
+}


### PR DESCRIPTION
## Summary
- Implement AzDO `list_open_prs` and `get_pr` through `az repos pr list/show`.
- Add AzDO PR JSON parsing for the RepoProvider `PullRequest` shape.
- Implement `submit_pr_review` vote/comment dispatch for Comment, Approve, and RequestChanges.

Closes #465

## Test plan
- [x] cargo fmt --check
- [x] cargo test azure_devops
- [x] cargo test
- [x] cargo clippy -- -D warnings