### PR TITLE
refactor: extract Claude agent provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ clap_mangen = "0.2"
 crossterm = { version = "0.28", features = ["event-stream"] }
 ratatui = "0.29"
 tokio = { version = "1", features = ["full"] }
+tokio-util = "0.7"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"

--- a/src/adapt/prompts.rs
+++ b/src/adapt/prompts.rs
@@ -308,30 +308,16 @@ pub async fn run_claude_print(
     prompt: &str,
     cwd: &std::path::Path,
 ) -> anyhow::Result<String> {
-    let output = tokio::process::Command::new("claude")
-        .args([
-            "--print",
-            "--output-format",
-            "text",
-            "--model",
-            model,
-            "-p",
-            prompt,
-        ])
-        .current_dir(cwd)
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .output()
+    let output = crate::agent_provider::ClaudeProvider::default()
+        .run_text(model, prompt, Some(cwd))
         .await
         .map_err(|e| anyhow::anyhow!("Failed to spawn claude CLI: {}", e))?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("Claude CLI failed: {}", stderr.trim());
+    if !output.status_success {
+        anyhow::bail!("Claude CLI failed: {}", output.stderr.trim());
     }
 
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    Ok(output.stdout)
 }
 
 /// Extract and parse a JSON block from Claude's response.

--- a/src/agent_provider/claude.rs
+++ b/src/agent_provider/claude.rs
@@ -1,0 +1,340 @@
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+use super::types::{
+    AgentError, AgentHealthCheck, AgentOutputFormat, AgentProvider, AgentProviderEvent,
+    AgentProviderId, AgentProviderKind, AgentRequest, AgentRunResult, AgentRunStarted,
+    AgentTextOutput, ParserBinding,
+};
+use crate::session::parser::parse_stream_line;
+use crate::session::types::StreamEvent;
+
+#[derive(Debug, Clone)]
+pub struct ClaudeProvider {
+    binary: String,
+}
+
+impl ClaudeProvider {
+    pub fn new(binary: impl Into<String>) -> Self {
+        Self {
+            binary: binary.into(),
+        }
+    }
+
+    pub fn build_stream_args(&self, request: &AgentRequest) -> Vec<String> {
+        let mut args = vec![
+            "--print".to_string(),
+            "--verbose".to_string(),
+            "--output-format".to_string(),
+            "stream-json".to_string(),
+            "--model".to_string(),
+            request.model.clone(),
+        ];
+
+        if let Some(mode) = request.permission_mode.as_deref()
+            && !mode.is_empty()
+            && mode != "default"
+        {
+            args.push("--permission-mode".to_string());
+            args.push(mode.to_string());
+        }
+
+        if !request.allowed_tools.is_empty() {
+            args.push("--allowedTools".to_string());
+            args.push(request.allowed_tools.join(","));
+        }
+
+        if let Some(appendix) = request.system_prompt_appendix.as_ref() {
+            args.push("--append-system-prompt".to_string());
+            args.push(appendix.clone());
+        }
+
+        args.push(request.prompt.clone());
+        args
+    }
+
+    pub fn build_text_args(&self, request: &AgentRequest) -> Vec<String> {
+        let mut args = vec![
+            "--print".to_string(),
+            "--output-format".to_string(),
+            "text".to_string(),
+        ];
+        if !request.model.trim().is_empty() {
+            args.push("--model".to_string());
+            args.push(request.model.clone());
+        }
+        args.push("-p".to_string());
+        args.push(request.prompt.clone());
+        args
+    }
+
+    pub async fn run_text(
+        &self,
+        model: &str,
+        prompt: &str,
+        cwd: Option<&Path>,
+    ) -> Result<AgentTextOutput, AgentError> {
+        let request = AgentRequest::text(
+            prompt.to_string(),
+            model.to_string(),
+            cwd.map(PathBuf::from),
+        );
+        let mut cmd = Command::new(&self.binary);
+        cmd.args(self.build_text_args(&request));
+        if let Some(cwd) = request.cwd.as_ref() {
+            cmd.current_dir(cwd);
+        }
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let output = cmd.output().await.map_err(|source| AgentError::Spawn {
+            provider_id: self.id().to_string(),
+            source,
+        })?;
+
+        Ok(AgentTextOutput {
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            status_success: output.status.success(),
+        })
+    }
+
+    pub fn health_check_blocking(&self) -> AgentHealthCheck {
+        match std::process::Command::new(&self.binary)
+            .arg("--version")
+            .output()
+        {
+            Ok(out) if out.status.success() => {
+                let version = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                AgentHealthCheck {
+                    provider_id: AgentProviderId::new(self.id()),
+                    available: true,
+                    version: Some(version.clone()),
+                    message: version,
+                }
+            }
+            Ok(out) => AgentHealthCheck {
+                provider_id: AgentProviderId::new(self.id()),
+                available: false,
+                version: None,
+                message: String::from_utf8_lossy(&out.stderr).trim().to_string(),
+            },
+            Err(_) => AgentHealthCheck {
+                provider_id: AgentProviderId::new(self.id()),
+                available: false,
+                version: None,
+                message: "not installed".to_string(),
+            },
+        }
+    }
+}
+
+impl Default for ClaudeProvider {
+    fn default() -> Self {
+        Self::new("claude")
+    }
+}
+
+#[async_trait::async_trait]
+impl AgentProvider for ClaudeProvider {
+    fn id(&self) -> &str {
+        "claude"
+    }
+
+    fn kind(&self) -> AgentProviderKind {
+        AgentProviderKind::Subprocess
+    }
+
+    fn parser_binding(&self) -> ParserBinding {
+        ParserBinding::claude_stream_json()
+    }
+
+    async fn health_check(&self) -> Result<AgentHealthCheck, AgentError> {
+        match Command::new(&self.binary).arg("--version").output().await {
+            Ok(out) if out.status.success() => {
+                let version = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                Ok(AgentHealthCheck {
+                    provider_id: AgentProviderId::new(self.id()),
+                    available: true,
+                    version: Some(version.clone()),
+                    message: version,
+                })
+            }
+            Ok(out) => Ok(AgentHealthCheck {
+                provider_id: AgentProviderId::new(self.id()),
+                available: false,
+                version: None,
+                message: String::from_utf8_lossy(&out.stderr).trim().to_string(),
+            }),
+            Err(source) => Err(AgentError::Spawn {
+                provider_id: self.id().to_string(),
+                source,
+            }),
+        }
+    }
+
+    async fn run(
+        &self,
+        request: AgentRequest,
+        events: mpsc::UnboundedSender<AgentProviderEvent>,
+        cancel: CancellationToken,
+    ) -> Result<AgentRunResult, AgentError> {
+        let mut cmd = Command::new(&self.binary);
+        match request.output_format {
+            AgentOutputFormat::StreamJson => {
+                cmd.args(self.build_stream_args(&request));
+            }
+            AgentOutputFormat::Text => {
+                cmd.args(self.build_text_args(&request));
+            }
+        }
+        if let Some(cwd) = request.cwd.as_ref() {
+            cmd.current_dir(cwd);
+        }
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let mut child = cmd.spawn().map_err(|source| AgentError::Spawn {
+            provider_id: self.id().to_string(),
+            source,
+        })?;
+        let process_id = child.id();
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| AgentError::Stream("No stdout from claude CLI".to_string()))?;
+        let stderr = child.stderr.take();
+
+        let _ = events.send(AgentProviderEvent::Started(AgentRunStarted { process_id }));
+
+        let stdout_events = events.clone();
+        let stdout_task = tokio::spawn(async move {
+            let reader = BufReader::new(stdout);
+            let mut lines = reader.lines();
+            let mut got_result = false;
+
+            while let Ok(Some(line)) = lines.next_line().await {
+                let parsed = parse_stream_line(&line);
+                for event in parsed {
+                    if matches!(event, StreamEvent::Completed { .. }) {
+                        got_result = true;
+                    }
+                    let _ = stdout_events.send(AgentProviderEvent::Stream(event));
+                }
+            }
+
+            if !got_result {
+                let _ = stdout_events.send(AgentProviderEvent::Stream(StreamEvent::Completed {
+                    cost_usd: 0.0,
+                }));
+            }
+        });
+
+        let stderr_task = stderr.map(|stderr| {
+            tokio::spawn(async move {
+                let reader = BufReader::new(stderr);
+                let mut lines = reader.lines();
+                let mut stderr_buf = String::new();
+
+                while let Ok(Some(line)) = lines.next_line().await {
+                    if !line.trim().is_empty() {
+                        if !stderr_buf.is_empty() {
+                            stderr_buf.push('\n');
+                        }
+                        stderr_buf.push_str(&line);
+                    }
+                }
+                stderr_buf
+            })
+        });
+
+        let status = tokio::select! {
+            _ = cancel.cancelled() => {
+                let _ = child.kill().await;
+                return Err(AgentError::Cancelled {
+                    provider_id: self.id().to_string(),
+                });
+            }
+            status = child.wait() => status.map_err(|err| AgentError::Stream(err.to_string()))?,
+        };
+
+        let _ = stdout_task.await;
+        let stderr_buf = match stderr_task {
+            Some(task) => task.await.unwrap_or_default(),
+            None => String::new(),
+        };
+
+        if !stderr_buf.is_empty() {
+            let _ = events.send(AgentProviderEvent::Stream(StreamEvent::Error {
+                message: stderr_buf.clone(),
+            }));
+        }
+
+        if !status.success() && !stderr_buf.is_empty() {
+            return Err(AgentError::FailedStatus {
+                provider_id: self.id().to_string(),
+                status: status.to_string(),
+                stderr: stderr_buf,
+            });
+        }
+
+        Ok(AgentRunResult {
+            exit_code: status.code(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request() -> AgentRequest {
+        let mut request = AgentRequest::stream_json("test prompt".into(), "claude-sonnet".into());
+        request.permission_mode = Some("bypassPermissions".to_string());
+        request.allowed_tools = vec!["Read".to_string(), "Write".to_string()];
+        request.system_prompt_appendix = Some("appendix".to_string());
+        request
+    }
+
+    #[test]
+    fn stream_args_match_existing_claude_contract() {
+        let provider = ClaudeProvider::default();
+        let args = provider.build_stream_args(&request());
+        assert_eq!(args[0], "--print");
+        assert!(args.iter().any(|arg| arg == "--verbose"));
+        assert!(
+            args.windows(2)
+                .any(|w| w == ["--output-format", "stream-json"])
+        );
+        assert!(args.windows(2).any(|w| w == ["--model", "claude-sonnet"]));
+        assert!(
+            args.windows(2)
+                .any(|w| w == ["--permission-mode", "bypassPermissions"])
+        );
+        assert!(
+            args.windows(2)
+                .any(|w| w == ["--allowedTools", "Read,Write"])
+        );
+        assert!(
+            args.windows(2)
+                .any(|w| w == ["--append-system-prompt", "appendix"])
+        );
+        assert_eq!(args.last().map(String::as_str), Some("test prompt"));
+    }
+
+    #[test]
+    fn default_permission_mode_is_excluded() {
+        let provider = ClaudeProvider::default();
+        let mut request = request();
+        request.permission_mode = Some("default".to_string());
+        let args = provider.build_stream_args(&request);
+        assert!(!args.iter().any(|arg| arg == "--permission-mode"));
+    }
+}

--- a/src/agent_provider/mod.rs
+++ b/src/agent_provider/mod.rs
@@ -1,0 +1,12 @@
+pub mod claude;
+pub mod types;
+
+#[allow(unused_imports)]
+pub use claude::ClaudeProvider;
+#[allow(unused_imports)]
+pub use types::{
+    AgentError, AgentHealthCheck, AgentOutputFormat, AgentProvider, AgentProviderDefinition,
+    AgentProviderEvent, AgentProviderFactory, AgentProviderId, AgentProviderKind,
+    AgentProvidersConfig, AgentRequest, AgentRunResult, AgentRunStarted, AgentTextOutput,
+    ParserBinding,
+};

--- a/src/agent_provider/types.rs
+++ b/src/agent_provider/types.rs
@@ -1,0 +1,326 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use thiserror::Error;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+use crate::session::types::StreamEvent;
+
+/// Transport class for an agent provider.
+///
+/// This intentionally describes how a provider is contacted, not how Maestro
+/// manages its lifecycle. Subprocess providers and HTTP providers implement the
+/// same `run` contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentProviderKind {
+    Subprocess,
+    Http,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AgentProviderId(String);
+
+impl AgentProviderId {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentOutputFormat {
+    StreamJson,
+    Text,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParserBinding {
+    pub name: String,
+    pub output_format: AgentOutputFormat,
+}
+
+impl ParserBinding {
+    pub fn claude_stream_json() -> Self {
+        Self {
+            name: "claude-stream-json".to_string(),
+            output_format: AgentOutputFormat::StreamJson,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentRequest {
+    pub prompt: String,
+    pub model: String,
+    pub cwd: Option<PathBuf>,
+    pub output_format: AgentOutputFormat,
+    pub permission_mode: Option<String>,
+    pub allowed_tools: Vec<String>,
+    pub system_prompt_appendix: Option<String>,
+}
+
+impl AgentRequest {
+    pub fn stream_json(prompt: String, model: String) -> Self {
+        Self {
+            prompt,
+            model,
+            cwd: None,
+            output_format: AgentOutputFormat::StreamJson,
+            permission_mode: None,
+            allowed_tools: Vec::new(),
+            system_prompt_appendix: None,
+        }
+    }
+
+    pub fn text(prompt: impl Into<String>, model: impl Into<String>, cwd: Option<PathBuf>) -> Self {
+        Self {
+            prompt: prompt.into(),
+            model: model.into(),
+            cwd,
+            output_format: AgentOutputFormat::Text,
+            permission_mode: None,
+            allowed_tools: Vec::new(),
+            system_prompt_appendix: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AgentRunStarted {
+    pub process_id: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AgentRunResult {
+    pub exit_code: Option<i32>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AgentTextOutput {
+    pub stdout: String,
+    pub stderr: String,
+    pub status_success: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AgentHealthCheck {
+    pub provider_id: AgentProviderId,
+    pub available: bool,
+    pub version: Option<String>,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentProviderDefinition {
+    pub id: String,
+    pub provider: String,
+    pub binary: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentProvidersConfig {
+    pub default_provider: String,
+    pub providers: Vec<AgentProviderDefinition>,
+}
+
+impl Default for AgentProvidersConfig {
+    fn default() -> Self {
+        Self {
+            default_provider: "claude".to_string(),
+            providers: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum AgentProviderEvent {
+    Started(AgentRunStarted),
+    Stream(StreamEvent),
+}
+
+#[derive(Debug, Error)]
+pub enum AgentError {
+    #[error("failed to spawn {provider_id}: {source}")]
+    Spawn {
+        provider_id: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("{provider_id} exited with status {status}: {stderr}")]
+    FailedStatus {
+        provider_id: String,
+        status: String,
+        stderr: String,
+    },
+    #[error("agent stream failed: {0}")]
+    Stream(String),
+    #[error("{provider_id} run was cancelled")]
+    Cancelled { provider_id: String },
+    #[error("invalid agent provider config: {0}")]
+    Config(String),
+}
+
+#[async_trait]
+pub trait AgentProvider: Send + Sync {
+    fn id(&self) -> &str;
+    fn kind(&self) -> AgentProviderKind;
+    fn parser_binding(&self) -> ParserBinding;
+
+    async fn health_check(&self) -> Result<AgentHealthCheck, AgentError>;
+
+    async fn run(
+        &self,
+        request: AgentRequest,
+        events: mpsc::UnboundedSender<AgentProviderEvent>,
+        cancel: CancellationToken,
+    ) -> Result<AgentRunResult, AgentError>;
+}
+
+#[derive(Clone)]
+pub struct AgentProviderFactory {
+    default_provider: Arc<dyn AgentProvider>,
+}
+
+impl AgentProviderFactory {
+    pub fn claude_default() -> Self {
+        Self {
+            default_provider: Arc::new(crate::agent_provider::claude::ClaudeProvider::default()),
+        }
+    }
+
+    pub fn from_config(config: AgentProvidersConfig) -> Result<Self, AgentError> {
+        let definition = config
+            .providers
+            .iter()
+            .find(|provider| provider.id == config.default_provider);
+
+        match definition {
+            Some(provider) if provider.provider == "claude" || provider.id == "claude" => {
+                let binary = provider.binary.as_deref().unwrap_or("claude");
+                Ok(Self {
+                    default_provider: Arc::new(crate::agent_provider::claude::ClaudeProvider::new(
+                        binary,
+                    )),
+                })
+            }
+            Some(provider) => Err(AgentError::Config(format!(
+                "unsupported default agent provider `{}`",
+                provider.provider
+            ))),
+            None if config.default_provider == "claude" => Ok(Self::claude_default()),
+            None => Err(AgentError::Config(format!(
+                "default agent provider `{}` is not configured",
+                config.default_provider
+            ))),
+        }
+    }
+
+    pub fn with_default_provider(provider: Arc<dyn AgentProvider>) -> Self {
+        Self {
+            default_provider: provider,
+        }
+    }
+
+    pub fn default_provider(&self) -> Arc<dyn AgentProvider> {
+        Arc::clone(&self.default_provider)
+    }
+}
+
+impl Default for AgentProviderFactory {
+    fn default() -> Self {
+        Self::claude_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct HttpStubProvider;
+
+    #[async_trait]
+    impl AgentProvider for HttpStubProvider {
+        fn id(&self) -> &str {
+            "http-stub"
+        }
+
+        fn kind(&self) -> AgentProviderKind {
+            AgentProviderKind::Http
+        }
+
+        fn parser_binding(&self) -> ParserBinding {
+            ParserBinding {
+                name: "stub-json".to_string(),
+                output_format: AgentOutputFormat::StreamJson,
+            }
+        }
+
+        async fn health_check(&self) -> Result<AgentHealthCheck, AgentError> {
+            Ok(AgentHealthCheck {
+                provider_id: AgentProviderId::new(self.id()),
+                available: true,
+                version: None,
+                message: "ok".to_string(),
+            })
+        }
+
+        async fn run(
+            &self,
+            _request: AgentRequest,
+            events: mpsc::UnboundedSender<AgentProviderEvent>,
+            _cancel: CancellationToken,
+        ) -> Result<AgentRunResult, AgentError> {
+            let _ = events.send(AgentProviderEvent::Started(AgentRunStarted {
+                process_id: None,
+            }));
+            let _ = events.send(AgentProviderEvent::Stream(StreamEvent::Completed {
+                cost_usd: 0.0,
+            }));
+            Ok(AgentRunResult { exit_code: None })
+        }
+    }
+
+    #[tokio::test]
+    async fn trait_supports_http_provider_without_subprocess_state() {
+        let provider: Arc<dyn AgentProvider> = Arc::new(HttpStubProvider);
+        assert_eq!(provider.kind(), AgentProviderKind::Http);
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        provider
+            .run(
+                AgentRequest::stream_json("prompt".into(), "model".into()),
+                tx,
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            rx.recv().await,
+            Some(AgentProviderEvent::Started(AgentRunStarted {
+                process_id: None
+            }))
+        ));
+        assert!(matches!(
+            rx.recv().await,
+            Some(AgentProviderEvent::Stream(StreamEvent::Completed { .. }))
+        ));
+    }
+
+    #[test]
+    fn factory_defaults_to_claude_provider() {
+        let factory = AgentProviderFactory::default();
+        assert_eq!(factory.default_provider().id(), "claude");
+    }
+
+    #[test]
+    fn factory_accepts_empty_config_as_legacy_claude() {
+        let factory = AgentProviderFactory::from_config(AgentProvidersConfig::default()).unwrap();
+        assert_eq!(factory.default_provider().id(), "claude");
+    }
+}

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,7 +1,7 @@
-use std::process::Command;
-
+use crate::agent_provider::ClaudeProvider;
 use crate::config::{Config, ProviderConfig};
 use crate::provider::types::ProviderKind;
+use std::process::Command;
 
 /// Severity of a preflight check.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -468,13 +468,9 @@ fn check_config_exists() -> CheckResult {
 }
 
 fn check_claude_cli() -> CheckResult {
-    match Command::new("claude").arg("--version").output() {
-        Ok(out) if out.status.success() => {
-            let version = sanitize(String::from_utf8_lossy(&out.stdout).trim());
-            build_claude_cli_result(true, &version)
-        }
-        _ => build_claude_cli_result(false, ""),
-    }
+    let health = ClaudeProvider::default().health_check_blocking();
+    let version = health.version.unwrap_or(health.message);
+    build_claude_cli_result(health.available, &sanitize(&version))
 }
 
 fn check_az_cli(severity: CheckSeverity) -> CheckResult {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@ pub mod icon_mode;
 pub mod icons;
 pub mod turboquant;
 
+pub mod agent_provider;
+
 #[path = "util"]
 pub mod util {
     pub mod formatting;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 #![warn(clippy::path_buf_push_overwrite)]
 #![warn(clippy::branches_sharing_code)]
 
+pub mod agent_provider;
 mod budget;
 mod changelog;
 mod cli;

--- a/src/review/auto_review.rs
+++ b/src/review/auto_review.rs
@@ -14,7 +14,6 @@ use crate::review::dispatch::ReviewDispatcher;
 use crate::review::parse::{parse_review_comment, render_review_comment};
 use crate::review::types::{PrNumber, ReviewReport};
 use anyhow::{Context, Result};
-use tokio::process::Command;
 
 pub async fn run_review_cycle(pr_number: u64, _owner: &str, _repo: &str) -> Result<ReviewReport> {
     let raw = run_claude_review(pr_number).await?;
@@ -31,14 +30,13 @@ pub async fn run_review_cycle(pr_number: u64, _owner: &str, _repo: &str) -> Resu
 /// Invoke `claude --print "/review <pr>"`. Falls back to an empty stub if
 /// the CLI isn't on PATH so the rest of the pipeline keeps working.
 async fn run_claude_review(pr_number: u64) -> Result<String> {
-    let output = Command::new("claude")
-        .args(["--print", &format!("/review {pr_number}")])
-        .output()
+    let output = crate::agent_provider::ClaudeProvider::default()
+        .run_text("", &format!("/review {pr_number}"), None)
         .await
         .with_context(|| "spawn claude --print /review");
     match output {
-        Ok(o) if o.status.success() => Ok(String::from_utf8_lossy(&o.stdout).into_owned()),
-        Ok(o) => Ok(String::from_utf8_lossy(&o.stderr).into_owned()),
+        Ok(o) if o.status_success => Ok(o.stdout),
+        Ok(o) => Ok(o.stderr),
         Err(_) => Ok(String::new()),
     }
 }

--- a/src/sanitize/analyzer.rs
+++ b/src/sanitize/analyzer.rs
@@ -33,23 +33,16 @@ impl SmellAnalyzer for ClaudeAnalyzer {
     ) -> anyhow::Result<AnalysisResult> {
         let prompt = build_prompt(scan, source_files).await?;
 
-        let output = tokio::process::Command::new("claude")
-            .args(["--print", "--output-format", "text", "--model", &self.model])
-            .arg(&prompt)
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .output()
+        let output = crate::agent_provider::ClaudeProvider::default()
+            .run_text(&self.model, &prompt, None)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to spawn claude CLI: {}", e))?;
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            tracing::warn!("Claude CLI exited with non-zero status: {}", stderr);
+        if !output.status_success {
+            tracing::warn!("Claude CLI exited with non-zero status: {}", output.stderr);
         }
 
-        let raw_text = String::from_utf8_lossy(&output.stdout);
-        let findings = parse_response(&raw_text);
+        let findings = parse_response(&output.stdout);
 
         Ok(AnalysisResult { findings })
     }

--- a/src/session/manager.rs
+++ b/src/session/manager.rs
@@ -1,12 +1,13 @@
-use super::parser::parse_stream_line;
 use super::types::{Session, SessionStatus, StreamEvent};
-use anyhow::{Context, Result};
+use crate::agent_provider::{
+    AgentError, AgentProvider, AgentProviderEvent, AgentRequest, ClaudeProvider,
+};
+use anyhow::{Result, anyhow};
 use chrono::Utc;
 use std::path::PathBuf;
-use std::process::Stdio;
-use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::process::{Child, Command};
+use std::sync::Arc;
 use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 
 /// Events sent from a session back to the coordinator/TUI.
 #[derive(Debug, Clone)]
@@ -17,7 +18,8 @@ pub struct SessionEvent {
 
 pub struct ManagedSession {
     pub session: Session,
-    child: Option<Child>,
+    provider: Arc<dyn AgentProvider>,
+    cancel_token: Option<CancellationToken>,
     /// Path to the git worktree for this session (Phase 1).
     pub worktree_path: Option<PathBuf>,
     /// Branch name for this session's worktree (e.g., "maestro/issue-42").
@@ -28,7 +30,6 @@ pub struct ManagedSession {
     pub permission_mode: Option<String>,
     /// Allowed tools whitelist.
     pub allowed_tools: Vec<String>,
-    claude_binary: String,
     last_tool_start: Option<std::time::Instant>,
     thinking_start: Option<std::time::Instant>,
 }
@@ -38,13 +39,13 @@ impl ManagedSession {
     pub fn new(session: Session) -> Self {
         Self {
             session,
-            child: None,
+            provider: Arc::new(ClaudeProvider::default()),
+            cancel_token: None,
             worktree_path: None,
             branch_name: None,
             system_prompt_appendix: None,
             permission_mode: None,
             allowed_tools: Vec::new(),
-            claude_binary: "claude".to_string(),
             last_tool_start: None,
             thinking_start: None,
         }
@@ -59,13 +60,13 @@ impl ManagedSession {
     ) -> Self {
         Self {
             session,
-            child: None,
+            provider: Arc::new(ClaudeProvider::default()),
+            cancel_token: None,
             worktree_path,
             branch_name,
             system_prompt_appendix,
             permission_mode: None,
             allowed_tools: Vec::new(),
-            claude_binary: "claude".to_string(),
             last_tool_start: None,
             thinking_start: None,
         }
@@ -73,51 +74,22 @@ impl ManagedSession {
 
     #[cfg(test)]
     fn set_claude_binary_for_test(&mut self, binary: impl Into<String>) {
-        self.claude_binary = binary.into();
+        self.provider = Arc::new(ClaudeProvider::new(binary));
     }
 
-    /// Build the CLI arguments for spawning the Claude process.
-    /// Extracted for testability — tests can inspect args without spawning.
-    fn build_args(&self) -> Vec<String> {
-        let mut args = vec![
-            "--print".to_string(),
-            "--verbose".to_string(),
-            "--output-format".to_string(),
-            "stream-json".to_string(),
-        ];
-
-        // Model selection
-        args.push("--model".to_string());
-        args.push(self.session.model.clone());
-
-        // Permission mode (default: bypassPermissions for unattended sessions)
-        if let Some(ref mode) = self.permission_mode
-            && !mode.is_empty()
-            && mode != "default"
-        {
-            args.push("--permission-mode".to_string());
-            args.push(mode.clone());
-        }
-
-        // Allowed tools whitelist
-        if !self.allowed_tools.is_empty() {
-            args.push("--allowedTools".to_string());
-            args.push(self.allowed_tools.join(","));
-        }
-
-        // Inject file claims via --append-system-prompt
-        if let Some(ref appendix) = self.system_prompt_appendix {
-            args.push("--append-system-prompt".to_string());
-            args.push(appendix.clone());
-        }
-
-        // Prompt is a positional argument (must be last)
-        args.push(self.session.prompt.clone());
-
-        args
+    fn build_request(&self) -> AgentRequest {
+        let mut request =
+            AgentRequest::stream_json(self.session.prompt.clone(), self.session.model.clone());
+        request.cwd.clone_from(&self.worktree_path);
+        request.permission_mode.clone_from(&self.permission_mode);
+        request.allowed_tools.clone_from(&self.allowed_tools);
+        request
+            .system_prompt_appendix
+            .clone_from(&self.system_prompt_appendix);
+        request
     }
 
-    /// Spawn the Claude CLI process and start streaming events.
+    /// Start the configured agent provider and stream events back to Maestro.
     pub async fn spawn(&mut self, tx: mpsc::UnboundedSender<SessionEvent>) -> Result<()> {
         use crate::session::transition::TransitionReason;
         let _ = self
@@ -125,26 +97,28 @@ impl ManagedSession {
             .transition_to(SessionStatus::Spawning, TransitionReason::Promoted);
         self.session.started_at = Some(Utc::now());
 
-        let mut cmd = Command::new(&self.claude_binary);
-        cmd.args(self.build_args());
+        let request = self.build_request();
+        let provider = Arc::clone(&self.provider);
+        let provider_id = provider.id().to_string();
+        let cancel = CancellationToken::new();
+        self.cancel_token = Some(cancel.clone());
+        let (provider_tx, mut provider_rx) = mpsc::unbounded_channel();
 
-        // Set working directory to worktree if available
-        if let Some(ref wt_path) = self.worktree_path {
-            cmd.current_dir(wt_path);
-        }
+        tokio::spawn(async move {
+            if let Err(err) = provider.run(request, provider_tx.clone(), cancel).await {
+                if matches!(err, AgentError::Cancelled { .. }) {
+                    return;
+                }
+                let _ = provider_tx.send(AgentProviderEvent::Stream(StreamEvent::Error {
+                    message: err.to_string(),
+                }));
+            }
+        });
 
-        cmd.stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-
-        let mut child = match cmd.spawn().with_context(|| {
-            format!(
-                "Failed to spawn Claude CLI using binary '{}'",
-                self.claude_binary
-            )
-        }) {
-            Ok(child) => child,
-            Err(err) => {
+        let first_event = match provider_rx.recv().await {
+            Some(event) => event,
+            None => {
+                let err = anyhow!("{provider_id} provider exited before startup");
                 let _ = self
                     .session
                     .transition_to(SessionStatus::Errored, TransitionReason::StreamError);
@@ -153,72 +127,44 @@ impl ManagedSession {
             }
         };
 
-        let pid = child.id().unwrap_or(0);
-        self.session.pid = Some(pid);
+        let started = match first_event {
+            AgentProviderEvent::Started(started) => started,
+            AgentProviderEvent::Stream(StreamEvent::Error { message }) => {
+                let err = anyhow!(message);
+                let _ = self
+                    .session
+                    .transition_to(SessionStatus::Errored, TransitionReason::StreamError);
+                self.session.log_activity(format!("Spawn failed: {err}"));
+                return Err(err);
+            }
+            AgentProviderEvent::Stream(event) => {
+                let _ = tx.send(SessionEvent {
+                    session_id: self.session.id,
+                    event,
+                });
+                crate::agent_provider::AgentRunStarted { process_id: None }
+            }
+        };
+
+        self.session.pid = started.process_id;
         let _ = self
             .session
             .transition_to(SessionStatus::Running, TransitionReason::Spawned);
-        self.session
-            .log_activity(format!("Session spawned (pid: {})", pid));
+        match started.process_id {
+            Some(pid) => self
+                .session
+                .log_activity(format!("Session spawned (pid: {})", pid)),
+            None => self.session.log_activity("Session spawned".into()),
+        }
 
-        let stdout = child.stdout.take().context("No stdout from claude CLI")?;
-        let stderr = child.stderr.take();
         let session_id = self.session.id;
-
-        // Stream reader task (stdout)
-        let tx2 = tx.clone();
         tokio::spawn(async move {
-            let reader = BufReader::new(stdout);
-            let mut lines = reader.lines();
-            let mut got_result = false;
-
-            while let Ok(Some(line)) = lines.next_line().await {
-                let events = parse_stream_line(&line);
-                for event in events {
-                    if matches!(event, StreamEvent::Completed { .. }) {
-                        got_result = true;
-                    }
+            while let Some(event) = provider_rx.recv().await {
+                if let AgentProviderEvent::Stream(event) = event {
                     let _ = tx.send(SessionEvent { session_id, event });
                 }
             }
-
-            // Only send fallback completion if we didn't get a real result event
-            if !got_result {
-                let _ = tx.send(SessionEvent {
-                    session_id,
-                    event: StreamEvent::Completed { cost_usd: 0.0 },
-                });
-            }
         });
-
-        // Stderr reader task — capture errors from Claude CLI
-        if let Some(stderr) = stderr {
-            tokio::spawn(async move {
-                let reader = BufReader::new(stderr);
-                let mut lines = reader.lines();
-                let mut stderr_buf = String::new();
-
-                while let Ok(Some(line)) = lines.next_line().await {
-                    if !line.trim().is_empty() {
-                        if !stderr_buf.is_empty() {
-                            stderr_buf.push('\n');
-                        }
-                        stderr_buf.push_str(&line);
-                    }
-                }
-
-                if !stderr_buf.is_empty() {
-                    let _ = tx2.send(SessionEvent {
-                        session_id,
-                        event: StreamEvent::Error {
-                            message: stderr_buf,
-                        },
-                    });
-                }
-            });
-        }
-
-        self.child = Some(child);
         Ok(())
     }
 
@@ -255,8 +201,8 @@ impl ManagedSession {
 
     /// Kill the child process.
     pub async fn kill(&mut self) -> Result<()> {
-        if let Some(ref mut child) = self.child {
-            child.kill().await.context("Failed to kill session")?;
+        if let Some(cancel) = self.cancel_token.take() {
+            cancel.cancel();
         }
         let _ = self.session.transition_to(
             SessionStatus::Killed,
@@ -471,7 +417,7 @@ mod tests {
     #[test]
     fn spawn_args_do_not_include_bare_flag() {
         let ms = make_managed("do something");
-        let args = ms.build_args();
+        let args = ClaudeProvider::default().build_stream_args(&ms.build_request());
         assert!(
             !args.iter().any(|a| a == "--bare"),
             "args must NOT contain --bare (breaks OAuth); got: {:?}",
@@ -482,7 +428,7 @@ mod tests {
     #[test]
     fn spawn_args_include_required_base_flags() {
         let ms = make_managed("test prompt");
-        let args = ms.build_args();
+        let args = ClaudeProvider::default().build_stream_args(&ms.build_request());
         for flag in &["--print", "--verbose", "--output-format", "stream-json"] {
             assert!(
                 args.iter().any(|a| a == flag),
@@ -497,7 +443,7 @@ mod tests {
     fn spawn_args_with_permission_mode_includes_permission_flag() {
         let mut ms = make_managed("test");
         ms.permission_mode = Some("bypassPermissions".to_string());
-        let args = ms.build_args();
+        let args = ClaudeProvider::default().build_stream_args(&ms.build_request());
         assert!(args.iter().any(|a| a == "--permission-mode"));
         assert!(args.iter().any(|a| a == "bypassPermissions"));
     }
@@ -506,7 +452,7 @@ mod tests {
     fn spawn_args_default_permission_mode_is_excluded() {
         let mut ms = make_managed("test");
         ms.permission_mode = Some("default".to_string());
-        let args = ms.build_args();
+        let args = ClaudeProvider::default().build_stream_args(&ms.build_request());
         assert!(
             !args.iter().any(|a| a == "--permission-mode"),
             "permission_mode=default must not emit --permission-mode flag"


### PR DESCRIPTION
## Summary

- Introduce the AgentProvider trait, request/result types, factory, and ClaudeProvider implementation.
- Route session spawning, review, adapt, sanitize, and doctor Claude calls through the provider abstraction.
- Preserve Claude stream/text argument behavior while adding cancellation-token based session stop handling.

Closes #547

## Test plan

- [x] cargo test --no-default-features
- [x] cargo test agent_provider --no-default-features
- [x] cargo test spawn_args --no-default-features
- [x] cargo fmt --check
