### PR TITLE
feat: validate configured agents in doctor

### DIFF
--- a/src/agent_provider/codex.rs
+++ b/src/agent_provider/codex.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::process::Stdio;
+use std::time::Duration;
 
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
@@ -185,11 +186,57 @@ impl AgentProvider for CodexProvider {
         match Command::new(&self.binary).arg("--version").output().await {
             Ok(out) if out.status.success() => {
                 let version = String::from_utf8_lossy(&out.stdout).trim().to_string();
+                let request = AgentRequest::stream_json(
+                    "Maestro doctor preflight. Respond with OK only.".to_string(),
+                    String::new(),
+                );
+                let mut preflight = Command::new(&self.binary);
+                preflight.args(self.build_stream_args(&request));
+                preflight.envs(&self.env);
+                preflight
+                    .stdin(Stdio::null())
+                    .stdout(Stdio::piped())
+                    .stderr(Stdio::piped())
+                    .kill_on_drop(true);
+
+                match tokio::time::timeout(Duration::from_secs(10), preflight.output()).await {
+                    Ok(Ok(preflight_out)) if preflight_out.status.success() => {}
+                    Ok(Ok(preflight_out)) => {
+                        let stderr = String::from_utf8_lossy(&preflight_out.stderr)
+                            .trim()
+                            .to_string();
+                        return Ok(AgentHealthCheck {
+                            provider_id: AgentProviderId::new(self.id()),
+                            available: false,
+                            version: Some(version),
+                            message: if stderr.is_empty() {
+                                "codex exec --json preflight failed".to_string()
+                            } else {
+                                stderr
+                            },
+                        });
+                    }
+                    Ok(Err(source)) => {
+                        return Err(AgentError::Spawn {
+                            provider_id: self.id().to_string(),
+                            source,
+                        });
+                    }
+                    Err(_) => {
+                        return Ok(AgentHealthCheck {
+                            provider_id: AgentProviderId::new(self.id()),
+                            available: false,
+                            version: Some(version),
+                            message: "codex exec --json preflight timed out after 10s".to_string(),
+                        });
+                    }
+                }
+
                 Ok(AgentHealthCheck {
                     provider_id: AgentProviderId::new(self.id()),
                     available: true,
                     version: Some(version.clone()),
-                    message: version,
+                    message: format!("{version}; exec --json preflight passed"),
                 })
             }
             Ok(out) => Ok(AgentHealthCheck {

--- a/src/agent_provider/codex/tests.rs
+++ b/src/agent_provider/codex/tests.rs
@@ -181,6 +181,31 @@ async fn run_returns_session_error_on_nonzero_exit() {
     assert!(err.to_string().contains("codex exited with status"));
 }
 
+#[tokio::test]
+async fn health_check_runs_version_and_json_preflight() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let codex = temp.path().join("codex");
+    std::fs::write(
+        &codex,
+        format!(
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'codex 1.2.3'; exit 0; fi\nprintf '%s\\n' \"$@\" > \"{}\"\nexit 0\n",
+            temp.path().join("health-argv.txt").display()
+        ),
+    )
+    .expect("write codex mock");
+    make_executable(&codex);
+
+    let provider = CodexProvider::new(codex.to_string_lossy().to_string());
+    let health = provider.health_check().await.expect("health check");
+
+    assert!(health.available);
+    assert_eq!(health.version.as_deref(), Some("codex 1.2.3"));
+    assert!(health.message.contains("exec --json preflight passed"));
+    let argv = std::fs::read_to_string(temp.path().join("health-argv.txt")).expect("argv");
+    assert!(argv.contains("exec\n"));
+    assert!(argv.contains("--json\n"));
+}
+
 fn codex_fixture_jsonl() -> &'static str {
     r#"{"type":"thread.started","thread_id":"t1"}
 {"type":"item.completed","item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Done."}]}}

