### PR TITLE
feat: add interactive init provider selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+- feat(init): add interactive provider detection with Azure DevOps prompts and `--non-interactive` GitHub defaults (#468)
+
 ## [0.23.0] - 2026-05-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ Maestro checks for new versions on startup and shows an in-TUI banner — press 
 ## Quick Start
 
 ```bash
-maestro init                                              # generate maestro.toml
+maestro init                                              # interactive maestro.toml setup
+maestro init --non-interactive                            # headless GitHub defaults
 maestro doctor                                            # verify gh/az/claude/git
 maestro run --prompt "Refactor the auth module to async"  # ad-hoc session
 maestro run --issue 42                                    # session for a GitHub issue
@@ -127,7 +128,7 @@ For the full command catalogue see [Wiki › CLI Reference](https://github.com/C
 
 ## Configuration
 
-Maestro reads `maestro.toml` from the project root. Run `maestro init` to generate it — the command auto-detects your project's tech stack (Rust, Node, Python, Go, or polyglot) and fills in sensible defaults for `build_command`, `test_command`, and `run_command`. Run `maestro init --reset` to re-detect and merge results into an existing file (existing keys are preserved).
+Maestro reads `maestro.toml` from the project root. Run `maestro init` to generate it — the command auto-detects your project's tech stack (Rust, Node, Python, Go, or polyglot), detects the provider from `origin`, and prompts you to confirm GitHub or Azure DevOps. Azure DevOps setup asks for the organization URL and project name, then persists the required experimental opt-in. Use `maestro init --non-interactive` for headless/CI setup; it skips remote detection and prompts, and writes GitHub provider defaults. Run `maestro init --reset` to re-detect and merge results into an existing file (existing keys are preserved).
 
 A minimal `maestro.toml`:
 
@@ -148,7 +149,17 @@ alert_threshold_pct = 80      # warn at 80% of budget
 
 [github]
 auto_pr = true
+
+[provider]
+kind = "github"
+issue_filter_labels = ["maestro:ready"]
+auto_pr = true
+auto_merge = false
+merge_method = "squash"
+cache_ttl_secs = 300
 ```
+
+Azure DevOps init writes `kind = "azure_devops"`, `organization`, `az_project`, and `[experimental] azure_devops = true`.
 
 The full schema — completion gates, context-overflow tuning, TurboQuant, provider/Azure DevOps configuration, notifications, and feature flags — is documented in [Wiki › Configuration Reference](https://github.com/CarlosDanielDev/maestro/wiki/Configuration-Reference).
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -145,6 +145,9 @@ pub enum Commands {
         /// merging detected defaults without overwriting customized keys.
         #[arg(long)]
         reset: bool,
+        /// Skip provider prompts/remote detection and write GitHub provider defaults.
+        #[arg(long)]
+        non_interactive: bool,
     },
     /// Clean orphaned worktrees left by crashed sessions
     Clean {
@@ -331,13 +334,37 @@ mod tests {
     #[test]
     fn init_subcommand_no_flag_parses_reset_false() {
         let cli = Cli::try_parse_from(["maestro", "init"]).unwrap();
-        assert!(matches!(cli.command, Some(Commands::Init { reset: false })));
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Init {
+                reset: false,
+                non_interactive: false,
+            })
+        ));
     }
 
     #[test]
     fn init_subcommand_reset_flag_parses_reset_true() {
         let cli = Cli::try_parse_from(["maestro", "init", "--reset"]).unwrap();
-        assert!(matches!(cli.command, Some(Commands::Init { reset: true })));
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Init {
+                reset: true,
+                non_interactive: false,
+            })
+        ));
+    }
+
+    #[test]
+    fn init_subcommand_non_interactive_parses_true() {
+        let cli = Cli::try_parse_from(["maestro", "init", "--non-interactive"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Init {
+                reset: false,
+                non_interactive: true,
+            })
+        ));
     }
 
     // ------------------------------------------------------------------

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -333,11 +333,9 @@ fn prompt_line(label: &str) -> Result<String> {
                 {
                     anyhow::bail!("maestro init aborted")
                 }
-                KeyCode::Backspace => {
-                    if value.pop().is_some() {
-                        eprint!("\u{8} \u{8}");
-                        std::io::stderr().flush().context("flushing prompt")?;
-                    }
+                KeyCode::Backspace if value.pop().is_some() => {
+                    eprint!("\u{8} \u{8}");
+                    std::io::stderr().flush().context("flushing prompt")?;
                 }
                 KeyCode::Char(c) => {
                     value.push(c);

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,36 +1,93 @@
 use anyhow::{Context, Result};
-use std::io::Write;
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEvent, KeyModifiers},
+    terminal,
+};
+use regex::Regex;
+use std::io::{IsTerminal, Write};
 use std::path::Path;
 
 use crate::init::{
-    FsProjectDetector, ProjectDetector, RenderOutcome, render_or_merge, walk::find_project_root,
+    FsProjectDetector, ProjectDetector, RenderOutcome, render_or_merge,
+    render_or_merge_with_provider, template::ProviderTemplate, walk::find_project_root,
 };
+use crate::provider::{detect_provider_from_remote, types::ProviderKind};
 
 /// Public entry point used by the CLI. Forwards to [`cmd_init_inner`]
 /// against the real filesystem and converts the logical exit code into
 /// either `Ok(())` (success) or a process-exit (failure).
-pub fn cmd_init(reset: bool) -> Result<()> {
+pub fn cmd_init(reset: bool, non_interactive: bool) -> Result<()> {
     let cwd = std::env::current_dir().context("reading current working directory")?;
     let root = find_project_root(&cwd);
     let detector = FsProjectDetector::new();
-    let code = cmd_init_inner(reset, &root, &detector)?;
+    let code =
+        if non_interactive || !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
+            cmd_init_inner(reset, &root, &detector)?
+        } else {
+            let remote_output = git_remote_verbose(&root)?;
+            let remote_url = first_origin_remote_url(&remote_output);
+            let mut prompter = TerminalInitPrompter;
+            cmd_init_inner_with_options(
+                reset,
+                &root,
+                &detector,
+                InitOptions::interactive(remote_url.as_deref(), &mut prompter),
+            )?
+        };
     if code != 0 {
         std::process::exit(code);
     }
     Ok(())
 }
 
+pub trait InitPrompter {
+    fn choose_provider(&mut self, detected: ProviderKind) -> Result<ProviderKind>;
+    fn prompt_azdo_organization(&mut self) -> Result<String>;
+    fn prompt_azdo_project(&mut self) -> Result<String>;
+}
+
+pub enum InitOptions<'a> {
+    NonInteractive,
+    Interactive {
+        remote_url: Option<&'a str>,
+        prompter: &'a mut dyn InitPrompter,
+    },
+}
+
+impl<'a> InitOptions<'a> {
+    pub fn non_interactive() -> Self {
+        Self::NonInteractive
+    }
+
+    pub fn interactive(remote_url: Option<&'a str>, prompter: &'a mut dyn InitPrompter) -> Self {
+        Self::Interactive {
+            remote_url,
+            prompter,
+        }
+    }
+}
+
 /// Pure orchestration helper: writes (or merges) `maestro.toml` and
 /// returns the logical exit code. Tests drive this directly with a
 /// `FakeProjectDetector` and a `tempfile::TempDir`.
