### PR TITLE
docs: document multi-agent setup and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Most deep guides live in the [project Wiki](https://github.com/CarlosDanielDev/m
 → [Wiki › Multi-Provider (GitHub & Azure)](https://github.com/CarlosDanielDev/maestro/wiki/Feature-Multi-Provider-GitHub-Azure) · [PR Review Automation](https://github.com/CarlosDanielDev/maestro/wiki/Feature-PR-Review-Automation) · [Issue and Milestone Wizards](https://github.com/CarlosDanielDev/maestro/wiki/Feature-Issue-and-Milestone-Wizards)
 
 ### Quality & autonomy
-- `maestro doctor` preflight checks — verifies `claude`, `gh`/`az`, `git` are installed and authenticated before spending API credits
+- `maestro doctor` preflight checks — verifies enabled agent providers, `gh`/`az`, and `git` before spending API credits
 - Configurable completion gates (fmt / clippy / test or any custom command) run after every session; failures of required gates block PR creation
 - Language-aware session prompt guardrails (Rust / TS / Python / Go) auto-injected, overridable via `guardrail_prompt`
 - Continuous mode (`--continuous` / `-C`) auto-advances through ready issues with a pause overlay on failure
@@ -65,10 +65,18 @@ Most deep guides live in the [project Wiki](https://github.com/CarlosDanielDev/m
 
 → [Wiki › TurboQuant Compression](https://github.com/CarlosDanielDev/maestro/wiki/Feature-TurboQuant-Compression) · [Cost and Token Dashboards](https://github.com/CarlosDanielDev/maestro/wiki/Feature-Cost-and-Token-Dashboards) · [Self-Upgrade](https://github.com/CarlosDanielDev/maestro/wiki/Feature-Self-Upgrade) · [Notifications](https://github.com/CarlosDanielDev/maestro/wiki/Feature-Notifications-Desktop-and-Slack)
 
+### Agent providers
+- Multi-agent runtime — Claude, Codex, Qwen, OpenCode, Ollama, and MiniMax can be configured side by side in `[agents]`
+- Subprocess providers — Claude, Codex, Qwen, and OpenCode run local CLIs
+- HTTP providers — Ollama and MiniMax stream through HTTP APIs
+- Claude remains the default when `[agents]` is omitted
+
+→ [Docs › Agent Providers](docs/agents/mod.md) · [Configuration Reference](docs/configuration.md) · [Example multi-agent config](examples/multi-agent/maestro.toml)
+
 ## Requirements
 
 - **Rust 1.89+** (edition 2024)
-- **Claude Code CLI** (`claude`) installed and on your `PATH`
+- **At least one agent provider**: Claude Code CLI (`claude`) by default, or another configured provider from `[agents]`
 - **GitHub CLI** (`gh`) — required when using the GitHub provider (default)
 - **Azure CLI** (`az`) — required when using the Azure DevOps provider; run `az login` to authenticate
 - macOS, Linux, or WSL
@@ -158,31 +166,75 @@ merge_method = "squash"
 cache_ttl_secs = 300
 ```
 
-To run sessions with Qwen Code instead of Claude Code, add a Qwen agent and
-select it with `--agent qwen`:
+### Multi-agent setup
+
+Claude is still the default when `[agents]` is absent. To add explicit agent
+providers, define `[agents]` and one table per provider. Use `--agent <id>` for
+one run or change `[agents].default` for the project.
 
 ```toml
 [agents]
-default = "qwen"
+default = "claude"
+
+[agents.claude]
+kind = "claude"
+enabled = true
+command = "claude"
+model = "opus"
+
+[agents.codex]
+kind = "codex"
+enabled = false
+command = "codex"
+model = "gpt-5.4-codex"
+sandbox = "workspace-write"
+json = true
 
 [agents.qwen]
 kind = "qwen"
+enabled = false
 command = "qwen"
 model = "qwen-test"
 extra_args = ["--auth-type", "openai"]
 
-[agents.qwen.env]
-OPENAI_BASE_URL = "https://api.example.com/v1"
+[agents.opencode]
+kind = "opencode"
+enabled = false
+command = "opencode"
+model = "openrouter/deepseek/deepseek-chat"
+
+[agents.ollama]
+kind = "ollama"
+enabled = false
+model = "qwen3"
+base_url = "http://localhost:11434"
+request_timeout_secs = 120
+
+[agents.minimax]
+kind = "minimax"
+enabled = false
+model = "MiniMax-M2.7"
+base_url = "https://api.minimax.io/v1"
+request_timeout_secs = 120
+api_key_env = "MINIMAX_API_KEY"
 ```
 
-Maestro invokes Qwen in non-interactive JSONL mode with
-`qwen --bare --output-format stream-json --include-partial-messages`.
-Set `OPENAI_API_KEY` in your shell, `.env`, or Qwen settings rather than in
-argv; direct CLI key flags may be visible in process listings.
+Subprocess providers (`claude`, `codex`, `qwen`, `opencode`) require a local
+CLI `command`. HTTP providers (`ollama`, `minimax`) require `base_url` and use
+`request_timeout_secs` for API calls.
+
+```bash
+maestro run --prompt "Refactor the auth module to async" --agent codex
+maestro run --issue 42 --agent ollama
+maestro doctor
+```
+
+See [Docs › Agent Providers](docs/agents/mod.md) for setup guides, migration
+notes, and troubleshooting for all supported providers.
 
 Azure DevOps init writes `kind = "azure_devops"`, `organization`, `az_project`, and `[experimental] azure_devops = true`.
 
-The full schema — completion gates, context-overflow tuning, TurboQuant, provider/Azure DevOps configuration, notifications, and feature flags — is documented in [Wiki › Configuration Reference](https://github.com/CarlosDanielDev/maestro/wiki/Configuration-Reference).
+The full schema — agent providers, completion gates, context-overflow tuning, TurboQuant, provider/Azure DevOps configuration, notifications, and feature flags — is documented in [Docs › Configuration Reference](docs/configuration.md) and [Wiki › Configuration Reference](https://github.com/CarlosDanielDev/maestro/wiki/Configuration-Reference).
 
 ## Architecture
 

--- a/docs/agents/claude.md
+++ b/docs/agents/claude.md
@@ -1,0 +1,63 @@
+# Claude Agent
+
+Claude is Maestro's default subprocess provider. If your `maestro.toml` omits
+`[agents]`, Maestro still runs Claude by using `[sessions].default_model`,
+`[sessions].permission_mode`, and `[sessions].allowed_tools`.
+
+## Install
+
+Install and authenticate the Claude CLI, then verify it is on `PATH`:
+
+```bash
+claude --version
+```
+
+Run:
+
+```bash
+maestro doctor
+```
+
+A healthy Claude check looks like:
+
+```text
+agent claude     OK      <claude version>
+```
+
+## Configuration
+
+Minimal explicit Claude agent:
+
+```toml
+[agents]
+default = "claude"
+
+[agents.claude]
+kind = "claude"
+enabled = true
+command = "claude"
+model = "opus"
+permission_mode = "bypassPermissions"
+allowed_tools = []
+```
+
+`model` can also be inherited from `[sessions].default_model` when omitted.
+`permission_mode` is passed to Claude as `--permission-mode` unless it is
+`default`; `allowed_tools` is passed as `--allowedTools` when non-empty.
+
+## Usage
+
+```bash
+maestro run --prompt "Refactor the parser" --agent claude
+maestro run --issue 42 --agent claude
+```
+
+## Troubleshooting
+
+- `not installed`: install the Claude CLI or set `command` to the full binary
+  path.
+- Authentication failures: run the Claude CLI directly and complete its login
+  flow.
+- Permission prompts block automation: choose the project-appropriate
+  `permission_mode`, such as `bypassPermissions`, or restrict tools with
+  `allowed_tools`.

--- a/docs/agents/codex.md
+++ b/docs/agents/codex.md
@@ -1,0 +1,78 @@
+# Codex Agent
+
+Codex is a subprocess provider. Maestro launches `codex exec`, requests JSON
+streaming by default, and parses the stream into normal Maestro session events.
+
+## Install And Authenticate
+
+Install the Codex CLI, sign in using the CLI's supported authentication flow,
+and verify it is on `PATH`:
+
+```bash
+codex --version
+codex exec --json "Respond with OK only."
+```
+
+Then run:
+
+```bash
+maestro doctor
+```
+
+A healthy Codex check looks like:
+
+```text
+agent codex      OK      <codex version>
+```
+
+## Configuration
+
+```toml
+[agents]
+default = "codex"
+
+[agents.codex]
+kind = "codex"
+enabled = true
+command = "codex"
+model = "gpt-5.4-codex"
+permission_mode = "yolo"
+sandbox = "workspace-write"
+json = true
+ephemeral = false
+profile = "work"
+extra_args = ["--reasoning-effort", "high"]
+
+[agents.codex.config_overrides]
+approval_policy = "never"
+
+[agents.codex.env]
+OPENAI_API_KEY = "set-this-in-your-shell-instead"
+```
+
+Prefer setting secrets in your shell or secret manager instead of writing them
+into `maestro.toml`.
+
+## Field Behavior
+
+- `sandbox` defaults to `workspace-write` and is passed as `--sandbox`.
+- `json` defaults to `true` and enables `--json`.
+- `ephemeral = true` adds `--ephemeral`.
+- `profile` adds `--profile <name>`.
+- `config_overrides` entries become repeated `--config key=value` flags.
+- `permission_mode = "yolo"` adds `--yolo`.
+- `extra_args` are appended before the prompt.
+
+## Usage
+
+```bash
+maestro run --prompt "Add tests for the retry policy" --agent codex
+```
+
+## Troubleshooting
+
+- `codex exec --json preflight failed`: run the printed command directly to
+  complete login, fix model access, or adjust sandbox settings.
+- Model errors: verify the configured `model` is available to your account.
+- Sandbox errors: try `sandbox = "workspace-write"` first, then tighten the
+  sandbox once the command is working.

--- a/docs/agents/minimax.md
+++ b/docs/agents/minimax.md
@@ -1,0 +1,79 @@
+# MiniMax Agent
+
+MiniMax is an HTTP provider. Maestro uses an OpenAI-compatible chat stream,
+reads the API key from an environment variable, and defaults to `MiniMax-M2.7`.
+
+## API Key
+
+Create an API key in the MiniMax developer platform, then export it before
+launching Maestro:
+
+```bash
+export MINIMAX_API_KEY="..."
+```
+
+Use a different environment variable name only if you also set `api_key_env`.
+
+## Configuration
+
+```toml
+[agents]
+default = "minimax"
+
+[agents.minimax]
+kind = "minimax"
+enabled = true
+model = "MiniMax-M2.7"
+base_url = "https://api.minimax.io/v1"
+request_timeout_secs = 120
+api_key_env = "MINIMAX_API_KEY"
+```
+
+Defaults:
+
+- `model = "MiniMax-M2.7"`
+- `base_url = "https://api.minimax.io/v1"`
+- `request_timeout_secs = 120`
+- `api_key_env = "MINIMAX_API_KEY"`
+
+## Model Choice
+
+| Model | Use When |
+| --- | --- |
+| `MiniMax-M2.7` | Default long-context coding and agent work |
+| `MiniMax-M2.7-highspeed` | Lower latency is more important than default routing |
+| `MiniMax-M2.5` | Your account or workload is pinned to the older M2.5 family |
+| `MiniMax-M2.1` | Compatibility with older MiniMax deployments matters |
+
+Only configure models that your MiniMax account and endpoint support.
+
+## Doctor Output
+
+Healthy:
+
+```text
+agent minimax    OK      MiniMax models endpoint reachable; model `MiniMax-M2.7` configured
+```
+
+Missing or invalid key:
+
+```text
+agent minimax    FAIL    invalid MINIMAX_API_KEY - check your key at platform.minimax.io
+```
+
+## Usage
+
+```bash
+maestro run --prompt "Implement a focused bug fix" --agent minimax
+```
+
+## Troubleshooting
+
+- **Missing key**: export the variable named by `api_key_env` in the same shell
+  that starts Maestro.
+- **401 unauthorized**: create a new key, confirm the account has API access,
+  and verify there are no extra quotes or spaces in the environment variable.
+- **Model rejected**: switch back to `MiniMax-M2.7` and confirm other model ids
+  in MiniMax's platform docs before changing the config.
+- **Rate limits**: reduce `sessions.max_concurrent`, wait for the quota window,
+  or use Ollama/OpenCode for lower-priority work.

--- a/docs/agents/mod.md
+++ b/docs/agents/mod.md
@@ -1,0 +1,130 @@
+# Agent Providers
+
+Maestro can run sessions through multiple agent providers. Claude remains the
+default when `maestro.toml` has no `[agents]` table, so existing projects do not
+need to migrate unless they want to use another runtime.
+
+Use `maestro run --agent <id>` to select a configured agent for one run, or set
+`[agents].default` to change the project default.
+
+```toml
+[agents]
+default = "claude"
+
+[agents.claude]
+kind = "claude"
+enabled = true
+command = "claude"
+model = "opus"
+```
+
+## Provider Types
+
+Maestro treats all providers through the same session lifecycle, but the
+transport differs:
+
+- **Subprocess providers** launch a local CLI and parse its streaming output.
+  Claude, Codex, Qwen, and OpenCode are subprocess providers. They require a
+  `command` and must not set `base_url`.
+- **HTTP providers** call an OpenAI-compatible HTTP API directly. Ollama and
+  MiniMax are HTTP providers. They require `base_url` and must not set
+  `command`.
+
+## Comparison
+
+| Agent | Transport | Cost | Requires | Notes |
+| --- | --- | --- | --- | --- |
+| Claude | Subprocess | Paid | Claude CLI | Default |
+| Codex | Subprocess | Paid | Codex CLI | OpenAI |
+| Qwen | Subprocess | Paid | Qwen CLI | Alibaba |
+| OpenCode | Subprocess | Varies | opencode CLI + auth | 75+ AI backends |
+| Ollama | HTTP | Free/local | `ollama serve` + model | Runs locally |
+| MiniMax | HTTP | Paid/cloud | `MINIMAX_API_KEY` | 204k context window |
+
+## Guides
+
+- [Claude](claude.md)
+- [Codex](codex.md)
+- [Qwen](qwen.md)
+- [OpenCode](opencode.md)
+- [Ollama](ollama.md)
+- [MiniMax](minimax.md)
+- [Configuration Reference](../configuration.md)
+
+## Migration
+
+If `[agents]` is absent, Maestro builds an implicit Claude agent from
+`[sessions]`:
+
+```toml
+[sessions]
+default_model = "opus"
+permission_mode = "bypassPermissions"
+allowed_tools = []
+```
+
+That implicit agent behaves like:
+
+```toml
+[agents]
+default = "claude"
+
+[agents.claude]
+kind = "claude"
+enabled = true
+command = "claude"
+model = "opus"
+permission_mode = "bypassPermissions"
+allowed_tools = []
+```
+
+Add an explicit `[agents]` table only when you want multiple providers, a
+non-Claude default, or provider-specific settings.
+
+## FAQ
+
+**Can I mix providers in one project?**
+
+Yes. Keep the project default stable, then use `maestro run --agent <id>` for
+specific runs. `maestro doctor` checks every enabled agent; the default agent is
+required and other enabled agents are optional.
+
+**Why does an enabled non-default agent show a doctor warning?**
+
+Non-default enabled agents are optional so they do not block the whole project.
+Disable agents you are not actively using with `enabled = false`.
+
+**Which OpenCode model should I pick?**
+
+Use OpenCode's `provider/model` format. `openrouter/deepseek/deepseek-chat` is
+a common low-cost cloud option, while `groq/llama-3.1-8b-instant` is useful for
+fast, cheap tasks. Availability and pricing depend on the provider account
+configured in OpenCode.
+
+**Why is Ollama slow?**
+
+Local speed depends on model size, RAM, CPU, and GPU acceleration. Start with a
+small model, confirm `ollama serve` is running, and increase
+`request_timeout_secs` for large models.
+
+**Can Ollama run on another machine?**
+
+Yes. Set `base_url` to the remote Ollama server, for example
+`http://devbox.local:11434`. Keep the network private or protect it with your
+own access controls.
+
+**How do I fix MiniMax 401 errors?**
+
+Confirm the environment variable named by `api_key_env` is set in the shell that
+launches Maestro. The default is `MINIMAX_API_KEY`.
+
+**Which MiniMax model should I choose?**
+
+`MiniMax-M2.7` is the default for long-context coding work. Use high-speed
+variants only if your MiniMax account and endpoint support them.
+
+**What happens on rate limits?**
+
+Maestro surfaces the provider error. Reduce concurrency, choose a cheaper or
+local provider for background work, or wait for the provider quota window to
+reset.

--- a/docs/agents/ollama.md
+++ b/docs/agents/ollama.md
@@ -1,0 +1,83 @@
+# Ollama Agent
+
+Ollama is an HTTP provider. Maestro calls Ollama's local OpenAI-compatible API
+and streams responses into normal Maestro session events.
+
+## Install And Start
+
+```bash
+brew install ollama
+ollama serve
+```
+
+In another terminal, pull and verify a model:
+
+```bash
+ollama pull qwen3
+ollama ls
+```
+
+## Configuration
+
+```toml
+[agents]
+default = "ollama"
+
+[agents.ollama]
+kind = "ollama"
+enabled = true
+model = "qwen3"
+base_url = "http://localhost:11434"
+request_timeout_secs = 120
+```
+
+`base_url` defaults to `http://localhost:11434` and
+`request_timeout_secs` defaults to `120`. Increase the timeout for large local
+models, slow CPUs, or remote Ollama hosts.
+
+Remote Ollama example:
+
+```toml
+[agents.ollama-remote]
+kind = "ollama"
+enabled = true
+model = "llama3.2"
+base_url = "http://devbox.local:11434"
+request_timeout_secs = 240
+```
+
+## Doctor Output
+
+Healthy:
+
+```text
+agent ollama     OK      Ollama <version>; model `qwen3` available
+```
+
+Model missing:
+
+```text
+agent ollama     FAIL    model `qwen3` is not available; run 'ollama pull qwen3'
+```
+
+Server not running:
+
+```text
+agent ollama     FAIL    <connection error>
+```
+
+## Usage
+
+```bash
+maestro run --prompt "Summarize the module boundaries" --agent ollama
+```
+
+## Troubleshooting
+
+- **Connection refused**: start `ollama serve` or fix `base_url`.
+- **Model not pulled**: run `ollama pull <model>` and confirm it appears in
+  `ollama ls`.
+- **Slow responses**: use a smaller model, enable GPU acceleration if available,
+  or raise `request_timeout_secs`.
+- **Remote host fails**: confirm the remote Ollama server is reachable from the
+  machine running Maestro.

--- a/docs/agents/opencode.md
+++ b/docs/agents/opencode.md
@@ -1,0 +1,116 @@
+# OpenCode Agent
+
+OpenCode is a subprocess provider. Maestro runs `opencode run --format json`,
+uses OpenCode's provider configuration, and expects model names in
+`provider/model` format.
+
+OpenCode can route to many cloud and local AI backends through its provider
+system, so cost and model availability depend on the OpenCode account and
+provider credentials you configure.
+
+## Install
+
+Use one of OpenCode's supported install methods:
+
+```bash
+brew install anomalyco/tap/opencode
+npm install -g opencode-ai
+curl -fsSL https://opencode.ai/install | bash
+```
+
+Verify:
+
+```bash
+opencode --version
+```
+
+## Authenticate
+
+Open OpenCode and run:
+
+```text
+/connect
+```
+
+Add credentials for the provider you want to use. Maestro's health check looks
+for OpenCode credentials at:
+
+```text
+~/.local/share/opencode/auth.json
+```
+
+If `XDG_DATA_HOME` is set, Maestro checks:
+
+```text
+$XDG_DATA_HOME/opencode/auth.json
+```
+
+## Configuration
+
+```toml
+[agents]
+default = "opencode"
+
+[agents.opencode]
+kind = "opencode"
+enabled = true
+command = "opencode"
+model = "openrouter/deepseek/deepseek-chat"
+extra_args = []
+```
+
+Low-cost examples:
+
+```toml
+[agents.opencode-openrouter]
+kind = "opencode"
+enabled = true
+command = "opencode"
+model = "openrouter/deepseek/deepseek-chat"
+
+[agents.opencode-groq]
+kind = "opencode"
+enabled = true
+command = "opencode"
+model = "groq/llama-3.1-8b-instant"
+```
+
+The exact model ids must exist in your OpenCode provider setup. Use
+`provider/model`, not only the bare model name.
+
+## Doctor Output
+
+Healthy:
+
+```text
+agent opencode   OK      <opencode version>
+```
+
+Auth missing:
+
+```text
+agent opencode   FAIL    opencode auth not found; run `opencode /connect` to authenticate with a provider
+```
+
+CLI missing:
+
+```text
+agent opencode   FAIL    opencode CLI not found; install with ...
+```
+
+## Usage
+
+```bash
+maestro run --prompt "Implement the issue parser" --agent opencode
+```
+
+## Troubleshooting
+
+- **Auth not configured**: run `opencode`, enter `/connect`, and add a provider
+  credential.
+- **Model not found**: check the provider/model id in OpenCode and confirm the
+  provider account has access.
+- **Wrong provider cost**: OpenCode delegates billing to the selected backend.
+  Check pricing with the backend provider before using it as the default.
+- **No JSON events**: update OpenCode and confirm `opencode run --format json`
+  works outside Maestro.

--- a/docs/agents/qwen.md
+++ b/docs/agents/qwen.md
@@ -1,0 +1,72 @@
+# Qwen Agent
+
+Qwen is a subprocess provider. Maestro runs Qwen in non-interactive streaming
+mode:
+
+```text
+qwen --bare --output-format stream-json --include-partial-messages ...
+```
+
+## Install And Authenticate
+
+Install the Qwen CLI and configure the provider credentials it should use. Then
+verify:
+
+```bash
+qwen --version
+```
+
+Run:
+
+```bash
+maestro doctor
+```
+
+A healthy Qwen check looks like:
+
+```text
+agent qwen       OK      <qwen version>
+```
+
+## Configuration
+
+```toml
+[agents]
+default = "qwen"
+
+[agents.qwen]
+kind = "qwen"
+enabled = true
+command = "qwen"
+model = "qwen-test"
+permission_mode = "bypassPermissions"
+extra_args = ["--auth-type", "openai"]
+
+[agents.qwen.env]
+OPENAI_BASE_URL = "https://api.example.com/v1"
+```
+
+Set API keys in your shell, `.env`, or Qwen's own settings rather than passing
+them through `extra_args`; command-line arguments may be visible in process
+listings.
+
+## Field Behavior
+
+- `model` is passed as `--model`.
+- `permission_mode` maps to Qwen's approval mode when supported by Maestro.
+- `extra_args` are appended before `--prompt`.
+- `env` values are added to the Qwen subprocess environment.
+
+## Usage
+
+```bash
+maestro run --prompt "Review the config loader" --agent qwen
+```
+
+## Troubleshooting
+
+- `not installed`: install Qwen or set `command` to the full binary path.
+- Authentication errors: run Qwen directly with the same `extra_args` and
+  environment.
+- Empty or malformed output: confirm your Qwen version supports
+  `--output-format stream-json`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,140 @@
+# Configuration Reference
+
+Maestro reads `maestro.toml` from the project root. This page documents the
+multi-agent configuration added for Claude, Codex, Qwen, OpenCode, Ollama, and
+MiniMax. For a complete working example, see
+`examples/multi-agent/maestro.toml`.
+
+## Agents Table
+
+```toml
+[agents]
+default = "claude"
+```
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `default` | string | `"claude"` | Agent id used when `maestro run --agent` is omitted. |
+
+If `[agents]` is absent, Maestro uses an implicit Claude agent built from
+`[sessions]`. If `[agents]` is present, `default` must reference an enabled
+entry.
+
+## Agent Entry
+
+Each `[agents.<id>]` table has these fields:
+
+| Field | Applies To | Type | Default | Description |
+| --- | --- | --- | --- | --- |
+| `kind` | all | string | required | One of `claude`, `codex`, `qwen`, `opencode`, `ollama`, `minimax`. |
+| `enabled` | all | bool | `true` | Disabled agents are ignored and cannot be selected. |
+| `command` | subprocess | string | provider binary for Codex/Qwen/OpenCode; required for Claude | CLI command or full path. Invalid for HTTP agents. |
+| `base_url` | HTTP | string | Ollama: `http://localhost:11434`; MiniMax: `https://api.minimax.io/v1` | HTTP endpoint. Invalid for subprocess agents. |
+| `model` | all | string | Claude inherits `[sessions].default_model`; MiniMax defaults to `MiniMax-M2.7`; Ollama requires one | Provider model id. |
+| `env` | subprocess | table | `{}` | Environment variables added to the subprocess. |
+| `extra_args` | subprocess | array of strings | `[]` | Extra CLI arguments appended before the prompt. |
+| `permission_mode` | Claude, Codex, Qwen | string | inherits `[sessions].permission_mode` for these kinds when absent | Permission or approval mode mapping. |
+| `allowed_tools` | Claude | array of strings | inherits `[sessions].allowed_tools` when absent | Passed to Claude as `--allowedTools` when non-empty. |
+| `sandbox` | Codex | string | `workspace-write` | Passed to Codex as `--sandbox`. |
+| `json` | Codex | bool | `true` | Adds `--json` for streamed runs. |
+| `ephemeral` | Codex | bool | `false` | Adds `--ephemeral`. |
+| `profile` | Codex | string | unset | Adds `--profile <name>`. |
+| `config_overrides` | Codex | table | `{}` | Each key becomes `--config key=value`. |
+| `cli_flags` | reserved | table | `{}` | Parsed and preserved for future provider-specific flags. |
+| `request_timeout_secs` | HTTP | integer | `120` | HTTP request timeout. |
+| `api_key_env` | HTTP | string | MiniMax: `MINIMAX_API_KEY`; Ollama: unset | Environment variable used for bearer auth when configured. |
+
+Subprocess agents require `command` and reject `base_url`. HTTP agents require
+`base_url` and reject `command`.
+
+## Claude
+
+```toml
+[agents.claude]
+kind = "claude"
+enabled = true
+command = "claude"
+model = "opus"
+permission_mode = "bypassPermissions"
+allowed_tools = []
+```
+
+## Codex
+
+```toml
+[agents.codex]
+kind = "codex"
+enabled = false
+command = "codex"
+model = "gpt-5.4-codex"
+permission_mode = "yolo"
+sandbox = "workspace-write"
+json = true
+ephemeral = false
+profile = "work"
+extra_args = ["--reasoning-effort", "high"]
+
+[agents.codex.config_overrides]
+approval_policy = "never"
+```
+
+## Qwen
+
+```toml
+[agents.qwen]
+kind = "qwen"
+enabled = false
+command = "qwen"
+model = "qwen-test"
+extra_args = ["--auth-type", "openai"]
+
+[agents.qwen.env]
+OPENAI_BASE_URL = "https://api.example.com/v1"
+```
+
+## OpenCode
+
+```toml
+[agents.opencode]
+kind = "opencode"
+enabled = false
+command = "opencode"
+model = "openrouter/deepseek/deepseek-chat"
+extra_args = []
+```
+
+OpenCode model ids should use `provider/model` format.
+
+## Ollama
+
+```toml
+[agents.ollama]
+kind = "ollama"
+enabled = false
+model = "qwen3"
+base_url = "http://localhost:11434"
+request_timeout_secs = 120
+```
+
+## MiniMax
+
+```toml
+[agents.minimax]
+kind = "minimax"
+enabled = false
+model = "MiniMax-M2.7"
+base_url = "https://api.minimax.io/v1"
+request_timeout_secs = 120
+api_key_env = "MINIMAX_API_KEY"
+```
+
+## Doctor Behavior
+
+`maestro doctor` validates provider setup:
+
+- With no explicit `[agents]`, it checks the implicit Claude CLI.
+- With explicit `[agents]`, it checks every enabled agent.
+- The default enabled agent is required.
+- Other enabled agents are optional warnings.
+
+Use `enabled = false` for configured examples that are not ready to run.

--- a/examples/multi-agent/maestro.toml
+++ b/examples/multi-agent/maestro.toml
@@ -1,0 +1,88 @@
+[project]
+repo = "owner/repo"
+base_branch = "main"
+
+[sessions]
+max_concurrent = 3
+stall_timeout_secs = 300
+default_model = "opus"
+default_mode = "orchestrator"
+permission_mode = "bypassPermissions"
+allowed_tools = []
+
+[agents]
+default = "claude"
+
+[agents.claude]
+kind = "claude"
+enabled = true
+command = "claude"
+model = "opus"
+permission_mode = "bypassPermissions"
+allowed_tools = []
+
+[agents.codex]
+kind = "codex"
+enabled = false
+command = "codex"
+model = "gpt-5.4-codex"
+permission_mode = "yolo"
+sandbox = "workspace-write"
+json = true
+ephemeral = false
+extra_args = []
+
+[agents.qwen]
+kind = "qwen"
+enabled = false
+command = "qwen"
+model = "qwen-test"
+extra_args = ["--auth-type", "openai"]
+
+[agents.qwen.env]
+OPENAI_BASE_URL = "https://api.example.com/v1"
+
+[agents.opencode]
+kind = "opencode"
+enabled = false
+command = "opencode"
+model = "openrouter/deepseek/deepseek-chat"
+extra_args = []
+
+[agents.ollama]
+kind = "ollama"
+enabled = false
+model = "qwen3"
+base_url = "http://localhost:11434"
+request_timeout_secs = 120
+
+[agents.minimax]
+kind = "minimax"
+enabled = false
+model = "MiniMax-M2.7"
+base_url = "https://api.minimax.io/v1"
+request_timeout_secs = 120
+api_key_env = "MINIMAX_API_KEY"
+
+[budget]
+per_session_usd = 5.0
+total_usd = 50.0
+alert_threshold_pct = 80
+
+[notifications]
+desktop = true
+slack = false
+slack_rate_limit_per_min = 10
+
+[provider]
+kind = "github"
+issue_filter_labels = ["maestro:ready"]
+auto_pr = true
+auto_merge = false
+merge_method = "squash"
+cache_ttl_secs = 300
+
+[gates]
+fmt = "cargo fmt -- --check"
+clippy = "cargo clippy -- -D warnings"
+test = "cargo test"

--- a/maestro.toml
+++ b/maestro.toml
@@ -132,3 +132,56 @@ milestone_naming = "ai"
 
 [views]
 agent_graph_enabled = true
+
+[agents]
+default = "codex"
+
+[agents.claude]
+kind = "claude"
+enabled = true
+command = "claude"
+model = "opus"
+permission_mode = "bypassPermissions"
+allowed_tools = []
+
+[agents.codex]
+kind = "codex"
+enabled = true
+command = "codex"
+model = "gpt-5.5"
+permission_mode = "yolo"
+sandbox = "workspace-write"
+json = true
+ephemeral = false
+profile = "work"
+extra_args = ["--reasoning-effort", "high"]
+
+[agents.minimax]
+kind = "minimax"
+enabled = true
+model = "MiniMax-M2.7"
+base_url = "https://api.minimax.io/v1"
+request_timeout_secs = 120
+api_key_env = "MINIMAX_API_KEY"
+
+[agents.ollama]
+kind = "ollama"
+enabled = true
+model = "qwen3"
+base_url = "http://localhost:11434"
+request_timeout_secs = 120
+
+[agents.opencode]
+kind = "opencode"
+enabled = true
+command = "opencode"
+model = "openrouter/deepseek/deepseek-chat"
+extra_args = []
+
+[agents.qwen]
+kind = "qwen"
+enabled = true
+command = "qwen"
+model = "qwen-test"
+permission_mode = "bypassPermissions"
+extra_args = ["--auth-type", "openai"]

--- a/src/config/agents_upgrade.rs
+++ b/src/config/agents_upgrade.rs
@@ -1,0 +1,328 @@
+use anyhow::{Context, Result};
+use toml::Value;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentConfigVersion {
+    ImplicitClaude,
+    PartialExplicitAgents,
+    ExplicitAgents,
+}
+
+impl AgentConfigVersion {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::ImplicitClaude => "legacy implicit-claude",
+            Self::PartialExplicitAgents => "partial explicit-agents",
+            Self::ExplicitAgents => "explicit agents",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentConfigUpgradePlan {
+    pub version: AgentConfigVersion,
+    pub needs_update: bool,
+    pub snippet: String,
+    pub normalized_toml: String,
+    pub keys_added: Vec<String>,
+}
+
+pub fn plan_agent_config_upgrade(existing_toml: &str) -> Result<AgentConfigUpgradePlan> {
+    let mut value: Value = toml::from_str(existing_toml).context("parsing maestro.toml")?;
+    let Some(root) = value.as_table_mut() else {
+        anyhow::bail!("maestro.toml root must be a table");
+    };
+
+    let defaults = AgentDefaults::from_root(root);
+    let mut keys_added = Vec::new();
+
+    if !root.contains_key("agents") {
+        let snippet = render_implicit_claude_snippet(&defaults);
+        let normalized_toml = append_snippet(existing_toml, &snippet);
+        return Ok(AgentConfigUpgradePlan {
+            version: AgentConfigVersion::ImplicitClaude,
+            needs_update: true,
+            snippet,
+            normalized_toml,
+            keys_added: vec![
+                "agents".to_string(),
+                "agents.default".to_string(),
+                "agents.claude".to_string(),
+                "agents.claude.kind".to_string(),
+                "agents.claude.enabled".to_string(),
+                "agents.claude.command".to_string(),
+                "agents.claude.model".to_string(),
+                "agents.claude.permission_mode".to_string(),
+                "agents.claude.allowed_tools".to_string(),
+            ],
+        });
+    }
+
+    let mut changed = false;
+    let Some(agents) = root.get_mut("agents").and_then(Value::as_table_mut) else {
+        anyhow::bail!("agents must be a table");
+    };
+
+    if !agents.contains_key("default") {
+        agents.insert("default".to_string(), Value::String("claude".to_string()));
+        keys_added.push("agents.default".to_string());
+        changed = true;
+    }
+
+    let default_agent = agents
+        .get("default")
+        .and_then(Value::as_str)
+        .unwrap_or("claude")
+        .to_string();
+
+    if default_agent == "claude" || !agents.contains_key(&default_agent) {
+        let claude_missing = !agents.contains_key("claude");
+        let claude = agents
+            .entry("claude".to_string())
+            .or_insert_with(|| Value::Table(toml::map::Map::new()));
+        let Some(claude_table) = claude.as_table_mut() else {
+            anyhow::bail!("agents.claude must be a table");
+        };
+        changed |= insert_missing(
+            claude_table,
+            "kind",
+            Value::String("claude".to_string()),
+            &mut keys_added,
+            "agents.claude.kind",
+        );
+        changed |= insert_missing(
+            claude_table,
+            "enabled",
+            Value::Boolean(true),
+            &mut keys_added,
+            "agents.claude.enabled",
+        );
+        changed |= insert_missing(
+            claude_table,
+            "command",
+            Value::String("claude".to_string()),
+            &mut keys_added,
+            "agents.claude.command",
+        );
+        if claude_missing {
+            changed |= insert_missing(
+                claude_table,
+                "model",
+                Value::String(defaults.model),
+                &mut keys_added,
+                "agents.claude.model",
+            );
+            changed |= insert_missing(
+                claude_table,
+                "permission_mode",
+                Value::String(defaults.permission_mode),
+                &mut keys_added,
+                "agents.claude.permission_mode",
+            );
+            changed |= insert_missing(
+                claude_table,
+                "allowed_tools",
+                Value::Array(defaults.allowed_tools),
+                &mut keys_added,
+                "agents.claude.allowed_tools",
+            );
+        }
+    }
+
+    if changed {
+        let normalized = toml::to_string_pretty(&value).context("serializing normalized TOML")?;
+        return Ok(AgentConfigUpgradePlan {
+            version: AgentConfigVersion::PartialExplicitAgents,
+            needs_update: true,
+            snippet: render_implicit_claude_snippet(&AgentDefaults::from_value(&value)),
+            normalized_toml: format!(
+                "# Normalized by Maestro agent config upgrade.\n# Existing values were preserved; missing [agents] keys were added.\n{normalized}"
+            ),
+            keys_added,
+        });
+    }
+
+    Ok(AgentConfigUpgradePlan {
+        version: AgentConfigVersion::ExplicitAgents,
+        needs_update: false,
+        snippet: String::new(),
+        normalized_toml: existing_toml.to_string(),
+        keys_added,
+    })
+}
+
+fn insert_missing(
+    table: &mut toml::map::Map<String, Value>,
+    key: &str,
+    value: Value,
+    keys_added: &mut Vec<String>,
+    dotted: &str,
+) -> bool {
+    if table.contains_key(key) {
+        return false;
+    }
+    table.insert(key.to_string(), value);
+    keys_added.push(dotted.to_string());
+    true
+}
+
+#[derive(Debug, Clone)]
+struct AgentDefaults {
+    model: String,
+    permission_mode: String,
+    allowed_tools: Vec<Value>,
+}
+
+impl AgentDefaults {
+    fn from_root(root: &toml::map::Map<String, Value>) -> Self {
+        let sessions = root.get("sessions").and_then(Value::as_table);
+        Self::from_sessions(sessions)
+    }
+
+    fn from_value(value: &Value) -> Self {
+        let sessions = value
+            .as_table()
+            .and_then(|root| root.get("sessions"))
+            .and_then(Value::as_table);
+        Self::from_sessions(sessions)
+    }
+
+    fn from_sessions(sessions: Option<&toml::map::Map<String, Value>>) -> Self {
+        let model = sessions
+            .and_then(|s| s.get("default_model"))
+            .and_then(Value::as_str)
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or("opus")
+            .to_string();
+        let permission_mode = sessions
+            .and_then(|s| s.get("permission_mode"))
+            .and_then(Value::as_str)
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or("bypassPermissions")
+            .to_string();
+        let allowed_tools = sessions
+            .and_then(|s| s.get("allowed_tools"))
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+
+        Self {
+            model,
+            permission_mode,
+            allowed_tools,
+        }
+    }
+}
+
+fn append_snippet(existing_toml: &str, snippet: &str) -> String {
+    let mut out = existing_toml.trim_end().to_string();
+    if !out.is_empty() {
+        out.push_str("\n\n");
+    }
+    out.push_str(snippet.trim_end());
+    out.push('\n');
+    out
+}
+
+fn render_implicit_claude_snippet(defaults: &AgentDefaults) -> String {
+    format!(
+        r#"[agents]
+default = "claude"
+
+[agents.claude]
+kind = "claude"
+enabled = true
+command = "claude"
+model = {}
+permission_mode = {}
+allowed_tools = {}
+"#,
+        toml_string(&defaults.model),
+        toml_string(&defaults.permission_mode),
+        toml_array(&defaults.allowed_tools)
+    )
+}
+
+fn toml_string(value: &str) -> String {
+    Value::String(value.to_string()).to_string()
+}
+
+fn toml_array(values: &[Value]) -> String {
+    let items: Vec<String> = values
+        .iter()
+        .map(|value| match value {
+            Value::String(s) => toml_string(s),
+            other => other.to_string(),
+        })
+        .collect();
+    format!("[{}]", items.join(", "))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plans_insert_for_implicit_claude_config() {
+        let existing = r#"[sessions]
+default_model = "sonnet"
+permission_mode = "acceptEdits"
+allowed_tools = ["Read", "Edit"]
+"#;
+
+        let plan = plan_agent_config_upgrade(existing).unwrap();
+
+        assert_eq!(plan.version, AgentConfigVersion::ImplicitClaude);
+        assert!(plan.needs_update);
+        assert!(plan.snippet.contains("[agents.claude]"));
+        assert!(plan.snippet.contains("model = \"sonnet\""));
+        assert!(plan.snippet.contains("permission_mode = \"acceptEdits\""));
+        assert!(
+            plan.snippet
+                .contains("allowed_tools = [\"Read\", \"Edit\"]")
+        );
+        assert!(toml::from_str::<Value>(&plan.normalized_toml).is_ok());
+    }
+
+    #[test]
+    fn plans_noop_for_complete_explicit_agents_config() {
+        let existing = r#"[sessions]
+default_model = "opus"
+
+[agents]
+default = "claude"
+
+[agents.claude]
+kind = "claude"
+enabled = true
+command = "claude"
+"#;
+
+        let plan = plan_agent_config_upgrade(existing).unwrap();
+
+        assert_eq!(plan.version, AgentConfigVersion::ExplicitAgents);
+        assert!(!plan.needs_update);
+        assert!(plan.snippet.is_empty());
+    }
+
+    #[test]
+    fn normalizes_partial_agents_config() {
+        let existing = r#"[sessions]
+default_model = "opus"
+
+[agents]
+
+[agents.claude]
+kind = "claude"
+"#;
+
+        let plan = plan_agent_config_upgrade(existing).unwrap();
+
+        assert_eq!(plan.version, AgentConfigVersion::PartialExplicitAgents);
+        assert!(plan.needs_update);
+        assert!(plan.normalized_toml.contains("default = \"claude\""));
+        assert!(plan.normalized_toml.contains("command = \"claude\""));
+        assert!(plan.keys_added.contains(&"agents.default".to_string()));
+        assert!(toml::from_str::<Value>(&plan.normalized_toml).is_ok());
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 
 mod adapt;
 mod agents;
+mod agents_upgrade;
 mod budget;
 mod experimental;
 mod flags;
@@ -24,6 +25,8 @@ mod views;
 
 pub use adapt::{AdaptSettings, MilestoneNaming};
 pub use agents::{AgentConfig, AgentKind, AgentsConfig};
+#[allow(unused_imports)]
+pub use agents_upgrade::{AgentConfigUpgradePlan, AgentConfigVersion, plan_agent_config_upgrade};
 pub use budget::BudgetConfig;
 pub use experimental::ExperimentalConfig;
 pub use flags::FlagsConfig;

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -4,6 +4,7 @@ use crate::agent_provider::{
 };
 use crate::config::{AgentKind, Config, ProviderConfig, ResolvedAgentConfig};
 use crate::provider::types::ProviderKind;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 /// Severity of a preflight check.
@@ -108,6 +109,8 @@ pub fn print_report(report: &DoctorReport) {
         println!("  Summary: {healthy}/{configured} agents healthy ({configured} configured)");
     }
 
+    print_agent_config_upgrade_hint();
+
     println!();
     if report.has_failures() {
         println!("  \x1b[31mSome required checks failed. Maestro may not work correctly.\x1b[0m");
@@ -194,6 +197,8 @@ pub fn run_all_checks_for_agent(config: Option<&Config>, agent_id: Option<&str>)
     if let Some(cfg) = config {
         checks.push(check_provider_matches_remote(cfg.provider.kind));
     }
+
+    checks.push(check_agent_config_schema());
 
     if let (Some(cfg), None) = (config, agent_id) {
         checks.extend(check_configured_agent_runtimes(cfg));
@@ -499,6 +504,83 @@ fn check_config_exists() -> CheckResult {
             "not found — run `maestro init`",
             CheckSeverity::Required,
         )
+    }
+}
+
+fn check_agent_config_schema() -> CheckResult {
+    let Some(path) = find_config_path(Path::new(".")) else {
+        return CheckResult::fail(
+            "agent config",
+            "no config file found; run `maestro init` first",
+            CheckSeverity::Optional,
+        );
+    };
+
+    let content = match std::fs::read_to_string(&path) {
+        Ok(content) => content,
+        Err(err) => {
+            return CheckResult::fail(
+                "agent config",
+                format!("could not read {}: {err}", path.display()),
+                CheckSeverity::Optional,
+            );
+        }
+    };
+
+    match crate::config::plan_agent_config_upgrade(&content) {
+        Ok(plan) if plan.needs_update => CheckResult::fail(
+            "agent config",
+            format!(
+                "{} schema; add {} missing key(s). Use Settings > Project > Normalize Agent Config or paste the suggested block below.",
+                plan.version.label(),
+                plan.keys_added.len()
+            ),
+            CheckSeverity::Optional,
+        ),
+        Ok(plan) => CheckResult::pass(
+            "agent config",
+            format!("{} schema", plan.version.label()),
+            CheckSeverity::Optional,
+        ),
+        Err(err) => CheckResult::fail(
+            "agent config",
+            format!("could not inspect [agents]: {err}"),
+            CheckSeverity::Optional,
+        ),
+    }
+}
+
+fn find_config_path(base: &Path) -> Option<PathBuf> {
+    ["maestro.toml", ".maestro/config.toml"]
+        .into_iter()
+        .map(|candidate| base.join(candidate))
+        .find(|path| path.exists())
+}
+
+fn print_agent_config_upgrade_hint() {
+    let Some(path) = find_config_path(Path::new(".")) else {
+        return;
+    };
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return;
+    };
+    let Ok(plan) = crate::config::plan_agent_config_upgrade(&content) else {
+        return;
+    };
+    if !plan.needs_update {
+        return;
+    }
+
+    println!();
+    println!(
+        "  Suggested [agents] normalization for {} ({})",
+        path.display(),
+        plan.version.label()
+    );
+    println!("  Apply from Settings > Project > Normalize Agent Config, or insert:");
+    println!();
+    for line in plan.snippet.trim_end().lines() {
+        println!("    {line}");
     }
 }
 

--- a/src/tui/screen_dispatch.rs
+++ b/src/tui/screen_dispatch.rs
@@ -330,6 +330,120 @@ fn handle_reset_settings_from_detection(app: &mut app::App) {
     );
 }
 
+/// Normalize the `[agents]` section in `maestro.toml` with the same
+/// insertion plan surfaced by `maestro doctor`.
+fn handle_normalize_agent_config(app: &mut app::App) {
+    use crate::init::walk;
+    use crate::tui::activity_log::LogLevel;
+
+    let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    let target = match app.config_path.clone() {
+        Some(p) => p,
+        None => walk::find_project_root(&cwd).join("maestro.toml"),
+    };
+
+    if !target.exists() {
+        app.activity_log.push_simple(
+            "Settings".into(),
+            format!(
+                "Agent config normalization failed: no maestro.toml at {}.",
+                target.display()
+            ),
+            LogLevel::Warn,
+        );
+        return;
+    }
+
+    let existing = match std::fs::read_to_string(&target) {
+        Ok(s) => s,
+        Err(e) => {
+            app.activity_log.push_simple(
+                "Settings".into(),
+                format!(
+                    "Agent config normalization failed reading {}: {}",
+                    target.display(),
+                    e
+                ),
+                LogLevel::Error,
+            );
+            return;
+        }
+    };
+
+    let plan = match crate::config::plan_agent_config_upgrade(&existing) {
+        Ok(plan) => plan,
+        Err(e) => {
+            app.activity_log.push_simple(
+                "Settings".into(),
+                format!("Agent config normalization failed: {e}"),
+                LogLevel::Error,
+            );
+            return;
+        }
+    };
+
+    if !plan.needs_update {
+        if let Some(s) = app.screen_state.settings_screen.as_mut() {
+            s.show_caveman_status(format!(
+                "Agent config already normalized ({})",
+                plan.version.label()
+            ));
+        }
+        app.activity_log.push_simple(
+            "Settings".into(),
+            format!("Agent config already normalized ({})", plan.version.label()),
+            LogLevel::Info,
+        );
+        return;
+    }
+
+    if let Err(e) = std::fs::write(&target, &plan.normalized_toml) {
+        app.activity_log.push_simple(
+            "Settings".into(),
+            format!(
+                "Agent config normalization failed writing {}: {}",
+                target.display(),
+                e
+            ),
+            LogLevel::Error,
+        );
+        return;
+    }
+
+    let cfg = match crate::config::Config::load(&target) {
+        Ok(c) => c,
+        Err(e) => {
+            app.activity_log.push_simple(
+                "Settings".into(),
+                format!("Agent config normalization wrote file but reload failed: {e}"),
+                LogLevel::Error,
+            );
+            return;
+        }
+    };
+
+    if let Some(s) = app.screen_state.settings_screen.as_mut() {
+        *s = crate::tui::screens::SettingsScreen::new(cfg.clone(), app.flags.clone())
+            .with_config_path(target.clone());
+        s.show_caveman_status(format!(
+            "Normalized agent config from {}; +{} key(s).",
+            plan.version.label(),
+            plan.keys_added.len()
+        ));
+    }
+    app.config = Some(cfg);
+    app.activity_log.push_simple(
+        "Settings".into(),
+        format!(
+            "Agent config normalized at {} from {}; +{} key(s). This uses the v0.25 [agents] schema consumed by v0.27 teams.",
+            target.display(),
+            plan.version.label(),
+            plan.keys_added.len()
+        ),
+        LogLevel::Info,
+    );
+}
+
 /// Process a ScreenAction returned by a screen's input handler.
 pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
     match action {
@@ -629,6 +743,9 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
         }
         ScreenAction::ResetSettingsFromDetection => {
             handle_reset_settings_from_detection(app);
+        }
+        ScreenAction::NormalizeAgentConfig => {
+            handle_normalize_agent_config(app);
         }
         ScreenAction::PreviewTheme(theme_config) => {
             if let Some(tc) = theme_config {

--- a/src/tui/screens/mod.rs
+++ b/src/tui/screens/mod.rs
@@ -143,6 +143,9 @@ pub enum ScreenAction {
     /// keys. Triggered by the "Reset Settings" action on Settings →
     /// Project (#505).
     ResetSettingsFromDetection,
+    /// Add or normalize the `[agents]` section in `maestro.toml` using
+    /// the same upgrade plan reported by `maestro doctor`.
+    NormalizeAgentConfig,
     /// Preview a theme temporarily (reverted on discard).
     PreviewTheme(Option<crate::tui::theme::ThemeConfig>),
     /// Start the adapt pipeline from the wizard screen.

--- a/src/tui/screens/settings/input.rs
+++ b/src/tui/screens/settings/input.rs
@@ -115,9 +115,8 @@ impl Screen for SettingsScreen {
                 if self.active_tab() == SettingsTab::Flags {
                     return ScreenAction::None;
                 }
-                // Special-case the "Reset Settings" row on the Project tab
-                // — Enter/Space triggers re-detection rather than the
-                // toggle's normal behaviour.
+                // Special-case Project action rows: Enter/Space triggers
+                // file operations rather than the toggle's normal behaviour.
                 if self.active_tab() == SettingsTab::Project
                     && matches!(*code, KeyCode::Enter | KeyCode::Char(' '))
                 {
@@ -128,6 +127,9 @@ impl Screen for SettingsScreen {
                         .unwrap_or("");
                     if label.starts_with("Reset Settings") {
                         return ScreenAction::ResetSettingsFromDetection;
+                    }
+                    if label.starts_with("Normalize Agent Config") {
+                        return ScreenAction::NormalizeAgentConfig;
                     }
                 }
                 // Delegate to active widget for non-navigation keys

--- a/src/tui/screens/settings/tabs/project.rs
+++ b/src/tui/screens/settings/tabs/project.rs
@@ -18,5 +18,9 @@ pub(super) fn build_fields(config: &Config) -> Vec<SettingsField> {
             "Reset Settings (re-detect project stack)",
             false,
         ))),
+        field(WidgetKind::Toggle(Toggle::new(
+            "Normalize Agent Config (add [agents])",
+            false,
+        ))),
     ]
 }

--- a/src/tui/screens/settings/tests/basic.rs
+++ b/src/tui/screens/settings/tests/basic.rs
@@ -68,6 +68,34 @@ fn reset_settings_row_returns_action_on_enter() {
 }
 
 #[test]
+fn project_tab_contains_normalize_agent_config_label() {
+    let screen = SettingsScreen::new(make_config(), make_flags());
+    let labels: Vec<&str> = screen.fields_per_tab[0]
+        .iter()
+        .map(|f| f.widget.label())
+        .collect();
+    assert!(
+        labels
+            .iter()
+            .any(|l| l.starts_with("Normalize Agent Config")),
+        "Project tab must include a 'Normalize Agent Config' action; got {:?}",
+        labels
+    );
+}
+
+#[test]
+fn normalize_agent_config_row_returns_action_on_enter() {
+    let mut screen = SettingsScreen::new(make_config(), make_flags());
+    let normalize_idx = screen.fields_per_tab[0]
+        .iter()
+        .position(|f| f.widget.label().starts_with("Normalize Agent Config"))
+        .expect("Normalize Agent Config row exists");
+    screen.field_index = normalize_idx;
+    let action = screen.handle_input(&key_event(KeyCode::Enter), InputMode::Normal);
+    assert_eq!(action, ScreenAction::NormalizeAgentConfig);
+}
+
+#[test]
 fn esc_returns_pop() {
     let mut screen = SettingsScreen::new(make_config(), make_flags());
     let action = screen.handle_input(&key_event(KeyCode::Esc), InputMode::Normal);


### PR DESCRIPTION
## Summary

- Adds a multi-agent provider documentation index covering Claude, Codex, Qwen, OpenCode, Ollama, and MiniMax.
- Adds a configuration reference and a complete multi-agent `maestro.toml` example.
- Updates the README requirements and setup section to point users to the new provider docs.

Closes #553

## Test plan

- [ ] cargo test --quiet
- [ ] cargo clippy -- -D warnings -A dead_code
- [ ] cargo fmt --check
- [x] manual verification: reviewed rendered Markdown structure and internal doc links