--- a/src/agent_provider/codex/tests.rs
+++ b/src/agent_provider/codex/tests.rs
@@ -72,20 +72,38 @@ fn default_permission_mode_does_not_emit_yolo() {
 async fn run_streams_events_from_mock_codex_cli_and_records_process_context() {
     let temp = tempfile::tempdir().expect("tempdir");
     let worktree = tempfile::tempdir().expect("worktree");
-    let codex = temp.path().join("codex");
-    std::fs::write(
-        &codex,
-        format!(
-            "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"{}\"\npwd > \"{}\"\nprintf '%s\\n' 'codex stderr line' >&2\ncat <<'EOF'\n{}\nEOF\n",
-            temp.path().join("argv.txt").display(),
-            temp.path().join("cwd.txt").display(),
-            codex_fixture_jsonl()
-        ),
-    )
-    .expect("write codex mock");
+    let codex = mock_codex_path();
     make_executable(&codex);
+    let stdout = temp.path().join("stdout.jsonl");
+    std::fs::write(&stdout, codex_fixture_jsonl()).expect("write codex stdout fixture");
 
-    let provider = CodexProvider::new(codex.to_string_lossy().to_string());
+    let provider = CodexProvider::with_config(
+        codex.to_string_lossy().to_string(),
+        None,
+        None,
+        None,
+        BTreeMap::new(),
+        Vec::new(),
+        BTreeMap::from([
+            (
+                "MAESTRO_MOCK_CODEX_ARGV".to_string(),
+                temp.path().join("argv.txt").display().to_string(),
+            ),
+            (
+                "MAESTRO_MOCK_CODEX_CWD".to_string(),
+                temp.path().join("cwd.txt").display().to_string(),
+            ),
+            (
+                "MAESTRO_MOCK_CODEX_STDERR".to_string(),
+                "codex stderr line".to_string(),
+            ),
+            (
+                "MAESTRO_MOCK_CODEX_STDOUT_FILE".to_string(),
+                stdout.display().to_string(),
+            ),
+        ]),
+        None,
+    );
     let mut request = request();
     request.cwd = Some(worktree.path().to_path_buf());
     let (tx, mut rx) = mpsc::unbounded_channel();
@@ -156,16 +174,25 @@ async fn run_streams_events_from_mock_codex_cli_and_records_process_context() {
 
 #[tokio::test]
 async fn run_returns_session_error_on_nonzero_exit() {
-    let temp = tempfile::tempdir().expect("tempdir");
-    let codex = temp.path().join("codex");
-    std::fs::write(
-        &codex,
-        "#!/bin/sh\nprintf '%s\\n' 'auth failed' >&2\nexit 42\n",
-    )
-    .expect("write codex mock");
+    let codex = mock_codex_path();
     make_executable(&codex);
 
-    let provider = CodexProvider::new(codex.to_string_lossy().to_string());
+    let provider = CodexProvider::with_config(
+        codex.to_string_lossy().to_string(),
+        None,
+        None,
+        None,
+        BTreeMap::new(),
+        Vec::new(),
+        BTreeMap::from([
+            (
+                "MAESTRO_MOCK_CODEX_STDERR".to_string(),
+                "auth failed".to_string(),
+            ),
+            ("MAESTRO_MOCK_CODEX_EXIT".to_string(), "42".to_string()),
+        ]),
+        None,
+    );
     let (tx, _rx) = mpsc::unbounded_channel();
     let mut request = request();
     request.cwd = None;
@@ -184,18 +211,28 @@ async fn run_returns_session_error_on_nonzero_exit() {
 #[tokio::test]
 async fn health_check_runs_version_and_json_preflight() {
     let temp = tempfile::tempdir().expect("tempdir");
-    let codex = temp.path().join("codex");
-    std::fs::write(
-        &codex,
-        format!(
-            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'codex 1.2.3'; exit 0; fi\nprintf '%s\\n' \"$@\" > \"{}\"\nexit 0\n",
-            temp.path().join("health-argv.txt").display()
-        ),
-    )
-    .expect("write codex mock");
+    let codex = mock_codex_path();
     make_executable(&codex);
 
-    let provider = CodexProvider::new(codex.to_string_lossy().to_string());
+    let provider = CodexProvider::with_config(
+        codex.to_string_lossy().to_string(),
+        None,
+        None,
+        None,
+        BTreeMap::new(),
+        Vec::new(),
+        BTreeMap::from([
+            (
+                "MAESTRO_MOCK_CODEX_ARGV".to_string(),
+                temp.path().join("health-argv.txt").display().to_string(),
+            ),
+            (
+                "MAESTRO_MOCK_CODEX_VERSION".to_string(),
+                "codex 1.2.3".to_string(),
+            ),
+        ]),
+        None,
+    );
     let health = provider.health_check().await.expect("health check");
 
     assert!(health.available);
@@ -210,6 +247,10 @@ fn codex_fixture_jsonl() -> &'static str {
     r#"{"type":"thread.started","thread_id":"t1"}
 {"type":"item.completed","item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Done."}]}}
 {"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":2}}"#
+}
+
+fn mock_codex_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/mock-codex-cli.sh")
 }
 
 #[cfg(unix)]