-///
-/// Exit codes:
-/// - 0 — wrote/merged successfully
-/// - 2 — `maestro.toml` already exists and `reset` is `false`
 pub fn cmd_init_inner(
     reset: bool,
     project_root: &Path,
     detector: &dyn ProjectDetector,
+) -> Result<i32> {
+    cmd_init_inner_with_options(
+        reset,
+        project_root,
+        detector,
+        InitOptions::non_interactive(),
+    )
+}
+
+pub fn cmd_init_inner_with_options(
+    reset: bool,
+    project_root: &Path,
+    detector: &dyn ProjectDetector,
+    options: InitOptions<'_>,
 ) -> Result<i32> {
     let target = project_root.join("maestro.toml");
 
@@ -51,7 +108,12 @@ pub fn cmd_init_inner(
         None
     };
 
-    let outcome = render_or_merge(detector, project_root, existing.as_deref())?;
+    let provider = provider_template_from_options(options)?;
+    let outcome = if provider == ProviderTemplate::github() {
+        render_or_merge(detector, project_root, existing.as_deref())?
+    } else {
+        render_or_merge_with_provider(detector, project_root, existing.as_deref(), &provider)?
+    };
 
     match outcome {
         RenderOutcome::Fresh { stacks, content } => {
@@ -112,3 +174,197 @@ pub fn cmd_init_inner(
 
     Ok(0)
 }
+
+fn provider_template_from_options(options: InitOptions<'_>) -> Result<ProviderTemplate> {
+    match options {
+        InitOptions::NonInteractive => Ok(ProviderTemplate::github()),
+        InitOptions::Interactive {
+            remote_url,
+            prompter,
+        } => {
+            let detected = remote_url
+                .map(detect_provider_from_remote)
+                .unwrap_or(ProviderKind::Github);
+            let selected = prompter.choose_provider(detected)?;
+            match selected {
+                ProviderKind::Github => Ok(ProviderTemplate::github()),
+                ProviderKind::AzureDevops => {
+                    let (organization, az_project) = prompt_azdo_fields(prompter)?;
+                    Ok(ProviderTemplate::azure_devops(organization, az_project))
+                }
+            }
+        }
+    }
+}
+
+pub fn first_origin_remote_url(remote_verbose: &str) -> Option<String> {
+    let mut first_origin = None;
+    for line in remote_verbose.lines() {
+        let mut parts = line.split_whitespace();
+        let name = parts.next();
+        let url = parts.next();
+        let kind = parts.next();
+        if name != Some("origin") {
+            continue;
+        }
+        let Some(url) = url else {
+            continue;
+        };
+        if first_origin.is_none() {
+            first_origin = Some(url.to_string());
+        }
+        if kind == Some("(fetch)") {
+            return Some(url.to_string());
+        }
+    }
+    first_origin
+}
+
+pub fn validate_azure_devops_organization_url(input: &str) -> bool {
+    let dev_azure = Regex::new(r"^https://dev\.azure\.com/[^/]+$").expect("valid regex");
+    let visualstudio = Regex::new(r"^https://[^/]+\.visualstudio\.com$").expect("valid regex");
+    !input.chars().any(char::is_control)
+        && (dev_azure.is_match(input) || visualstudio.is_match(input))
+}
+
+pub fn validate_azure_devops_project(input: &str) -> bool {
+    !input.trim().is_empty() && !input.chars().any(char::is_control)
+}
+
+pub fn prompt_azdo_fields(prompter: &mut dyn InitPrompter) -> Result<(String, String)> {
+    let organization = loop {
+        let value = prompter.prompt_azdo_organization()?;
+        let trimmed = value.trim();
+        if validate_azure_devops_organization_url(trimmed) {
+            break trimmed.to_string();
+        }
+        eprintln!(
+            "Azure DevOps organization must be https://dev.azure.com/<org> or https://<org>.visualstudio.com"
+        );
+    };
+
+    let az_project = loop {
+        let value = prompter.prompt_azdo_project()?;
+        let trimmed = value.trim();
+        if validate_azure_devops_project(trimmed) {
+            break trimmed.to_string();
+        }
+        eprintln!("Azure DevOps project is required.");
+    };
+
+    Ok((organization, az_project))
+}
+
+fn git_remote_verbose(project_root: &Path) -> Result<String> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .arg("remote")
+        .arg("-v")
+        .output()
+        .with_context(|| format!("running git remote -v in {}", project_root.display()))?;
+    if !output.status.success() {
+        return Ok(String::new());
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+struct TerminalInitPrompter;
+
+impl InitPrompter for TerminalInitPrompter {
+    fn choose_provider(&mut self, detected: ProviderKind) -> Result<ProviderKind> {
+        let default_key = match detected {
+            ProviderKind::Github => "G",
+            ProviderKind::AzureDevops => "A",
+        };
+        eprintln!(
+            "Provider [{}]: press Enter for detected default, g for GitHub, a for Azure DevOps",
+            default_key
+        );
+        loop {
+            let key = read_key()?;
+            match key.code {
+                KeyCode::Enter => return Ok(detected),
+                KeyCode::Char('g') | KeyCode::Char('G') => return Ok(ProviderKind::Github),
+                KeyCode::Char('a') | KeyCode::Char('A') => return Ok(ProviderKind::AzureDevops),
+                KeyCode::Esc | KeyCode::Char('c')
+                    if key.modifiers.contains(KeyModifiers::CONTROL) =>
+                {
+                    anyhow::bail!("maestro init aborted")
+                }
+                _ => eprintln!("Choose g, a, or Enter."),
+            }
+        }
+    }
+
+    fn prompt_azdo_organization(&mut self) -> Result<String> {
+        prompt_line("Azure DevOps organization URL")
+    }
+
+    fn prompt_azdo_project(&mut self) -> Result<String> {
+        prompt_line("Azure DevOps project")
+    }
+}
+
+fn read_key() -> Result<KeyEvent> {
+    let _raw = RawModeGuard::new()?;
+    let result = loop {
+        if let Event::Key(key) = event::read().context("reading terminal event")? {
+            break key;
+        }
+    };
+    Ok(result)
+}
+
+fn prompt_line(label: &str) -> Result<String> {
+    eprint!("{label}: ");
+    std::io::stderr().flush().context("flushing prompt")?;
+    let _raw = RawModeGuard::new()?;
+    let mut value = String::new();
+    loop {
+        if let Event::Key(key) = event::read().context("reading terminal event")? {
+            match key.code {
+                KeyCode::Enter => {
+                    eprintln!();
+                    return Ok(value);
+                }
+                KeyCode::Esc | KeyCode::Char('c') | KeyCode::Char('d')
+                    if key.modifiers.contains(KeyModifiers::CONTROL) =>
+                {
+                    anyhow::bail!("maestro init aborted")
+                }
+                KeyCode::Backspace => {
+                    if value.pop().is_some() {
+                        eprint!("\u{8} \u{8}");
+                        std::io::stderr().flush().context("flushing prompt")?;
+                    }
+                }
+                KeyCode::Char(c) => {
+                    value.push(c);
+                    eprint!("{c}");
+                    std::io::stderr().flush().context("flushing prompt")?;
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+struct RawModeGuard;
+
+impl RawModeGuard {
+    fn new() -> Result<Self> {
+        terminal::enable_raw_mode().context("enabling raw mode")?;
+        Ok(Self)
+    }
+}
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        let _ = terminal::disable_raw_mode();
+    }
+}
+
+#[cfg(test)]
+#[path = "init_tests.rs"]
+mod tests;

--- a/src/commands/init_tests.rs
+++ b/src/commands/init_tests.rs
@@ -1,0 +1,40 @@
+use super::*;
+
+#[test]
+fn first_origin_remote_url_prefers_fetch_url() {
+    let remote = "upstream\thttps://example.com/upstream.git (fetch)\n\
+                  origin\tgit@github.com:owner/repo.git (push)\n\
+                  origin\thttps://github.com/owner/repo.git (fetch)\n";
+    assert_eq!(
+        first_origin_remote_url(remote).as_deref(),
+        Some("https://github.com/owner/repo.git")
+    );
+}
+
+#[test]
+fn validate_azure_devops_org_accepts_supported_forms() {
+    assert!(validate_azure_devops_organization_url(
+        "https://dev.azure.com/MyOrg"
+    ));
+    assert!(validate_azure_devops_organization_url(
+        "https://MyOrg.visualstudio.com"
+    ));
+}
+
+#[test]
+fn validate_azure_devops_org_rejects_invalid_forms() {
+    for input in [
+        "http://dev.azure.com/MyOrg",
+        "https://dev.azure.com/",
+        "https://dev.azure.com/MyOrg/Project",
+        "https://MyOrg@dev.azure.com/MyOrg",
+        "https://example.com/MyOrg",
+        "dev.azure.com/MyOrg",
+        "",
+    ] {
+        assert!(
+            !validate_azure_devops_organization_url(input),
+            "accepted {input:?}"
+        );
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -17,7 +17,7 @@ pub use dashboard::cmd_dashboard;
 pub use doctor::cmd_doctor;
 pub use init::cmd_init;
 #[cfg(test)]
-pub use init::cmd_init_inner;
+pub use init::{InitOptions, InitPrompter, cmd_init_inner, cmd_init_inner_with_options};
 pub use logs::cmd_logs;
 pub use queue::{cmd_add, cmd_queue};
 pub use resume::cmd_resume;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
@@ -148,10 +149,20 @@ impl Config {
     }
 
     pub fn validate(&self) -> Result<()> {
-        if self.provider.kind == crate::provider::types::ProviderKind::AzureDevops
-            && !self.experimental.azure_devops
-        {
-            anyhow::bail!(Self::AZURE_DEVOPS_EXPERIMENTAL_ERROR);
+        if self.provider.kind == crate::provider::types::ProviderKind::AzureDevops {
+            if !self.experimental.azure_devops {
+                anyhow::bail!(Self::AZURE_DEVOPS_EXPERIMENTAL_ERROR);
+            }
+            let organization = self.provider.organization.as_deref().unwrap_or("").trim();
+            if !valid_azure_devops_organization_url(organization) {
+                anyhow::bail!(
+                    "provider.organization must be https://dev.azure.com/<org> or https://<org>.visualstudio.com for azure_devops"
+                );
+            }
+            let project = self.provider.az_project.as_deref().unwrap_or("").trim();
+            if project.is_empty() || project.chars().any(char::is_control) {
+                anyhow::bail!("provider.az_project is required for azure_devops");
+            }
         }
 
         Ok(())
@@ -166,6 +177,13 @@ impl Config {
         }
         provider
     }
+}
+
+fn valid_azure_devops_organization_url(input: &str) -> bool {
+    let dev_azure = Regex::new(r"^https://dev\.azure\.com/[^/]+$").expect("valid regex");
+    let visualstudio = Regex::new(r"^https://[^/]+\.visualstudio\.com$").expect("valid regex");
+    !input.chars().any(char::is_control)
+        && (dev_azure.is_match(input) || visualstudio.is_match(input))
 }
 
 /// A `Config` bundled with the filesystem path it was loaded from.

--- a/src/config/tests/experimental.rs
+++ b/src/config/tests/experimental.rs
@@ -34,6 +34,8 @@ fn config_validate_accepts_azure_devops_with_experimental_opt_in() {
         r#"{MINIMAL_TOML}
 [provider]
 kind = "azure_devops"
+organization = "https://dev.azure.com/MyOrg"
+az_project = "MyProject"
 
 [experimental]
 azure_devops = true
@@ -46,6 +48,44 @@ azure_devops = true
     if let Err(err) = cfg.validate() {
         panic!("explicit opt-in must pass: {err}");
     }
+}
+
+#[test]
+fn config_validate_rejects_azure_devops_missing_fields() {
+    let toml_str = format!(
+        r#"{MINIMAL_TOML}
+[provider]
+kind = "azure_devops"
+
+[experimental]
+azure_devops = true
+"#
+    );
+    let cfg: Config = toml::from_str(&toml_str).expect("azure devops config parses");
+    let err = cfg
+        .validate()
+        .expect_err("azure devops fields are required");
+    assert!(err.to_string().contains("provider.organization"));
+}
+
+#[test]
+fn config_validate_rejects_azure_devops_invalid_organization() {
+    let toml_str = format!(
+        r#"{MINIMAL_TOML}
+[provider]
+kind = "azure_devops"
+organization = "https://dev.azure.com/MyOrg/Project"
+az_project = "MyProject"
+
+[experimental]
+azure_devops = true
+"#
+    );
+    let cfg: Config = toml::from_str(&toml_str).expect("azure devops config parses");
+    let err = cfg
+        .validate()
+        .expect_err("azure devops organization must be valid");
+    assert!(err.to_string().contains("provider.organization"));
 }
 
 #[test]

--- a/src/config/tests/roundtrip.rs
+++ b/src/config/tests/roundtrip.rs
@@ -53,6 +53,70 @@ alert_threshold_pct = 80
 }
 
 #[test]
+fn config_save_round_trip_with_azure_devops_provider() {
+    use crate::provider::types::ProviderKind;
+    use std::io::Write;
+
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    write!(
+        f,
+        r#"{MINIMAL_TOML}
+[provider]
+kind = "azure_devops"
+organization = "https://dev.azure.com/MyOrg"
+az_project = "MyProject"
+
+[experimental]
+azure_devops = true
+"#
+    )
+    .unwrap();
+
+    let original = Config::load(f.path()).expect("load failed");
+    let out = tempfile::NamedTempFile::new().unwrap();
+    original.save(out.path()).expect("save failed");
+    let reloaded = Config::load(out.path()).expect("reload failed");
+
+    assert_eq!(original, reloaded);
+    assert_eq!(reloaded.provider.kind, ProviderKind::AzureDevops);
+    assert_eq!(
+        reloaded.provider.organization.as_deref(),
+        Some("https://dev.azure.com/MyOrg")
+    );
+    assert_eq!(reloaded.provider.az_project.as_deref(), Some("MyProject"));
+    assert!(reloaded.experimental.azure_devops);
+}
+
+#[test]
+fn config_save_round_trip_with_github_provider_omits_default_experimental() {
+    use crate::provider::types::ProviderKind;
+    use std::io::Write;
+
+    let mut f = tempfile::NamedTempFile::new().unwrap();
+    write!(
+        f,
+        r#"{MINIMAL_TOML}
+[provider]
+kind = "github"
+"#
+    )
+    .unwrap();
+
+    let original = Config::load(f.path()).expect("load failed");
+    let out = tempfile::NamedTempFile::new().unwrap();
+    original.save(out.path()).expect("save failed");
+    let serialized = std::fs::read_to_string(out.path()).unwrap();
+    let reloaded = Config::load(out.path()).expect("reload failed");
+
+    assert_eq!(reloaded.provider.kind, ProviderKind::Github);
+    assert_eq!(original, reloaded);
+    assert!(
+        !serialized.contains("[experimental]"),
+        "default experimental section should be omitted: {serialized}"
+    );
+}
+
+#[test]
 fn config_save_round_trip_full() {
     use std::io::Write;
     let mut f = tempfile::NamedTempFile::new().unwrap();

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -41,6 +41,25 @@ pub fn render_or_merge(
 ) -> Result<RenderOutcome> {
     let stacks = detector.detect(project_root);
     let defaults = template::render(&stacks);
+    render_or_merge_defaults(stacks, defaults, existing)
+}
+
+pub fn render_or_merge_with_provider(
+    detector: &dyn ProjectDetector,
+    project_root: &Path,
+    existing: Option<&str>,
+    provider: &template::ProviderTemplate,
+) -> Result<RenderOutcome> {
+    let stacks = detector.detect(project_root);
+    let defaults = template::render_with_provider(&stacks, provider);
+    render_or_merge_defaults(stacks, defaults, existing)
+}
+
+fn render_or_merge_defaults(
+    stacks: Vec<DetectedStack>,
+    defaults: String,
+    existing: Option<&str>,
+) -> Result<RenderOutcome> {
     match existing {
         None => Ok(RenderOutcome::Fresh {
             stacks,

--- a/src/init/template.rs
+++ b/src/init/template.rs
@@ -4,6 +4,7 @@
 //! `[gates].test_command` change with the detected stack.
 
 use super::DetectedStack;
+use crate::provider::types::ProviderKind;
 
 /// Per-stack default commands.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -12,6 +13,34 @@ pub struct StackDefaults {
     pub build_command: &'static str,
     pub test_command: &'static str,
     pub run_command: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderTemplate {
+    pub kind: ProviderKind,
+    pub organization: Option<String>,
+    pub az_project: Option<String>,
+    pub azure_devops_experimental: bool,
+}
+
+impl ProviderTemplate {
+    pub fn github() -> Self {
+        Self {
+            kind: ProviderKind::Github,
+            organization: None,
+            az_project: None,
+            azure_devops_experimental: false,
+        }
+    }
+
+    pub fn azure_devops(organization: String, az_project: String) -> Self {
+        Self {
+            kind: ProviderKind::AzureDevops,
+            organization: Some(organization),
+            az_project: Some(az_project),
+            azure_devops_experimental: true,
+        }
+    }
 }
 
 impl StackDefaults {
@@ -53,11 +82,17 @@ impl StackDefaults {
 ///
 /// Empty `stacks` produces a generic template with commented placeholders.
 pub fn render(stacks: &[DetectedStack]) -> String {
+    render_with_provider(stacks, &ProviderTemplate::github())
+}
+
+pub fn render_with_provider(stacks: &[DetectedStack], provider: &ProviderTemplate) -> String {
     let project_block = render_project_block(stacks);
     let gates_test_command = stacks
         .first()
         .map(|s| StackDefaults::for_stack(*s).test_command)
         .unwrap_or("");
+    let provider_block = render_provider_block(provider);
+    let experimental_block = render_experimental_block(provider);
 
     format!(
         r#"{project_block}
@@ -80,6 +115,8 @@ auto_pr = true
 auto_merge = false                      # Set to true to auto-merge PRs after CI + review pass
 merge_method = "squash"                 # Options: merge, squash, rebase
 cache_ttl_secs = 300
+
+{provider_block}{experimental_block}
 
 [gates]
 enabled = true
@@ -110,6 +147,53 @@ work_tick_interval_secs = 10
 # ci_auto_fix = false      # default: false
 "#
     )
+}
+
+fn render_provider_block(provider: &ProviderTemplate) -> String {
+    let kind = match provider.kind {
+        ProviderKind::Github => "github",
+        ProviderKind::AzureDevops => "azure_devops",
+    };
+    let mut block = format!(
+        "[provider]\n\
+         kind = \"{kind}\"\n\
+         issue_filter_labels = [\"maestro:ready\"]\n\
+         auto_pr = true\n\
+         auto_merge = false\n\
+         merge_method = \"squash\"\n\
+         cache_ttl_secs = 300\n"
+    );
+    if let Some(org) = provider.organization.as_deref() {
+        block.push_str(&format!("organization = {}\n", toml_basic_string(org)));
+    }
+    if let Some(project) = provider.az_project.as_deref() {
+        block.push_str(&format!("az_project = {}\n", toml_basic_string(project)));
+    }
+    block
+}
+
+fn toml_basic_string(value: &str) -> String {
+    let mut out = String::from("\"");
+    for c in value.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+fn render_experimental_block(provider: &ProviderTemplate) -> String {
+    if provider.azure_devops_experimental {
+        String::from("\n[experimental]\nazure_devops = true\n")
+    } else {
+        String::new()
+    }
 }
 
 fn render_project_block(stacks: &[DetectedStack]) -> String {
@@ -249,6 +333,32 @@ mod tests {
         let out = render(&[DetectedStack::Rust]);
         assert!(!out.contains("[experimental]"), "{out}");
         assert!(!out.contains("azure_devops"), "{out}");
+    }
+
+    #[test]
+    fn template_render_includes_github_provider_section() {
+        let out = render(&[DetectedStack::Rust]);
+        assert!(out.contains("[provider]"), "{out}");
+        assert!(out.contains("kind = \"github\""), "{out}");
+    }
+
+    #[test]
+    fn template_render_azure_devops_provider_includes_experimental_opt_in() {
+        let out = render_with_provider(
+            &[DetectedStack::Rust],
+            &ProviderTemplate::azure_devops(
+                "https://dev.azure.com/MyOrg".into(),
+                "MyProject".into(),
+            ),
+        );
+        assert!(out.contains("kind = \"azure_devops\""), "{out}");
+        assert!(
+            out.contains("organization = \"https://dev.azure.com/MyOrg\""),
+            "{out}"
+        );
+        assert!(out.contains("az_project = \"MyProject\""), "{out}");
+        assert!(out.contains("[experimental]"), "{out}");
+        assert!(out.contains("azure_devops = true"), "{out}");
     }
 
     #[test]

--- a/src/integration_tests/init.rs
+++ b/src/integration_tests/init.rs
@@ -5,8 +5,9 @@
 use std::fs;
 use tempfile::tempdir;
 
-use crate::commands::cmd_init_inner;
+use crate::commands::{InitOptions, InitPrompter, cmd_init_inner, cmd_init_inner_with_options};
 use crate::init::{DetectedStack, FakeProjectDetector};
+use crate::provider::types::ProviderKind;
 
 #[test]
 fn cmd_init_writes_file_on_fresh_init() {
@@ -94,4 +95,96 @@ fn cmd_init_reset_adds_missing_keys_to_existing_file() {
         "{body}"
     );
     assert!(body.contains("test_command = \"go test ./...\""), "{body}");
+}
+
+struct ScriptedPrompter {
+    provider: ProviderKind,
+    organizations: Vec<String>,
+    projects: Vec<String>,
+}
+
+impl ScriptedPrompter {
+    fn new(provider: ProviderKind, organizations: &[&str], projects: &[&str]) -> Self {
+        Self {
+            provider,
+            organizations: organizations
+                .iter()
+                .map(|s| (*s).to_string())
+                .rev()
+                .collect(),
+            projects: projects.iter().map(|s| (*s).to_string()).rev().collect(),
+        }
+    }
+}
+
+impl InitPrompter for ScriptedPrompter {
+    fn choose_provider(&mut self, _detected: ProviderKind) -> anyhow::Result<ProviderKind> {
+        Ok(self.provider)
+    }
+
+    fn prompt_azdo_organization(&mut self) -> anyhow::Result<String> {
+        self.organizations
+            .pop()
+            .ok_or_else(|| anyhow::anyhow!("no scripted organization"))
+    }
+
+    fn prompt_azdo_project(&mut self) -> anyhow::Result<String> {
+        self.projects
+            .pop()
+            .ok_or_else(|| anyhow::anyhow!("no scripted project"))
+    }
+}
+
+#[test]
+fn cmd_init_non_interactive_writes_github_provider_default() {
+    let dir = tempdir().unwrap();
+    let detector = FakeProjectDetector::new(vec![DetectedStack::Rust]);
+
+    let code =
+        cmd_init_inner_with_options(false, dir.path(), &detector, InitOptions::non_interactive())
+            .expect("non-interactive init ok");
+
+    assert_eq!(code, 0);
+    let body = fs::read_to_string(dir.path().join("maestro.toml")).unwrap();
+    assert!(body.contains("[provider]"), "{body}");
+    assert!(body.contains("kind = \"github\""), "{body}");
+    assert!(!body.contains("[experimental]"), "{body}");
+}
+
+#[test]
+fn cmd_init_detects_azdo_remote_and_reprompts_invalid_organization() {
+    let dir = tempdir().unwrap();
+    let detector = FakeProjectDetector::new(vec![DetectedStack::Rust]);
+    let mut prompter = ScriptedPrompter::new(
+        ProviderKind::AzureDevops,
+        &["https://example.com/org", "https://dev.azure.com/MyOrg"],
+        &["", "MyProject"],
+    );
+
+    let code = cmd_init_inner_with_options(
+        false,
+        dir.path(),
+        &detector,
+        InitOptions::interactive(
+            Some("git@ssh.dev.azure.com:v3/MyOrg/MyProject/MyRepo"),
+            &mut prompter,
+        ),
+    )
+    .expect("interactive azdo init ok");
+
+    assert_eq!(code, 0);
+    let body = fs::read_to_string(dir.path().join("maestro.toml")).unwrap();
+    assert!(body.contains("[provider]"), "{body}");
+    assert!(body.contains("kind = \"azure_devops\""), "{body}");
+    assert!(
+        body.contains("organization = \"https://dev.azure.com/MyOrg\""),
+        "{body}"
+    );
+    assert!(body.contains("az_project = \"MyProject\""), "{body}");
+    assert!(body.contains("[experimental]"), "{body}");
+    assert!(body.contains("azure_devops = true"), "{body}");
+
+    let loaded = crate::config::Config::load(&dir.path().join("maestro.toml")).unwrap();
+    assert_eq!(loaded.provider.kind, ProviderKind::AzureDevops);
+    assert!(loaded.experimental.azure_devops);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,10 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Some(Commands::Init { reset }) => cmd_init(reset),
+        Some(Commands::Init {
+            reset,
+            non_interactive,
+        }) => cmd_init(reset, non_interactive),
         Some(Commands::Clean { dry_run }) => cmd_clean(dry_run),
         Some(Commands::Logs { session, export }) => cmd_logs(session, export),
         Some(Commands::Resume { session }) => cmd_resume(session).await,


### PR DESCRIPTION
## Summary

- Add interactive `maestro init` provider selection with origin-based GitHub/Azure DevOps defaults.
- Render Azure DevOps provider config with required organization, project, and experimental opt-in.
- Preserve headless behavior through `maestro init --non-interactive` and non-TTY fallback.

Closes #468

## Test plan

- [x] cargo test --quiet
- [x] cargo test init --all-targets
- [x] cargo clippy -- -D warnings -A dead_code
- [x] cargo fmt --check
- [x] git diff --check
