### PR TITLE
feat: stabilize azure devops provider config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 
 ### Added
+- feat(config): mark Azure DevOps stable by default and retire the `experimental.azure_devops` startup gate (#471)
 - feat(init): add interactive provider detection with Azure DevOps prompts and `--non-interactive` GitHub defaults (#468)
 
 ## [0.23.0] - 2026-05-04

--- a/src/config/experimental.rs
+++ b/src/config/experimental.rs
@@ -1,13 +1,27 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExperimentalConfig {
-    #[serde(default)]
+    /// Retained for backward compatibility with pre-v0.24.0 configs. Azure
+    /// DevOps is stable; this flag defaults to true and no longer gates use.
+    #[serde(default = "default_azure_devops")]
     pub azure_devops: bool,
+}
+
+impl Default for ExperimentalConfig {
+    fn default() -> Self {
+        Self {
+            azure_devops: default_azure_devops(),
+        }
+    }
 }
 
 impl ExperimentalConfig {
     pub fn is_default(&self) -> bool {
-        !self.azure_devops
+        self.azure_devops
     }
+}
+
+fn default_azure_devops() -> bool {
+    true
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -86,13 +86,16 @@ pub struct Config {
 }
 
 impl Config {
-    pub const AZURE_DEVOPS_EXPERIMENTAL_ERROR: &'static str = "Azure DevOps provider is experimental and not yet feature-complete. To opt in, set `[experimental] azure_devops = true` in maestro.toml. Otherwise set `provider.kind = \"github\"`.";
-
     pub fn load(path: &Path) -> Result<Self> {
         let content =
             std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
         let config: Self =
             toml::from_str(&content).with_context(|| format!("parsing {}", path.display()))?;
+        if has_legacy_azure_devops_flag(&content)
+            && config.provider.kind != crate::provider::types::ProviderKind::AzureDevops
+        {
+            log_legacy_azure_devops_config(false);
+        }
         config.validate()?;
         Ok(config)
     }
@@ -150,9 +153,7 @@ impl Config {
 
     pub fn validate(&self) -> Result<()> {
         if self.provider.kind == crate::provider::types::ProviderKind::AzureDevops {
-            if !self.experimental.azure_devops {
-                anyhow::bail!(Self::AZURE_DEVOPS_EXPERIMENTAL_ERROR);
-            }
+            log_legacy_azure_devops_config(self.experimental.azure_devops);
             let organization = self.provider.organization.as_deref().unwrap_or("").trim();
             if !valid_azure_devops_organization_url(organization) {
                 anyhow::bail!(
@@ -176,6 +177,28 @@ impl Config {
             provider.repo = Some(self.project.repo.clone());
         }
         provider
+    }
+}
+
+fn has_legacy_azure_devops_flag(content: &str) -> bool {
+    let Ok(value) = content.parse::<toml::Value>() else {
+        return false;
+    };
+    matches!(
+        value
+            .get("experimental")
+            .and_then(|experimental| experimental.get("azure_devops"))
+            .and_then(toml::Value::as_bool),
+        Some(false)
+    )
+}
+
+fn log_legacy_azure_devops_config(azure_devops: bool) {
+    if !azure_devops {
+        tracing::debug!(
+            "`experimental.azure_devops = false` is retained for backward compatibility; \
+             Azure DevOps is stable and no startup gate is applied"
+        );
     }
 }
 

--- a/src/config/tests/experimental.rs
+++ b/src/config/tests/experimental.rs
@@ -1,35 +1,32 @@
 use super::*;
 
 #[test]
-fn experimental_config_default_disables_azure_devops() {
-    assert!(!ExperimentalConfig::default().azure_devops);
+fn experimental_config_default_enables_azure_devops() {
+    assert!(ExperimentalConfig::default().azure_devops);
 }
 
 #[test]
-fn config_validate_rejects_azure_devops_without_experimental_opt_in() {
+fn config_validate_accepts_azure_devops_without_experimental_section() {
     let toml_str = format!(
         r#"{MINIMAL_TOML}
 [provider]
 kind = "azure_devops"
+organization = "https://dev.azure.com/MyOrg"
+az_project = "MyProject"
 "#
     );
     let cfg: Config = match toml::from_str(&toml_str) {
         Ok(cfg) => cfg,
         Err(err) => panic!("azure devops config must parse: {err}"),
     };
-    let err = match cfg.validate() {
-        Ok(()) => panic!("azure devops must require opt-in"),
-        Err(err) => err,
-    };
-    assert_eq!(err.to_string(), Config::AZURE_DEVOPS_EXPERIMENTAL_ERROR);
-    assert!(
-        err.to_string()
-            .contains("[experimental] azure_devops = true")
-    );
+    assert!(cfg.experimental.azure_devops);
+    if let Err(err) = cfg.validate() {
+        panic!("azure devops GA config must pass: {err}");
+    }
 }
 
 #[test]
-fn config_validate_accepts_azure_devops_with_experimental_opt_in() {
+fn config_validate_accepts_azure_devops_with_legacy_flag_false() {
     let toml_str = format!(
         r#"{MINIMAL_TOML}
 [provider]
@@ -38,15 +35,16 @@ organization = "https://dev.azure.com/MyOrg"
 az_project = "MyProject"
 
 [experimental]
-azure_devops = true
+azure_devops = false
 "#
     );
     let cfg: Config = match toml::from_str(&toml_str) {
         Ok(cfg) => cfg,
-        Err(err) => panic!("azure devops opt-in config must parse: {err}"),
+        Err(err) => panic!("azure devops legacy config must parse: {err}"),
     };
+    assert!(!cfg.experimental.azure_devops);
     if let Err(err) = cfg.validate() {
-        panic!("explicit opt-in must pass: {err}");
+        panic!("legacy false flag must not gate azure devops: {err}");
     }
 }
 
@@ -56,9 +54,6 @@ fn config_validate_rejects_azure_devops_missing_fields() {
         r#"{MINIMAL_TOML}
 [provider]
 kind = "azure_devops"
-
-[experimental]
-azure_devops = true
 "#
     );
     let cfg: Config = toml::from_str(&toml_str).expect("azure devops config parses");
@@ -76,9 +71,6 @@ fn config_validate_rejects_azure_devops_invalid_organization() {
 kind = "azure_devops"
 organization = "https://dev.azure.com/MyOrg/Project"
 az_project = "MyProject"
-
-[experimental]
-azure_devops = true
 "#
     );
     let cfg: Config = toml::from_str(&toml_str).expect("azure devops config parses");
@@ -111,12 +103,12 @@ azure_devops = {azure_devops}
 }
 
 #[test]
-fn config_without_experimental_section_defaults_to_false_and_round_trips() {
+fn config_without_experimental_section_defaults_to_true_and_round_trips() {
     let cfg: Config = match toml::from_str(MINIMAL_TOML) {
         Ok(cfg) => cfg,
         Err(err) => panic!("minimal config must parse: {err}"),
     };
-    assert!(!cfg.experimental.azure_devops);
+    assert!(cfg.experimental.azure_devops);
 
     let serialized = match toml::to_string_pretty(&cfg) {
         Ok(serialized) => serialized,
@@ -131,5 +123,27 @@ fn config_without_experimental_section_defaults_to_false_and_round_trips() {
         Ok(reloaded) => reloaded,
         Err(err) => panic!("serialized config must parse: {err}"),
     };
-    assert!(!reloaded.experimental.azure_devops);
+    assert!(reloaded.experimental.azure_devops);
+}
+
+#[test]
+fn config_with_legacy_false_experimental_flag_round_trips() {
+    let toml_str = format!(
+        r#"{MINIMAL_TOML}
+[experimental]
+azure_devops = false
+"#
+    );
+    let cfg: Config = match toml::from_str(&toml_str) {
+        Ok(cfg) => cfg,
+        Err(err) => panic!("legacy config must parse: {err}"),
+    };
+    assert!(!cfg.experimental.azure_devops);
+
+    let serialized = match toml::to_string_pretty(&cfg) {
+        Ok(serialized) => serialized,
+        Err(err) => panic!("serialize config: {err}"),
+    };
+    assert!(serialized.contains("[experimental]"), "{serialized}");
+    assert!(serialized.contains("azure_devops = false"), "{serialized}");
 }

--- a/src/init/template.rs
+++ b/src/init/template.rs
@@ -20,7 +20,6 @@ pub struct ProviderTemplate {
     pub kind: ProviderKind,
     pub organization: Option<String>,
     pub az_project: Option<String>,
-    pub azure_devops_experimental: bool,
 }
 
 impl ProviderTemplate {
@@ -29,7 +28,6 @@ impl ProviderTemplate {
             kind: ProviderKind::Github,
             organization: None,
             az_project: None,
-            azure_devops_experimental: false,
         }
     }
 
@@ -38,7 +36,6 @@ impl ProviderTemplate {
             kind: ProviderKind::AzureDevops,
             organization: Some(organization),
             az_project: Some(az_project),
-            azure_devops_experimental: true,
         }
     }
 }
@@ -92,7 +89,6 @@ pub fn render_with_provider(stacks: &[DetectedStack], provider: &ProviderTemplat
         .map(|s| StackDefaults::for_stack(*s).test_command)
         .unwrap_or("");
     let provider_block = render_provider_block(provider);
-    let experimental_block = render_experimental_block(provider);
 
     format!(
         r#"{project_block}
@@ -116,7 +112,7 @@ auto_merge = false                      # Set to true to auto-merge PRs after CI
 merge_method = "squash"                 # Options: merge, squash, rebase
 cache_ttl_secs = 300
 
-{provider_block}{experimental_block}
+{provider_block}
 
 [gates]
 enabled = true
@@ -186,14 +182,6 @@ fn toml_basic_string(value: &str) -> String {
     }
     out.push('"');
     out
-}
-
-fn render_experimental_block(provider: &ProviderTemplate) -> String {
-    if provider.azure_devops_experimental {
-        String::from("\n[experimental]\nazure_devops = true\n")
-    } else {
-        String::new()
-    }
 }
 
 fn render_project_block(stacks: &[DetectedStack]) -> String {
@@ -343,7 +331,7 @@ mod tests {
     }
 
     #[test]
-    fn template_render_azure_devops_provider_includes_experimental_opt_in() {
+    fn template_render_azure_devops_provider_omits_experimental_opt_in() {
         let out = render_with_provider(
             &[DetectedStack::Rust],
             &ProviderTemplate::azure_devops(
@@ -357,8 +345,8 @@ mod tests {
             "{out}"
         );
         assert!(out.contains("az_project = \"MyProject\""), "{out}");
-        assert!(out.contains("[experimental]"), "{out}");
-        assert!(out.contains("azure_devops = true"), "{out}");
+        assert!(!out.contains("[experimental]"), "{out}");
+        assert!(!out.contains("azure_devops = true"), "{out}");
     }
 
     #[test]

--- a/src/integration_tests/init.rs
+++ b/src/integration_tests/init.rs
@@ -181,8 +181,8 @@ fn cmd_init_detects_azdo_remote_and_reprompts_invalid_organization() {
         "{body}"
     );
     assert!(body.contains("az_project = \"MyProject\""), "{body}");
-    assert!(body.contains("[experimental]"), "{body}");
-    assert!(body.contains("azure_devops = true"), "{body}");
+    assert!(!body.contains("[experimental]"), "{body}");
+    assert!(!body.contains("azure_devops = true"), "{body}");
 
     let loaded = crate::config::Config::load(&dir.path().join("maestro.toml")).unwrap();
     assert_eq!(loaded.provider.kind, ProviderKind::AzureDevops);

--- a/src/provider/types.rs
+++ b/src/provider/types.rs
@@ -19,7 +19,7 @@ fn blocked_by_regex() -> &'static regex::Regex {
 pub enum ProviderKind {
     #[default]
     Github,
-    /// Experimental until v0.24.0; requires `experimental.azure_devops = true`.
+    /// Azure DevOps provider.
     AzureDevops,
 }
 


### PR DESCRIPTION
## Summary

- Default Azure DevOps config support to stable behavior while retaining the legacy experimental flag for older configs
- Remove generated `[experimental] azure_devops = true` from init templates and update init/config coverage
- Refresh provider docs and changelog entry for the GA config path

Closes #471

## Test plan

- [x] cargo test --quiet
- [x] cargo clippy -- -D warnings -A dead_code
- [x] cargo fmt --check
- [x] manual verification: reviewed generated Azure DevOps init template output expectations