--- a/src/agent_provider/minimax/mod.rs
+++ b/src/agent_provider/minimax/mod.rs
@@ -265,6 +265,52 @@ mod tests {
         assert!(!rendered.contains("secret-value"));
     }
 
+    #[tokio::test]
+    async fn health_check_passes_when_models_endpoint_is_reachable() {
+        let base_url = spawn_test_server(
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n\r\n{\"data\":[]}",
+        )
+        .await;
+        let provider = MinimaxProvider::new_with_api_key_lookup(
+            "minimax",
+            base_url,
+            "MiniMax-M2.7",
+            5,
+            Some("MINIMAX_API_KEY".to_string()),
+            |_| Some("test-key".to_string()),
+        )
+        .expect("provider");
+
+        let health = provider.health_check().await.expect("health check");
+
+        assert!(health.available);
+        assert!(health.message.contains("models endpoint reachable"));
+    }
+
+    #[tokio::test]
+    async fn health_check_maps_unauthorized_without_exposing_key_value() {
+        let base_url = spawn_test_server(
+            "HTTP/1.1 401 Unauthorized\r\ncontent-type: application/json\r\n\r\n\
+             {\"error\":\"invalid key\"}",
+        )
+        .await;
+        let provider = MinimaxProvider::new_with_api_key_lookup(
+            "minimax",
+            base_url,
+            "MiniMax-M2.7",
+            5,
+            Some("MINIMAX_API_KEY".to_string()),
+            |_| Some("secret-value".to_string()),
+        )
+        .expect("provider");
+
+        let err = provider.health_check().await.expect_err("401");
+        let rendered = err.to_string();
+
+        assert!(rendered.contains("invalid MINIMAX_API_KEY"));
+        assert!(!rendered.contains("secret-value"));
+    }
+
     async fn spawn_test_server(response: &'static str) -> String {
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
         let addr = listener.local_addr().expect("addr");

--- a/src/agent_provider/ollama/mod.rs
+++ b/src/agent_provider/ollama/mod.rs
@@ -198,6 +198,42 @@ mod tests {
         assert!(err.to_string().contains("run 'ollama pull missing-model'"));
     }
 
+    #[tokio::test]
+    async fn health_check_fetches_version_and_verifies_model_tag() {
+        let base_url = spawn_test_server_sequence(vec![
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n\r\n\
+             {\"version\":\"0.5.7\"}",
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n\r\n\
+             {\"models\":[{\"name\":\"llama3.2\"}]}",
+        ])
+        .await;
+        let provider =
+            OllamaProvider::new("ollama", base_url, "llama3.2", 5, None).expect("provider");
+
+        let health = provider.health_check().await.expect("health check");
+
+        assert!(health.available);
+        assert_eq!(health.version.as_deref(), Some("0.5.7"));
+        assert!(health.message.contains("model `llama3.2` available"));
+    }
+
+    #[tokio::test]
+    async fn health_check_reports_model_pull_hint_when_tag_is_missing() {
+        let base_url = spawn_test_server_sequence(vec![
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n\r\n\
+             {\"version\":\"0.5.7\"}",
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n\r\n\
+             {\"models\":[{\"name\":\"other\"}]}",
+        ])
+        .await;
+        let provider =
+            OllamaProvider::new("ollama", base_url, "missing-model", 5, None).expect("provider");
+
+        let err = provider.health_check().await.expect_err("missing model");
+
+        assert!(err.to_string().contains("ollama pull missing-model"));
+    }
+
     async fn spawn_test_server(response: &'static str) -> String {
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
         let addr = listener.local_addr().expect("addr");
@@ -206,6 +242,21 @@ mod tests {
                 let mut request = vec![0_u8; 2048];
                 let _ = socket.read(&mut request).await;
                 let _ = socket.write_all(response.as_bytes()).await;
+            }
+        });
+        format!("http://{addr}")
+    }
+
+    async fn spawn_test_server_sequence(responses: Vec<&'static str>) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        tokio::spawn(async move {
+            for response in responses {
+                if let Ok((mut socket, _)) = listener.accept().await {
+                    let mut request = vec![0_u8; 2048];
+                    let _ = socket.read(&mut request).await;
+                    let _ = socket.write_all(response.as_bytes()).await;
+                }
             }
         });
         format!("http://{addr}")

--- a/src/agent_provider/opencode.rs
+++ b/src/agent_provider/opencode.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::path::PathBuf;
 use std::process::Stdio;
 
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -26,6 +27,7 @@ pub struct OpenCodeProvider {
     binary: String,
     extra_args: Vec<String>,
     env: BTreeMap<String, String>,
+    auth_path: Option<PathBuf>,
 }
 
 impl OpenCodeProvider {
@@ -34,6 +36,7 @@ impl OpenCodeProvider {
             binary: binary.into(),
             extra_args: Vec::new(),
             env: BTreeMap::new(),
+            auth_path: None,
         }
     }
 
@@ -46,7 +49,14 @@ impl OpenCodeProvider {
             binary: binary.into(),
             extra_args,
             env,
+            auth_path: None,
         }
+    }
+
+    #[cfg(test)]
+    fn with_auth_path(mut self, auth_path: PathBuf) -> Self {
+        self.auth_path = Some(auth_path);
+        self
     }
 
     pub fn build_stream_args(&self, request: &AgentRequest) -> Vec<String> {
@@ -72,7 +82,7 @@ impl OpenCodeProvider {
         {
             Ok(out) if out.status.success() => {
                 let version = String::from_utf8_lossy(&out.stdout).trim().to_string();
-                let auth_path = opencode_auth_path();
+                let auth_path = self.auth_path();
                 if auth_path.exists() {
                     AgentHealthCheck {
                         provider_id: AgentProviderId::new(self.id()),
@@ -118,6 +128,10 @@ impl OpenCodeProvider {
         args.extend(self.extra_args.iter().cloned());
         args.push(opencode_prompt(request));
     }
+
+    fn auth_path(&self) -> PathBuf {
+        self.auth_path.clone().unwrap_or_else(opencode_auth_path)
+    }
 }
 
 impl Default for OpenCodeProvider {
@@ -147,7 +161,7 @@ impl AgentProvider for OpenCodeProvider {
         match Command::new(&self.binary).arg("--version").output().await {
             Ok(out) if out.status.success() => {
                 let version = String::from_utf8_lossy(&out.stdout).trim().to_string();
-                let auth_path = opencode_auth_path();
+                let auth_path = self.auth_path();
                 if auth_path.exists() {
                     Ok(AgentHealthCheck {
                         provider_id: AgentProviderId::new(self.id()),

--- a/src/agent_provider/opencode/tests.rs
+++ b/src/agent_provider/opencode/tests.rs
@@ -263,6 +263,56 @@ async fn missing_binary_surfaces_install_instructions() {
     );
 }
 
+#[tokio::test]
+async fn health_check_requires_auth_file_after_version_passes() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let opencode = temp.path().join("opencode");
+    std::fs::write(
+        &opencode,
+        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'opencode 0.9.0'; exit 0; fi\nexit 0\n",
+    )
+    .expect("write opencode mock");
+    make_executable(&opencode);
+
+    let provider = OpenCodeProvider::new(opencode.to_string_lossy().to_string())
+        .with_auth_path(temp.path().join("opencode/auth.json"));
+
+    let health = provider.health_check().await.expect("health check");
+
+    assert!(!health.available);
+    assert_eq!(health.version.as_deref(), Some("opencode 0.9.0"));
+    assert!(
+        health
+            .message
+            .contains("run `opencode /connect` to authenticate with a provider")
+    );
+}
+
+#[tokio::test]
+async fn health_check_passes_when_auth_file_exists() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let bin_dir = temp.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("bin dir");
+    let opencode = bin_dir.join("opencode");
+    let auth_path = temp.path().join("opencode/auth.json");
+    std::fs::create_dir_all(auth_path.parent().expect("auth parent")).expect("auth dir");
+    std::fs::write(&auth_path, "{}").expect("auth file");
+    std::fs::write(
+        &opencode,
+        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'opencode 0.9.0'; exit 0; fi\nexit 0\n",
+    )
+    .expect("write opencode mock");
+    make_executable(&opencode);
+
+    let provider =
+        OpenCodeProvider::new(opencode.to_string_lossy().to_string()).with_auth_path(auth_path);
+
+    let health = provider.health_check().await.expect("health check");
+
+    assert!(health.available);
+    assert_eq!(health.message, "opencode 0.9.0");
+}
+
 fn opencode_fixture_jsonl() -> &'static str {
     r#"{"type":"step_start","part":{"type":"step-start"}}
 {"type":"text","part":{"type":"text","text":"Done."}}

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -103,6 +103,11 @@ pub fn print_report(report: &DoctorReport) {
         println!("  {:<16} {} {}", check.name, status, check.message);
     }
 
+    if let Some((configured, healthy)) = agent_health_counts(report) {
+        println!();
+        println!("  Summary: {healthy}/{configured} agents healthy ({configured} configured)");
+    }
+
     println!();
     if report.has_failures() {
         println!("  \x1b[31mSome required checks failed. Maestro may not work correctly.\x1b[0m");
@@ -119,6 +124,23 @@ pub fn print_report(report: &DoctorReport) {
 /// Strip control characters from subprocess output for safe terminal display.
 fn sanitize(s: &str) -> String {
     s.chars().filter(|c| !c.is_control()).collect()
+}
+
+fn agent_health_counts(report: &DoctorReport) -> Option<(usize, usize)> {
+    let configured = report
+        .checks
+        .iter()
+        .filter(|check| check.name.starts_with("agent "))
+        .count();
+    if configured == 0 {
+        return None;
+    }
+    let healthy = report
+        .checks
+        .iter()
+        .filter(|check| check.name.starts_with("agent ") && check.passed)
+        .count();
+    Some((configured, healthy))
 }
 
 /// Validate preflight checks and return an error if required checks fail.
@@ -173,7 +195,11 @@ pub fn run_all_checks_for_agent(config: Option<&Config>, agent_id: Option<&str>)
         checks.push(check_provider_matches_remote(cfg.provider.kind));
     }
 
-    checks.push(check_agent_runtime_for_agent(config, agent_id));
+    if let (Some(cfg), None) = (config, agent_id) {
+        checks.extend(check_configured_agent_runtimes(cfg));
+    } else {
+        checks.push(check_agent_runtime_for_agent(config, agent_id));
+    }
 
     if provider_kind == ProviderKind::Github
         && checks.iter().any(|c| c.name == "gh auth" && c.passed)
@@ -488,43 +514,116 @@ fn check_agent_runtime_for_agent(config: Option<&Config>, agent_id: Option<&str>
     };
 
     match config.resolve_agent(agent_id) {
-        Ok(resolved) => match resolved.config.kind {
-            AgentKind::Claude => check_claude_cli(),
-            AgentKind::Codex => check_subprocess_agent(
-                "codex cli",
-                CodexProvider::new(resolved.config.command.as_deref().unwrap_or("codex"))
-                    .health_check_blocking(),
-            ),
-            AgentKind::Qwen => check_subprocess_agent(
-                "qwen cli",
-                QwenProvider::new(resolved.config.command.as_deref().unwrap_or("qwen"))
-                    .health_check_blocking(),
-            ),
-            AgentKind::Opencode => check_subprocess_agent(
-                "opencode cli",
-                OpenCodeProvider::new(resolved.config.command.as_deref().unwrap_or("opencode"))
-                    .health_check_blocking(),
-            ),
-            AgentKind::Ollama => check_ollama_agent(resolved),
-            AgentKind::Minimax => check_minimax_agent(resolved),
-        },
+        Ok(resolved) => check_resolved_agent_runtime(resolved, CheckSeverity::Required),
         Err(err) => CheckResult::fail("agent config", err.to_string(), CheckSeverity::Required),
     }
 }
 
-fn check_subprocess_agent(
-    name: impl Into<String>,
-    health: crate::agent_provider::AgentHealthCheck,
+fn check_configured_agent_runtimes(config: &Config) -> Vec<CheckResult> {
+    if config.agents.entries.is_empty() {
+        return vec![check_agent_runtime_for_agent(Some(config), None)];
+    }
+
+    config
+        .agents
+        .entries
+        .iter()
+        .filter(|(_, agent)| agent.enabled)
+        .map(|(id, _)| match config.resolve_agent(Some(id)) {
+            Ok(resolved) => {
+                let severity = if resolved.id == config.agents.default {
+                    CheckSeverity::Required
+                } else {
+                    CheckSeverity::Optional
+                };
+                check_resolved_agent_runtime(resolved, severity)
+            }
+            Err(err) => CheckResult::fail(
+                format!("agent {id}"),
+                err.to_string(),
+                if id == &config.agents.default {
+                    CheckSeverity::Required
+                } else {
+                    CheckSeverity::Optional
+                },
+            ),
+        })
+        .collect()
+}
+
+fn check_resolved_agent_runtime(
+    resolved: ResolvedAgentConfig,
+    severity: CheckSeverity,
 ) -> CheckResult {
-    let version = health.version.unwrap_or(health.message);
-    if health.available {
-        CheckResult::pass(name, sanitize(&version), CheckSeverity::Required)
-    } else {
-        CheckResult::fail(name, sanitize(&version), CheckSeverity::Required)
+    match resolved.config.kind {
+        AgentKind::Claude => check_agent_health(
+            format!("agent {}", resolved.id),
+            ClaudeProvider::new(resolved.config.command.as_deref().unwrap_or("claude"))
+                .health_check_blocking(),
+            severity,
+        ),
+        AgentKind::Codex => check_subprocess_agent(
+            &resolved.id,
+            CodexProvider::with_config(
+                resolved.config.command.as_deref().unwrap_or("codex"),
+                resolved.config.sandbox.clone(),
+                resolved.config.ephemeral,
+                resolved.config.profile.clone(),
+                resolved.config.config_overrides.clone(),
+                resolved.config.extra_args.clone(),
+                resolved.config.env.clone(),
+                resolved.config.json,
+            ),
+            severity,
+        ),
+        AgentKind::Qwen => check_subprocess_agent(
+            &resolved.id,
+            QwenProvider::with_config(
+                resolved.config.command.as_deref().unwrap_or("qwen"),
+                resolved.config.extra_args.clone(),
+                resolved.config.env.clone(),
+            ),
+            severity,
+        ),
+        AgentKind::Opencode => check_subprocess_agent(
+            &resolved.id,
+            OpenCodeProvider::with_config(
+                resolved.config.command.as_deref().unwrap_or("opencode"),
+                resolved.config.extra_args.clone(),
+                resolved.config.env.clone(),
+            ),
+            severity,
+        ),
+        AgentKind::Ollama => check_ollama_agent(resolved, severity),
+        AgentKind::Minimax => check_minimax_agent(resolved, severity),
     }
 }
 
-fn check_ollama_agent(resolved: ResolvedAgentConfig) -> CheckResult {
+fn check_subprocess_agent<P>(id: &str, provider: P, severity: CheckSeverity) -> CheckResult
+where
+    P: AgentProvider + Send + 'static,
+{
+    run_agent_health_check(format!("agent {id}"), provider, severity)
+}
+
+fn check_agent_health(
+    name: impl Into<String>,
+    health: crate::agent_provider::AgentHealthCheck,
+    severity: CheckSeverity,
+) -> CheckResult {
+    if health.available {
+        let message = if health.message.trim().is_empty() {
+            health.version.unwrap_or_else(|| "ready".to_string())
+        } else {
+            health.message
+        };
+        CheckResult::pass(name, sanitize(&message), severity)
+    } else {
+        CheckResult::fail(name, sanitize(&health.message), severity)
+    }
+}
+
+fn check_ollama_agent(resolved: ResolvedAgentConfig, severity: CheckSeverity) -> CheckResult {
     let model = match resolved
         .config
         .model
@@ -534,33 +633,34 @@ fn check_ollama_agent(resolved: ResolvedAgentConfig) -> CheckResult {
         Some(model) => model,
         None => {
             return CheckResult::fail(
-                "ollama",
+                format!("agent {}", resolved.id),
                 format!("agents.{}.model is required for ollama", resolved.id),
-                CheckSeverity::Required,
+                severity,
             );
         }
     };
 
+    let id = resolved.id.clone();
     let provider = match OllamaProvider::new(
-        resolved.id,
+        id.clone(),
         resolved
             .config
             .base_url
             .unwrap_or_else(|| "http://localhost:11434".to_string()),
         model,
-        resolved.config.request_timeout_secs.unwrap_or(120),
+        2,
         resolved.config.api_key_env,
     ) {
         Ok(provider) => provider,
         Err(err) => {
-            return CheckResult::fail("ollama", err.to_string(), CheckSeverity::Required);
+            return CheckResult::fail(format!("agent {}", resolved.id), err.to_string(), severity);
         }
     };
 
-    run_agent_health_check("ollama", provider)
+    run_agent_health_check(format!("agent {id}"), provider, severity)
 }
 
-fn check_minimax_agent(resolved: ResolvedAgentConfig) -> CheckResult {
+fn check_minimax_agent(resolved: ResolvedAgentConfig, severity: CheckSeverity) -> CheckResult {
     let model = resolved
         .config
         .model
@@ -568,14 +668,15 @@ fn check_minimax_agent(resolved: ResolvedAgentConfig) -> CheckResult {
         .filter(|model| !model.trim().is_empty())
         .unwrap_or_else(|| "MiniMax-M2.7".to_string());
 
+    let id = resolved.id.clone();
     let provider = match MinimaxProvider::new(
-        resolved.id,
+        id.clone(),
         resolved
             .config
             .base_url
             .unwrap_or_else(|| "https://api.minimax.io/v1".to_string()),
         model,
-        resolved.config.request_timeout_secs.unwrap_or(120),
+        2,
         resolved
             .config
             .api_key_env
@@ -583,17 +684,23 @@ fn check_minimax_agent(resolved: ResolvedAgentConfig) -> CheckResult {
     ) {
         Ok(provider) => provider,
         Err(err) => {
-            return CheckResult::fail("minimax", err.to_string(), CheckSeverity::Required);
+            return CheckResult::fail(format!("agent {}", resolved.id), err.to_string(), severity);
         }
     };
 
-    run_agent_health_check("minimax", provider)
+    run_agent_health_check(format!("agent {id}"), provider, severity)
 }
 
-fn run_agent_health_check<P>(name: &'static str, provider: P) -> CheckResult
+fn run_agent_health_check<P>(
+    name: impl Into<String>,
+    provider: P,
+    severity: CheckSeverity,
+) -> CheckResult
 where
     P: AgentProvider + Send + 'static,
 {
+    let name = name.into();
+    let panic_name = name.clone();
     std::thread::spawn(move || {
         let runtime = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -601,19 +708,17 @@ where
         {
             Ok(runtime) => runtime,
             Err(err) => {
-                return CheckResult::fail(name, err.to_string(), CheckSeverity::Required);
+                return CheckResult::fail(name, err.to_string(), severity);
             }
         };
 
         match runtime.block_on(provider.health_check()) {
-            Ok(health) => {
-                CheckResult::pass(name, sanitize(&health.message), CheckSeverity::Required)
-            }
-            Err(err) => CheckResult::fail(name, err.to_string(), CheckSeverity::Required),
+            Ok(health) => check_agent_health(name, health, severity),
+            Err(err) => CheckResult::fail(name, err.to_string(), severity),
         }
     })
     .join()
-    .unwrap_or_else(|_| CheckResult::fail(name, "health check panicked", CheckSeverity::Required))
+    .unwrap_or_else(|_| CheckResult::fail(panic_name, "health check panicked", severity))
 }
 
 fn check_az_cli(severity: CheckSeverity) -> CheckResult {
@@ -959,6 +1064,132 @@ mod tests {
     fn validate_preflight_returns_ok_on_empty_report() {
         let report = DoctorReport { checks: vec![] };
         assert!(validate_preflight(&report).is_ok());
+    }
+
+    #[test]
+    fn agent_health_counts_reports_configured_and_healthy_agents() {
+        let report = DoctorReport {
+            checks: vec![
+                CheckResult::pass("git", "ok", CheckSeverity::Required),
+                CheckResult::pass("agent claude", "ready", CheckSeverity::Required),
+                CheckResult::fail("agent qwen", "not installed", CheckSeverity::Optional),
+            ],
+        };
+
+        assert_eq!(agent_health_counts(&report), Some((2, 1)));
+    }
+
+    #[test]
+    fn optional_agent_failure_does_not_fail_report() {
+        let report = DoctorReport {
+            checks: vec![
+                CheckResult::pass("agent claude", "ready", CheckSeverity::Required),
+                CheckResult::fail("agent qwen", "not installed", CheckSeverity::Optional),
+            ],
+        };
+
+        assert!(!report.has_failures());
+        assert!(report.has_warnings());
+    }
+
+    #[test]
+    fn default_agent_failure_fails_report() {
+        let report = DoctorReport {
+            checks: vec![
+                CheckResult::fail("agent claude", "not installed", CheckSeverity::Required),
+                CheckResult::pass("agent qwen", "ready", CheckSeverity::Optional),
+            ],
+        };
+
+        assert!(report.has_failures());
+    }
+
+    #[test]
+    fn failed_agent_health_preserves_actionable_message_when_version_exists() {
+        let result = check_agent_health(
+            "agent opencode",
+            crate::agent_provider::AgentHealthCheck {
+                provider_id: crate::agent_provider::AgentProviderId::new("opencode"),
+                available: false,
+                version: Some("opencode 1.0.0".to_string()),
+                message: "run `opencode /connect` to authenticate with a provider".to_string(),
+            },
+            CheckSeverity::Optional,
+        );
+
+        assert!(!result.passed);
+        assert!(result.message.contains("opencode /connect"));
+        assert!(!result.message.contains("1.0.0"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn configured_agent_runtime_checks_iterate_enabled_agents_only() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let claude = fake_binary(temp.path(), "fake-claude", "claude 1.0.0");
+        let qwen = fake_binary(temp.path(), "fake-qwen", "qwen 0.9.0");
+        let config_path = temp.path().join("maestro.toml");
+        std::fs::write(
+            &config_path,
+            format!(
+                r#"[project]
+repo = "owner/repo"
+[sessions]
+default_model = "sonnet"
+permission_mode = "acceptEdits"
+[budget]
+[provider]
+kind = "github"
+[notifications]
+[agents]
+default = "claude"
+[agents.claude]
+kind = "claude"
+command = "{}"
+[agents.qwen]
+kind = "qwen"
+command = "{}"
+[agents.opencode]
+kind = "opencode"
+enabled = false
+command = "missing-opencode"
+"#,
+                claude.display(),
+                qwen.display()
+            ),
+        )
+        .expect("write config");
+        let config = Config::load(&config_path).expect("load config");
+
+        let checks = check_configured_agent_runtimes(&config);
+
+        assert_eq!(checks.len(), 2);
+        assert!(checks.iter().any(|check| check.name == "agent claude"
+            && check.passed
+            && check.severity == CheckSeverity::Required));
+        assert!(checks.iter().any(|check| check.name == "agent qwen"
+            && check.passed
+            && check.severity == CheckSeverity::Optional));
+        assert!(!checks.iter().any(|check| check.name == "agent opencode"));
+    }
+
+    #[cfg(unix)]
+    fn fake_binary(dir: &std::path::Path, name: &str, version: &str) -> std::path::PathBuf {
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = dir.join(name);
+        let mut file = std::fs::File::create(&path).expect("create fake binary");
+        writeln!(file, "#!/bin/sh").expect("write shebang");
+        writeln!(file, "if [ \"$1\" = \"--version\" ]; then").expect("write branch");
+        writeln!(file, "  echo '{version}'").expect("write version");
+        writeln!(file, "  exit 0").expect("write exit");
+        writeln!(file, "fi").expect("write fi");
+        writeln!(file, "exit 0").expect("write default");
+        let mut perms = std::fs::metadata(&path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms).expect("chmod");
+        path
     }
 
     #[test]

--- a/tests/fixtures/mock-codex-cli.sh
+++ b/tests/fixtures/mock-codex-cli.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "${MAESTRO_MOCK_CODEX_VERSION:-codex 1.2.3}"
+  exit 0
+fi
+
+if [ -n "$MAESTRO_MOCK_CODEX_ARGV" ]; then
+  printf '%s\n' "$@" > "$MAESTRO_MOCK_CODEX_ARGV"
+fi
+
+if [ -n "$MAESTRO_MOCK_CODEX_CWD" ]; then
+  pwd > "$MAESTRO_MOCK_CODEX_CWD"
+fi
+
+if [ -n "$MAESTRO_MOCK_CODEX_STDERR" ]; then
+  printf '%s\n' "$MAESTRO_MOCK_CODEX_STDERR" >&2
+fi
+
+if [ -n "$MAESTRO_MOCK_CODEX_STDOUT_FILE" ]; then
+  cat "$MAESTRO_MOCK_CODEX_STDOUT_FILE"
+fi
+
+if [ -n "$MAESTRO_MOCK_CODEX_EXIT" ]; then
+  exit "$MAESTRO_MOCK_CODEX_EXIT"
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- Validate every enabled configured agent in `maestro doctor`, with default-agent failures required and non-default failures reported as warnings.
- Add Codex JSON preflight plus provider health coverage for OpenCode auth, Ollama tags, and MiniMax models/API-key handling.
- Print an agent health summary in doctor output.

Closes #550

## Test plan

- [x] cargo test
- [x] cargo fmt
- [x] cargo clippy -- -D warnings -A dead_code
