### PR TITLE
chore(workflow): script milestone graph updates

### DIFF
--- a/.claude/commands/pushup.md
+++ b/.claude/commands/pushup.md
@@ -96,51 +96,19 @@ If the repo doesn't have that label, skip this step (don't fail).
 
 Update the milestone's dependency graph to mark this issue with ✅. **This step runs before the issue close so that a failure here leaves the issue open and `/pushup` can be safely re-run** — closing the issue first would orphan the milestone graph if this step blew up.
 
-1. **Fetch the issue's milestone:**
+1. Fetch the issue's milestone:
 ```bash
-gh issue view <issue-number> --json milestone --jq '.milestone.number'
+MILESTONE=$(gh issue view <issue-number> --json milestone --jq '.milestone.number')
 ```
 
-2. **If the issue has a milestone**, fetch its current description:
+2. If the issue has no milestone, log that no milestone graph exists and continue to Step 6.5.
+
+3. If the issue has a milestone, run the mechanical updater and treat its exit code as the gate:
 ```bash
-gh api repos/<owner>/<repo>/milestones/<milestone-number> --jq '.description'
+python3 scripts/update-milestone-graph.py --milestone "$MILESTONE" --issue "<issue-number>"
 ```
 
-3. **Idempotency check (MANDATORY before any string-replace):**
-
-   - If the description already contains `• ✅ #<issue-number>` (or `- ✅ #<issue-number>`) at the start of a bullet line, the issue is already marked complete. Log "issue already marked complete in milestone graph — skipping idempotent re-stamp" and SKIP to step 7 (do not PATCH).
-   - This keeps a re-run of `/pushup` safe.
-
-4. **Anchored bullet replace.** Update the issue's bullet entry from `• #<issue-number>` to `• ✅ #<issue-number>` — but ONLY when `#<issue-number>` appears at the start of a bullet item (preceded by start-of-line + `• ` or `- `). NEVER replace `#<issue-number>` tokens that appear inside prose.
-
-   Safe (DO replace):
-   ```
-   • #521 feat(tui): keybinding to manually trigger PR creation
-   - #521 feat(tui): keybinding to manually trigger PR creation
-   ```
-
-   Unsafe (DO NOT replace — these are prose, not bullet entries):
-   ```
-   Level 1 — depends on #521 (must merge first):
-   This blocks #521 because the AC4 preflight needs to land first.
-   See note in #521 about the architect's reconciliation.
-   ```
-
-   The model-driven PATCH must read the description, find the matching bullet line, replace ONLY that line, and leave every other occurrence of `#<issue-number>` untouched.
-
-5. **Level header roll-up.** If, after the replace in step 4, every bullet at the same indentation level inside its `Level N — …:` block is now prefixed with `✅`, append ` (COMPLETED ✅)` to that level header — but only if it is not already there (idempotent).
-
-6. **Sequence-line update.** The `Sequence:` line uses tokens like `#521 ∥ #520 ∥ #525` separated by `→` and `∥`. Replace only EXACT token matches: a `#<issue-number>` token bounded by whitespace, `(`, `)`, `→`, or `∥` — not a prefix-match. Example:
-
-   - Token `#52` must NOT match inside `#521`. Use word-boundary logic: `#52` is a different token than `#521`.
-   - When all bullets in a level are now ✅, the parenthesized group of that level in `Sequence:` becomes `✅(LN: #a ∥ #b ∥ ...)` (idempotent — if it is already in `✅(LN: …)` form, leave it alone).
-
-7. **PATCH the milestone (only if step 3's idempotency check passed):**
-```bash
-gh api repos/<owner>/<repo>/milestones/<milestone-number> -X PATCH -f description="<updated-description>"
-```
-
-8. **Verify the PATCH succeeded** by re-fetching `description` and asserting your edit is present. If verification fails, abort `/pushup` here — the issue is still open, so the run can be retried safely.
+The script handles idempotency, anchored bullet replacement, level-header roll-up, `Sequence:` token-boundary rewrites, PATCH, and post-PATCH verification. A re-run where the issue is already stamped exits 0 with an "already marked" log line.
 
 **This step is NON-NEGOTIABLE.** Every closed issue MUST be reflected in the milestone graph. If it fails, **STOP** — do not proceed to Step 6.5 (issue close).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+- chore(workflow): add scripted milestone dependency-graph updater for `/pushup` (#554)
+
 ## [0.22.0] - 2026-05-04
 
 ### Added

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -523,13 +523,17 @@ maestro/
 │           ├── api-contract-validation/
 │           ├── project-patterns/
 │           └── security-patterns/
-├── scripts/                               # Project-level shell scripts and config for architecture, file-size, and coverage checks
+├── scripts/                               # Project-level shell scripts and config for architecture, file-size, coverage, and workflow automation
 │   ├── allowlist-large-files.txt          # Allowlist for large files exempted from size checks; src/tui/screens/milestone_health/state/tests/mod.rs added (deadline 2026-07-22, pending at(step) helper)  [Issue #500]
 │   ├── architecture-layers.yml            # Layer dependency rules for check-layers.sh
 │   ├── check-coverage-tiers.sh            # Validate test-coverage tier thresholds
 │   ├── check-file-size.sh                 # Enforce per-file LOC limits (500-line rule)
 │   ├── check-layers.sh                    # Enforce architecture layer boundaries
-│   └── coverage-tiers.yml                 # Coverage tier definitions
+│   ├── coverage-tiers.yml                 # Coverage tier definitions
+│   ├── update-milestone-graph.py          # Mechanical /pushup milestone dependency-graph updater with dry-run and post-PATCH verification  [Issue #554]
+│   └── tests/                             # Pytest coverage for workflow automation scripts
+│       ├── test_update_milestone_graph.py # Unit tests for idempotency, anchored replacement, roll-up, token boundaries, dry-run, and verification failure  [Issue #554]
+│       └── fixtures/                      # Markdown milestone graph fixtures for update-milestone-graph.py tests  [Issue #554]
 ├── benches/                               # Criterion benchmark crates
 │   ├── parser.rs                          # Benchmark: stream-json parser throughput  [Issue #19]
 │   └── turboquant.rs                      # Benchmark: TurboQuant quantization pipeline throughput

--- a/scripts/tests/fixtures/milestone-fresh.md
+++ b/scripts/tests/fixtures/milestone-fresh.md
@@ -1,0 +1,10 @@
+Milestone fixture
+
+## Dependency Graph (Implementation Order)
+
+Level 0 — workflow mechanization:
+• #554 chore(workflow): scripted milestone dependency-graph update for /pushup
+• #555 chore(workflow): DOR linter
+• #556 chore(workflow): mechanize /pushup commit + PR scaffolding
+
+Sequence: (#554 ∥ #555 ∥ #556)

--- a/scripts/tests/fixtures/milestone-rolled-up.md
+++ b/scripts/tests/fixtures/milestone-rolled-up.md
@@ -1,0 +1,10 @@
+Milestone fixture
+
+## Dependency Graph (Implementation Order)
+
+Level 2 — final polish:
+• ✅ #10 first completed task
+• ✅ #11 second completed task
+• #12 final task in level
+
+Sequence: (#10 ∥ #11 ∥ #12)

--- a/scripts/tests/fixtures/milestone-token-boundary.md
+++ b/scripts/tests/fixtures/milestone-token-boundary.md
@@ -1,0 +1,13 @@
+Milestone fixture
+
+This prose mentions #521 and #52 but neither should be rewritten.
+
+## Dependency Graph (Implementation Order)
+
+Level 0 — smaller boundary check (COMPLETED ✅):
+• ✅ #52 smaller issue
+
+Level 1 — larger boundary check:
+• #521 larger issue
+
+Sequence: ✅(L0: #52) → (#521)

--- a/scripts/tests/test_update_milestone_graph.py
+++ b/scripts/tests/test_update_milestone_graph.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "update-milestone-graph.py"
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+spec = importlib.util.spec_from_file_location("update_milestone_graph", SCRIPT)
+update_milestone_graph = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = update_milestone_graph
+spec.loader.exec_module(update_milestone_graph)
+
+
+def fixture(name: str) -> str:
+    return (FIXTURES / name).read_text()
+
+
+def test_idempotent_rerun_exits_zero_without_patch(monkeypatch, capsys):
+    description = fixture("milestone-fresh.md").replace("• #554", "• ✅ #554")
+    patch_called = False
+
+    monkeypatch.setattr(update_milestone_graph, "resolve_repo", lambda: "owner/repo")
+    monkeypatch.setattr(
+        update_milestone_graph, "fetch_description", lambda _repo, _milestone: description
+    )
+
+    def fail_patch(_repo, _milestone, _description):
+        nonlocal patch_called
+        patch_called = True
+
+    monkeypatch.setattr(update_milestone_graph, "patch_description", fail_patch)
+
+    assert update_milestone_graph.main(["--milestone", "1", "--issue", "554"]) == 0
+    assert "already marked" in capsys.readouterr().out
+    assert not patch_called
+
+
+def test_anchored_bullet_replace_does_not_rewrite_prose():
+    before = (
+        "Depends on #554 in prose.\n\n"
+        "Level 0 — workflow mechanization:\n"
+        "• #554 chore(workflow): scripted milestone dependency-graph update\n"
+        "A note blocks #554 but is not a bullet.\n\n"
+        "Sequence: (#554)\n"
+    )
+
+    result = update_milestone_graph.update_description(before, 554)
+
+    assert "Depends on #554 in prose." in result.description
+    assert "A note blocks #554 but is not a bullet." in result.description
+    assert "• ✅ #554 chore(workflow)" in result.description
+
+
+def test_level_rollup_at_boundary_and_idempotent_second_run():
+    before = fixture("milestone-rolled-up.md")
+
+    result = update_milestone_graph.update_description(before, 12)
+    assert "Level 2 — final polish: (COMPLETED ✅)" in result.description
+    assert "Sequence: ✅(L2: #10 ∥ #11 ∥ #12)" in result.description
+
+    second = update_milestone_graph.update_description(result.description, 12)
+    assert second.already_marked
+    assert result.description.count("(COMPLETED ✅)") == 1
+
+
+def test_sequence_token_boundary_does_not_match_52_inside_521():
+    before = fixture("milestone-token-boundary.md")
+
+    result = update_milestone_graph.update_description(before, 521)
+
+    assert "• ✅ #52 smaller issue" in result.description
+    assert "• ✅ #521 larger issue" in result.description
+    assert "This prose mentions #521 and #52 but neither should be rewritten." in result.description
+    assert "Sequence: ✅(L0: #52) → ✅(L1: #521)" in result.description
+
+
+def test_dry_run_prints_patch_body(monkeypatch, capsys):
+    monkeypatch.setattr(update_milestone_graph, "resolve_repo", lambda: "owner/repo")
+    monkeypatch.setattr(
+        update_milestone_graph,
+        "fetch_description",
+        lambda _repo, _milestone: fixture("milestone-fresh.md"),
+    )
+
+    def fail_patch(_repo, _milestone, _description):
+        raise AssertionError("dry-run must not PATCH")
+
+    monkeypatch.setattr(update_milestone_graph, "patch_description", fail_patch)
+
+    assert (
+        update_milestone_graph.main(["--milestone", "1", "--issue", "554", "--dry-run"])
+        == 0
+    )
+    body = json.loads(capsys.readouterr().out)
+    assert body["description"].count("• ✅ #554") == 1
+
+
+def test_verification_failure_path_returns_nonzero(monkeypatch, capsys):
+    before = fixture("milestone-fresh.md")
+    fetches = iter([before, before])
+
+    monkeypatch.setattr(update_milestone_graph, "resolve_repo", lambda: "owner/repo")
+    monkeypatch.setattr(
+        update_milestone_graph,
+        "fetch_description",
+        lambda _repo, _milestone: next(fetches),
+    )
+    monkeypatch.setattr(update_milestone_graph, "patch_description", lambda *_args: None)
+
+    assert update_milestone_graph.main(["--milestone", "1", "--issue", "554"]) == 1
+    assert "verification failed" in capsys.readouterr().err

--- a/scripts/update-milestone-graph.py
+++ b/scripts/update-milestone-graph.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Mark an issue complete in a GitHub milestone dependency graph."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+
+
+COMPLETED = "(COMPLETED ✅)"
+
+
+class MilestoneGraphError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class UpdateResult:
+    description: str
+    changed: bool
+    already_marked: bool
+    issue_marked: bool
+    level_completed: bool
+
+
+def completed_bullet_re(issue: int) -> re.Pattern[str]:
+    return re.compile(rf"^(\s*[•-]) ✅ #{issue}\b", re.MULTILINE)
+
+
+def pending_bullet_re(issue: int) -> re.Pattern[str]:
+    return re.compile(rf"^(\s*[•-]) #{issue}\b", re.MULTILINE)
+
+
+def is_token_char_allowed_before(ch: str | None) -> bool:
+    return ch is None or ch.isspace() or ch in "(→∥"
+
+
+def is_token_char_allowed_after(ch: str | None) -> bool:
+    return ch is None or ch.isspace() or ch in ")→∥"
+
+
+def contains_issue_token(text: str, issue: int) -> bool:
+    needle = f"#{issue}"
+    start = 0
+    while True:
+        idx = text.find(needle, start)
+        if idx == -1:
+            return False
+        before = text[idx - 1] if idx > 0 else None
+        after_idx = idx + len(needle)
+        after = text[after_idx] if after_idx < len(text) else None
+        if is_token_char_allowed_before(before) and is_token_char_allowed_after(after):
+            return True
+        start = idx + len(needle)
+
+
+def bullet_info(line: str) -> tuple[str, bool] | None:
+    match = re.match(r"^(\s*)[•-]\s+(✅\s+)?#\d+\b", line)
+    if not match:
+        return None
+    return match.group(1), match.group(2) is not None
+
+
+def find_issue_line(lines: list[str], issue: int) -> int:
+    pattern = re.compile(rf"^(\s*)[•-]\s+✅\s+#{issue}\b")
+    for idx, line in enumerate(lines):
+        if pattern.search(line):
+            return idx
+    raise MilestoneGraphError(f"failed to find marked bullet for #{issue}")
+
+
+def find_level_header(lines: list[str], issue_line: int) -> tuple[int, int]:
+    pattern = re.compile(r"^\s*Level\s+(\d+)\s+—.*:")
+    for idx in range(issue_line - 1, -1, -1):
+        match = pattern.match(lines[idx])
+        if match:
+            return idx, int(match.group(1))
+    raise MilestoneGraphError("marked issue is not inside a Level block")
+
+
+def level_block_end(lines: list[str], header_idx: int) -> int:
+    pattern = re.compile(r"^\s*Level\s+\d+\s+—.*:")
+    for idx in range(header_idx + 1, len(lines)):
+        if pattern.match(lines[idx]):
+            return idx
+    return len(lines)
+
+
+def roll_up_level_if_complete(
+    lines: list[str], issue_line: int
+) -> tuple[list[str], int, bool]:
+    header_idx, level = find_level_header(lines, issue_line)
+    info = bullet_info(lines[issue_line])
+    if info is None:
+        raise MilestoneGraphError("marked issue line is not a bullet")
+    issue_indent, _ = info
+    end_idx = level_block_end(lines, header_idx)
+
+    same_indent_bullets: list[bool] = []
+    for line in lines[header_idx + 1 : end_idx]:
+        current = bullet_info(line)
+        if current and current[0] == issue_indent:
+            same_indent_bullets.append(current[1])
+
+    if not same_indent_bullets or not all(same_indent_bullets):
+        return lines, level, False
+
+    if COMPLETED not in lines[header_idx]:
+        lines = lines.copy()
+        lines[header_idx] = f"{lines[header_idx]} {COMPLETED}"
+    return lines, level, True
+
+
+def sequence_group_spans(sequence: str) -> list[tuple[int, int, bool, str]]:
+    spans: list[tuple[int, int, bool, str]] = []
+    idx = 0
+    while idx < len(sequence):
+        start = sequence.find("(", idx)
+        if start == -1:
+            break
+        end = sequence.find(")", start + 1)
+        if end == -1:
+            break
+        prefix = sequence[max(0, start - 1) : start]
+        spans.append((start, end + 1, prefix == "✅", sequence[start + 1 : end]))
+        idx = end + 1
+    return spans
+
+
+def update_sequence_line(sequence: str, issue: int, level: int) -> str:
+    if not sequence.startswith("Sequence:"):
+        return sequence
+
+    for start, end, already_done, content in sequence_group_spans(sequence):
+        if not contains_issue_token(content, issue):
+            continue
+        updated_content = content
+        if not re.match(r"\s*L\d+\s*:", updated_content):
+            updated_content = f"L{level}: {updated_content}"
+        updated_group = f"({updated_content})"
+        prefix = "" if already_done else "✅"
+        return f"{sequence[:start]}{prefix}{updated_group}{sequence[end:]}"
+
+    raise MilestoneGraphError(f"failed to find #{issue} token in Sequence line")
+
+
+def update_sequence_if_level_complete(
+    lines: list[str], issue: int, level: int, level_completed: bool
+) -> list[str]:
+    if not level_completed:
+        return lines
+
+    for idx, line in enumerate(lines):
+        if line.startswith("Sequence:"):
+            updated = update_sequence_line(line, issue, level)
+            if updated == line:
+                return lines
+            lines = lines.copy()
+            lines[idx] = updated
+            return lines
+
+    raise MilestoneGraphError("missing Sequence line")
+
+
+def update_description(description: str, issue: int) -> UpdateResult:
+    if completed_bullet_re(issue).search(description):
+        return UpdateResult(description, False, True, True, False)
+
+    updated, count = pending_bullet_re(issue).subn(rf"\1 ✅ #{issue}", description, count=1)
+    if count == 0:
+        raise MilestoneGraphError(f"no pending bullet found for #{issue}")
+
+    lines = updated.splitlines()
+    trailing_newline = updated.endswith("\n")
+    issue_line = find_issue_line(lines, issue)
+    lines, level, level_completed = roll_up_level_if_complete(lines, issue_line)
+    lines = update_sequence_if_level_complete(lines, issue, level, level_completed)
+    final = "\n".join(lines)
+    if trailing_newline:
+        final += "\n"
+
+    return UpdateResult(final, final != description, False, True, level_completed)
+
+
+def run_gh(args: list[str]) -> str:
+    proc = subprocess.run(
+        ["gh", *args],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if proc.returncode != 0:
+        raise MilestoneGraphError(proc.stderr.strip() or f"gh {' '.join(args)} failed")
+    return proc.stdout
+
+
+def resolve_repo() -> str:
+    payload = run_gh(["api", "repos/:owner/:repo"])
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise MilestoneGraphError("failed to parse repository metadata from gh") from exc
+    full_name = data.get("full_name")
+    if not isinstance(full_name, str) or "/" not in full_name:
+        raise MilestoneGraphError("gh repository metadata did not include full_name")
+    return full_name
+
+
+def fetch_description(repo: str, milestone: int) -> str:
+    payload = run_gh(["api", f"repos/{repo}/milestones/{milestone}"])
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise MilestoneGraphError("failed to parse milestone payload from gh") from exc
+    description = data.get("description")
+    if not isinstance(description, str):
+        raise MilestoneGraphError("milestone payload did not include a string description")
+    return description
+
+
+def patch_description(repo: str, milestone: int, description: str) -> None:
+    run_gh(
+        [
+            "api",
+            f"repos/{repo}/milestones/{milestone}",
+            "-X",
+            "PATCH",
+            "-f",
+            f"description={description}",
+        ]
+    )
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Mark an issue complete in a milestone dependency graph."
+    )
+    parser.add_argument("positional", nargs="*", metavar="N")
+    parser.add_argument("--milestone", type=int, help="GitHub milestone number")
+    parser.add_argument("--issue", type=int, help="Issue number to mark complete")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the would-be PATCH body instead of calling the GitHub API",
+    )
+    args = parser.parse_args(argv)
+
+    if args.positional:
+        if len(args.positional) != 2:
+            parser.error("positional form requires exactly: <milestone> <issue>")
+        if args.milestone is not None or args.issue is not None:
+            parser.error("use either positional arguments or --milestone/--issue, not both")
+        args.milestone = int(args.positional[0])
+        args.issue = int(args.positional[1])
+
+    if args.milestone is None or args.issue is None:
+        parser.error("--milestone and --issue are required")
+    if args.milestone <= 0 or args.issue <= 0:
+        parser.error("--milestone and --issue must be positive integers")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        repo = resolve_repo()
+        original = fetch_description(repo, args.milestone)
+        result = update_description(original, args.issue)
+        if result.already_marked:
+            print(f"already marked: issue #{args.issue} is complete in milestone graph")
+            return 0
+        if args.dry_run:
+            print(json.dumps({"description": result.description}, ensure_ascii=False))
+            return 0
+
+        patch_description(repo, args.milestone, result.description)
+        verified = fetch_description(repo, args.milestone)
+        if not completed_bullet_re(args.issue).search(verified):
+            raise MilestoneGraphError("verification failed: updated bullet was not present")
+        if result.level_completed and result.description != verified:
+            raise MilestoneGraphError("verification failed: milestone description differs")
+        print(f"marked issue #{args.issue} in milestone #{args.milestone}")
+        return 0
+    except MilestoneGraphError as exc:
+        print(f"update-milestone-graph: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a mechanical `scripts/update-milestone-graph.py` updater for stamping completed issues in milestone dependency graphs.
- Cover idempotency, anchored bullet replacement, sequence token boundaries, dry-run behavior, and verification failure paths with pytest tests.
- Update `/pushup` documentation to call the script before issue close.

Closes #554

## Test plan
- [x] `git diff --check`
- [x] `/tmp/maestro-pytest-venv/bin/python -m pytest scripts/tests`
- [x] `python3 scripts/update-milestone-graph.py --milestone 45 --issue 554 --dry-run`