### PR TITLE
[Maestro] #620 ci(quality): add cargo-dupes code duplication gate to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,24 @@ jobs:
       - name: Check coverage tiers
         run: bash scripts/check-coverage-tiers.sh coverage.lcov
 
+  duplication:
+    # Wave stats — report mode during baseline phase.
+    # The job always exits 0 (cargo dupes stats never fails). It prints the
+    # full JSON duplication report for visibility and trend tracking.
+    # Activation path: once baseline is stable, replace 'stats' with
+    #   cargo dupes check --max-exact-percent <X> --max-near-percent <Y>
+    # and remove this comment block. Each threshold activation is a dedicated PR.
+    name: Code Duplication
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-dupes
+        run: cargo install cargo-dupes --locked --version 0.2.1
+      - name: Duplication report (baseline metrics)
+        run: cargo dupes stats --format json
+
   layers:
     # Wave 2.3 — layer violation enforcement.
     # Blocking by default (no continue-on-error). Existing violations

--- a/docs/RUST-GUARDRAILS.md
+++ b/docs/RUST-GUARDRAILS.md
@@ -399,6 +399,20 @@ CI fails when any deadline is in the past. Extensions require a PR bumping the d
 
 During Wave 1 implementation, `scripts/check-file-size.sh` was found to have a pre-existing silent-pass bug: its `wc -l` output parsing left `lines` as an empty string, which made the `(( lines > MAX_LINES ))` comparison evaluate to `0 > 500 → false` for every file. The 500 LOC cap had been cosmetic since its introduction. Fixed in the same PR; 23 previously-invisible violations surfaced and were pre-added to the allowlist with the same 14-day placeholder deadline.
 
+## Code duplication (Wave stats → Wave check)
+
+**Tool:** `cargo dupes` (code-dupes crate) pinned to `0.2.1`. Config: `dupes.toml` at repo root (`min-nodes = 15`, `min-lines = 5`, `threshold = 0.85`, `exclude-tests = true`, `exclude = ["src/integration_tests/**"]`).
+
+**Baseline (stats mode, 2026-05-06, cargo dupes 0.2.1):**
+- `exact_duplicate_percent`: 13.05%
+- `near_duplicate_percent`: 4.82%
+- Totals: `total_code_units = 7,555`; `exact_duplicate_groups = 678`; `near_duplicate_groups = 226`.
+
+**Activation path:**
+- **Wave stats (current):** CI job `duplication` runs `cargo dupes stats --format json` and prints the full JSON; non-blocking by design.
+- **Wave check (future):** switch the CI command to `cargo dupes check --max-exact-percent <X> --max-near-percent <Y>` once the baseline stabilizes. Initial thresholds should be baseline + 2% buffer (approx. exact ≤ 15.1%, near ≤ 6.9%) to avoid noise; long-term enforcement targets remain `--max-exact-percent 3.0` and `--max-near-percent 15.0` per the activation table.
+- **Scope:** `--exclude-tests` keeps `#[test]` and `#[cfg(test)]` modules out of the denominator; `src/integration_tests/**` is excluded to avoid fixture-heavy drift. Revisit excludes before tightening thresholds.
+
 **Pre-flight hook.**
 
 `.claude/hooks/preflight.sh` runs fast per-PR gates locally (fmt + clippy + file-size) so `/implement` catches regressions before a branch is created.

--- a/dupes.toml
+++ b/dupes.toml
@@ -1,0 +1,17 @@
+[dupes]
+# Only analyze functions with enough substance to be meaningful duplicates.
+min-nodes = 15
+min-lines = 5
+
+# Similarity score for near-duplicate detection (0.0–1.0). 0.85 avoids noise
+# from trivially similar small functions while catching real structural duplication.
+threshold = 0.85
+
+# Skip test functions and cfg(test) modules — intentional duplication of
+# setup/teardown patterns is expected and acceptable in tests.
+exclude-tests = true
+
+# Skip generated or fixture-heavy paths.
+exclude = [
+  "src/integration_tests/**",
+]


### PR DESCRIPTION
Closes #620

## Summary

Automated implementation for issue #620: ci(quality): add cargo-dupes code duplication gate to CI pipeline

## Files Changed

- `/Users/carlos/projects/maestro/.maestro/worktrees/issue-620/.github/workflows/ci.yml`
- `/Users/carlos/projects/maestro/.maestro/worktrees/issue-620/docs/RUST-GUARDRAILS.md`

## Cost Report

- **Cost**: $0.00

---
*Generated by [Maestro](https://github.com/maestro)*
