### PR TITLE
chore(workflow): add DOR lint fast path

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -103,22 +103,92 @@ Exit codes:
 - `6` — dirty tree, user chose abort. Abort cleanly.
 - `7+` — preflight.sh failure. Abort with its stderr.
 
-### Step 3: Read cached issue JSON
+### Step 3: Read cached issue JSON and summary
 
-The hook has cached the issue JSON at `$GATE_LOG_DIR/issue.json`. Read it directly — no second `gh` call.
+The hook has cached the issue JSON at `$GATE_LOG_DIR/issue.json` and a condensed
+DOR summary at `$GATE_LOG_DIR/issue-summary.md`. Read them directly — no second
+`gh` call. Prefer `issue-summary.md` for downstream subagents that only need the
+issue requirements; keep `issue.json` for mechanical gates and fallback checks
+that need labels, state, comments, or other structured fields.
 
 ```bash
 cat "$GATE_LOG_DIR/issue.json"
+cat "$GATE_LOG_DIR/issue-summary.md"
 ```
 
 ### Step 4: Gatekeeper (GATE — MANDATORY)
 
-Invoke `subagent-gatekeeper` via the `Agent` tool. Pass the issue JSON (from `$GATE_LOG_DIR/issue.json`), selected mode, and repo name.
+Run the mechanical DOR lint first. It writes `$GATE_LOG_DIR/dor-lint.json` and
+always exits 0; the JSON verdict decides whether the subagent can be skipped.
+
+```bash
+scripts/dor-lint.sh "$GATE_LOG_DIR/issue.json" >/dev/null
+
+lint_passed=$(jq -r .passed "$GATE_LOG_DIR/dor-lint.json")
+all_blockers_closed=$(jq -r '.blocker_states | to_entries | all(.value == "CLOSED")' "$GATE_LOG_DIR/dor-lint.json")
+contract_required=$(jq -r '.reasons | index("contract validation required") != null' "$GATE_LOG_DIR/dor-lint.json")
+
+if [ "$lint_passed" = "true" ] && \
+   [ "$all_blockers_closed" = "true" ] && \
+   [ "$contract_required" = "false" ]; then
+  python3 - "$GATE_LOG_DIR/dor-lint.json" "$GATE_LOG_DIR/gatekeeper.json" <<'PY'
+import json
+import sys
+
+lint = json.load(open(sys.argv[1]))
+task_map = {
+    "feature": "implementation",
+    "bug": "implementation",
+    "trivial": "implementation",
+    "docs": "docs",
+    "refactor": "refactor",
+}
+report = {
+    "report_version": 1,
+    "status": "PASS",
+    "task_type": task_map.get(lint.get("task_type"), "implementation"),
+    "dor": {
+        "passed": True,
+        "missing_sections": [],
+        "weak_sections": [],
+    },
+    "blockers": {
+        "passed": True,
+        "open": [],
+    },
+    "contracts": {
+        "passed": True,
+        "missing": [],
+    },
+    "remediation": {
+        "comment_body": "",
+        "labels_to_add": [],
+    },
+    "reasons": [],
+}
+json.dump(report, open(sys.argv[2], "w"), separators=(",", ":"))
+open(sys.argv[2], "a").write("\n")
+PY
+  task_type=$(jq -r .task_type "$GATE_LOG_DIR/gatekeeper.json")
+  echo "Gatekeeper fast-path PASS (task_type: $task_type)"
+  export TASK_TYPE="$task_type"
+else
+  echo "DOR lint did not qualify for fast-path; invoking subagent-gatekeeper."
+fi
+```
+
+If the fast path did not write `$GATE_LOG_DIR/gatekeeper.json`, invoke
+`subagent-gatekeeper` via the `Agent` tool. Pass the issue JSON (from
+`$GATE_LOG_DIR/issue.json`), selected mode, and repo name. This preserves the
+subagent interface for ambiguous lint failures, missing sections, open blockers,
+and contract-validation cases.
 
 The subagent's response will contain a fenced `json gatekeeper` code block. Pipe its full response through the parser:
 
 ```bash
-echo "$SUBAGENT_RESPONSE" | python3 .claude/hooks/parse_gatekeeper_report.py > "$GATE_LOG_DIR/gatekeeper.json"
+if [ ! -f "$GATE_LOG_DIR/gatekeeper.json" ]; then
+  echo "$SUBAGENT_RESPONSE" | python3 .claude/hooks/parse_gatekeeper_report.py > "$GATE_LOG_DIR/gatekeeper.json"
+fi
 ```
 
 Then branch on the parsed report:
