### PR TITLE
refactor: add provider parser adapters

### DIFF
--- a/scripts/tests/test_update_milestone_graph.py
+++ b/scripts/tests/test_update_milestone_graph.py
@@ -69,6 +69,22 @@ def test_level_rollup_at_boundary_and_idempotent_second_run():
     assert result.description.count("(COMPLETED ✅)") == 1
 
 
+def test_sequence_standalone_issue_token_rolls_up_level():
+    before = (
+        "Level 2 — parser adapters:\n"
+        "• #552 feat: parser adapters\n\n"
+        "Level 3 — follow-up:\n"
+        "• #553 docs\n\n"
+        "Sequence: ✅(L1: #548 ∥ #589) → #552 → #553\n"
+    )
+
+    result = update_milestone_graph.update_description(before, 552)
+
+    assert "Level 2 — parser adapters: (COMPLETED ✅)" in result.description
+    assert "• ✅ #552 feat: parser adapters" in result.description
+    assert "Sequence: ✅(L1: #548 ∥ #589) → ✅(L2: #552) → #553" in result.description
+
+
 def test_sequence_token_boundary_does_not_match_52_inside_521():
     before = fixture("milestone-token-boundary.md")
 

--- a/scripts/update-milestone-graph.py
+++ b/scripts/update-milestone-graph.py
@@ -145,6 +145,19 @@ def update_sequence_line(sequence: str, issue: int, level: int) -> str:
         prefix = "" if already_done else "✅"
         return f"{sequence[:start]}{prefix}{updated_group}{sequence[end:]}"
 
+    needle = f"#{issue}"
+    start = 0
+    while True:
+        idx = sequence.find(needle, start)
+        if idx == -1:
+            break
+        before = sequence[idx - 1] if idx > 0 else None
+        after_idx = idx + len(needle)
+        after = sequence[after_idx] if after_idx < len(sequence) else None
+        if is_token_char_allowed_before(before) and is_token_char_allowed_after(after):
+            return f"{sequence[:idx]}✅(L{level}: {needle}){sequence[after_idx:]}"
+        start = idx + len(needle)
+
     raise MilestoneGraphError(f"failed to find #{issue} token in Sequence line")
 
 

