### PR TITLE
refactor: extract OpenAI-compatible SSE parser

### DIFF
--- a/src/agent_provider/minimax/client.rs
+++ b/src/agent_provider/minimax/client.rs
@@ -117,22 +117,19 @@ impl MinimaxClient {
 
             while let Some(next) = stream.next().await {
                 match next {
-                    Ok(bytes) => {
-                        let text = String::from_utf8_lossy(&bytes);
-                        match parser.push_chunk(&text) {
-                            Ok(events) => {
-                                for event in events {
-                                    if tx.send(Ok(event)).await.is_err() {
-                                        return;
-                                    }
+                    Ok(bytes) => match parser.push_bytes(&bytes) {
+                        Ok(events) => {
+                            for event in events {
+                                if tx.send(Ok(event)).await.is_err() {
+                                    return;
                                 }
                             }
-                            Err(err) => {
-                                let _ = tx.send(Err(MinimaxError::MalformedSse(err))).await;
-                                return;
-                            }
                         }
-                    }
+                        Err(err) => {
+                            let _ = tx.send(Err(MinimaxError::MalformedSse(err))).await;
+                            return;
+                        }
+                    },
                     Err(err) if err.is_timeout() => {
                         let _ = tx
                             .send(Err(MinimaxError::Timeout {

--- a/src/agent_provider/ollama/http.rs
+++ b/src/agent_provider/ollama/http.rs
@@ -102,22 +102,19 @@ impl OllamaHttpClient {
 
             while let Some(next) = stream.next().await {
                 match next {
-                    Ok(bytes) => {
-                        let text = String::from_utf8_lossy(&bytes);
-                        match parser.push_chunk(&text) {
-                            Ok(events) => {
-                                for event in events {
-                                    if tx.send(Ok(event)).await.is_err() {
-                                        return;
-                                    }
+                    Ok(bytes) => match parser.push_bytes(&bytes) {
+                        Ok(events) => {
+                            for event in events {
+                                if tx.send(Ok(event)).await.is_err() {
+                                    return;
                                 }
                             }
-                            Err(err) => {
-                                let _ = tx.send(Err(OllamaError::MalformedSse(err))).await;
-                                return;
-                            }
                         }
-                    }
+                        Err(err) => {
+                            let _ = tx.send(Err(OllamaError::MalformedSse(err))).await;
+                            return;
+                        }
+                    },
                     Err(err) if err.is_timeout() => {
                         let _ = tx
                             .send(Err(OllamaError::Timeout {

--- a/src/agent_provider/openai_compat/snapshots/maestro__agent_provider__openai_compat__sse__tests__openai_compatible_sse_failure.snap
+++ b/src/agent_provider/openai_compat/snapshots/maestro__agent_provider__openai_compat__sse__tests__openai_compatible_sse_failure.snap
@@ -1,0 +1,15 @@
+---
+source: src/agent_provider/openai_compat/sse.rs
+expression: events
+---
+[
+    Error {
+        message: "quota exceeded",
+    },
+    Unknown {
+        raw: "{\"choices\": [}",
+    },
+    Unknown {
+        raw: "unexpected finish_reason: length",
+    },
+]

--- a/src/agent_provider/openai_compat/snapshots/maestro__agent_provider__openai_compat__sse__tests__openai_compatible_sse_success.snap
+++ b/src/agent_provider/openai_compat/snapshots/maestro__agent_provider__openai_compat__sse__tests__openai_compatible_sse_success.snap
@@ -1,0 +1,12 @@
+---
+source: src/agent_provider/openai_compat/sse.rs
+expression: events
+---
+[
+    AssistantMessage {
+        text: "hello",
+    },
+    Completed {
+        cost_usd: 0.0,
+    },
+]

--- a/src/agent_provider/openai_compat/sse.rs
+++ b/src/agent_provider/openai_compat/sse.rs
@@ -6,7 +6,7 @@ use crate::session::types::StreamEvent;
 
 #[derive(Debug, Clone, Default)]
 pub struct OpenAiCompatibleSseParser {
-    buffer: String,
+    buffer: Vec<u8>,
     completed: bool,
 }
 
@@ -16,16 +16,16 @@ impl OpenAiCompatibleSseParser {
     }
 
     pub fn push_chunk(&mut self, chunk: &str) -> Result<Vec<StreamEvent>, String> {
-        self.buffer.push_str(chunk);
+        self.push_bytes(chunk.as_bytes())
+    }
+
+    pub fn push_bytes(&mut self, chunk: &[u8]) -> Result<Vec<StreamEvent>, String> {
+        self.buffer.extend_from_slice(chunk);
         let mut events = Vec::new();
 
-        while let Some(frame_end) = find_frame_end(&self.buffer) {
-            let frame = self.buffer[..frame_end].to_string();
-            let drain_to = if self.buffer[frame_end..].starts_with("\r\n\r\n") {
-                frame_end + 4
-            } else {
-                frame_end + 2
-            };
+        while let Some((frame_end, delimiter_len)) = find_frame_end(&self.buffer) {
+            let frame = self.buffer[..frame_end].to_vec();
+            let drain_to = frame_end + delimiter_len;
             self.buffer.drain(..drain_to);
             events.extend(self.parse_frame(&frame)?);
         }
@@ -34,7 +34,7 @@ impl OpenAiCompatibleSseParser {
     }
 
     pub fn finish(&mut self) -> Result<Vec<StreamEvent>, String> {
-        if self.buffer.trim().is_empty() {
+        if self.buffer.iter().all(u8::is_ascii_whitespace) {
             return Ok(Vec::new());
         }
 
@@ -42,11 +42,17 @@ impl OpenAiCompatibleSseParser {
         self.parse_frame(&frame)
     }
 
-    fn parse_frame(&mut self, frame: &str) -> Result<Vec<StreamEvent>, String> {
+    fn parse_frame(&mut self, frame: &[u8]) -> Result<Vec<StreamEvent>, String> {
+        let Ok(frame) = std::str::from_utf8(frame) else {
+            return Ok(vec![StreamEvent::Unknown {
+                raw: String::from_utf8_lossy(frame).to_string(),
+            }]);
+        };
+
         let data = frame
-            .lines()
-            .filter_map(|line| line.strip_prefix("data:"))
-            .map(str::trim_start)
+            .split('\n')
+            .map(|line| line.strip_suffix('\r').unwrap_or(line))
+            .filter_map(data_field_value)
             .collect::<Vec<_>>()
             .join("\n");
 
@@ -61,8 +67,12 @@ impl OpenAiCompatibleSseParser {
             return Ok(vec![StreamEvent::Completed { cost_usd: 0.0 }]);
         }
 
-        let value: Value = serde_json::from_str(&data)
-            .map_err(|err| format!("malformed OpenAI-compatible SSE JSON: {err}"))?;
+        let value: Value = match serde_json::from_str(&data) {
+            Ok(value) => value,
+            Err(_) => {
+                return Ok(vec![StreamEvent::Unknown { raw: data }]);
+            }
+        };
         Ok(self.parse_json_event(&value))
     }
 
@@ -126,7 +136,7 @@ impl OpenAiCompatibleSseParser {
                 });
             }
             Some(other) => events.push(StreamEvent::Unknown {
-                raw: format!("finish_reason:{other}"),
+                raw: format!("unexpected finish_reason: {other}"),
             }),
             None => {}
         }
@@ -135,8 +145,26 @@ impl OpenAiCompatibleSseParser {
     }
 }
 
-fn find_frame_end(buffer: &str) -> Option<usize> {
-    buffer.find("\n\n").or_else(|| buffer.find("\r\n\r\n"))
+fn find_frame_end(buffer: &[u8]) -> Option<(usize, usize)> {
+    let lf = find_bytes(buffer, b"\n\n").map(|index| (index, 2));
+    let crlf = find_bytes(buffer, b"\r\n\r\n").map(|index| (index, 4));
+    match (lf, crlf) {
+        (Some(lf), Some(crlf)) => Some(if lf.0 < crlf.0 { lf } else { crlf }),
+        (Some(lf), None) => Some(lf),
+        (None, Some(crlf)) => Some(crlf),
+        (None, None) => None,
+    }
+}
+
+fn find_bytes(buffer: &[u8], needle: &[u8]) -> Option<usize> {
+    buffer
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+fn data_field_value(line: &str) -> Option<&str> {
+    let value = line.strip_prefix("data:")?;
+    Some(value.strip_prefix(' ').unwrap_or(value))
 }
 
 fn error_message(error: &Value) -> String {
@@ -152,27 +180,135 @@ fn error_message(error: &Value) -> String {
 mod tests {
     use super::*;
 
-    #[test]
-    fn parses_content_and_stop() {
+    fn parse_all(input: &str) -> Vec<StreamEvent> {
         let mut parser = OpenAiCompatibleSseParser::new();
-        let events = parser
-            .push_chunk(
-                "data: {\"choices\":[{\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}\n\n\
-                 data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n\
-                 data: [DONE]\n\n",
-            )
-            .expect("valid sse");
+        let mut events = parser.push_chunk(input).expect("parse chunk");
+        events.extend(parser.finish().expect("finish parser"));
+        events
+    }
 
-        assert!(matches!(
-            events.first(),
-            Some(StreamEvent::AssistantMessage { text }) if text == "hello"
-        ));
-        assert_eq!(
-            events
-                .iter()
-                .filter(|event| matches!(event, StreamEvent::Completed { .. }))
-                .count(),
-            1
+    #[test]
+    fn valid_stream_maps_content_tool_calls_stop_and_done() {
+        let events = parse_all(
+            "event: completion.chunk\n\
+             data: {\"choices\":[{\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}\n\n\
+             data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"id\":\"call_1\"}]},\"finish_reason\":null}]}\n\n\
+             data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n\
+             data: {\"choices\":[{\"delta\":{\"content\":\" world\"},\"finish_reason\":\"stop\"}]}\n\n\
+             data: [DONE]\n\n",
         );
+
+        assert!(matches!(&events[0], StreamEvent::AssistantMessage { text } if text == "hello"));
+        assert!(matches!(&events[1], StreamEvent::ToolUse { tool, .. } if tool == "tool_calls"));
+        assert!(matches!(&events[2], StreamEvent::ToolUse { tool, .. } if tool == "tool_calls"));
+        assert!(matches!(&events[3], StreamEvent::AssistantMessage { text } if text == " world"));
+        assert!(matches!(&events[4], StreamEvent::Completed { .. }));
+        assert_eq!(events.len(), 5);
+    }
+
+    #[test]
+    fn malformed_json_inside_data_becomes_unknown() {
+        let events = parse_all("data: {\"choices\": [}\n\n");
+
+        assert!(matches!(&events[..], [StreamEvent::Unknown { raw }] if raw == "{\"choices\": [}"));
+    }
+
+    #[test]
+    fn unexpected_finish_reason_becomes_unknown() {
+        let events =
+            parse_all("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"length\"}]}\n\n");
+
+        assert!(
+            matches!(&events[..], [StreamEvent::Unknown { raw }] if raw == "unexpected finish_reason: length")
+        );
+    }
+
+    #[test]
+    fn missing_choices_array_becomes_unknown() {
+        let events =
+            parse_all("data: {\"id\":\"chatcmpl_1\",\"object\":\"chat.completion.chunk\"}\n\n");
+
+        assert!(
+            matches!(&events[..], [StreamEvent::Unknown { raw }] if raw.contains("\"chatcmpl_1\""))
+        );
+    }
+
+    #[test]
+    fn premature_stream_end_parses_remaining_frame() {
+        let events = parse_all(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"tail\"},\"finish_reason\":null}]}",
+        );
+
+        assert!(matches!(&events[..], [StreamEvent::AssistantMessage { text }] if text == "tail"));
+    }
+
+    #[test]
+    fn preserves_utf8_split_across_byte_chunks() {
+        let frame =
+            "data: {\"choices\":[{\"delta\":{\"content\":\"olá\"},\"finish_reason\":null}]}\n\n";
+        let split = frame
+            .as_bytes()
+            .windows("á".len())
+            .position(|window| window == "á".as_bytes())
+            .expect("accented byte");
+        let mut parser = OpenAiCompatibleSseParser::new();
+
+        let first = parser
+            .push_bytes(&frame.as_bytes()[..split + 1])
+            .expect("first chunk");
+        let second = parser
+            .push_bytes(&frame.as_bytes()[split + 1..])
+            .expect("second chunk");
+
+        assert!(first.is_empty());
+        assert!(matches!(&second[..], [StreamEvent::AssistantMessage { text }] if text == "olá"));
+    }
+
+    #[test]
+    fn multiline_data_fields_are_joined_with_newlines() {
+        let events = parse_all(
+            "data: {\"choices\":[\n\
+             data: {\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}\n\
+             data: ]}\n\n",
+        );
+
+        assert!(matches!(&events[..], [StreamEvent::AssistantMessage { text }] if text == "hello"));
+    }
+
+    #[test]
+    fn top_level_error_maps_to_error_event() {
+        let events = parse_all("data: {\"error\":{\"message\":\"bad request\"}}\n\n");
+
+        assert!(
+            matches!(&events[..], [StreamEvent::Error { message }] if message == "bad request")
+        );
+    }
+
+    #[test]
+    fn done_without_prior_frames_completes_stream() {
+        let events = parse_all("data: [DONE]\n\n");
+
+        assert!(matches!(&events[..], [StreamEvent::Completed { .. }]));
+    }
+
+    #[test]
+    fn representative_success_snapshot() {
+        let events = parse_all(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}\r\n\r\n\
+             data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\r\n\r\n",
+        );
+
+        insta::assert_debug_snapshot!("openai_compatible_sse_success", events);
+    }
+
+    #[test]
+    fn representative_failure_snapshot() {
+        let events = parse_all(
+            "data: {\"error\":{\"message\":\"quota exceeded\"}}\n\n\
+             data: {\"choices\": [}\n\n\
+             data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"length\"}]}\n\n",
+        );
+
+        insta::assert_debug_snapshot!("openai_compatible_sse_failure", events);
     }
 }


### PR DESCRIPTION
## Summary

- Stores OpenAI-compatible SSE chunks as bytes so UTF-8 split boundaries are preserved until complete frames arrive.
- Converts malformed JSON and unexpected finish reasons into Unknown stream events instead of failing provider streams.
- Updates Ollama and MiniMax streaming clients to feed raw response bytes into the shared parser.

Closes #652

## Test plan

- [x] cargo test --quiet
- [x] cargo clippy -- -D warnings -A dead_code
- [x] cargo fmt --check
- [x] manual verification: cargo test openai_compat::sse --lib