@@ -269,7 +339,9 @@ Vibe mode skips 6a and 6c. All gates use `bash` (not `sh`) — `${PIPESTATUS[0]}
 
 #### 6a. `subagent-architect` → blueprint
 
-Orchestrator mode only. Invoke `subagent-architect` with the issue JSON and the architecture blueprint request. If Step 5 chose Continue, prepend the resumption context prompt.
+Orchestrator mode only. Invoke `subagent-architect` with the condensed issue
+summary from `$GATE_LOG_DIR/issue-summary.md` and the architecture blueprint
+request. If Step 5 chose Continue, prepend the resumption context prompt.
 
 #### 6b. `/validate-contracts` (if architect blueprint touches API endpoints)
 

--- a/.claude/hooks/implement-gates.sh
+++ b/.claude/hooks/implement-gates.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # Pre-check hook for /implement.
 # Argument: $1 = issue number.
+# Outputs in $GATE_LOG_DIR:
+#   issue.json        — full gh issue payload fetched in Gate 4
+#   issue-summary.md  — condensed DOR-section summary for downstream agents
+#   dor-lint.json     — created later by /implement Step 4 fast-path lint
 #
 # Optional flags (parsed after the issue number):
 #   --dirty-tree-action=<stash|abort|ask>
@@ -10,6 +14,9 @@
 #       Default: ask if stdin is a TTY, otherwise abort with a clear message.
 
 set -euo pipefail
+
+hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$hook_dir/../.." && pwd)"
 
 issue_number="${1:-}"
 shift || true
@@ -66,6 +73,12 @@ if ! gh issue view "$issue_number" \
   > "$GATE_LOG_DIR/issue.json" 2>"$GATE_LOG_DIR/gh-error.log"; then
   echo "implement-gates: failed to fetch issue #${issue_number}" >&2
   cat "$GATE_LOG_DIR/gh-error.log" >&2
+  exit 1
+fi
+
+if ! "$repo_root/scripts/condense-issue.sh" "$GATE_LOG_DIR/issue.json" \
+  > "$GATE_LOG_DIR/issue-summary.md"; then
+  echo "implement-gates: failed to condense issue #${issue_number}" >&2
   exit 1
 fi
 
@@ -165,6 +178,6 @@ fi
 # $HOME/.cache/maestro to avoid the /tmp symlink-attack vector on multi-user
 # Linux. /implement Step 2 walks the same resolution chain on read.
 # shellcheck disable=SC1091
-source "$(dirname "$0")/sentinel-path.sh"
+source "$hook_dir/sentinel-path.sh"
 echo -n "$GATE_LOG_DIR" > "$SENTINEL_PATH"
 echo "sentinel: $SENTINEL_PATH"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 - chore(workflow): add scripted milestone dependency-graph updater for `/pushup` (#554)
+- chore(workflow): add `/implement` DOR lint fast path and condensed issue summaries (#555)
 
 ## [0.22.0] - 2026-05-04
 

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -529,11 +529,15 @@ maestro/
 │   ├── check-coverage-tiers.sh            # Validate test-coverage tier thresholds
 │   ├── check-file-size.sh                 # Enforce per-file LOC limits (500-line rule)
 │   ├── check-layers.sh                    # Enforce architecture layer boundaries
+│   ├── condense-issue.sh                  # Emit deterministic DOR-section issue-summary.md from cached gh issue JSON  [Issue #555]
 │   ├── coverage-tiers.yml                 # Coverage tier definitions
+│   ├── dor-lint.sh                        # Fast mechanical DOR lint for /implement; writes dor-lint.json and resolves blocker states  [Issue #555]
 │   ├── update-milestone-graph.py          # Mechanical /pushup milestone dependency-graph updater with dry-run and post-PATCH verification  [Issue #554]
-│   └── tests/                             # Pytest coverage for workflow automation scripts
+│   └── tests/                             # Pytest and bats coverage for workflow automation scripts
+│       ├── test_condense_issue.bats       # bats tests for deterministic condensed issue summaries  [Issue #555]
+│       ├── test_dor_lint.bats             # bats tests for DOR lint, blocker states, contracts, and label task-type mapping  [Issue #555]
 │       ├── test_update_milestone_graph.py # Unit tests for idempotency, anchored replacement, roll-up, token boundaries, dry-run, and verification failure  [Issue #554]
-│       └── fixtures/                      # Markdown milestone graph fixtures for update-milestone-graph.py tests  [Issue #554]
+│       └── fixtures/                      # Markdown milestone graph fixtures plus issue JSON fixtures for DOR lint and summary tests  [Issues #554, #555]
 ├── benches/                               # Criterion benchmark crates
 │   ├── parser.rs                          # Benchmark: stream-json parser throughput  [Issue #19]
 │   └── turboquant.rs                      # Benchmark: TurboQuant quantization pipeline throughput

--- a/scripts/condense-issue.sh
+++ b/scripts/condense-issue.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Emit a deterministic markdown issue summary from cached gh issue JSON.
+#
+# Usage:
+#   scripts/condense-issue.sh /path/to/issue.json > /path/to/issue-summary.md
+
+set -euo pipefail
+
+issue_json="${1:-}"
+if [ -z "$issue_json" ]; then
+  echo "condense-issue: issue JSON path required" >&2
+  exit 1
+fi
+
+python3 - "$issue_json" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+ORDER = [
+    "Overview",
+    "Expected Behavior",
+    "Acceptance Criteria",
+    "Blocked By",
+    "Files to Modify",
+]
+
+
+def section_map(body):
+    matches = list(
+        re.finditer(r"(?m)^##[ \t]+(.+?)[ \t]*#*[ \t]*$", body or "")
+    )
+    sections = {}
+    for index, match in enumerate(matches):
+        title = match.group(1).strip()
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(body)
+        sections[title] = body[start:end].strip()
+    return sections
+
+
+issue = json.loads(Path(sys.argv[1]).read_text())
+title = str(issue.get("title") or "").strip()
+sections = section_map(issue.get("body") or "")
+
+parts = [f"# {title}"]
+for name in ORDER:
+    content = sections.get(name)
+    if content is None:
+        continue
+    parts.append(f"## {name}\n\n{content.rstrip()}")
+
+sys.stdout.write("\n\n".join(parts).rstrip() + "\n")
+PY

--- a/scripts/dor-lint.sh
+++ b/scripts/dor-lint.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Fast mechanical DOR lint for /implement.
+#
+# Usage:
+#   scripts/dor-lint.sh /path/to/issue.json
+#
+# Always exits 0. The verdict is written to dor-lint.json beside issue.json
+# and echoed to stdout.
+
+set -uo pipefail
+
+issue_json="${1:-}"
+
+if [ -z "$issue_json" ]; then
+  printf '%s\n' '{"passed":false,"missing":[],"blockers":[],"blocker_states":{},"task_type":"trivial","reasons":["issue JSON path required"]}'
+  exit 0
+fi
+
+python3 - "$issue_json" <<'PY'
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def empty_report(reason):
+    return {
+        "passed": False,
+        "missing": [],
+        "blockers": [],
+        "blocker_states": {},
+        "task_type": "trivial",
+        "reasons": [reason],
+    }
+
+
+def label_names(issue):
+    labels = issue.get("labels") or []
+    names = []
+    for label in labels:
+        if isinstance(label, dict):
+            name = label.get("name")
+        else:
+            name = str(label)
+        if name:
+            names.append(str(name).lower())
+    return names
+
+
+def task_type(labels):
+    label_set = set(labels)
+    if "bug" in label_set or "type:bug" in label_set:
+        return "bug"
+    if "documentation" in label_set or "type:docs" in label_set:
+        return "docs"
+    if "tech-debt" in label_set or "refactor" in label_set or "type:refactor" in label_set:
+        return "refactor"
+    if "enhancement" in label_set or "type:feature" in label_set:
+        return "feature"
+    return "trivial"
+
+
+def section_map(body):
+    matches = list(
+        re.finditer(r"(?m)^##[ \t]+(.+?)[ \t]*#*[ \t]*$", body or "")
+    )
+    sections = {}
+    for index, match in enumerate(matches):
+        title = match.group(1).strip()
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(body)
+        sections[title] = body[start:end].strip()
+    return sections
+
+
+def blocker_numbers(blocked_by):
+    numbers = []
+    seen = set()
+    for match in re.finditer(r"(?<![\w/.-])#(\d+)\b", blocked_by or ""):
+        number = int(match.group(1))
+        if number not in seen:
+            seen.add(number)
+            numbers.append(number)
+    return numbers
+
+
+def blocker_state(number):
+    try:
+        completed = subprocess.run(
+            ["gh", "issue", "view", str(number), "--json", "state"],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        return "OPEN", f"could not resolve blocker: #{number}"
+
+    if completed.returncode != 0:
+        return "OPEN", f"could not resolve blocker: #{number}"
+
+    try:
+        state = json.loads(completed.stdout).get("state", "OPEN")
+    except json.JSONDecodeError:
+        state = "OPEN"
+    state = str(state).upper()
+    if state not in {"OPEN", "CLOSED"}:
+        state = "OPEN"
+    return state, None
+
+
+path = Path(sys.argv[1])
+try:
+    issue = json.loads(path.read_text())
+except Exception as exc:  # noqa: BLE001 - linter must report, not fail.
+    report = empty_report(f"could not read issue JSON: {exc}")
+else:
+    body = issue.get("body") or ""
+    labels = label_names(issue)
+    sections = section_map(body)
+    required = [
+        "Overview",
+        "Expected Behavior",
+        "Acceptance Criteria",
+        "Blocked By",
+        "Definition of Done",
+    ]
+    if "bug" in set(labels) or "type:bug" in set(labels):
+        required.extend(["Current Behavior", "Steps to Reproduce"])
+
+    missing = [name for name in required if name not in sections]
+    reasons = [f"missing section: {name}" for name in missing]
+
+    blockers = blocker_numbers(sections.get("Blocked By", ""))
+    if re.search(r"\b[\w.-]+/[\w.-]+#\d+\b", sections.get("Blocked By", "")):
+        reasons.append("cross-repo blocker requires gatekeeper")
+
+    blocker_states = {}
+    for number in blockers:
+        state, reason = blocker_state(number)
+        blocker_states[str(number)] = state
+        if reason:
+            reasons.append(reason)
+        if state != "CLOSED":
+            reasons.append(f"open blocker: #{number}")
+
+    if "docs/api-contracts/" in body:
+        reasons.append("contract validation required")
+
+    report = {
+        "passed": not reasons,
+        "missing": missing,
+        "blockers": blockers,
+        "blocker_states": blocker_states,
+        "task_type": task_type(labels),
+        "reasons": reasons,
+    }
+
+out_path = path.with_name("dor-lint.json")
+out_path.write_text(json.dumps(report, sort_keys=True, separators=(",", ":")) + "\n")
+print(json.dumps(report, sort_keys=True, separators=(",", ":")))
+PY
+
+exit 0

--- a/scripts/tests/fixtures/issue-conformant.json
+++ b/scripts/tests/fixtures/issue-conformant.json
@@ -1,0 +1,6 @@
+{
+  "title": "Add configurable retry policy",
+  "body": "## Overview\n\nSessions need a configurable retry policy for transient failures.\n\n## Expected Behavior\n\nTransient failures retry according to config; permanent failures do not retry.\n\n## Acceptance Criteria\n\n- [ ] Retry count is configurable\n- [ ] Permanent errors do not retry\n\n## Files to Modify\n\n- src/session/retry.rs\n- src/config/sessions.rs\n\n## Test Hints\n\nUnit-test retry classification with a fake clock.\n\n## Blocked By\n\n- #42\n\n## Definition of Done\n\n- [ ] Tests pass\n",
+  "labels": [{"name": "enhancement"}],
+  "state": "OPEN"
+}

--- a/scripts/tests/fixtures/issue-missing-ac.json
+++ b/scripts/tests/fixtures/issue-missing-ac.json
@@ -1,0 +1,6 @@
+{
+  "title": "Add color theme config",
+  "body": "## Overview\n\nUsers need configurable TUI themes.\n\n## Expected Behavior\n\nThe TUI loads a theme from maestro.toml.\n\n## Blocked By\n\n- None\n\n## Definition of Done\n\n- [ ] Tests pass\n",
+  "labels": [{"name": "enhancement"}],
+  "state": "OPEN"
+}

--- a/scripts/tests/fixtures/issue-with-contract-ref.json
+++ b/scripts/tests/fixtures/issue-with-contract-ref.json
@@ -1,0 +1,6 @@
+{
+  "title": "Wire new API contract",
+  "body": "## Overview\n\nUse the schema in docs/api-contracts/review-comment.json.\n\n## Expected Behavior\n\nReview comments are validated before posting.\n\n## Acceptance Criteria\n\n- [ ] Contract validation runs before posting\n\n## Blocked By\n\n- None\n\n## Definition of Done\n\n- [ ] Tests pass\n",
+  "labels": [{"name": "enhancement"}],
+  "state": "OPEN"
+}

--- a/scripts/tests/fixtures/issue-with-open-blockers.json
+++ b/scripts/tests/fixtures/issue-with-open-blockers.json
@@ -1,0 +1,6 @@
+{
+  "title": "Consume upstream retry policy",
+  "body": "## Overview\n\nUse retry policy defined in an upstream issue.\n\n## Expected Behavior\n\nSessions honor the upstream retry policy.\n\n## Acceptance Criteria\n\n- [ ] Retry limit is honored\n\n## Blocked By\n\n- #99\n\n## Definition of Done\n\n- [ ] Tests pass\n",
+  "labels": [{"name": "tech-debt"}],
+  "state": "OPEN"
+}

--- a/scripts/tests/test_condense_issue.bats
+++ b/scripts/tests/test_condense_issue.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  SCRIPT="$REPO_ROOT/scripts/condense-issue.sh"
+  FIXTURES="$REPO_ROOT/scripts/tests/fixtures"
+}
+
+@test "full DOR issue summary matches snapshot" {
+  run "$SCRIPT" "$FIXTURES/issue-conformant.json"
+  [ "$status" -eq 0 ]
+  expected="$(mktemp)"
+  cat > "$expected" <<'EOF'
+# Add configurable retry policy
+
+## Overview
+
+Sessions need a configurable retry policy for transient failures.
+
+## Expected Behavior
+
+Transient failures retry according to config; permanent failures do not retry.
+
+## Acceptance Criteria
+
+- [ ] Retry count is configurable
+- [ ] Permanent errors do not retry
+
+## Blocked By
+
+- #42
+
+## Files to Modify
+
+- src/session/retry.rs
+- src/config/sessions.rs
+EOF
+  diff -u "$expected" <(printf '%s\n' "$output")
+}
+
+@test "missing sections are omitted" {
+  run "$SCRIPT" "$FIXTURES/issue-missing-ac.json"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"## Acceptance Criteria"* ]]
+  [[ "$output" == *"## Overview"* ]]
+  [[ "$output" == *"## Blocked By"* ]]
+}
+
+@test "output is deterministic" {
+  first="$(mktemp)"
+  second="$(mktemp)"
+
+  "$SCRIPT" "$FIXTURES/issue-conformant.json" > "$first"
+  "$SCRIPT" "$FIXTURES/issue-conformant.json" > "$second"
+
+  diff -u "$first" "$second"
+}

--- a/scripts/tests/test_dor_lint.bats
+++ b/scripts/tests/test_dor_lint.bats
@@ -1,0 +1,175 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  SCRIPT="$REPO_ROOT/scripts/dor-lint.sh"
+  FIXTURES="$REPO_ROOT/scripts/tests/fixtures"
+  TEST_DIR="$(mktemp -d)"
+  cp "$FIXTURES"/issue-*.json "$TEST_DIR"/
+
+  SHIM_DIR="$(mktemp -d)"
+  cat > "$SHIM_DIR/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "issue" ] && [ "${2:-}" = "view" ]; then
+  issue="${3:-}"
+  case "$issue" in
+    42) echo '{"state":"CLOSED"}' ;;
+    99) echo '{"state":"OPEN"}' ;;
+    *) echo '{"state":"CLOSED"}' ;;
+  esac
+  exit 0
+fi
+
+echo "fake gh: unsupported command $*" >&2
+exit 2
+EOF
+  chmod +x "$SHIM_DIR/gh"
+  PATH="$SHIM_DIR:$PATH"
+  export PATH
+}
+
+teardown() {
+  rm -rf "$SHIM_DIR" "$TEST_DIR"
+}
+
+@test "passes conformant issue with closed blocker" {
+  run "$SCRIPT" "$TEST_DIR/issue-conformant.json"
+  [ "$status" -eq 0 ]
+
+  output_file="$TEST_DIR/dor-lint.json"
+  [ -f "$output_file" ]
+  [ "$(jq -r .passed "$output_file")" = "true" ]
+  [ "$(jq -r '.blocker_states["42"]' "$output_file")" = "CLOSED" ]
+  [ "$(jq -r .task_type "$output_file")" = "feature" ]
+}
+
+@test "fails when Acceptance Criteria is missing" {
+  run "$SCRIPT" "$TEST_DIR/issue-missing-ac.json"
+  [ "$status" -eq 0 ]
+
+  [ "$(jq -r .passed "$TEST_DIR/dor-lint.json")" = "false" ]
+  jq -e '.missing | index("Acceptance Criteria")' "$TEST_DIR/dor-lint.json" >/dev/null
+}
+
+@test "fails when Blocked By is missing" {
+  issue_json="$(mktemp)"
+  jq 'del(.body) + {body: "## Overview\n\nx\n\n## Expected Behavior\n\nx\n\n## Acceptance Criteria\n\n- [ ] x\n\n## Definition of Done\n\n- [ ] done\n"}' \
+    "$TEST_DIR/issue-conformant.json" > "$issue_json"
+
+  run "$SCRIPT" "$issue_json"
+  [ "$status" -eq 0 ]
+
+  [ "$(jq -r .passed "$(dirname "$issue_json")/dor-lint.json")" = "false" ]
+  jq -e '.missing | index("Blocked By")' "$(dirname "$issue_json")/dor-lint.json" >/dev/null
+}
+
+@test "fails when a blocker is open" {
+  run "$SCRIPT" "$TEST_DIR/issue-with-open-blockers.json"
+  [ "$status" -eq 0 ]
+
+  [ "$(jq -r .passed "$TEST_DIR/dor-lint.json")" = "false" ]
+  [ "$(jq -r '.blocker_states["99"]' "$TEST_DIR/dor-lint.json")" = "OPEN" ]
+  jq -e '.reasons | index("open blocker: #99")' "$TEST_DIR/dor-lint.json" >/dev/null
+}
+
+@test "cross repo blocker forces fall-through" {
+  issue_json="$(mktemp)"
+  jq '.body |= sub("- #42"; "- owner/repo#42")' "$TEST_DIR/issue-conformant.json" > "$issue_json"
+
+  run "$SCRIPT" "$issue_json"
+  [ "$status" -eq 0 ]
+
+  lint_json="$(dirname "$issue_json")/dor-lint.json"
+  [ "$(jq -r .passed "$lint_json")" = "false" ]
+  jq -e '.reasons | index("cross-repo blocker requires gatekeeper")' "$lint_json" >/dev/null
+  [ "$(jq -r '.blockers | length' "$lint_json")" -eq 0 ]
+}
+
+@test "contract reference forces fall-through" {
+  run "$SCRIPT" "$TEST_DIR/issue-with-contract-ref.json"
+  [ "$status" -eq 0 ]
+
+  [ "$(jq -r .passed "$TEST_DIR/dor-lint.json")" = "false" ]
+  jq -e '.reasons | index("contract validation required")' "$TEST_DIR/dor-lint.json" >/dev/null
+}
+
+@test "bug label requires bug-only sections and maps task type" {
+  issue_json="$(mktemp)"
+  jq '.labels = [{"name":"bug"}]' "$TEST_DIR/issue-conformant.json" > "$issue_json"
+
+  run "$SCRIPT" "$issue_json"
+  [ "$status" -eq 0 ]
+
+  [ "$(jq -r .task_type "$(dirname "$issue_json")/dor-lint.json")" = "bug" ]
+  jq -e '.missing | index("Current Behavior")' "$(dirname "$issue_json")/dor-lint.json" >/dev/null
+  jq -e '.missing | index("Steps to Reproduce")' "$(dirname "$issue_json")/dor-lint.json" >/dev/null
+}
+
+@test "label maps documentation to docs" {
+  issue_json="$(mktemp)"
+  jq '.labels = [{"name":"documentation"}]' "$TEST_DIR/issue-conformant.json" > "$issue_json"
+
+  run "$SCRIPT" "$issue_json"
+  [ "$status" -eq 0 ]
+
+  [ "$(jq -r .task_type "$(dirname "$issue_json")/dor-lint.json")" = "docs" ]
+}
+
+@test "label maps type docs to docs" {
+  issue_json="$(mktemp)"
+  jq '.labels = [{"name":"type:docs"}]' "$TEST_DIR/issue-conformant.json" > "$issue_json"
+
+  run "$SCRIPT" "$issue_json"
+  [ "$status" -eq 0 ]
+
+  [ "$(jq -r .task_type "$(dirname "$issue_json")/dor-lint.json")" = "docs" ]
+}
+
+@test "label maps tech debt to refactor" {
+  issue_json="$(mktemp)"
+  jq '.labels = [{"name":"tech-debt"}]' "$TEST_DIR/issue-conformant.json" > "$issue_json"
+
+  run "$SCRIPT" "$issue_json"
+  [ "$status" -eq 0 ]
+
+  [ "$(jq -r .task_type "$(dirname "$issue_json")/dor-lint.json")" = "refactor" ]
+}
+
+@test "label maps refactor to refactor" {
+  issue_json="$(mktemp)"
+  jq '.labels = [{"name":"refactor"}]' "$TEST_DIR/issue-conformant.json" > "$issue_json"
+
+  run "$SCRIPT" "$issue_json"
+  [ "$status" -eq 0 ]
+
+  [ "$(jq -r .task_type "$(dirname "$issue_json")/dor-lint.json")" = "refactor" ]
+}
+
+@test "label maps enhancement to feature" {
+  run "$SCRIPT" "$TEST_DIR/issue-conformant.json"
+  [ "$status" -eq 0 ]
+
+  [ "$(jq -r .task_type "$TEST_DIR/dor-lint.json")" = "feature" ]
+}
+
+@test "label maps type feature to feature" {
+  issue_json="$(mktemp)"
+  jq '.labels = [{"name":"type:feature"}]' "$TEST_DIR/issue-conformant.json" > "$issue_json"
+
+  run "$SCRIPT" "$issue_json"
+  [ "$status" -eq 0 ]
+
+  [ "$(jq -r .task_type "$(dirname "$issue_json")/dor-lint.json")" = "feature" ]
+}
+
+@test "unknown labels map to trivial" {
+  issue_json="$(mktemp)"
+  jq '.labels = [{"name":"question"}]' "$TEST_DIR/issue-conformant.json" > "$issue_json"
+
+  run "$SCRIPT" "$issue_json"
+  [ "$status" -eq 0 ]
+
+  [ "$(jq -r .task_type "$(dirname "$issue_json")/dor-lint.json")" = "trivial" ]
+}

--- a/tests/hooks/implement-gates.bats
+++ b/tests/hooks/implement-gates.bats
@@ -7,6 +7,8 @@
 #   2. Sets up PATH with fake-gh.sh and fake-cargo.sh in front.
 #   3. Invokes the hook with environment overrides as needed.
 #   4. Asserts exit code and relevant stdout/stderr.
+#
+# shellcheck disable=SC2030,SC2031
 
 setup() {
   REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
@@ -22,7 +24,7 @@ setup() {
 
   # Scratch git repo.
   TEST_REPO="$("$FIXTURES/init-test-repo.sh")"
-  cd "$TEST_REPO"
+  cd "$TEST_REPO" || exit
 }
 
 teardown() {
@@ -61,7 +63,9 @@ teardown() {
   [[ "$output" == *"/tmp/maestro-123-"* ]]
   log_dir=$(echo "$output" | grep -oE '/tmp/maestro-123-[0-9]+' | head -1)
   [ -f "$log_dir/issue.json" ]
+  [ -f "$log_dir/issue-summary.md" ]
   python3 -c "import json; json.load(open('$log_dir/issue.json'))"
+  [[ "$(cat "$log_dir/issue-summary.md")" == *"# test issue"* ]]
 }
 
 @test "exits 1 when issue is CLOSED" {
@@ -97,10 +101,10 @@ teardown() {
   echo "dirty" > new-file.txt
   git add new-file.txt
   export FAKE_CARGO_TEST_EXIT=0
-  run bash -c "echo 'S' | bash '$HOOK' 123"
+  run bash "$HOOK" 123 --dirty-tree-action=stash
   [ "$status" -eq 0 ]
   [[ "$output" == *"stashed as 'auto-stash before /implement #123'"* ]]
-  [ -n "$(git stash list | grep 'auto-stash before /implement #123')" ]
+  git stash list | grep -q 'auto-stash before /implement #123'
 }
 
 @test "calls preflight.sh when present and propagates exit code on failure" {


### PR DESCRIPTION
## Summary
- Add a mechanical DOR lint fast path for /implement gatekeeper decisions.
- Cache a condensed DOR issue summary during implement pre-checks for downstream agents.
- Cover the new lint and summary scripts plus the hook integration with Bats tests.

Closes #555

## Test plan
- [x] bats scripts/tests/test_condense_issue.bats scripts/tests/test_dor_lint.bats tests/hooks/implement-gates.bats
- [x] cargo test