--- a/src/agent_provider/codex.rs
+++ b/src/agent_provider/codex.rs
@@ -6,7 +6,7 @@ use tokio::process::Command;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
-mod parser;
+pub(crate) mod parser;
 
 use super::types::{
     AgentError, AgentHealthCheck, AgentOutputFormat, AgentProvider, AgentProviderEvent,

--- a/src/agent_provider/codex/parser.rs
+++ b/src/agent_provider/codex/parser.rs
@@ -5,12 +5,12 @@ use serde_json::Value;
 use crate::session::types::{StreamEvent, TokenUsage};
 
 #[derive(Debug, Default)]
-pub(super) struct CodexStreamParser {
+pub(crate) struct CodexStreamParser {
     tool_names_by_id: HashMap<String, String>,
 }
 
 impl CodexStreamParser {
-    pub(super) fn parse_line(&mut self, line: &str) -> Vec<StreamEvent> {
+    pub(crate) fn parse_line(&mut self, line: &str) -> Vec<StreamEvent> {
         let line = line.trim();
         if line.is_empty() {
             return vec![StreamEvent::Unknown { raw: String::new() }];
@@ -26,6 +26,9 @@ impl CodexStreamParser {
             Some("thread.started") | Some("turn.started") | Some("item.started") => Vec::new(),
             Some("item.completed") => self.parse_item_completed(&v),
             Some("turn.completed") => self.parse_turn_completed(&v),
+            Some("turn.failed") => vec![StreamEvent::Error {
+                message: extract_error_message(&v).unwrap_or_else(|| "codex turn failed".into()),
+            }],
             Some("error") => vec![StreamEvent::Error {
                 message: extract_error_message(&v).unwrap_or_else(|| "codex run failed".into()),
             }],
@@ -38,7 +41,7 @@ impl CodexStreamParser {
     fn parse_item_completed(&mut self, v: &Value) -> Vec<StreamEvent> {
         let item = v.get("item").unwrap_or(v);
         match item.get("type").and_then(Value::as_str) {
-            Some("message") => parse_codex_message(item),
+            Some("message") | Some("agent_message") => parse_codex_message(item),
             Some("function_call") | Some("tool_call") => {
                 let id = item
                     .get("call_id")
@@ -108,7 +111,11 @@ impl CodexStreamParser {
 }
 
 fn parse_codex_message(item: &Value) -> Vec<StreamEvent> {
-    if item.get("role").and_then(Value::as_str) != Some("assistant") {
+    if item
+        .get("role")
+        .and_then(Value::as_str)
+        .is_some_and(|role| role != "assistant")
+    {
         return Vec::new();
     }
     let text = item
@@ -128,6 +135,11 @@ fn parse_codex_message(item: &Value) -> Vec<StreamEvent> {
             })
         })
         .or_else(|| item.get("text").and_then(Value::as_str).map(str::to_string))
+        .or_else(|| {
+            item.get("message")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
         .unwrap_or_default();
 
     if text.is_empty() {
@@ -197,6 +209,9 @@ fn extract_command_preview(input: &Value) -> Option<String> {
 fn extract_error_message(v: &Value) -> Option<String> {
     v.get("message")
         .or_else(|| v.pointer("/error/message"))
+        .or_else(|| v.pointer("/error/data/message"))
+        .or_else(|| v.pointer("/turn/error/message"))
+        .or_else(|| v.pointer("/turn/error/data/message"))
         .or_else(|| v.get("error"))
         .and_then(Value::as_str)
         .map(str::to_string)
@@ -258,5 +273,25 @@ mod tests {
                 .iter()
                 .any(|event| matches!(event, StreamEvent::Completed { .. }))
         );
+    }
+
+    #[test]
+    fn parser_maps_agent_message_and_turn_failed() {
+        let mut parser = CodexStreamParser::default();
+
+        let message = parser.parse_line(
+            r#"{"type":"item.completed","item":{"type":"agent_message","text":"Hello"}}"#,
+        );
+        assert!(matches!(
+            message.as_slice(),
+            [StreamEvent::AssistantMessage { text }] if text == "Hello"
+        ));
+
+        let failed =
+            parser.parse_line(r#"{"type":"turn.failed","error":{"message":"model failed"}}"#);
+        assert!(matches!(
+            failed.as_slice(),
+            [StreamEvent::Error { message }] if message == "model failed"
+        ));
     }
 }

--- a/src/agent_provider/mod.rs
+++ b/src/agent_provider/mod.rs
@@ -4,6 +4,7 @@ pub mod minimax;
 pub mod ollama;
 pub mod openai_compat;
 pub mod opencode;
+pub mod parser;
 pub mod qwen;
 mod qwen_parser;
 #[cfg(test)]

--- a/src/agent_provider/opencode.rs
+++ b/src/agent_provider/opencode.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 use std::process::Stdio;
 
-use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 use tokio::sync::mpsc;
@@ -13,7 +12,9 @@ use super::types::{
     ParserBinding,
 };
 use crate::session::types::StreamEvent;
-use crate::session::types::TokenUsage;
+
+mod parser;
+pub use parser::OpenCodeJsonParser;
 
 const OPENCODE_INSTALL_MESSAGE: &str = "opencode CLI not found; install with `brew install anomalyco/tap/opencode`, \
      `curl -fsSL https://opencode.ai/install | bash`, or `npm install -g opencode-ai`";
@@ -300,218 +301,6 @@ impl AgentProvider for OpenCodeProvider {
             exit_code: status.code(),
         })
     }
-}
-
-#[derive(Debug, Default)]
-pub struct OpenCodeJsonParser {
-    stdout_bytes: Vec<u8>,
-}
-
-impl OpenCodeJsonParser {
-    pub fn parse_line(&mut self, line: &str) -> Vec<StreamEvent> {
-        self.stdout_bytes.extend_from_slice(line.as_bytes());
-        self.stdout_bytes.push(b'\n');
-
-        let line = line.trim();
-        if line.is_empty() {
-            return vec![StreamEvent::Unknown { raw: String::new() }];
-        }
-
-        let Ok(value) = serde_json::from_str::<Value>(line) else {
-            return vec![StreamEvent::Unknown {
-                raw: line.to_string(),
-            }];
-        };
-
-        match value.get("type").and_then(Value::as_str) {
-            Some("step_start") => Vec::new(),
-            Some("text") => parse_text_event(&value),
-            Some("tool_use") => parse_tool_use_event(&value),
-            Some("step_finish") => parse_step_finish_event(&value),
-            Some("error") => vec![StreamEvent::Error {
-                message: opencode_error_message(&value),
-            }],
-            Some(_) | None => vec![StreamEvent::Unknown {
-                raw: line.to_string(),
-            }],
-        }
-    }
-
-    pub fn stdout_bytes(&self) -> &[u8] {
-        &self.stdout_bytes
-    }
-}
-
-fn parse_text_event(value: &Value) -> Vec<StreamEvent> {
-    value
-        .pointer("/part/text")
-        .and_then(Value::as_str)
-        .filter(|text| !text.is_empty())
-        .map(|text| {
-            vec![StreamEvent::AssistantMessage {
-                text: text.to_string(),
-            }]
-        })
-        .unwrap_or_else(|| {
-            vec![StreamEvent::Unknown {
-                raw: value.to_string(),
-            }]
-        })
-}
-
-fn parse_tool_use_event(value: &Value) -> Vec<StreamEvent> {
-    let Some(part) = value.get("part") else {
-        return vec![StreamEvent::Unknown {
-            raw: value.to_string(),
-        }];
-    };
-
-    let tool = part
-        .get("tool")
-        .and_then(Value::as_str)
-        .unwrap_or("unknown")
-        .to_string();
-    let state = part.get("state");
-    let input = state.and_then(|state| state.get("input"));
-    let file_path = input
-        .and_then(extract_opencode_file_path)
-        .or_else(|| state.and_then(extract_opencode_metadata_file_path));
-    let command_preview = input.and_then(extract_opencode_command_preview);
-    let is_error = state
-        .and_then(|state| state.get("status"))
-        .and_then(Value::as_str)
-        .is_some_and(|status| status != "completed");
-
-    vec![
-        StreamEvent::ToolUse {
-            tool: tool.clone(),
-            file_path,
-            command_preview,
-            subagent_name: None,
-        },
-        StreamEvent::ToolResult { tool, is_error },
-    ]
-}
-
-fn parse_step_finish_event(value: &Value) -> Vec<StreamEvent> {
-    let Some(part) = value.get("part") else {
-        return vec![StreamEvent::Unknown {
-            raw: value.to_string(),
-        }];
-    };
-
-    let mut events = Vec::new();
-    if let Some(tokens) = part.get("tokens") {
-        events.push(StreamEvent::TokenUpdate {
-            usage: parse_opencode_tokens(tokens),
-        });
-    }
-
-    match part.get("reason").and_then(Value::as_str) {
-        Some("stop") => events.push(StreamEvent::Completed {
-            cost_usd: part.get("cost").and_then(Value::as_f64).unwrap_or(0.0),
-        }),
-        Some("tool-calls") => {}
-        Some(reason) => events.push(StreamEvent::Unknown {
-            raw: format!("opencode step_finish reason:{reason}"),
-        }),
-        None => events.push(StreamEvent::Unknown {
-            raw: value.to_string(),
-        }),
-    }
-
-    events
-}
-
-fn parse_opencode_tokens(tokens: &Value) -> TokenUsage {
-    TokenUsage {
-        input_tokens: tokens.get("input").and_then(Value::as_u64).unwrap_or(0),
-        output_tokens: tokens.get("output").and_then(Value::as_u64).unwrap_or(0),
-        cache_read_tokens: tokens
-            .pointer("/cache/read")
-            .and_then(Value::as_u64)
-            .unwrap_or(0),
-        cache_creation_tokens: tokens
-            .pointer("/cache/write")
-            .and_then(Value::as_u64)
-            .unwrap_or(0),
-    }
-}
-
-fn extract_opencode_file_path(input: &Value) -> Option<String> {
-    input
-        .get("filePath")
-        .or_else(|| input.get("file_path"))
-        .or_else(|| input.get("path"))
-        .and_then(Value::as_str)
-        .map(str::to_string)
-        .or_else(|| {
-            input
-                .get("patchText")
-                .and_then(Value::as_str)
-                .and_then(extract_patch_file_path)
-        })
-}
-
-fn extract_opencode_metadata_file_path(state: &Value) -> Option<String> {
-    state
-        .pointer("/metadata/files")
-        .and_then(Value::as_array)
-        .and_then(|files| files.first())
-        .and_then(|file| {
-            file.get("relativePath")
-                .or_else(|| file.get("filePath"))
-                .and_then(Value::as_str)
-        })
-        .map(str::to_string)
-}
-
-fn extract_opencode_command_preview(input: &Value) -> Option<String> {
-    input
-        .get("command")
-        .or_else(|| input.get("cmd"))
-        .or_else(|| input.get("patchText"))
-        .and_then(Value::as_str)
-        .map(short_preview)
-}
-
-fn extract_patch_file_path(patch: &str) -> Option<String> {
-    patch.lines().find_map(|line| {
-        line.strip_prefix("*** Add File: ")
-            .or_else(|| line.strip_prefix("*** Update File: "))
-            .or_else(|| line.strip_prefix("*** Delete File: "))
-            .map(str::to_string)
-    })
-}
-
-fn short_preview(value: &str) -> String {
-    if value.len() > 60 {
-        let boundary = char_boundary(value, 60);
-        format!("{}...", &value[..boundary])
-    } else {
-        value.to_string()
-    }
-}
-
-fn char_boundary(s: &str, max_bytes: usize) -> usize {
-    if max_bytes >= s.len() {
-        return s.len();
-    }
-    let mut i = max_bytes;
-    while !s.is_char_boundary(i) && i > 0 {
-        i -= 1;
-    }
-    i
-}
-
-fn opencode_error_message(value: &Value) -> String {
-    value
-        .pointer("/error/data/message")
-        .or_else(|| value.pointer("/error/message"))
-        .or_else(|| value.get("message"))
-        .and_then(Value::as_str)
-        .unwrap_or("opencode run failed")
-        .to_string()
 }
 
 fn opencode_prompt(request: &AgentRequest) -> String {

--- a/src/agent_provider/opencode.rs
+++ b/src/agent_provider/opencode.rs
@@ -13,6 +13,7 @@ use super::types::{
     ParserBinding,
 };
 use crate::session::types::StreamEvent;
+use crate::session::types::TokenUsage;
 
 const OPENCODE_INSTALL_MESSAGE: &str = "opencode CLI not found; install with `brew install anomalyco/tap/opencode`, \
      `curl -fsSL https://opencode.ai/install | bash`, or `npm install -g opencode-ai`";
@@ -136,7 +137,7 @@ impl AgentProvider for OpenCodeProvider {
 
     fn parser_binding(&self) -> ParserBinding {
         ParserBinding {
-            name: "opencode-json-stub".to_string(),
+            name: "opencode-json".to_string(),
             output_format: AgentOutputFormat::StreamJson,
         }
     }
@@ -323,6 +324,13 @@ impl OpenCodeJsonParser {
         };
 
         match value.get("type").and_then(Value::as_str) {
+            Some("step_start") => Vec::new(),
+            Some("text") => parse_text_event(&value),
+            Some("tool_use") => parse_tool_use_event(&value),
+            Some("step_finish") => parse_step_finish_event(&value),
+            Some("error") => vec![StreamEvent::Error {
+                message: opencode_error_message(&value),
+            }],
             Some(_) | None => vec![StreamEvent::Unknown {
                 raw: line.to_string(),
             }],
@@ -332,6 +340,178 @@ impl OpenCodeJsonParser {
     pub fn stdout_bytes(&self) -> &[u8] {
         &self.stdout_bytes
     }
+}
+
+fn parse_text_event(value: &Value) -> Vec<StreamEvent> {
+    value
+        .pointer("/part/text")
+        .and_then(Value::as_str)
+        .filter(|text| !text.is_empty())
+        .map(|text| {
+            vec![StreamEvent::AssistantMessage {
+                text: text.to_string(),
+            }]
+        })
+        .unwrap_or_else(|| {
+            vec![StreamEvent::Unknown {
+                raw: value.to_string(),
+            }]
+        })
+}
+
+fn parse_tool_use_event(value: &Value) -> Vec<StreamEvent> {
+    let Some(part) = value.get("part") else {
+        return vec![StreamEvent::Unknown {
+            raw: value.to_string(),
+        }];
+    };
+
+    let tool = part
+        .get("tool")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_string();
+    let state = part.get("state");
+    let input = state.and_then(|state| state.get("input"));
+    let file_path = input
+        .and_then(extract_opencode_file_path)
+        .or_else(|| state.and_then(extract_opencode_metadata_file_path));
+    let command_preview = input.and_then(extract_opencode_command_preview);
+    let is_error = state
+        .and_then(|state| state.get("status"))
+        .and_then(Value::as_str)
+        .is_some_and(|status| status != "completed");
+
+    vec![
+        StreamEvent::ToolUse {
+            tool: tool.clone(),
+            file_path,
+            command_preview,
+            subagent_name: None,
+        },
+        StreamEvent::ToolResult { tool, is_error },
+    ]
+}
+
+fn parse_step_finish_event(value: &Value) -> Vec<StreamEvent> {
+    let Some(part) = value.get("part") else {
+        return vec![StreamEvent::Unknown {
+            raw: value.to_string(),
+        }];
+    };
+
+    let mut events = Vec::new();
+    if let Some(tokens) = part.get("tokens") {
+        events.push(StreamEvent::TokenUpdate {
+            usage: parse_opencode_tokens(tokens),
+        });
+    }
+
+    match part.get("reason").and_then(Value::as_str) {
+        Some("stop") => events.push(StreamEvent::Completed {
+            cost_usd: part.get("cost").and_then(Value::as_f64).unwrap_or(0.0),
+        }),
+        Some("tool-calls") => {}
+        Some(reason) => events.push(StreamEvent::Unknown {
+            raw: format!("opencode step_finish reason:{reason}"),
+        }),
+        None => events.push(StreamEvent::Unknown {
+            raw: value.to_string(),
+        }),
+    }
+
+    events
+}
+
+fn parse_opencode_tokens(tokens: &Value) -> TokenUsage {
+    TokenUsage {
+        input_tokens: tokens.get("input").and_then(Value::as_u64).unwrap_or(0),
+        output_tokens: tokens.get("output").and_then(Value::as_u64).unwrap_or(0),
+        cache_read_tokens: tokens
+            .pointer("/cache/read")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        cache_creation_tokens: tokens
+            .pointer("/cache/write")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+    }
+}
+
+fn extract_opencode_file_path(input: &Value) -> Option<String> {
+    input
+        .get("filePath")
+        .or_else(|| input.get("file_path"))
+        .or_else(|| input.get("path"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| {
+            input
+                .get("patchText")
+                .and_then(Value::as_str)
+                .and_then(extract_patch_file_path)
+        })
+}
+
+fn extract_opencode_metadata_file_path(state: &Value) -> Option<String> {
+    state
+        .pointer("/metadata/files")
+        .and_then(Value::as_array)
+        .and_then(|files| files.first())
+        .and_then(|file| {
+            file.get("relativePath")
+                .or_else(|| file.get("filePath"))
+                .and_then(Value::as_str)
+        })
+        .map(str::to_string)
+}
+
+fn extract_opencode_command_preview(input: &Value) -> Option<String> {
+    input
+        .get("command")
+        .or_else(|| input.get("cmd"))
+        .or_else(|| input.get("patchText"))
+        .and_then(Value::as_str)
+        .map(short_preview)
+}
+
+fn extract_patch_file_path(patch: &str) -> Option<String> {
+    patch.lines().find_map(|line| {
+        line.strip_prefix("*** Add File: ")
+            .or_else(|| line.strip_prefix("*** Update File: "))
+            .or_else(|| line.strip_prefix("*** Delete File: "))
+            .map(str::to_string)
+    })
+}
+
+fn short_preview(value: &str) -> String {
+    if value.len() > 60 {
+        let boundary = char_boundary(value, 60);
+        format!("{}...", &value[..boundary])
+    } else {
+        value.to_string()
+    }
+}
+
+fn char_boundary(s: &str, max_bytes: usize) -> usize {
+    if max_bytes >= s.len() {
+        return s.len();
+    }
+    let mut i = max_bytes;
+    while !s.is_char_boundary(i) && i > 0 {
+        i -= 1;
+    }
+    i
+}
+
+fn opencode_error_message(value: &Value) -> String {
+    value
+        .pointer("/error/data/message")
+        .or_else(|| value.pointer("/error/message"))
+        .or_else(|| value.get("message"))
+        .and_then(Value::as_str)
+        .unwrap_or("opencode run failed")
+        .to_string()
 }
 
 fn opencode_prompt(request: &AgentRequest) -> String {

--- a/src/agent_provider/opencode/parser.rs
+++ b/src/agent_provider/opencode/parser.rs
@@ -1,0 +1,215 @@
+use serde_json::Value;
+
+use crate::session::types::{StreamEvent, TokenUsage};
+
+#[derive(Debug, Default)]
+pub struct OpenCodeJsonParser {
+    stdout_bytes: Vec<u8>,
+}
+
+impl OpenCodeJsonParser {
+    pub fn parse_line(&mut self, line: &str) -> Vec<StreamEvent> {
+        self.stdout_bytes.extend_from_slice(line.as_bytes());
+        self.stdout_bytes.push(b'\n');
+
+        let line = line.trim();
+        if line.is_empty() {
+            return vec![StreamEvent::Unknown { raw: String::new() }];
+        }
+
+        let Ok(value) = serde_json::from_str::<Value>(line) else {
+            return vec![StreamEvent::Unknown {
+                raw: line.to_string(),
+            }];
+        };
+
+        match value.get("type").and_then(Value::as_str) {
+            Some("step_start") => Vec::new(),
+            Some("text") => parse_text_event(&value),
+            Some("tool_use") => parse_tool_use_event(&value),
+            Some("step_finish") => parse_step_finish_event(&value),
+            Some("error") => vec![StreamEvent::Error {
+                message: opencode_error_message(&value),
+            }],
+            Some(_) | None => vec![StreamEvent::Unknown {
+                raw: line.to_string(),
+            }],
+        }
+    }
+
+    pub fn stdout_bytes(&self) -> &[u8] {
+        &self.stdout_bytes
+    }
+}
+
+fn parse_text_event(value: &Value) -> Vec<StreamEvent> {
+    value
+        .pointer("/part/text")
+        .and_then(Value::as_str)
+        .filter(|text| !text.is_empty())
+        .map(|text| {
+            vec![StreamEvent::AssistantMessage {
+                text: text.to_string(),
+            }]
+        })
+        .unwrap_or_else(|| {
+            vec![StreamEvent::Unknown {
+                raw: value.to_string(),
+            }]
+        })
+}
+
+fn parse_tool_use_event(value: &Value) -> Vec<StreamEvent> {
+    let Some(part) = value.get("part") else {
+        return vec![StreamEvent::Unknown {
+            raw: value.to_string(),
+        }];
+    };
+
+    let tool = part
+        .get("tool")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_string();
+    let state = part.get("state");
+    let input = state.and_then(|state| state.get("input"));
+    let file_path = input
+        .and_then(extract_opencode_file_path)
+        .or_else(|| state.and_then(extract_opencode_metadata_file_path));
+    let command_preview = input.and_then(extract_opencode_command_preview);
+    let is_error = state
+        .and_then(|state| state.get("status"))
+        .and_then(Value::as_str)
+        .is_some_and(|status| status != "completed");
+
+    vec![
+        StreamEvent::ToolUse {
+            tool: tool.clone(),
+            file_path,
+            command_preview,
+            subagent_name: None,
+        },
+        StreamEvent::ToolResult { tool, is_error },
+    ]
+}
+
+fn parse_step_finish_event(value: &Value) -> Vec<StreamEvent> {
+    let Some(part) = value.get("part") else {
+        return vec![StreamEvent::Unknown {
+            raw: value.to_string(),
+        }];
+    };
+
+    let mut events = Vec::new();
+    if let Some(tokens) = part.get("tokens") {
+        events.push(StreamEvent::TokenUpdate {
+            usage: parse_opencode_tokens(tokens),
+        });
+    }
+
+    match part.get("reason").and_then(Value::as_str) {
+        Some("stop") => events.push(StreamEvent::Completed {
+            cost_usd: part.get("cost").and_then(Value::as_f64).unwrap_or(0.0),
+        }),
+        Some("tool-calls") => {}
+        Some(reason) => events.push(StreamEvent::Unknown {
+            raw: format!("opencode step_finish reason:{reason}"),
+        }),
+        None => events.push(StreamEvent::Unknown {
+            raw: value.to_string(),
+        }),
+    }
+
+    events
+}
+
+fn parse_opencode_tokens(tokens: &Value) -> TokenUsage {
+    TokenUsage {
+        input_tokens: tokens.get("input").and_then(Value::as_u64).unwrap_or(0),
+        output_tokens: tokens.get("output").and_then(Value::as_u64).unwrap_or(0),
+        cache_read_tokens: tokens
+            .pointer("/cache/read")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        cache_creation_tokens: tokens
+            .pointer("/cache/write")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+    }
+}
+
+fn extract_opencode_file_path(input: &Value) -> Option<String> {
+    input
+        .get("filePath")
+        .or_else(|| input.get("file_path"))
+        .or_else(|| input.get("path"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| {
+            input
+                .get("patchText")
+                .and_then(Value::as_str)
+                .and_then(extract_patch_file_path)
+        })
+}
+
+fn extract_opencode_metadata_file_path(state: &Value) -> Option<String> {
+    state
+        .pointer("/metadata/files")
+        .and_then(Value::as_array)
+        .and_then(|files| files.first())
+        .and_then(|file| {
+            file.get("relativePath")
+                .or_else(|| file.get("filePath"))
+                .and_then(Value::as_str)
+        })
+        .map(str::to_string)
+}
+
+fn extract_opencode_command_preview(input: &Value) -> Option<String> {
+    input
+        .get("command")
+        .or_else(|| input.get("cmd"))
+        .or_else(|| input.get("patchText"))
+        .and_then(Value::as_str)
+        .map(short_preview)
+}
+
+fn extract_patch_file_path(patch: &str) -> Option<String> {
+    patch.lines().find_map(|line| {
+        line.strip_prefix("*** Add File: ")
+            .or_else(|| line.strip_prefix("*** Update File: "))
+            .or_else(|| line.strip_prefix("*** Delete File: "))
+            .map(str::to_string)
+    })
+}
+
+fn short_preview(value: &str) -> String {
+    if value.len() > 60 {
+        let boundary = char_boundary(value, 60);
+        format!("{}...", &value[..boundary])
+    } else {
+        value.to_string()
+    }
+}
+
+fn char_boundary(s: &str, max_bytes: usize) -> usize {
+    if max_bytes >= s.len() {
+        return s.len();
+    }
+    let mut i = max_bytes;
+    while !s.is_char_boundary(i) && i > 0 {
+        i -= 1;
+    }
+    i
+}
+
+fn opencode_error_message(value: &Value) -> String {
+    value
+        .pointer("/error/data/message")
+        .or_else(|| value.pointer("/error/message"))
+        .or_else(|| value.get("message"))
+        .and_then(Value::as_str)
+        .unwrap_or("opencode run failed")
+        .to_string()
+}

--- a/src/agent_provider/opencode/tests.rs
+++ b/src/agent_provider/opencode/tests.rs
@@ -40,16 +40,96 @@ fn stream_args_match_opencode_run_contract() {
 }
 
 #[test]
-fn json_parser_captures_stdout_and_emits_unknown() {
+fn json_parser_captures_stdout_and_maps_known_events() {
     let mut parser = OpenCodeJsonParser::default();
 
-    let events = parser.parse_line(r#"{"type":"session.started","id":"s1"}"#);
+    let events = parser.parse_line(r#"{"type":"text","part":{"type":"text","text":"Done."}}"#);
 
-    assert!(matches!(events.as_slice(), [StreamEvent::Unknown { .. }]));
+    assert!(matches!(
+        events.as_slice(),
+        [StreamEvent::AssistantMessage { text }] if text == "Done."
+    ));
     assert_eq!(
         parser.stdout_bytes(),
-        b"{\"type\":\"session.started\",\"id\":\"s1\"}\n"
+        b"{\"type\":\"text\",\"part\":{\"type\":\"text\",\"text\":\"Done.\"}}\n"
     );
+}
+
+#[test]
+fn json_parser_maps_success_fixture() {
+    let mut parser = OpenCodeJsonParser::default();
+    let events: Vec<StreamEvent> =
+        include_str!("../../../tests/fixtures/opencode_output_sample.jsonl")
+            .lines()
+            .flat_map(|line| parser.parse_line(line))
+            .collect();
+
+    assert!(events.iter().any(
+        |event| matches!(event, StreamEvent::AssistantMessage { text } if text.contains("Reading note.txt"))
+    ));
+    assert!(events.iter().any(|event| {
+        matches!(
+            event,
+            StreamEvent::ToolUse {
+                tool,
+                file_path: Some(path),
+                ..
+            } if tool == "read" && path.ends_with("note.txt")
+        )
+    }));
+    assert!(events.iter().any(|event| {
+        matches!(
+            event,
+            StreamEvent::ToolUse {
+                tool,
+                file_path: Some(path),
+                ..
+            } if tool == "apply_patch" && path == "result.txt"
+        )
+    }));
+    assert!(events.iter().any(|event| {
+        matches!(event, StreamEvent::TokenUpdate { usage } if usage.input_tokens == 217 && usage.output_tokens == 16 && usage.cache_read_tokens == 10368)
+    }));
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, StreamEvent::Completed { cost_usd } if *cost_usd == 0.0))
+    );
+}
+
+#[test]
+fn json_parser_maps_error_fixture() {
+    let mut parser = OpenCodeJsonParser::default();
+    let events: Vec<StreamEvent> =
+        include_str!("../../../tests/fixtures/opencode_error_sample.jsonl")
+            .lines()
+            .flat_map(|line| parser.parse_line(line))
+            .collect();
+
+    assert!(matches!(
+        events.as_slice(),
+        [StreamEvent::Error { message }] if message == "Model not found: anthropic/claude-sonnet-4-5."
+    ));
+}
+
+#[test]
+fn json_parser_handles_malformed_and_unknown() {
+    let mut parser = OpenCodeJsonParser::default();
+
+    assert!(matches!(
+        parser.parse_line("{not-json").as_slice(),
+        [StreamEvent::Unknown { raw }] if raw == "{not-json"
+    ));
+    assert!(matches!(
+        parser
+            .parse_line(r#"{"type":"session.started","id":"s1"}"#)
+            .as_slice(),
+        [StreamEvent::Unknown { raw }] if raw.contains("session.started")
+    ));
+    assert!(matches!(
+        parser.parse_line(r#"{"type":"text"}"#).as_slice(),
+        [StreamEvent::Unknown { raw }] if raw.contains("\"text\"")
+    ));
 }
 
 #[tokio::test]
@@ -90,15 +170,15 @@ async fn run_streams_events_from_mock_opencode_cli_and_records_process_context()
         }))
     ));
 
-    let mut saw_unknown = false;
+    let mut saw_message = false;
     let mut saw_stderr = false;
     let mut saw_completed = false;
     while let Some(event) = rx.recv().await {
         match event {
-            AgentProviderEvent::Stream(StreamEvent::Unknown { raw })
-                if raw.contains("session.started") =>
+            AgentProviderEvent::Stream(StreamEvent::AssistantMessage { text })
+                if text == "Done." =>
             {
-                saw_unknown = true;
+                saw_message = true;
             }
             AgentProviderEvent::Stream(StreamEvent::Error { message })
                 if message == "opencode stderr line" =>
@@ -110,12 +190,12 @@ async fn run_streams_events_from_mock_opencode_cli_and_records_process_context()
             }
             _ => {}
         }
-        if saw_unknown && saw_stderr && saw_completed {
+        if saw_message && saw_stderr && saw_completed {
             break;
         }
     }
 
-    assert!(saw_unknown);
+    assert!(saw_message);
     assert!(saw_stderr);
     assert!(saw_completed);
 
@@ -184,8 +264,9 @@ async fn missing_binary_surfaces_install_instructions() {
 }
 
 fn opencode_fixture_jsonl() -> &'static str {
-    r#"{"type":"session.started","id":"s1"}
-{"type":"message.delta","text":"Done."}"#
+    r#"{"type":"step_start","part":{"type":"step-start"}}
+{"type":"text","part":{"type":"text","text":"Done."}}
+{"type":"step_finish","part":{"type":"step-finish","reason":"stop","tokens":{"input":1,"output":1,"cache":{"read":0,"write":0}},"cost":0}}"#
 }
 
 #[cfg(unix)]

--- a/src/agent_provider/parser.rs
+++ b/src/agent_provider/parser.rs
@@ -1,0 +1,135 @@
+#![deny(clippy::unwrap_used)]
+
+use std::str::FromStr;
+
+use super::codex::parser::CodexStreamParser;
+use super::openai_compat::sse::OpenAiCompatibleSseParser;
+use super::opencode::OpenCodeJsonParser;
+use super::qwen_parser::QwenStreamParser;
+use crate::session::parser::parse_stream_line;
+use crate::session::types::StreamEvent;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentParserKind {
+    Claude,
+    Codex,
+    Qwen,
+    Opencode,
+    Ollama,
+    Minimax,
+}
+
+impl FromStr for AgentParserKind {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "claude" => Ok(Self::Claude),
+            "codex" => Ok(Self::Codex),
+            "qwen" => Ok(Self::Qwen),
+            "opencode" => Ok(Self::Opencode),
+            "ollama" => Ok(Self::Ollama),
+            "minimax" => Ok(Self::Minimax),
+            other => Err(format!("unsupported agent parser kind `{other}`")),
+        }
+    }
+}
+
+pub trait AgentStreamParser: Send {
+    fn parse_line(&mut self, line: &str) -> Vec<StreamEvent>;
+
+    fn finish(&mut self) -> Vec<StreamEvent> {
+        Vec::new()
+    }
+}
+
+pub fn parser_for_kind(kind: AgentParserKind) -> Box<dyn AgentStreamParser> {
+    match kind {
+        AgentParserKind::Claude => Box::new(ClaudeStreamParser),
+        AgentParserKind::Codex => Box::<CodexStreamParser>::default(),
+        AgentParserKind::Qwen => Box::<QwenStreamParser>::default(),
+        AgentParserKind::Opencode => Box::<OpenCodeJsonParser>::default(),
+        AgentParserKind::Ollama | AgentParserKind::Minimax => Box::new(OpenAiSseLineParser {
+            parser: OpenAiCompatibleSseParser::new(),
+        }),
+    }
+}
+
+pub fn parser_for_provider(provider: &str) -> Result<Box<dyn AgentStreamParser>, String> {
+    provider.parse().map(parser_for_kind)
+}
+
+#[derive(Debug)]
+struct ClaudeStreamParser;
+
+impl AgentStreamParser for ClaudeStreamParser {
+    fn parse_line(&mut self, line: &str) -> Vec<StreamEvent> {
+        parse_stream_line(line)
+    }
+}
+
+#[derive(Debug)]
+struct OpenAiSseLineParser {
+    parser: OpenAiCompatibleSseParser,
+}
+
+impl AgentStreamParser for OpenAiSseLineParser {
+    fn parse_line(&mut self, line: &str) -> Vec<StreamEvent> {
+        match self.parser.push_chunk(&format!("{line}\n")) {
+            Ok(events) => events,
+            Err(message) => vec![StreamEvent::Error { message }],
+        }
+    }
+
+    fn finish(&mut self) -> Vec<StreamEvent> {
+        match self.parser.finish() {
+            Ok(events) => events,
+            Err(message) => vec![StreamEvent::Error { message }],
+        }
+    }
+}
+
+impl AgentStreamParser for CodexStreamParser {
+    fn parse_line(&mut self, line: &str) -> Vec<StreamEvent> {
+        CodexStreamParser::parse_line(self, line)
+    }
+}
+
+impl AgentStreamParser for QwenStreamParser {
+    fn parse_line(&mut self, line: &str) -> Vec<StreamEvent> {
+        QwenStreamParser::parse_line(self, line)
+    }
+}
+
+impl AgentStreamParser for OpenCodeJsonParser {
+    fn parse_line(&mut self, line: &str) -> Vec<StreamEvent> {
+        OpenCodeJsonParser::parse_line(self, line)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn factory_selects_all_agent_parsers() {
+        for provider in ["claude", "codex", "qwen", "opencode", "ollama", "minimax"] {
+            parser_for_provider(provider).expect("known provider");
+        }
+    }
+
+    #[test]
+    fn ollama_and_minimax_share_sse_parser_behavior() {
+        for kind in [AgentParserKind::Ollama, AgentParserKind::Minimax] {
+            let mut parser = parser_for_kind(kind);
+            let mut events = parser.parse_line(
+                r#"data: {"choices":[{"delta":{"content":"hi"},"finish_reason":null}]}"#,
+            );
+            events.extend(parser.parse_line(""));
+            assert!(matches!(
+                events.as_slice(),
+                [StreamEvent::AssistantMessage { text }] if text == "hi"
+            ));
+        }
+    }
+}

--- a/src/agent_provider/types_tests.rs
+++ b/src/agent_provider/types_tests.rs
@@ -66,7 +66,7 @@ async fn trait_supports_http_provider_without_subprocess_state() {
             CancellationToken::new(),
         )
         .await
-        .unwrap();
+        .expect("stub provider run should succeed");
 
     assert!(matches!(
         rx.recv().await,
@@ -88,7 +88,8 @@ fn factory_defaults_to_claude_provider() {
 
 #[test]
 fn factory_accepts_empty_config_as_legacy_claude() {
-    let factory = AgentProviderFactory::from_config(AgentProvidersConfig::default()).unwrap();
+    let factory = AgentProviderFactory::from_config(AgentProvidersConfig::default())
+        .expect("empty config should create legacy claude factory");
     assert_eq!(factory.default_provider().id(), "claude");
 }
 
@@ -106,7 +107,7 @@ fn factory_accepts_qwen_provider() {
             api_key_env: None,
         }],
     })
-    .unwrap();
+    .expect("qwen provider config should build factory");
 
     assert_eq!(factory.default_provider().id(), "qwen");
 }
@@ -125,7 +126,7 @@ fn factory_accepts_codex_provider() {
             api_key_env: None,
         }],
     })
-    .unwrap();
+    .expect("codex provider config should build factory");
 
     assert_eq!(factory.default_provider().id(), "codex");
 }
@@ -144,7 +145,7 @@ fn factory_accepts_opencode_provider() {
             api_key_env: None,
         }],
     })
-    .unwrap();
+    .expect("opencode provider config should build factory");
 
     assert_eq!(factory.default_provider().id(), "opencode");
     assert_eq!(
@@ -167,7 +168,7 @@ fn factory_accepts_ollama_provider() {
             api_key_env: None,
         }],
     })
-    .unwrap();
+    .expect("ollama provider config should build factory");
 
     assert_eq!(factory.default_provider().id(), "ollama");
     assert_eq!(factory.default_provider().kind(), AgentProviderKind::Http);
@@ -187,7 +188,7 @@ fn factory_accepts_minimax_provider() {
             api_key_env: Some("MINIMAX_API_KEY".to_string()),
         }],
     })
