### PR TITLE
feat: add Minimax provider runtime

### DIFF
--- a/src/agent_provider/minimax/client.rs
+++ b/src/agent_provider/minimax/client.rs
@@ -1,0 +1,221 @@
+#![deny(clippy::unwrap_used)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::StreamExt;
+use reqwest::StatusCode;
+use serde_json::json;
+use tokio::sync::mpsc;
+
+use super::types::MinimaxError;
+use crate::agent_provider::openai_compat::sse::OpenAiCompatibleSseParser;
+use crate::session::types::StreamEvent;
+
+type ApiKeyLookup = Arc<dyn Fn(&str) -> Option<String> + Send + Sync>;
+
+#[derive(Clone)]
+pub struct MinimaxClient {
+    client: reqwest::Client,
+    base_url: String,
+    timeout: Duration,
+    api_key_env: String,
+    api_key_lookup: ApiKeyLookup,
+}
+
+impl std::fmt::Debug for MinimaxClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MinimaxClient")
+            .field("base_url", &self.base_url)
+            .field("timeout", &self.timeout)
+            .field("api_key_env", &self.api_key_env)
+            .finish_non_exhaustive()
+    }
+}
+
+impl MinimaxClient {
+    pub fn new(
+        base_url: impl Into<String>,
+        timeout: Duration,
+        api_key_env: impl Into<String>,
+    ) -> Result<Self, MinimaxError> {
+        Self::with_api_key_lookup(base_url, timeout, api_key_env, |name| {
+            std::env::var(name).ok()
+        })
+    }
+
+    pub(crate) fn with_api_key_lookup(
+        base_url: impl Into<String>,
+        timeout: Duration,
+        api_key_env: impl Into<String>,
+        api_key_lookup: impl Fn(&str) -> Option<String> + Send + Sync + 'static,
+    ) -> Result<Self, MinimaxError> {
+        let client = reqwest::Client::builder()
+            .timeout(timeout)
+            .build()
+            .map_err(|err| MinimaxError::Request(err.to_string()))?;
+
+        Ok(Self {
+            client,
+            base_url: trim_base_url(base_url.into()),
+            timeout,
+            api_key_env: api_key_env.into(),
+            api_key_lookup: Arc::new(api_key_lookup),
+        })
+    }
+
+    pub async fn models_health(&self) -> Result<(), MinimaxError> {
+        let token = self.api_key()?;
+        tracing::debug!(
+            provider = "minimax",
+            api_key_env = %self.api_key_env,
+            "checking MiniMax models endpoint"
+        );
+        let response = self
+            .send(self.client.get(self.url("/models")).bearer_auth(token))
+            .await?;
+        map_empty_status(response.status(), &self.api_key_env)
+    }
+
+    pub async fn chat_stream(
+        &self,
+        model: &str,
+        prompt: &str,
+    ) -> Result<mpsc::Receiver<Result<StreamEvent, MinimaxError>>, MinimaxError> {
+        let token = self.api_key()?;
+        let body = json!({
+            "model": model,
+            "stream": true,
+            "messages": [
+                { "role": "user", "content": prompt }
+            ]
+        });
+        tracing::debug!(
+            provider = "minimax",
+            api_key_env = %self.api_key_env,
+            model = %model,
+            "starting MiniMax chat completion stream"
+        );
+        let response = self
+            .send(
+                self.client
+                    .post(self.url("/chat/completions"))
+                    .bearer_auth(token)
+                    .json(&body),
+            )
+            .await?;
+        let status = response.status();
+        if !status.is_success() {
+            return Err(map_status(status, &self.api_key_env));
+        }
+
+        let (tx, rx) = mpsc::channel(64);
+        let timeout_secs = self.timeout.as_secs();
+        tokio::spawn(async move {
+            let mut parser = OpenAiCompatibleSseParser::new();
+            let mut stream = response.bytes_stream();
+
+            while let Some(next) = stream.next().await {
+                match next {
+                    Ok(bytes) => {
+                        let text = String::from_utf8_lossy(&bytes);
+                        match parser.push_chunk(&text) {
+                            Ok(events) => {
+                                for event in events {
+                                    if tx.send(Ok(event)).await.is_err() {
+                                        return;
+                                    }
+                                }
+                            }
+                            Err(err) => {
+                                let _ = tx.send(Err(MinimaxError::MalformedSse(err))).await;
+                                return;
+                            }
+                        }
+                    }
+                    Err(err) if err.is_timeout() => {
+                        let _ = tx
+                            .send(Err(MinimaxError::Timeout {
+                                seconds: timeout_secs,
+                            }))
+                            .await;
+                        return;
+                    }
+                    Err(err) => {
+                        let _ = tx.send(Err(MinimaxError::Network(err.to_string()))).await;
+                        return;
+                    }
+                }
+            }
+
+            match parser.finish() {
+                Ok(events) => {
+                    for event in events {
+                        if tx.send(Ok(event)).await.is_err() {
+                            return;
+                        }
+                    }
+                }
+                Err(err) => {
+                    let _ = tx.send(Err(MinimaxError::MalformedSse(err))).await;
+                }
+            }
+        });
+
+        Ok(rx)
+    }
+
+    async fn send(
+        &self,
+        request: reqwest::RequestBuilder,
+    ) -> Result<reqwest::Response, MinimaxError> {
+        request.send().await.map_err(|err| {
+            if err.is_timeout() {
+                MinimaxError::Timeout {
+                    seconds: self.timeout.as_secs(),
+                }
+            } else if err.is_connect() {
+                MinimaxError::Network(format!("could not connect to {}", self.base_url))
+            } else {
+                MinimaxError::Request(err.to_string())
+            }
+        })
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{}", self.base_url, path)
+    }
+
+    fn api_key(&self) -> Result<String, MinimaxError> {
+        (self.api_key_lookup)(&self.api_key_env)
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| MinimaxError::MissingApiKey {
+                env: self.api_key_env.clone(),
+            })
+    }
+}
+
+fn trim_base_url(mut base_url: String) -> String {
+    while base_url.ends_with('/') {
+        base_url.pop();
+    }
+    base_url
+}
+
+fn map_empty_status(status: StatusCode, api_key_env: &str) -> Result<(), MinimaxError> {
+    if status.is_success() {
+        Ok(())
+    } else {
+        Err(map_status(status, api_key_env))
+    }
+}
+
+fn map_status(status: StatusCode, api_key_env: &str) -> MinimaxError {
+    if status == StatusCode::UNAUTHORIZED {
+        MinimaxError::Unauthorized {
+            env: api_key_env.to_string(),
+        }
+    } else {
+        MinimaxError::HttpStatus(status.as_u16())
+    }
+}

