### PR TITLE
feat: add qwen code provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,28 @@ merge_method = "squash"
 cache_ttl_secs = 300
 ```
 
+To run sessions with Qwen Code instead of Claude Code, add a Qwen agent and
+select it with `--agent qwen`:
+
+```toml
+[agents]
+default = "qwen"
+
+[agents.qwen]
+kind = "qwen"
+command = "qwen"
+model = "qwen-test"
+extra_args = ["--auth-type", "openai"]
+
+[agents.qwen.env]
+OPENAI_BASE_URL = "https://api.example.com/v1"
+```
+
+Maestro invokes Qwen in non-interactive JSONL mode with
+`qwen --bare --output-format stream-json --include-partial-messages`.
+Set `OPENAI_API_KEY` in your shell, `.env`, or Qwen settings rather than in
+argv; direct CLI key flags may be visible in process listings.
+
 Azure DevOps init writes `kind = "azure_devops"`, `organization`, `az_project`, and `[experimental] azure_devops = true`.
 
 The full schema — completion gates, context-overflow tuning, TurboQuant, provider/Azure DevOps configuration, notifications, and feature flags — is documented in [Wiki › Configuration Reference](https://github.com/CarlosDanielDev/maestro/wiki/Configuration-Reference).

--- a/src/agent_provider/mod.rs
+++ b/src/agent_provider/mod.rs
@@ -1,8 +1,14 @@
 pub mod claude;
+pub mod qwen;
+mod qwen_parser;
+#[cfg(test)]
+mod qwen_tests;
 pub mod types;
 
 #[allow(unused_imports)]
 pub use claude::ClaudeProvider;
+#[allow(unused_imports)]
+pub use qwen::QwenProvider;
 #[allow(unused_imports)]
 pub use types::{
     AgentError, AgentHealthCheck, AgentOutputFormat, AgentProvider, AgentProviderDefinition,

--- a/src/agent_provider/qwen.rs
+++ b/src/agent_provider/qwen.rs
@@ -1,0 +1,326 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+use super::qwen_parser::QwenStreamParser;
+use super::types::{
+    AgentError, AgentHealthCheck, AgentOutputFormat, AgentProvider, AgentProviderEvent,
+    AgentProviderId, AgentProviderKind, AgentRequest, AgentRunResult, AgentRunStarted,
+    AgentTextOutput, ParserBinding,
+};
+use crate::session::types::StreamEvent;
+
+#[derive(Debug, Clone)]
+pub struct QwenProvider {
+    binary: String,
+    extra_args: Vec<String>,
+    env: BTreeMap<String, String>,
+}
+
+impl QwenProvider {
+    pub fn new(binary: impl Into<String>) -> Self {
+        Self {
+            binary: binary.into(),
+            extra_args: Vec::new(),
+            env: BTreeMap::new(),
+        }
+    }
+
+    pub fn with_config(
+        binary: impl Into<String>,
+        extra_args: Vec<String>,
+        env: BTreeMap<String, String>,
+    ) -> Self {
+        Self {
+            binary: binary.into(),
+            extra_args,
+            env,
+        }
+    }
+
+    pub fn build_stream_args(&self, request: &AgentRequest) -> Vec<String> {
+        let mut args = vec![
+            "--bare".to_string(),
+            "--output-format".to_string(),
+            "stream-json".to_string(),
+            "--include-partial-messages".to_string(),
+        ];
+        self.push_common_args(&mut args, request);
+        args
+    }
+
+    pub fn build_text_args(&self, request: &AgentRequest) -> Vec<String> {
+        let mut args = vec![
+            "--bare".to_string(),
+            "--output-format".to_string(),
+            "text".to_string(),
+        ];
+        self.push_common_args(&mut args, request);
+        args
+    }
+
+    pub async fn run_text(
+        &self,
+        model: &str,
+        prompt: &str,
+        cwd: Option<&Path>,
+    ) -> Result<AgentTextOutput, AgentError> {
+        let request = AgentRequest::text(
+            prompt.to_string(),
+            model.to_string(),
+            cwd.map(PathBuf::from),
+        );
+        let mut cmd = Command::new(&self.binary);
+        cmd.args(self.build_text_args(&request));
+        cmd.envs(&self.env);
+        if let Some(cwd) = request.cwd.as_ref() {
+            cmd.current_dir(cwd);
+        }
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let output = cmd.output().await.map_err(|source| AgentError::Spawn {
+            provider_id: self.id().to_string(),
+            source,
+        })?;
+
+        Ok(AgentTextOutput {
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            status_success: output.status.success(),
+        })
+    }
+
+    pub fn health_check_blocking(&self) -> AgentHealthCheck {
+        match std::process::Command::new(&self.binary)
+            .arg("--version")
+            .output()
+        {
+            Ok(out) if out.status.success() => {
+                let version = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                AgentHealthCheck {
+                    provider_id: AgentProviderId::new(self.id()),
+                    available: true,
+                    version: Some(version.clone()),
+                    message: version,
+                }
+            }
+            Ok(out) => AgentHealthCheck {
+                provider_id: AgentProviderId::new(self.id()),
+                available: false,
+                version: None,
+                message: String::from_utf8_lossy(&out.stderr).trim().to_string(),
+            },
+            Err(_) => AgentHealthCheck {
+                provider_id: AgentProviderId::new(self.id()),
+                available: false,
+                version: None,
+                message: "not installed".to_string(),
+            },
+        }
+    }
+
+    fn push_common_args(&self, args: &mut Vec<String>, request: &AgentRequest) {
+        if !request.model.trim().is_empty() {
+            args.push("--model".to_string());
+            args.push(request.model.clone());
+        }
+
+        if let Some(mode) = qwen_approval_mode(request.permission_mode.as_deref()) {
+            args.push("--approval-mode".to_string());
+            args.push(mode.to_string());
+        }
+
+        args.extend(self.extra_args.iter().cloned());
+        args.push("--prompt".to_string());
+        args.push(qwen_prompt(request));
+    }
+}
+
+impl Default for QwenProvider {
+    fn default() -> Self {
+        Self::new("qwen")
+    }
+}
+
+#[async_trait::async_trait]
+impl AgentProvider for QwenProvider {
+    fn id(&self) -> &str {
+        "qwen"
+    }
+
+    fn kind(&self) -> AgentProviderKind {
+        AgentProviderKind::Subprocess
+    }
+
+    fn parser_binding(&self) -> ParserBinding {
+        ParserBinding {
+            name: "qwen-stream-json".to_string(),
+            output_format: AgentOutputFormat::StreamJson,
+        }
+    }
+
+    async fn health_check(&self) -> Result<AgentHealthCheck, AgentError> {
+        match Command::new(&self.binary).arg("--version").output().await {
+            Ok(out) if out.status.success() => {
+                let version = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                Ok(AgentHealthCheck {
+                    provider_id: AgentProviderId::new(self.id()),
+                    available: true,
+                    version: Some(version.clone()),
+                    message: version,
+                })
+            }
+            Ok(out) => Ok(AgentHealthCheck {
+                provider_id: AgentProviderId::new(self.id()),
+                available: false,
+                version: None,
+                message: String::from_utf8_lossy(&out.stderr).trim().to_string(),
+            }),
+            Err(source) => Err(AgentError::Spawn {
+                provider_id: self.id().to_string(),
+                source,
+            }),
+        }
+    }
+
+    async fn run(
+        &self,
+        request: AgentRequest,
+        events: mpsc::UnboundedSender<AgentProviderEvent>,
+        cancel: CancellationToken,
+    ) -> Result<AgentRunResult, AgentError> {
+        let mut cmd = Command::new(&self.binary);
+        match request.output_format {
+            AgentOutputFormat::StreamJson => {
+                cmd.args(self.build_stream_args(&request));
+            }
+            AgentOutputFormat::Text => {
+                cmd.args(self.build_text_args(&request));
+            }
+        }
+        cmd.envs(&self.env);
+        if let Some(cwd) = request.cwd.as_ref() {
+            cmd.current_dir(cwd);
+        }
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let mut child = cmd.spawn().map_err(|source| AgentError::Spawn {
+            provider_id: self.id().to_string(),
+            source,
+        })?;
+        let process_id = child.id();
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| AgentError::Stream("No stdout from qwen CLI".to_string()))?;
+        let stderr = child.stderr.take();
+
+        let _ = events.send(AgentProviderEvent::Started(AgentRunStarted { process_id }));
+
+        let stdout_events = events.clone();
+        let stdout_task = tokio::spawn(async move {
+            let reader = BufReader::new(stdout);
+            let mut lines = reader.lines();
+            let mut parser = QwenStreamParser::default();
+            let mut got_result = false;
+
+            while let Ok(Some(line)) = lines.next_line().await {
+                let parsed = parser.parse_line(&line);
+                for event in parsed {
+                    if matches!(event, StreamEvent::Completed { .. }) {
+                        got_result = true;
+                    }
+                    let _ = stdout_events.send(AgentProviderEvent::Stream(event));
+                }
+            }
+
+            if !got_result {
+                let _ = stdout_events.send(AgentProviderEvent::Stream(StreamEvent::Completed {
+                    cost_usd: 0.0,
+                }));
+            }
+        });
+
+        let stderr_task = stderr.map(|stderr| {
+            tokio::spawn(async move {
+                let reader = BufReader::new(stderr);
+                let mut lines = reader.lines();
+                let mut stderr_buf = String::new();
+
+                while let Ok(Some(line)) = lines.next_line().await {
+                    if !line.trim().is_empty() {
+                        if !stderr_buf.is_empty() {
+                            stderr_buf.push('\n');
+                        }
+                        stderr_buf.push_str(&line);
+                    }
+                }
+                stderr_buf
+            })
+        });
+
+        let status = tokio::select! {
+            _ = cancel.cancelled() => {
+                let _ = child.kill().await;
+                return Err(AgentError::Cancelled {
+                    provider_id: self.id().to_string(),
+                });
+            }
+            status = child.wait() => status.map_err(|err| AgentError::Stream(err.to_string()))?,
+        };
+
+        let _ = stdout_task.await;
+        let stderr_buf = match stderr_task {
+            Some(task) => task.await.unwrap_or_default(),
+            None => String::new(),
+        };
+
+        if !stderr_buf.is_empty() {
+            let _ = events.send(AgentProviderEvent::Stream(StreamEvent::Error {
+                message: stderr_buf.clone(),
+            }));
+        }
+
+        if !status.success() && !stderr_buf.is_empty() {
+            return Err(AgentError::FailedStatus {
+                provider_id: self.id().to_string(),
+                status: status.to_string(),
+                stderr: stderr_buf,
+            });
+        }
+
+        Ok(AgentRunResult {
+            exit_code: status.code(),
+        })
+    }
+}
+
+fn qwen_approval_mode(mode: Option<&str>) -> Option<&str> {
+    match mode.map(str::trim).filter(|mode| !mode.is_empty()) {
+        Some("bypassPermissions") => Some("yolo"),
+        Some("acceptEdits") => Some("auto_edit"),
+        Some("default") | None => None,
+        Some(mode) => Some(mode),
+    }
+}
+
+fn qwen_prompt(request: &AgentRequest) -> String {
+    match request.system_prompt_appendix.as_deref() {
+        Some(appendix) if !appendix.trim().is_empty() => {
+            format!(
+                "Maestro session context:\n{}\n\nUser task:\n{}",
+                appendix, request.prompt
+            )
+        }
+        _ => request.prompt.clone(),
+    }
+}

--- a/src/agent_provider/qwen_parser.rs
+++ b/src/agent_provider/qwen_parser.rs
@@ -1,0 +1,289 @@
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+use crate::session::types::StreamEvent;
+
+#[derive(Debug, Default)]
+pub struct QwenStreamParser {
+    tool_blocks: HashMap<u64, QwenToolBlock>,
+    tool_names_by_id: HashMap<String, String>,
+    text_delta_seen_in_message: bool,
+}
+
+#[derive(Debug, Default)]
+struct QwenToolBlock {
+    id: Option<String>,
+    name: String,
+    partial_json: String,
+}
+
+impl QwenStreamParser {
+    pub fn parse_line(&mut self, line: &str) -> Vec<StreamEvent> {
+        let line = line.trim();
+        if line.is_empty() {
+            return vec![StreamEvent::Unknown { raw: String::new() }];
+        }
+
+        let Ok(v) = serde_json::from_str::<Value>(line) else {
+            return vec![StreamEvent::Unknown {
+                raw: line.to_string(),
+            }];
+        };
+
+        match v.get("type").and_then(|t| t.as_str()) {
+            Some("stream_event") => self.parse_stream_event(&v),
+            Some("assistant") => self.parse_assistant(&v),
+            Some("user") => self.parse_user(&v),
+            Some("result") => self.parse_result(&v),
+            Some("error") => vec![StreamEvent::Error {
+                message: v
+                    .get("error")
+                    .and_then(|e| e.get("message"))
+                    .and_then(|m| m.as_str())
+                    .unwrap_or("unknown error")
+                    .to_string(),
+            }],
+            Some("system") => vec![StreamEvent::Unknown { raw: v.to_string() }],
+            _ => vec![StreamEvent::Unknown {
+                raw: line.to_string(),
+            }],
+        }
+    }
+
+    fn parse_stream_event(&mut self, v: &Value) -> Vec<StreamEvent> {
+        let Some(event) = v.get("event") else {
+            return vec![StreamEvent::Unknown { raw: v.to_string() }];
+        };
+        match event.get("type").and_then(|t| t.as_str()) {
+            Some("message_start") => {
+                self.text_delta_seen_in_message = false;
+                Vec::new()
+            }
+            Some("message_stop") => {
+                self.text_delta_seen_in_message = false;
+                Vec::new()
+            }
+            Some("content_block_start") => {
+                self.track_content_block_start(event);
+                Vec::new()
+            }
+            Some("content_block_delta") => self.parse_content_block_delta(event),
+            Some("content_block_stop") => self.parse_content_block_stop(event),
+            _ => vec![StreamEvent::Unknown { raw: v.to_string() }],
+        }
+    }
+
+    fn track_content_block_start(&mut self, event: &Value) {
+        let Some(index) = event.get("index").and_then(|i| i.as_u64()) else {
+            return;
+        };
+        let Some(block) = event.get("content_block") else {
+            return;
+        };
+        if block.get("type").and_then(|t| t.as_str()) != Some("tool_use") {
+            return;
+        }
+
+        let id = block
+            .get("id")
+            .and_then(|id| id.as_str())
+            .map(str::to_string);
+        let name = block
+            .get("name")
+            .and_then(|name| name.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+        self.tool_blocks.insert(
+            index,
+            QwenToolBlock {
+                id,
+                name,
+                partial_json: String::new(),
+            },
+        );
+    }
+
+    fn parse_content_block_delta(&mut self, event: &Value) -> Vec<StreamEvent> {
+        let Some(delta) = event.get("delta") else {
+            return Vec::new();
+        };
+        match delta.get("type").and_then(|t| t.as_str()) {
+            Some("text_delta") => {
+                let text = delta
+                    .get("text")
+                    .and_then(|text| text.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                self.text_delta_seen_in_message = true;
+                if text.starts_with("[API Error:") {
+                    vec![StreamEvent::Error { message: text }]
+                } else {
+                    vec![StreamEvent::AssistantMessage { text }]
+                }
+            }
+            Some("input_json_delta") => {
+                if let Some(index) = event.get("index").and_then(|i| i.as_u64())
+                    && let Some(block) = self.tool_blocks.get_mut(&index)
+                    && let Some(partial) = delta.get("partial_json").and_then(|p| p.as_str())
+                {
+                    block.partial_json.push_str(partial);
+                }
+                Vec::new()
+            }
+            _ => Vec::new(),
+        }
+    }
+
+    fn parse_content_block_stop(&mut self, event: &Value) -> Vec<StreamEvent> {
+        let Some(index) = event.get("index").and_then(|i| i.as_u64()) else {
+            return Vec::new();
+        };
+        let Some(block) = self.tool_blocks.remove(&index) else {
+            return Vec::new();
+        };
+
+        let input = serde_json::from_str::<Value>(&block.partial_json).ok();
+        let file_path = input.as_ref().and_then(extract_file_path);
+        let command_preview = input.as_ref().and_then(extract_command_preview);
+        if let Some(id) = block.id.as_ref() {
+            self.tool_names_by_id.insert(id.clone(), block.name.clone());
+        }
+        vec![StreamEvent::ToolUse {
+            tool: block.name,
+            file_path,
+            command_preview,
+            subagent_name: None,
+        }]
+    }
+
+    fn parse_assistant(&mut self, v: &Value) -> Vec<StreamEvent> {
+        let Some(content) = v
+            .get("message")
+            .and_then(|m| m.get("content"))
+            .and_then(|c| c.as_array())
+        else {
+            return vec![StreamEvent::Unknown { raw: v.to_string() }];
+        };
+
+        let mut events = Vec::new();
+        for block in content {
+            match block.get("type").and_then(|t| t.as_str()) {
+                Some("text") => {
+                    let text = block
+                        .get("text")
+                        .and_then(|text| text.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    if text.starts_with("[API Error:") {
+                        events.push(StreamEvent::Error { message: text });
+                    } else if !self.text_delta_seen_in_message && !text.is_empty() {
+                        events.push(StreamEvent::AssistantMessage { text });
+                    }
+                }
+                Some("tool_use") if !self.tool_was_streamed(block) => {
+                    let tool = block
+                        .get("name")
+                        .and_then(|name| name.as_str())
+                        .unwrap_or("unknown")
+                        .to_string();
+                    let input = block.get("input");
+                    if let Some(id) = block.get("id").and_then(|id| id.as_str()) {
+                        self.tool_names_by_id.insert(id.to_string(), tool.clone());
+                    }
+                    events.push(StreamEvent::ToolUse {
+                        tool,
+                        file_path: input.and_then(extract_file_path),
+                        command_preview: input.and_then(extract_command_preview),
+                        subagent_name: None,
+                    });
+                }
+                _ => {}
+            }
+        }
+        events
+    }
+
+    fn tool_was_streamed(&self, block: &Value) -> bool {
+        block
+            .get("id")
+            .and_then(|id| id.as_str())
+            .is_some_and(|id| self.tool_names_by_id.contains_key(id))
+    }
+
+    fn parse_user(&self, v: &Value) -> Vec<StreamEvent> {
+        let Some(content) = v
+            .get("message")
+            .and_then(|m| m.get("content"))
+            .and_then(|c| c.as_array())
+        else {
+            return vec![StreamEvent::Unknown { raw: v.to_string() }];
+        };
+
+        content
+            .iter()
+            .filter(|block| block.get("type").and_then(|t| t.as_str()) == Some("tool_result"))
+            .map(|block| {
+                let tool = block
+                    .get("tool_use_id")
+                    .and_then(|id| id.as_str())
+                    .and_then(|id| self.tool_names_by_id.get(id))
+                    .cloned()
+                    .unwrap_or_else(|| "unknown".to_string());
+                let is_error = block
+                    .get("is_error")
+                    .and_then(|is_error| is_error.as_bool())
+                    .unwrap_or(false);
+                StreamEvent::ToolResult { tool, is_error }
+            })
+            .collect()
+    }
+
+    fn parse_result(&self, v: &Value) -> Vec<StreamEvent> {
+        let mut events = Vec::new();
+        if v.get("is_error").and_then(|is_error| is_error.as_bool()) == Some(true) {
+            let message = v
+                .get("result")
+                .and_then(|result| result.as_str())
+                .or_else(|| v.get("error").and_then(|error| error.as_str()))
+                .unwrap_or("qwen run failed")
+                .to_string();
+            events.push(StreamEvent::Error { message });
+        }
+        events.push(StreamEvent::Completed { cost_usd: 0.0 });
+        events
+    }
+}
+
+fn extract_file_path(input: &Value) -> Option<String> {
+    input
+        .get("file_path")
+        .or_else(|| input.get("path"))
+        .and_then(|path| path.as_str())
+        .map(str::to_string)
+}
+
+fn extract_command_preview(input: &Value) -> Option<String> {
+    input
+        .get("command")
+        .and_then(|command| command.as_str())
+        .map(|command| {
+            if command.len() > 60 {
+                let boundary = char_boundary(command, 60);
+                format!("{}...", &command[..boundary])
+            } else {
+                command.to_string()
+            }
+        })
+}
+
+fn char_boundary(s: &str, max_bytes: usize) -> usize {
+    if max_bytes >= s.len() {
+        return s.len();
+    }
+    let mut i = max_bytes;
+    while !s.is_char_boundary(i) && i > 0 {
+        i -= 1;
+    }
+    i
+}

--- a/src/agent_provider/qwen_tests.rs
+++ b/src/agent_provider/qwen_tests.rs
@@ -1,0 +1,157 @@
+use std::collections::BTreeMap;
+
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+use super::qwen::QwenProvider;
+use super::qwen_parser::QwenStreamParser;
+use super::types::{AgentProvider, AgentProviderEvent, AgentRequest, AgentRunStarted};
+use crate::session::types::StreamEvent;
+
+fn request() -> AgentRequest {
+    let mut request = AgentRequest::stream_json("test prompt".into(), "qwen-test".into());
+    request.permission_mode = Some("bypassPermissions".to_string());
+    request.system_prompt_appendix = Some("appendix".to_string());
+    request
+}
+
+#[test]
+fn stream_args_match_qwen_research_contract() {
+    let provider = QwenProvider::with_config(
+        "qwen",
+        vec!["--auth-type".to_string(), "openai".to_string()],
+        BTreeMap::new(),
+    );
+    let args = provider.build_stream_args(&request());
+    assert!(
+        args.windows(2)
+            .any(|w| w == ["--output-format", "stream-json"])
+    );
+    assert!(args.iter().any(|arg| arg == "--bare"));
+    assert!(args.iter().any(|arg| arg == "--include-partial-messages"));
+    assert!(args.windows(2).any(|w| w == ["--model", "qwen-test"]));
+    assert!(args.windows(2).any(|w| w == ["--approval-mode", "yolo"]));
+    assert!(args.windows(2).any(|w| w == ["--auth-type", "openai"]));
+    assert!(args.windows(2).any(|w| w
+        == [
+            "--prompt",
+            "Maestro session context:\nappendix\n\nUser task:\ntest prompt"
+        ]));
+}
+
+#[test]
+fn text_args_use_qwen_text_output() {
+    let provider = QwenProvider::default();
+    let args = provider.build_text_args(&request());
+    assert!(args.windows(2).any(|w| w == ["--output-format", "text"]));
+    assert!(!args.iter().any(|arg| arg == "--include-partial-messages"));
+}
+
+#[test]
+fn fixture_maps_to_stream_events() {
+    let fixture = include_str!("../../tests/fixtures/qwen_output_sample.jsonl");
+    let mut parser = QwenStreamParser::default();
+    let events: Vec<StreamEvent> = fixture
+        .lines()
+        .flat_map(|line| parser.parse_line(line))
+        .collect();
+
+    assert!(events.iter().any(|event| {
+        matches!(
+            event,
+            StreamEvent::ToolUse {
+                tool,
+                file_path: Some(path),
+                ..
+            } if tool == "read_file" && path.ends_with("README.md")
+        )
+    }));
+    assert!(events.iter().any(|event| {
+        matches!(
+            event,
+            StreamEvent::ToolResult {
+                tool,
+                is_error: false,
+            } if tool == "read_file"
+        )
+    }));
+    assert!(events.iter().any(|event| {
+        matches!(
+            event,
+            StreamEvent::AssistantMessage { text }
+                if text == "The README title identifies the project as Maestro."
+        )
+    }));
+    assert!(
+        events.iter().any(|event| {
+            matches!(event, StreamEvent::Completed { cost_usd } if *cost_usd == 0.0)
+        })
+    );
+}
+
+#[test]
+fn api_error_text_maps_to_error_even_with_success_result() {
+    let mut parser = QwenStreamParser::default();
+    let events = parser.parse_line(
+        r#"{"type":"assistant","message":{"content":[{"type":"text","text":"[API Error: bad gateway]"}]}}"#,
+    );
+
+    assert!(matches!(
+        events.first(),
+        Some(StreamEvent::Error { message }) if message == "[API Error: bad gateway]"
+    ));
+}
+
+#[tokio::test]
+async fn run_streams_events_from_mock_qwen_cli() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let qwen = temp.path().join("qwen");
+    std::fs::write(
+        &qwen,
+        format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"{}\"\ncat \"{}\"\n",
+            temp.path().join("argv.txt").display(),
+            std::path::Path::new("tests/fixtures/qwen_output_sample.jsonl").display()
+        ),
+    )
+    .expect("write qwen mock");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&qwen).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&qwen, perms).expect("chmod");
+    }
+
+    let provider = QwenProvider::new(qwen.to_string_lossy().to_string());
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let result = provider
+        .run(request(), tx, CancellationToken::new())
+        .await
+        .expect("mock qwen run");
+
+    assert_eq!(result.exit_code, Some(0));
+    assert!(matches!(
+        rx.recv().await,
+        Some(AgentProviderEvent::Started(AgentRunStarted {
+            process_id: Some(_)
+        }))
+    ));
+
+    let mut saw_completed = false;
+    while let Some(event) = rx.recv().await {
+        if matches!(
+            event,
+            AgentProviderEvent::Stream(StreamEvent::Completed { .. })
+        ) {
+            saw_completed = true;
+            break;
+        }
+    }
+    assert!(saw_completed);
+
+    let argv = std::fs::read_to_string(temp.path().join("argv.txt")).expect("argv");
+    assert!(argv.contains("--bare"));
+    assert!(argv.contains("--output-format\nstream-json"));
+    assert!(argv.contains("--include-partial-messages"));
+}

--- a/src/agent_provider/types.rs
+++ b/src/agent_provider/types.rs
@@ -208,6 +208,14 @@ impl AgentProviderFactory {
                     )),
                 })
             }
+            Some(provider) if provider.provider == "qwen" || provider.id == "qwen" => {
+                let binary = provider.binary.as_deref().unwrap_or("qwen");
+                Ok(Self {
+                    default_provider: Arc::new(crate::agent_provider::qwen::QwenProvider::new(
+                        binary,
+                    )),
+                })
+            }
             Some(provider) => Err(AgentError::Config(format!(
                 "unsupported default agent provider `{}`",
                 provider.provider
@@ -322,5 +330,20 @@ mod tests {
     fn factory_accepts_empty_config_as_legacy_claude() {
         let factory = AgentProviderFactory::from_config(AgentProvidersConfig::default()).unwrap();
         assert_eq!(factory.default_provider().id(), "claude");
+    }
+
+    #[test]
+    fn factory_accepts_qwen_provider() {
+        let factory = AgentProviderFactory::from_config(AgentProvidersConfig {
+            default_provider: "qwen".to_string(),
+            providers: vec![AgentProviderDefinition {
+                id: "qwen".to_string(),
+                provider: "qwen".to_string(),
+                binary: Some("qwen".to_string()),
+            }],
+        })
+        .unwrap();
+
+        assert_eq!(factory.default_provider().id(), "qwen");
     }
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -92,7 +92,10 @@ pub async fn cmd_run(
         bypass_review,
     );
     app.pool.set_provider(selected_provider);
-    if resolved_agent.config.kind == crate::config::AgentKind::Claude {
+    if matches!(
+        resolved_agent.config.kind,
+        crate::config::AgentKind::Claude | crate::config::AgentKind::Qwen
+    ) {
         app.pool.set_permission_mode(
             resolved_agent
                 .config
@@ -225,6 +228,16 @@ fn provider_for_agent(
             let command = resolved.config.command.as_deref().unwrap_or("claude");
             Ok(std::sync::Arc::new(
                 crate::agent_provider::ClaudeProvider::new(command),
+            ))
+        }
+        crate::config::AgentKind::Qwen => {
+            let command = resolved.config.command.as_deref().unwrap_or("qwen");
+            Ok(std::sync::Arc::new(
+                crate::agent_provider::QwenProvider::with_config(
+                    command,
+                    resolved.config.extra_args.clone(),
+                    resolved.config.env.clone(),
+                ),
             ))
         }
         other => anyhow::bail!(

--- a/src/config/agents.rs
+++ b/src/config/agents.rs
@@ -187,6 +187,7 @@ struct AgentConfigRaw {
 impl From<AgentConfigRaw> for AgentConfig {
     fn from(raw: AgentConfigRaw) -> Self {
         let command = raw.command.or_else(|| match raw.kind {
+            AgentKind::Qwen => Some("qwen".to_string()),
             AgentKind::Opencode => Some("opencode".to_string()),
             _ => None,
         });

--- a/src/config/tests/agents.rs
+++ b/src/config/tests/agents.rs
@@ -154,6 +154,27 @@ model = "openrouter/deepseek/deepseek-coder-v2"
 }
 
 #[test]
+fn agents_config_parses_qwen_default_command() {
+    let cfg: AgentsConfig = toml::from_str(
+        r#"
+default = "qwen"
+
+[qwen]
+kind = "qwen"
+model = "qwen-test"
+extra_args = ["--auth-type", "openai"]
+"#,
+    )
+    .expect("parse failed");
+
+    let qwen = cfg.entries.get("qwen").expect("qwen agent");
+    assert_eq!(qwen.kind, AgentKind::Qwen);
+    assert_eq!(qwen.command.as_deref(), Some("qwen"));
+    assert_eq!(qwen.model.as_deref(), Some("qwen-test"));
+    assert_eq!(qwen.extra_args, ["--auth-type", "openai"]);
+}
+
+#[test]
 fn config_validate_rejects_unknown_default_agent() {
     let err = load_config(&format!(
         r#"{MINIMAL_TOML}


### PR DESCRIPTION
## Summary

- Add QwenProvider subprocess runtime with stream-json/text command construction and config/env support
- Add Qwen stream-json parser coverage using the #650 fixture plus mock CLI integration
- Wire Qwen into agent selection, provider factory defaults, config parsing, and README setup docs

Closes #548

## Test plan

- [x] cargo test
- [x] cargo clippy -- -D warnings
- [x] cargo fmt --check
- [x] manual verification: confirmed PR command/body wiring and issue #548 milestone context