-    .unwrap();
+    .expect("minimax provider config should build factory");
 
     assert_eq!(factory.default_provider().id(), "minimax");
     assert_eq!(factory.default_provider().kind(), AgentProviderKind::Http);

--- a/src/session/types.rs
+++ b/src/session/types.rs
@@ -534,7 +534,7 @@ impl Session {
     }
 }
 
-/// Events emitted by the Claude CLI JSON stream that we care about.
+/// Provider-neutral events emitted by agent output parsers.
 #[derive(Debug, Clone)]
 pub enum StreamEvent {
     /// Assistant started producing a message


### PR DESCRIPTION
## Summary

- Adds an `AgentParserKind` factory that selects Claude, Codex, Qwen, OpenCode, Ollama, and MiniMax parsers behind one provider-neutral trait.
- Extends Codex and OpenCode parsing for production event mapping, including assistant text, tool use/results, token usage, completion, malformed JSON, unknown events, and errors.
- Covers the new parser paths with unit tests and OpenCode fixture-driven tests.
- Fixes the milestone updater edge case for standalone sequence tokens so this `/pushup` can stamp Level 2 correctly.
- Splits the OpenCode parser into its own module to keep file-size lint green.

Closes #552

## Test plan

- [x] cargo test --quiet
- [x] cargo clippy -- -D warnings -A dead_code
- [x] cargo fmt --check
- [x] scripts/check-file-size.sh
- [x] python3 scripts/update-milestone-graph.py --milestone 49 --issue 552 --dry-run
- [x] python3 -m py_compile scripts/update-milestone-graph.py scripts/tests/test_update_milestone_graph.py
- [ ] python3 -m pytest scripts/tests/test_update_milestone_graph.py (pytest is not installed in this environment)
- [x] manual verification: reviewed staged diff and confirmed only parser-adapter and milestone-updater files are included
