### PR TITLE
fix: restore codex and PR completion flows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ flate2 = "1"
 tar = "0.4"
 tempfile = "3"
 thiserror = "2"
+shlex = "1"
 
 [build-dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/maestro.toml
+++ b/maestro.toml
@@ -148,13 +148,12 @@ allowed_tools = []
 kind = "codex"
 enabled = true
 command = "codex"
-model = "gpt-5.5"
+model = "gpt-5.1-codex-max"
 permission_mode = "yolo"
 sandbox = "workspace-write"
 json = true
 ephemeral = false
-profile = "work"
-extra_args = ["--reasoning-effort", "high"]
+extra_args = []
 
 [agents.minimax]
 kind = "minimax"

--- a/src/agent_provider/codex/parser.rs
+++ b/src/agent_provider/codex/parser.rs
@@ -24,7 +24,7 @@ impl CodexStreamParser {
 
         match v.get("type").and_then(Value::as_str) {
             Some("thread.started") | Some("turn.started") | Some("item.started") => Vec::new(),
-            Some("item.completed") => self.parse_item_completed(&v),
+            Some("item.completed") | Some("item.updated") => self.parse_item_event(&v),
             Some("turn.completed") => self.parse_turn_completed(&v),
             Some("turn.failed") => vec![StreamEvent::Error {
                 message: extract_error_message(&v).unwrap_or_else(|| "codex turn failed".into()),
@@ -38,7 +38,7 @@ impl CodexStreamParser {
         }
     }
 
-    fn parse_item_completed(&mut self, v: &Value) -> Vec<StreamEvent> {
+    fn parse_item_event(&mut self, v: &Value) -> Vec<StreamEvent> {
         let item = v.get("item").unwrap_or(v);
         match item.get("type").and_then(Value::as_str) {
             Some("message") | Some("agent_message") => parse_codex_message(item),
@@ -83,6 +83,9 @@ impl CodexStreamParser {
                     .unwrap_or(false);
                 vec![StreamEvent::ToolResult { tool, is_error }]
             }
+            Some("command_execution") => parse_command_execution(item),
+            Some("file_change") => parse_file_change(item),
+            Some("todo_list") => parse_todo_list(item),
             Some("reasoning") => item
                 .get("summary")
                 .or_else(|| item.get("text"))
@@ -108,6 +111,95 @@ impl CodexStreamParser {
         events.push(StreamEvent::Completed { cost_usd: 0.0 });
         events
     }
+}
+
+fn parse_command_execution(item: &Value) -> Vec<StreamEvent> {
+    let command = item
+        .get("command")
+        .and_then(Value::as_str)
+        .map(truncate_command_preview);
+    let is_error = item
+        .get("exit_code")
+        .and_then(Value::as_i64)
+        .is_some_and(|code| code != 0)
+        || item
+            .get("status")
+            .and_then(Value::as_str)
+            .is_some_and(|status| status == "failed" || status == "error");
+
+    vec![
+        StreamEvent::ToolUse {
+            tool: "Bash".to_string(),
+            file_path: None,
+            command_preview: command,
+            subagent_name: None,
+        },
+        StreamEvent::ToolResult {
+            tool: "Bash".to_string(),
+            is_error,
+        },
+    ]
+}
+
+fn parse_file_change(item: &Value) -> Vec<StreamEvent> {
+    let changes = item
+        .get("changes")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten();
+
+    let mut events = Vec::new();
+    for change in changes {
+        let tool = match change.get("kind").and_then(Value::as_str) {
+            Some("add") | Some("create") => "Write",
+            Some("delete") | Some("remove") => "Edit",
+            _ => "Edit",
+        };
+        events.push(StreamEvent::ToolUse {
+            tool: tool.to_string(),
+            file_path: change
+                .get("path")
+                .or_else(|| change.get("file_path"))
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            command_preview: None,
+            subagent_name: None,
+        });
+        events.push(StreamEvent::ToolResult {
+            tool: tool.to_string(),
+            is_error: false,
+        });
+    }
+
+    if events.is_empty() {
+        events.push(StreamEvent::ToolUse {
+            tool: "Edit".to_string(),
+            file_path: None,
+            command_preview: None,
+            subagent_name: None,
+        });
+    }
+
+    events
+}
+
+fn parse_todo_list(item: &Value) -> Vec<StreamEvent> {
+    let is_error = item
+        .get("status")
+        .and_then(Value::as_str)
+        .is_some_and(|status| status == "failed" || status == "error");
+    vec![
+        StreamEvent::ToolUse {
+            tool: "TodoWrite".to_string(),
+            file_path: None,
+            command_preview: None,
+            subagent_name: None,
+        },
+        StreamEvent::ToolResult {
+            tool: "TodoWrite".to_string(),
+            is_error,
+        },
+    ]
 }
 
 fn parse_codex_message(item: &Value) -> Vec<StreamEvent> {
@@ -196,14 +288,16 @@ fn extract_command_preview(input: &Value) -> Option<String> {
         .get("command")
         .or_else(|| input.get("cmd"))
         .and_then(Value::as_str)
-        .map(|command| {
-            if command.len() > 60 {
-                let boundary = char_boundary(command, 60);
-                format!("{}...", &command[..boundary])
-            } else {
-                command.to_string()
-            }
-        })
+        .map(truncate_command_preview)
+}
+
+fn truncate_command_preview(command: &str) -> String {
+    if command.len() > 60 {
+        let boundary = char_boundary(command, 60);
+        format!("{}...", &command[..boundary])
+    } else {
+        command.to_string()
+    }
 }
 
 fn extract_error_message(v: &Value) -> Option<String> {
@@ -229,69 +323,5 @@ fn char_boundary(s: &str, max_bytes: usize) -> usize {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parser_maps_codex_jsonl_to_stream_events() {
-        let mut parser = CodexStreamParser::default();
-        let events: Vec<StreamEvent> = [
-            r#"{"type":"thread.started","thread_id":"t1"}"#,
-            r#"{"type":"item.completed","item":{"type":"function_call","call_id":"call_1","name":"shell","arguments":"{\"command\":\"cargo test\",\"path\":\"src/lib.rs\"}"}}"#,
-            r#"{"type":"item.completed","item":{"type":"function_call_output","call_id":"call_1","output":"ok"}}"#,
-            r#"{"type":"item.completed","item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Done."}]}}"#,
-            r#"{"type":"turn.completed","usage":{"input_tokens":10,"output_tokens":5,"cached_input_tokens":2}}"#,
-        ]
-        .into_iter()
-        .flat_map(|line| parser.parse_line(line))
-        .collect();
-
-        assert!(events.iter().any(|event| {
-            matches!(
-                event,
-                StreamEvent::ToolUse {
-                    tool,
-                    file_path: Some(path),
-                    command_preview: Some(command),
-                    ..
-                } if tool == "shell" && path == "src/lib.rs" && command == "cargo test"
-            )
-        }));
-        assert!(
-            events
-                .iter()
-                .any(|event| matches!(event, StreamEvent::ToolResult { tool, is_error: false } if tool == "shell"))
-        );
-        assert!(events.iter().any(
-            |event| matches!(event, StreamEvent::AssistantMessage { text } if text == "Done.")
-        ));
-        assert!(events.iter().any(|event| {
-            matches!(event, StreamEvent::TokenUpdate { usage } if usage.input_tokens == 10 && usage.output_tokens == 5 && usage.cache_read_tokens == 2)
-        }));
-        assert!(
-            events
-                .iter()
-                .any(|event| matches!(event, StreamEvent::Completed { .. }))
-        );
-    }
-
-    #[test]
-    fn parser_maps_agent_message_and_turn_failed() {
-        let mut parser = CodexStreamParser::default();
-
-        let message = parser.parse_line(
-            r#"{"type":"item.completed","item":{"type":"agent_message","text":"Hello"}}"#,
-        );
-        assert!(matches!(
-            message.as_slice(),
-            [StreamEvent::AssistantMessage { text }] if text == "Hello"
-        ));
-
-        let failed =
-            parser.parse_line(r#"{"type":"turn.failed","error":{"message":"model failed"}}"#);
-        assert!(matches!(
-            failed.as_slice(),
-            [StreamEvent::Error { message }] if message == "model failed"
-        ));
-    }
-}
+#[path = "parser_tests.rs"]
+mod tests;

--- a/src/agent_provider/codex/parser_tests.rs
+++ b/src/agent_provider/codex/parser_tests.rs
@@ -1,0 +1,153 @@
+use super::*;
+
+#[test]
+fn parser_maps_codex_jsonl_to_stream_events() {
+    let mut parser = CodexStreamParser::default();
+    let events: Vec<StreamEvent> = [
+        r#"{"type":"thread.started","thread_id":"t1"}"#,
+        r#"{"type":"item.completed","item":{"type":"function_call","call_id":"call_1","name":"shell","arguments":"{\"command\":\"cargo test\",\"path\":\"src/lib.rs\"}"}}"#,
+        r#"{"type":"item.completed","item":{"type":"function_call_output","call_id":"call_1","output":"ok"}}"#,
+        r#"{"type":"item.completed","item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Done."}]}}"#,
+        r#"{"type":"turn.completed","usage":{"input_tokens":10,"output_tokens":5,"cached_input_tokens":2}}"#,
+    ]
+    .into_iter()
+    .flat_map(|line| parser.parse_line(line))
+    .collect();
+
+    assert!(events.iter().any(|event| {
+        matches!(
+            event,
+            StreamEvent::ToolUse {
+                tool,
+                file_path: Some(path),
+                command_preview: Some(command),
+                ..
+            } if tool == "shell" && path == "src/lib.rs" && command == "cargo test"
+        )
+    }));
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, StreamEvent::ToolResult { tool, is_error: false } if tool == "shell"))
+    );
+    assert!(
+        events.iter().any(
+            |event| matches!(event, StreamEvent::AssistantMessage { text } if text == "Done.")
+        )
+    );
+    assert!(events.iter().any(|event| {
+        matches!(event, StreamEvent::TokenUpdate { usage } if usage.input_tokens == 10 && usage.output_tokens == 5 && usage.cache_read_tokens == 2)
+    }));
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, StreamEvent::Completed { .. }))
+    );
+}
+
+#[test]
+fn parser_maps_agent_message_and_turn_failed() {
+    let mut parser = CodexStreamParser::default();
+
+    let message = parser
+        .parse_line(r#"{"type":"item.completed","item":{"type":"agent_message","text":"Hello"}}"#);
+    assert!(matches!(
+        message.as_slice(),
+        [StreamEvent::AssistantMessage { text }] if text == "Hello"
+    ));
+
+    let failed = parser.parse_line(r#"{"type":"turn.failed","error":{"message":"model failed"}}"#);
+    assert!(matches!(
+        failed.as_slice(),
+        [StreamEvent::Error { message }] if message == "model failed"
+    ));
+}
+
+#[test]
+fn parser_maps_current_codex_command_execution_events() {
+    let mut parser = CodexStreamParser::default();
+
+    let events = parser.parse_line(
+        r#"{"type":"item.completed","item":{"aggregated_output":"ok\n","command":"/bin/zsh -lc 'bats tests/scripts/release.bats'","exit_code":1,"id":"item_35","status":"failed","type":"command_execution"}}"#,
+    );
+
+    assert!(matches!(
+        events.as_slice(),
+        [
+            StreamEvent::ToolUse {
+                tool,
+                command_preview: Some(command),
+                ..
+            },
+            StreamEvent::ToolResult {
+                tool: result_tool,
+                is_error: true
+            }
+        ] if tool == "Bash"
+            && result_tool == "Bash"
+            && command == "/bin/zsh -lc 'bats tests/scripts/release.bats'"
+    ));
+}
+
+#[test]
+fn parser_maps_current_codex_file_change_events() {
+    let mut parser = CodexStreamParser::default();
+
+    let events = parser.parse_line(
+        r#"{"type":"item.completed","item":{"changes":[{"kind":"update","path":"/tmp/work/scripts/release.sh"},{"kind":"add","path":"/tmp/work/tests/scripts/release.bats"}],"id":"item_18","status":"completed","type":"file_change"}}"#,
+    );
+
+    assert!(events.iter().any(|event| {
+        matches!(
+            event,
+            StreamEvent::ToolUse {
+                tool,
+                file_path: Some(path),
+                ..
+            } if tool == "Edit" && path == "/tmp/work/scripts/release.sh"
+        )
+    }));
+    assert!(events.iter().any(|event| {
+        matches!(
+            event,
+            StreamEvent::ToolUse {
+                tool,
+                file_path: Some(path),
+                ..
+            } if tool == "Write" && path == "/tmp/work/tests/scripts/release.bats"
+        )
+    }));
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(
+                event,
+                StreamEvent::ToolResult {
+                    is_error: false,
+                    ..
+                }
+            ))
+            .count(),
+        2
+    );
+}
+
+#[test]
+fn parser_maps_current_codex_todo_updates() {
+    let mut parser = CodexStreamParser::default();
+
+    let events = parser.parse_line(
+        r#"{"type":"item.updated","item":{"id":"item_3","type":"todo_list","items":[{"text":"Inspect release script","completed":true},{"text":"Run tests","completed":false}]}}"#,
+    );
+
+    assert!(matches!(
+        events.as_slice(),
+        [
+            StreamEvent::ToolUse { tool, .. },
+            StreamEvent::ToolResult {
+                tool: result_tool,
+                is_error: false
+            }
+        ] if tool == "TodoWrite" && result_tool == "TodoWrite"
+    ));
+}

--- a/src/review/dispatch.rs
+++ b/src/review/dispatch.rs
@@ -53,12 +53,13 @@ impl ReviewDispatcher {
             .replace("{pr_number}", &pr_number.to_string())
             .replace("{branch}", branch);
 
-        let parts: Vec<&str> = command.split_whitespace().collect();
+        let parts = shlex::split(&command)
+            .ok_or_else(|| anyhow::anyhow!("Invalid review command quoting"))?;
         if parts.is_empty() {
             anyhow::bail!("Empty review command");
         }
 
-        let output = Command::new(parts[0]).args(&parts[1..]).output()?;
+        let output = Command::new(&parts[0]).args(&parts[1..]).output()?;
 
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
@@ -216,6 +217,17 @@ mod tests {
         let result = dispatcher.dispatch(1, "main").unwrap();
         assert!(result.success);
         assert!(result.output.contains("review-output-marker"));
+    }
+
+    #[test]
+    fn dispatch_preserves_quoted_review_body_as_one_arg() {
+        let dispatcher = ReviewDispatcher::new(ReviewConfig {
+            enabled: true,
+            command: "printf '%s' 'Automated review by Maestro'".into(),
+        });
+        let result = dispatcher.dispatch(1, "main").unwrap();
+        assert!(result.success);
+        assert_eq!(result.output, "Automated review by Maestro");
     }
 
     #[test]

--- a/src/tui/app/auto_pr.rs
+++ b/src/tui/app/auto_pr.rs
@@ -116,6 +116,15 @@ impl App {
                     format!("PR already exists for branch {} — see {}", branch, url),
                     LogLevel::Info,
                 );
+                self.ci_poller.add_check(PendingPrCheck {
+                    pr_number: existing,
+                    issue_number,
+                    branch: branch.to_string(),
+                    created_at: Instant::now(),
+                    check_count: 0,
+                    fix_attempt: 0,
+                    awaiting_fix_ci: false,
+                });
                 return;
             }
             Ok(_) => {}

--- a/src/tui/app/auto_pr_tests.rs
+++ b/src/tui/app/auto_pr_tests.rs
@@ -151,6 +151,14 @@ async fn auto_pr_skips_creation_when_pr_already_exists_for_branch() {
         has_existing_log,
         "activity log must reference the existing PR URL (AC4)"
     );
+    let pending = app
+        .ci_poller
+        .pending_pr_checks
+        .iter()
+        .find(|check| check.pr_number == 55)
+        .expect("existing PR must be registered for CI polling and completion summary");
+    assert_eq!(pending.issue_number, 42);
+    assert_eq!(pending.branch, "maestro/issue-42");
 }
 
 #[tokio::test]

--- a/src/tui/input_handler.rs
+++ b/src/tui/input_handler.rs
@@ -235,6 +235,12 @@ fn handle_completion_summary(app: &mut App, key: &KeyEvent) -> KeyAction {
         (KeyCode::Enter, _) | (KeyCode::Esc, _) => {
             app.transition_to_dashboard();
         }
+        (KeyCode::Char('s'), _) => {
+            app.transition_to_dashboard();
+        }
+        (KeyCode::Char('o'), _) => {
+            open_first_completion_pr(app);
+        }
         (KeyCode::Char('i'), _) => {
             app.completion_summary = None;
             app.completion_summary_dismissed = true;
@@ -297,11 +303,75 @@ fn handle_completion_summary(app: &mut App, key: &KeyEvent) -> KeyAction {
     }
     if !matches!(
         key.code,
-        KeyCode::Up | KeyCode::Down | KeyCode::Char('k' | 'j')
+        KeyCode::Up | KeyCode::Down | KeyCode::Char('k' | 'j' | 'o')
     ) {
         app.completion_summary = None;
     }
     KeyAction::Consumed
+}
+
+fn open_first_completion_pr(app: &mut App) {
+    let pr_link = app.completion_summary.as_ref().and_then(|summary| {
+        summary
+            .sessions
+            .iter()
+            .find_map(|session| non_empty_url(&session.pr_link))
+    });
+
+    let Some(url) = pr_link else {
+        app.activity_log.push_simple(
+            "PR".into(),
+            "No PR link available for completed sessions".to_string(),
+            LogLevel::Warn,
+        );
+        return;
+    };
+
+    match open_url(&url) {
+        Ok(()) => {
+            app.activity_log
+                .push_simple("PR".into(), format!("Opened {}", url), LogLevel::Info)
+        }
+        Err(e) => app.activity_log.push_simple(
+            "PR".into(),
+            format!("Failed to open {}: {}", url, e),
+            LogLevel::Error,
+        ),
+    }
+}
+
+fn non_empty_url(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        Some(trimmed.to_string())
+    } else {
+        None
+    }
+}
+
+fn open_url(url: &str) -> std::io::Result<()> {
+    #[cfg(target_os = "macos")]
+    let mut command = {
+        let mut command = std::process::Command::new("open");
+        command.arg(url);
+        command
+    };
+
+    #[cfg(target_os = "windows")]
+    let mut command = {
+        let mut command = std::process::Command::new("cmd");
+        command.args(["/C", "start", "", url]);
+        command
+    };
+
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    let mut command = {
+        let mut command = std::process::Command::new("xdg-open");
+        command.arg(url);
+        command
+    };
+
+    command.spawn().map(|_| ())
 }
 
 /// Recovery-modal key dispatch. Unlike the success handler, this one
@@ -1992,7 +2062,7 @@ mod tests {
     }
 
     #[test]
-    fn completion_summary_s_key_does_nothing_when_no_failed_gates_session() {
+    fn completion_summary_s_key_dismisses_success_modal() {
         let calls: Arc<Mutex<Vec<PathBuf>>> = Arc::new(Mutex::new(Vec::new()));
         let launcher = CapturingShellLauncher {
             calls: calls.clone(),
@@ -2004,7 +2074,45 @@ mod tests {
 
         handle_completion_summary(&mut app, &key('s'));
 
-        // Success modal does not bind `s`, so the launcher must not be called.
+        assert_eq!(app.tui_mode, TuiMode::Dashboard);
+        assert!(app.completion_summary.is_none());
+        assert!(app.completion_summary_dismissed);
         assert!(calls.lock().expect("mutex").is_empty());
+    }
+
+    #[test]
+    fn completion_summary_o_key_without_pr_link_keeps_success_modal_open_and_logs_warning() {
+        let mut app = make_app();
+        app.tui_mode = TuiMode::CompletionSummary;
+        app.completion_summary = Some(completed_summary());
+
+        handle_completion_summary(&mut app, &key('o'));
+
+        assert_eq!(app.tui_mode, TuiMode::CompletionSummary);
+        assert!(
+            app.completion_summary.is_some(),
+            "[o] without a PR link should leave the modal open"
+        );
+        assert!(
+            app.activity_log.entries().iter().any(|entry| {
+                entry.message.contains("No PR link available")
+                    && matches!(entry.level, LogLevel::Warn)
+            }),
+            "[o] without a PR link should explain the missing URL in the activity log"
+        );
+    }
+
+    #[test]
+    fn non_empty_url_accepts_only_http_urls() {
+        assert_eq!(
+            non_empty_url(" https://github.com/owner/repo/pull/686 ").as_deref(),
+            Some("https://github.com/owner/repo/pull/686")
+        );
+        assert_eq!(
+            non_empty_url("http://example.test").as_deref(),
+            Some("http://example.test")
+        );
+        assert!(non_empty_url("").is_none());
+        assert!(non_empty_url("not a url").is_none());
     }
 }

--- a/src/tui/navigation/mode_hints.rs
+++ b/src/tui/navigation/mode_hints.rs
@@ -331,29 +331,39 @@ pub fn mode_keymap(
             FKeyVis::Minimal,
             &[
                 InlineHint {
+                    key: "o",
+                    action: "Open PR",
+                    priority: 0,
+                },
+                InlineHint {
+                    key: "s",
+                    action: "Dismiss",
+                    priority: 1,
+                },
+                InlineHint {
                     key: "i",
                     action: "Browse",
-                    priority: 0,
+                    priority: 2,
                 },
                 InlineHint {
                     key: "r",
                     action: "New Prompt",
-                    priority: 1,
+                    priority: 3,
                 },
                 InlineHint {
                     key: "l",
                     action: "Logs",
-                    priority: 2,
+                    priority: 4,
                 },
                 InlineHint {
                     key: "d",
                     action: "Dashboard",
-                    priority: 3,
+                    priority: 5,
                 },
                 InlineHint {
                     key: "q",
                     action: "Quit",
-                    priority: 4,
+                    priority: 6,
                 },
             ],
         ),

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__completion_overlay__snapshot_completion_overlay_success_modal_80x24.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__completion_overlay__snapshot_completion_overlay_success_modal_80x24.snap
@@ -12,7 +12,7 @@ expression: term.backend()
 "            ║                                                      ║            "
 "            ║  Total: $0.12  (1 session)                           ║            "
 "            ║                                                      ║            "
-"            ║  [i] Browse  [r] New Prompt  [l] Logs  [d] Dashboard ║            "
+"            ║  [o] Open PR  [s] Dismiss  [i] Browse  [r] New Prompt║            "
 "            ║                                                      ║            "
 "            ║                                                      ║            "
 "            ║                                                      ║            "


### PR DESCRIPTION
## Summary

- update the Codex agent config to a working model/CLI argument shape
- map current Codex JSON stream events so the TUI shows tool, file, and todo activity
- register existing branch PRs with completion/CI state and add completion summary Open PR/Dismiss actions
- parse review commands with shell-style quoting so quoted gh review bodies remain one argument

## Testing

- cargo fmt --check
- cargo check
- cargo test