--- a/src/agent_provider/minimax/mod.rs
+++ b/src/agent_provider/minimax/mod.rs
@@ -1,0 +1,280 @@
+#![deny(clippy::unwrap_used)]
+
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+mod client;
+pub mod types;
+
+pub use client::MinimaxClient;
+pub use types::MinimaxError;
+
+use super::types::{
+    AgentError, AgentHealthCheck, AgentOutputFormat, AgentProvider, AgentProviderEvent,
+    AgentProviderId, AgentProviderKind, AgentRequest, AgentRunResult, AgentRunStarted,
+    ParserBinding,
+};
+
+const DEFAULT_API_KEY_ENV: &str = "MINIMAX_API_KEY";
+
+#[derive(Debug, Clone)]
+pub struct MinimaxProvider {
+    id: String,
+    model: String,
+    http: MinimaxClient,
+}
+
+impl MinimaxProvider {
+    pub fn new(
+        id: impl Into<String>,
+        base_url: impl Into<String>,
+        model: impl Into<String>,
+        request_timeout_secs: u64,
+        api_key_env: Option<String>,
+    ) -> Result<Self, MinimaxError> {
+        Self::with_client(
+            id,
+            model,
+            MinimaxClient::new(
+                base_url,
+                Duration::from_secs(request_timeout_secs),
+                api_key_env.unwrap_or_else(|| DEFAULT_API_KEY_ENV.to_string()),
+            )?,
+        )
+    }
+
+    fn with_client(
+        id: impl Into<String>,
+        model: impl Into<String>,
+        http: MinimaxClient,
+    ) -> Result<Self, MinimaxError> {
+        Ok(Self {
+            id: id.into(),
+            model: model.into(),
+            http,
+        })
+    }
+
+    #[cfg(test)]
+    fn new_with_api_key_lookup(
+        id: impl Into<String>,
+        base_url: impl Into<String>,
+        model: impl Into<String>,
+        request_timeout_secs: u64,
+        api_key_env: Option<String>,
+        api_key_lookup: impl Fn(&str) -> Option<String> + Send + Sync + 'static,
+    ) -> Result<Self, MinimaxError> {
+        Self::with_client(
+            id,
+            model,
+            MinimaxClient::with_api_key_lookup(
+                base_url,
+                Duration::from_secs(request_timeout_secs),
+                api_key_env.unwrap_or_else(|| DEFAULT_API_KEY_ENV.to_string()),
+                api_key_lookup,
+            )?,
+        )
+    }
+}
+
+#[async_trait::async_trait]
+impl AgentProvider for MinimaxProvider {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn kind(&self) -> AgentProviderKind {
+        AgentProviderKind::Http
+    }
+
+    fn parser_binding(&self) -> ParserBinding {
+        ParserBinding {
+            name: "openai-compatible-sse".to_string(),
+            output_format: AgentOutputFormat::StreamJson,
+        }
+    }
+
+    async fn health_check(&self) -> Result<AgentHealthCheck, AgentError> {
+        self.http
+            .models_health()
+            .await
+            .map_err(MinimaxError::into_agent_error)?;
+
+        Ok(AgentHealthCheck {
+            provider_id: AgentProviderId::new(self.id()),
+            available: true,
+            version: None,
+            message: format!(
+                "MiniMax models endpoint reachable; model `{}` configured",
+                self.model
+            ),
+        })
+    }
+
+    async fn run(
+        &self,
+        request: AgentRequest,
+        events: mpsc::UnboundedSender<AgentProviderEvent>,
+        cancel: CancellationToken,
+    ) -> Result<AgentRunResult, AgentError> {
+        let model = if request.model.trim().is_empty() {
+            self.model.as_str()
+        } else {
+            request.model.as_str()
+        };
+
+        let mut stream = self
+            .http
+            .chat_stream(model, &request.prompt)
+            .await
+            .map_err(MinimaxError::into_agent_error)?;
+        let _ = events.send(AgentProviderEvent::Started(AgentRunStarted {
+            process_id: None,
+        }));
+
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => {
+                    return Err(AgentError::Cancelled {
+                        provider_id: self.id().to_string(),
+                    });
+                }
+                next = stream.recv() => {
+                    let Some(next) = next else {
+                        break;
+                    };
+                    match next {
+                        Ok(event) => {
+                            let _ = events.send(AgentProviderEvent::Stream(event));
+                        }
+                        Err(err) => {
+                            return Err(err.into_agent_error());
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(AgentRunResult { exit_code: None })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::types::StreamEvent;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    #[tokio::test]
+    async fn streams_openai_compatible_sse() {
+        let base_url = spawn_test_server(
+            "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\n\r\n\
+             data: {\"choices\":[{\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}\n\n\
+             data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n\
+             data: [DONE]\n\n",
+        )
+        .await;
+        let provider = MinimaxProvider::new_with_api_key_lookup(
+            "minimax",
+            base_url,
+            "MiniMax-M2.7",
+            5,
+            Some("MINIMAX_API_KEY".to_string()),
+            |_| Some("test-key".to_string()),
+        )
+        .expect("provider");
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        provider
+            .run(
+                AgentRequest::stream_json("say hi".to_string(), "MiniMax-M2.7".to_string()),
+                tx,
+                CancellationToken::new(),
+            )
+            .await
+            .expect("run");
+
+        assert!(matches!(
+            rx.recv().await,
+            Some(AgentProviderEvent::Started(_))
+        ));
+        assert!(matches!(
+            rx.recv().await,
+            Some(AgentProviderEvent::Stream(StreamEvent::AssistantMessage { text })) if text == "hello"
+        ));
+        assert!(matches!(
+            rx.recv().await,
+            Some(AgentProviderEvent::Stream(StreamEvent::Completed { .. }))
+        ));
+    }
+
+    #[tokio::test]
+    async fn maps_unauthorized_status() {
+        let base_url = spawn_test_server(
+            "HTTP/1.1 401 Unauthorized\r\ncontent-type: application/json\r\n\r\n\
+             {\"error\":\"invalid key\"}",
+        )
+        .await;
+        let provider = MinimaxProvider::new_with_api_key_lookup(
+            "minimax",
+            base_url,
+            "MiniMax-M2.7",
+            5,
+            Some("MINIMAX_API_KEY".to_string()),
+            |_| Some("test-key".to_string()),
+        )
+        .expect("provider");
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let err = provider
+            .run(
+                AgentRequest::stream_json("say hi".to_string(), "MiniMax-M2.7".to_string()),
+                tx,
+                CancellationToken::new(),
+            )
+            .await
+            .expect_err("401 should fail");
+
+        assert!(
+            err.to_string()
+                .contains("invalid MINIMAX_API_KEY — check your key at platform.minimax.io")
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_api_key_uses_env_var_name_only() {
+        let base_url = spawn_test_server(
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n\r\n{\"data\":[]}",
+        )
+        .await;
+        let provider = MinimaxProvider::new_with_api_key_lookup(
+            "minimax",
+            base_url,
+            "MiniMax-M2.7",
+            5,
+            Some("MINIMAX_API_KEY".to_string()),
+            |_| None,
+        )
+        .expect("provider");
+        let err = provider.health_check().await.expect_err("missing key");
+        let rendered = err.to_string();
+
+        assert!(rendered.contains("set MINIMAX_API_KEY to your MiniMax API key"));
+        assert!(!rendered.contains("secret-value"));
+    }
+
+    async fn spawn_test_server(response: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        tokio::spawn(async move {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                let mut request = vec![0_u8; 2048];
+                let _ = socket.read(&mut request).await;
+                let _ = socket.write_all(response.as_bytes()).await;
+            }
+        });
+        format!("http://{addr}")
+    }
+}

--- a/src/agent_provider/minimax/types.rs
+++ b/src/agent_provider/minimax/types.rs
@@ -1,0 +1,27 @@
+#![deny(clippy::unwrap_used)]
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum MinimaxError {
+    #[error("MiniMax API key is missing; set {env} to your MiniMax API key")]
+    MissingApiKey { env: String },
+    #[error("invalid {env} — check your key at platform.minimax.io")]
+    Unauthorized { env: String },
+    #[error("MiniMax returned HTTP status {0}")]
+    HttpStatus(u16),
+    #[error("malformed MiniMax SSE stream: {0}")]
+    MalformedSse(String),
+    #[error("MiniMax request timed out after {seconds}s")]
+    Timeout { seconds: u64 },
+    #[error("MiniMax network issue: {0}")]
+    Network(String),
+    #[error("MiniMax request failed: {0}")]
+    Request(String),
+}
+
+impl MinimaxError {
+    pub fn into_agent_error(self) -> crate::agent_provider::types::AgentError {
+        crate::agent_provider::types::AgentError::Stream(self.to_string())
+    }
+}

--- a/src/agent_provider/mod.rs
+++ b/src/agent_provider/mod.rs
@@ -1,5 +1,6 @@
 pub mod claude;
 pub mod codex;
+pub mod minimax;
 pub mod ollama;
 pub mod openai_compat;
 pub mod qwen;
@@ -14,6 +15,8 @@ mod types_tests;
 pub use claude::ClaudeProvider;
 #[allow(unused_imports)]
 pub use codex::CodexProvider;
+#[allow(unused_imports)]
+pub use minimax::MinimaxProvider;
 #[allow(unused_imports)]
 pub use ollama::OllamaProvider;
 #[allow(unused_imports)]

--- a/src/agent_provider/types.rs
+++ b/src/agent_provider/types.rs
@@ -252,6 +252,31 @@ impl AgentProviderFactory {
                     ),
                 })
             }
+            Some(provider) if provider.provider == "minimax" || provider.id == "minimax" => {
+                let model = provider
+                    .model
+                    .clone()
+                    .unwrap_or_else(|| "MiniMax-M2.7".to_string());
+                let base_url = provider
+                    .base_url
+                    .clone()
+                    .unwrap_or_else(|| "https://api.minimax.io/v1".to_string());
+                Ok(Self {
+                    default_provider: Arc::new(
+                        crate::agent_provider::minimax::MinimaxProvider::new(
+                            provider.id.clone(),
+                            base_url,
+                            model,
+                            provider.request_timeout_secs.unwrap_or(120),
+                            provider
+                                .api_key_env
+                                .clone()
+                                .or_else(|| Some("MINIMAX_API_KEY".to_string())),
+                        )
+                        .map_err(crate::agent_provider::minimax::MinimaxError::into_agent_error)?,
+                    ),
+                })
+            }
             Some(provider) => Err(AgentError::Config(format!(
                 "unsupported default agent provider `{}`",
                 provider.provider

--- a/src/agent_provider/types_tests.rs
+++ b/src/agent_provider/types_tests.rs
@@ -149,3 +149,23 @@ fn factory_accepts_ollama_provider() {
     assert_eq!(factory.default_provider().id(), "ollama");
     assert_eq!(factory.default_provider().kind(), AgentProviderKind::Http);
 }
+
+#[test]
+fn factory_accepts_minimax_provider() {
+    let factory = AgentProviderFactory::from_config(AgentProvidersConfig {
+        default_provider: "minimax".to_string(),
+        providers: vec![AgentProviderDefinition {
+            id: "minimax".to_string(),
+            provider: "minimax".to_string(),
+            binary: None,
+            base_url: Some("https://api.minimax.io/v1".to_string()),
+            model: Some("MiniMax-M2.7".to_string()),
+            request_timeout_secs: Some(5),
+            api_key_env: Some("MINIMAX_API_KEY".to_string()),
+        }],
+    })
+    .unwrap();
+
+    assert_eq!(factory.default_provider().id(), "minimax");
+    assert_eq!(factory.default_provider().kind(), AgentProviderKind::Http);
+}

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -45,12 +45,18 @@ pub async fn cmd_run(
 
     if !skip_doctor {
         let config_ref = config.clone();
-        let report =
-            tokio::task::spawn_blocking(move || crate::doctor::run_all_checks(Some(&config_ref)))
-                .await?;
+        let report_agent = agent.clone();
+        let report = tokio::task::spawn_blocking(move || {
+            crate::doctor::run_all_checks_for_agent(Some(&config_ref), report_agent.as_deref())
+        })
+        .await?;
         let validation_config = config.clone();
+        let validation_agent = agent.clone();
         let validation = tokio::task::spawn_blocking(move || {
-            crate::doctor::validate_provider_setup(&validation_config)
+            crate::doctor::validate_provider_setup_for_agent(
+                &validation_config,
+                validation_agent.as_deref(),
+            )
         })
         .await?;
         if let Err(e) = validation {
@@ -277,6 +283,32 @@ fn provider_for_agent(
                     model,
                     resolved.config.request_timeout_secs.unwrap_or(120),
                     resolved.config.api_key_env.clone(),
+                )
+                .map_err(|err| anyhow::anyhow!(err.to_string()))?,
+            ))
+        }
+        crate::config::AgentKind::Minimax => {
+            let model = resolved
+                .config
+                .model
+                .clone()
+                .filter(|model| !model.trim().is_empty())
+                .unwrap_or_else(|| "MiniMax-M2.7".to_string());
+            Ok(std::sync::Arc::new(
+                crate::agent_provider::MinimaxProvider::new(
+                    resolved.id.clone(),
+                    resolved
+                        .config
+                        .base_url
+                        .clone()
+                        .unwrap_or_else(|| "https://api.minimax.io/v1".to_string()),
+                    model,
+                    resolved.config.request_timeout_secs.unwrap_or(120),
+                    resolved
+                        .config
+                        .api_key_env
+                        .clone()
+                        .or_else(|| Some("MINIMAX_API_KEY".to_string())),
                 )
                 .map_err(|err| anyhow::anyhow!(err.to_string()))?,
             ))

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,5 +1,5 @@
 use crate::agent_provider::{
-    AgentProvider, ClaudeProvider, CodexProvider, OllamaProvider, QwenProvider,
+    AgentProvider, ClaudeProvider, CodexProvider, MinimaxProvider, OllamaProvider, QwenProvider,
 };
 use crate::config::{AgentKind, Config, ProviderConfig, ResolvedAgentConfig};
 use crate::provider::types::ProviderKind;
@@ -82,44 +82,7 @@ impl DoctorReport {
 
 /// Run all preflight checks and return a report.
 pub fn run_all_checks(config: Option<&Config>) -> DoctorReport {
-    let provider_kind = config.map(|cfg| cfg.provider.kind).unwrap_or_default();
-    let mut checks = vec![
-        check_git_installed(),
-        check_git_user_config(),
-        check_git_remote(),
-    ];
-
-    match provider_kind {
-        ProviderKind::Github => {
-            checks.push(check_gh_installed());
-            checks.push(check_gh_authenticated());
-        }
-        ProviderKind::AzureDevops => {
-            checks.push(check_az_cli(CheckSeverity::Required));
-            checks.push(check_az_identity(CheckSeverity::Required));
-            if let Some(cfg) = config {
-                checks.push(check_azdo_config(&cfg.provider));
-            }
-            checks.push(check_azdo_remote());
-        }
-    }
-
-    checks.push(check_config_exists());
-
-    if let Some(cfg) = config {
-        checks.push(check_provider_matches_remote(cfg.provider.kind));
-    }
-
-    checks.push(check_agent_runtime(config));
-
-    // Only check repo access if gh is authenticated
-    if provider_kind == ProviderKind::Github
-        && checks.iter().any(|c| c.name == "gh auth" && c.passed)
-    {
-        checks.push(check_gh_repo_accessible());
-    }
-
-    DoctorReport { checks }
+    run_all_checks_for_agent(config, None)
 }
 
 /// Print a formatted report to stdout.
@@ -172,9 +135,52 @@ pub fn validate_preflight(report: &DoctorReport) -> anyhow::Result<()> {
 }
 
 /// Validate provider-aware setup checks and return an error if required checks fail.
-pub fn validate_provider_setup(config: &Config) -> anyhow::Result<()> {
-    let report = run_all_checks(Some(config));
+pub fn validate_provider_setup_for_agent(
+    config: &Config,
+    agent_id: Option<&str>,
+) -> anyhow::Result<()> {
+    let report = run_all_checks_for_agent(Some(config), agent_id);
     validate_preflight(&report)
+}
+
+pub fn run_all_checks_for_agent(config: Option<&Config>, agent_id: Option<&str>) -> DoctorReport {
+    let provider_kind = config.map(|cfg| cfg.provider.kind).unwrap_or_default();
+    let mut checks = vec![
+        check_git_installed(),
+        check_git_user_config(),
+        check_git_remote(),
+    ];
+
+    match provider_kind {
+        ProviderKind::Github => {
+            checks.push(check_gh_installed());
+            checks.push(check_gh_authenticated());
+        }
+        ProviderKind::AzureDevops => {
+            checks.push(check_az_cli(CheckSeverity::Required));
+            checks.push(check_az_identity(CheckSeverity::Required));
+            if let Some(cfg) = config {
+                checks.push(check_azdo_config(&cfg.provider));
+            }
+            checks.push(check_azdo_remote());
+        }
+    }
+
+    checks.push(check_config_exists());
+
+    if let Some(cfg) = config {
+        checks.push(check_provider_matches_remote(cfg.provider.kind));
+    }
+
+    checks.push(check_agent_runtime_for_agent(config, agent_id));
+
+    if provider_kind == ProviderKind::Github
+        && checks.iter().any(|c| c.name == "gh auth" && c.passed)
+    {
+        checks.push(check_gh_repo_accessible());
+    }
+
+    DoctorReport { checks }
 }
 
 /// Pure, testable core of the claude cli check.
@@ -475,12 +481,12 @@ fn check_claude_cli() -> CheckResult {
     build_claude_cli_result(health.available, &sanitize(&version))
 }
 
-fn check_agent_runtime(config: Option<&Config>) -> CheckResult {
+fn check_agent_runtime_for_agent(config: Option<&Config>, agent_id: Option<&str>) -> CheckResult {
     let Some(config) = config else {
         return check_claude_cli();
     };
 
-    match config.resolve_agent(None) {
+    match config.resolve_agent(agent_id) {
         Ok(resolved) => match resolved.config.kind {
             AgentKind::Claude => check_claude_cli(),
             AgentKind::Codex => check_subprocess_agent(
@@ -494,6 +500,7 @@ fn check_agent_runtime(config: Option<&Config>) -> CheckResult {
                     .health_check_blocking(),
             ),
             AgentKind::Ollama => check_ollama_agent(resolved),
+            AgentKind::Minimax => check_minimax_agent(resolved),
             other => CheckResult::fail(
                 format!("{} agent", other.as_str()),
                 "provider runtime is not implemented yet",
@@ -550,6 +557,36 @@ fn check_ollama_agent(resolved: ResolvedAgentConfig) -> CheckResult {
     };
 
     run_agent_health_check("ollama", provider)
+}
+
+fn check_minimax_agent(resolved: ResolvedAgentConfig) -> CheckResult {
+    let model = resolved
+        .config
+        .model
+        .clone()
+        .filter(|model| !model.trim().is_empty())
+        .unwrap_or_else(|| "MiniMax-M2.7".to_string());
+
+    let provider = match MinimaxProvider::new(
+        resolved.id,
+        resolved
+            .config
+            .base_url
+            .unwrap_or_else(|| "https://api.minimax.io/v1".to_string()),
+        model,
+        resolved.config.request_timeout_secs.unwrap_or(120),
+        resolved
+            .config
+            .api_key_env
+            .or_else(|| Some("MINIMAX_API_KEY".to_string())),
+    ) {
+        Ok(provider) => provider,
+        Err(err) => {
+            return CheckResult::fail("minimax", err.to_string(), CheckSeverity::Required);
+        }
+    };
+
+    run_agent_health_check("minimax", provider)
 }
 
 fn run_agent_health_check<P>(name: &'static str, provider: P) -> CheckResult


### PR DESCRIPTION
## Summary

- Add a MiniMax OpenAI-compatible HTTP provider with SSE streaming and health checks.
- Wire MiniMax into provider factory, run-time agent selection, and doctor validation.
- Cover MiniMax factory setup and provider error/streaming behavior with tests.

Closes #616

## Test plan

- [x] cargo test --quiet
- [x] cargo clippy -- -D warnings -A dead_code
- [x] cargo fmt --check
- [x] manual verification: reviewed staged MiniMax provider wiring and PR diff scope
