### PR TITLE
feat: theme agent graph and session loading

### DIFF
--- a/src/agent_provider/opencode.rs
+++ b/src/agent_provider/opencode.rs
@@ -1,10 +1,12 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::process::Stdio;
+use std::time::Duration;
 
 use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::process::Command;
+use tokio::process::{Child, Command};
 use tokio::sync::mpsc;
+use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 
 use super::types::{
@@ -21,6 +23,8 @@ const OPENCODE_INSTALL_MESSAGE: &str = "opencode CLI not found; install with `br
      `curl -fsSL https://opencode.ai/install | bash`, or `npm install -g opencode-ai`";
 const OPENCODE_AUTH_MESSAGE: &str =
     "opencode auth not found; run `opencode /connect` to authenticate with a provider";
+const OPENCODE_ETXTBSY_RETRIES: usize = 3;
+const OPENCODE_ETXTBSY_RETRY_DELAY: Duration = Duration::from_millis(10);
 
 #[derive(Debug, Clone)]
 pub struct OpenCodeProvider {
@@ -132,6 +136,56 @@ impl OpenCodeProvider {
     fn auth_path(&self) -> PathBuf {
         self.auth_path.clone().unwrap_or_else(opencode_auth_path)
     }
+
+    async fn version_output(&self) -> std::io::Result<std::process::Output> {
+        let mut attempts = 0;
+        loop {
+            match Command::new(&self.binary).arg("--version").output().await {
+                Err(source)
+                    if is_executable_file_busy(&source) && attempts < OPENCODE_ETXTBSY_RETRIES =>
+                {
+                    attempts += 1;
+                    sleep(OPENCODE_ETXTBSY_RETRY_DELAY).await;
+                }
+                result => return result,
+            }
+        }
+    }
+
+    fn run_command(&self, request: &AgentRequest) -> Command {
+        let mut cmd = Command::new(&self.binary);
+        match request.output_format {
+            AgentOutputFormat::StreamJson => {
+                cmd.args(self.build_stream_args(request));
+            }
+            AgentOutputFormat::Text => {
+                cmd.args(self.build_text_args(request));
+            }
+        }
+        cmd.envs(&self.env);
+        if let Some(cwd) = request.cwd.as_ref() {
+            cmd.current_dir(cwd);
+        }
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        cmd
+    }
+
+    async fn spawn_run_command(&self, request: &AgentRequest) -> std::io::Result<Child> {
+        let mut attempts = 0;
+        loop {
+            match self.run_command(request).spawn() {
+                Err(source)
+                    if is_executable_file_busy(&source) && attempts < OPENCODE_ETXTBSY_RETRIES =>
+                {
+                    attempts += 1;
+                    sleep(OPENCODE_ETXTBSY_RETRY_DELAY).await;
+                }
+                result => return result,
+            }
+        }
+    }
 }
 
 impl Default for OpenCodeProvider {
@@ -158,7 +212,7 @@ impl AgentProvider for OpenCodeProvider {
     }
 
     async fn health_check(&self) -> Result<AgentHealthCheck, AgentError> {
-        match Command::new(&self.binary).arg("--version").output().await {
+        match self.version_output().await {
             Ok(out) if out.status.success() => {
                 let version = String::from_utf8_lossy(&out.stdout).trim().to_string();
                 let auth_path = self.auth_path();
@@ -200,32 +254,18 @@ impl AgentProvider for OpenCodeProvider {
         events: mpsc::UnboundedSender<AgentProviderEvent>,
         cancel: CancellationToken,
     ) -> Result<AgentRunResult, AgentError> {
-        let mut cmd = Command::new(&self.binary);
-        match request.output_format {
-            AgentOutputFormat::StreamJson => {
-                cmd.args(self.build_stream_args(&request));
-            }
-            AgentOutputFormat::Text => {
-                cmd.args(self.build_text_args(&request));
-            }
-        }
-        cmd.envs(&self.env);
-        if let Some(cwd) = request.cwd.as_ref() {
-            cmd.current_dir(cwd);
-        }
-        cmd.stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-
-        let mut child = cmd.spawn().map_err(|source| match source.kind() {
-            std::io::ErrorKind::NotFound => {
-                AgentError::Config(OPENCODE_INSTALL_MESSAGE.to_string())
-            }
-            _ => AgentError::Spawn {
-                provider_id: self.id().to_string(),
-                source,
-            },
-        })?;
+        let mut child =
+            self.spawn_run_command(&request)
+                .await
+                .map_err(|source| match source.kind() {
+                    std::io::ErrorKind::NotFound => {
+                        AgentError::Config(OPENCODE_INSTALL_MESSAGE.to_string())
+                    }
+                    _ => AgentError::Spawn {
+                        provider_id: self.id().to_string(),
+                        source,
+                    },
+                })?;
         let process_id = child.id();
         let stdout = child
             .stdout
@@ -314,6 +354,18 @@ impl AgentProvider for OpenCodeProvider {
         Ok(AgentRunResult {
             exit_code: status.code(),
         })
+    }
+}
+
+fn is_executable_file_busy(source: &std::io::Error) -> bool {
+    #[cfg(unix)]
+    {
+        source.raw_os_error() == Some(26)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = source;
+        false
     }
 }
 

--- a/src/tui/agent_graph/render.rs
+++ b/src/tui/agent_graph/render.rs
@@ -8,7 +8,7 @@
 use ratatui::{
     Frame,
     layout::{Alignment, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     symbols::Marker,
     text::Line,
     widgets::{
@@ -24,6 +24,7 @@ use super::model::{GraphEdge, GraphNode, NodeId, NodeKind};
 use super::personalities::{Sprite, glyph_for_role, role_abbrev, role_color};
 use crate::session::types::{Session, SessionStatus};
 use crate::tui::spinner::graph_node_frame;
+use crate::tui::theme::Theme;
 
 /// Radial distance for the ASCII-mode `[ROLE] #NNN` label. The agent glyph
 /// is a 1×1 cell rectangle, so a small offset suffices.
@@ -37,17 +38,22 @@ const SPRITE_LABEL_BUFFER_CELLS: f64 = 1.5;
 const MIN_WIDTH: u16 = 80;
 const MIN_HEIGHT: u16 = 24;
 
+pub(crate) struct GraphRenderOptions<'a> {
+    pub(crate) use_nerd_font: bool,
+    pub(crate) tick: usize,
+    pub(crate) sessions: &'a [&'a Session],
+    pub(crate) theme: &'a Theme,
+}
+
 pub(crate) fn draw_agent_graph(
     f: &mut Frame,
     area: Rect,
     nodes: &[GraphNode],
     edges: &[GraphEdge],
-    use_nerd_font: bool,
-    tick: usize,
-    sessions: &[&Session],
+    options: GraphRenderOptions<'_>,
 ) {
     if area.width < MIN_WIDTH || area.height < MIN_HEIGHT {
-        draw_too_small(f, area);
+        draw_too_small(f, area, options.theme);
         return;
     }
     let agent_count = nodes
@@ -63,14 +69,14 @@ pub(crate) fn draw_agent_graph(
     // file edges is still a meaningful graph (agent at center, files in the
     // outer ring) and is more informative than the placeholder card.
     if agent_count == 0 || (agent_count == 1 && file_count == 0) {
-        draw_single_agent_card(f, area, nodes);
+        draw_single_agent_card(f, area, nodes, options.theme);
         return;
     }
 
     let layout = ConcentricLayout;
     let positions = layout.position(nodes, edges);
 
-    let marker = if use_nerd_font {
+    let marker = if options.use_nerd_font {
         Marker::Braille
     } else {
         Marker::Block
@@ -81,17 +87,18 @@ pub(crate) fn draw_agent_graph(
     let positions_for_paint = positions;
     let inner_cols = area.width.saturating_sub(2);
     let inner_rows = area.height.saturating_sub(2);
-    let session_infos: Vec<SessionRenderInfo> = sessions
+    let session_infos: Vec<SessionRenderInfo> = options
+        .sessions
         .iter()
         .map(|s| SessionRenderInfo::from_session(s))
         .collect();
+    let file_color = options.theme.accent_info;
+    let graph_block = graph_block(options.theme);
+    let tick = options.tick;
+    let use_nerd_font = options.use_nerd_font;
 
     let canvas = Canvas::default()
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title(" agent graph "),
-        )
+        .block(graph_block)
         .marker(marker)
         .x_bounds([-1.0, 1.0])
         .y_bounds([-1.0, 1.0])
@@ -179,8 +186,7 @@ pub(crate) fn draw_agent_graph(
                     }
                     NodeKind::File => {
                         // Label anchored at the edge endpoint; any y-offset reintroduces the gap. See ADR #569.
-                        let (color, modifier) = file_style();
-                        let style = Style::default().fg(color).add_modifier(modifier);
+                        let style = Style::default().fg(file_color);
                         let pt = CanvasPoint { x: p.x, y: p.y };
                         let (lx, rendered) = place_file_label(pt, &label, inner_cols);
                         ctx.print(lx, p.y, Line::styled(rendered, style));
@@ -237,18 +243,19 @@ fn find_session<'a>(
     sessions.iter().find(|s| s.id == *uuid)
 }
 
-fn draw_too_small(f: &mut Frame, area: Rect) {
+fn draw_too_small(f: &mut Frame, area: Rect, theme: &Theme) {
     let msg = format!(
         "Agent graph requires {MIN_WIDTH}×{MIN_HEIGHT} (current: {}×{}). Press [g] for panels.",
         area.width, area.height
     );
     let para = Paragraph::new(msg)
+        .style(Style::default().fg(theme.text_secondary))
         .alignment(Alignment::Center)
-        .block(Block::default().borders(Borders::ALL));
+        .block(graph_block(theme));
     f.render_widget(para, area);
 }
 
-fn draw_single_agent_card(f: &mut Frame, area: Rect, nodes: &[GraphNode]) {
+fn draw_single_agent_card(f: &mut Frame, area: Rect, nodes: &[GraphNode], theme: &Theme) {
     let label = nodes
         .iter()
         .find(|n| matches!(n.kind, NodeKind::Agent { .. }))
@@ -261,22 +268,35 @@ fn draw_single_agent_card(f: &mut Frame, area: Rect, nodes: &[GraphNode]) {
         .collect();
 
     let body = vec![
-        Line::from(format!("▶  {label}  RUNNING")),
-        Line::from(format!("    Files: {}", files.join(", "))),
+        Line::styled(
+            format!("▶  {label}  RUNNING"),
+            Style::default().fg(theme.status_color(SessionStatus::Running)),
+        ),
+        Line::styled(
+            format!("    Files: {}", files.join(", ")),
+            Style::default().fg(theme.text_secondary),
+        ),
         Line::from(""),
-        Line::from("1 agent, no files touched yet — graph activates on first file edit"),
+        Line::styled(
+            "1 agent, no files touched yet — graph activates on first file edit",
+            Style::default().fg(theme.text_secondary),
+        ),
     ];
 
-    let para = Paragraph::new(body).alignment(Alignment::Center).block(
-        Block::default()
-            .borders(Borders::ALL)
-            .title(" agent graph "),
-    );
+    let para = Paragraph::new(body)
+        .alignment(Alignment::Center)
+        .block(graph_block(theme));
     f.render_widget(para, area);
 }
 
-fn file_style() -> (Color, Modifier) {
-    (Color::Cyan, Modifier::empty())
+fn graph_block(theme: &Theme) -> Block<'static> {
+    Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme.border_inactive))
+        .title(Line::styled(
+            " agent graph ",
+            Style::default().fg(theme.title_accent),
+        ))
 }
 
 /// Status modifier layered on top of an agent's role color.

--- a/src/tui/agent_graph/render_label_placement_tests.rs
+++ b/src/tui/agent_graph/render_label_placement_tests.rs
@@ -5,7 +5,7 @@
 use ratatui::{Terminal, backend::TestBackend};
 use uuid::Uuid;
 
-use super::draw_agent_graph;
+use super::{GraphRenderOptions, draw_agent_graph};
 use crate::session::types::{Session, SessionStatus};
 use crate::tui::agent_graph::model::build_graph;
 
@@ -32,7 +32,18 @@ fn render_buffer(
     let mut terminal = Terminal::new(TestBackend::new(120, 40)).unwrap();
     terminal
         .draw(|f| {
-            draw_agent_graph(f, f.area(), &nodes, &edges, use_nerd_font, tick, sessions);
+            draw_agent_graph(
+                f,
+                f.area(),
+                &nodes,
+                &edges,
+                GraphRenderOptions {
+                    use_nerd_font,
+                    tick,
+                    sessions,
+                    theme: &crate::tui::theme::Theme::dark(),
+                },
+            );
         })
         .unwrap();
     terminal.backend().buffer().clone()

--- a/src/tui/agent_graph/render_sprite_tests.rs
+++ b/src/tui/agent_graph/render_sprite_tests.rs
@@ -7,7 +7,7 @@
 use ratatui::{Terminal, backend::TestBackend, style::Color};
 use uuid::Uuid;
 
-use super::draw_agent_graph;
+use super::{GraphRenderOptions, draw_agent_graph};
 use crate::session::types::{Session, SessionStatus};
 use crate::tui::agent_graph::model::build_graph;
 
@@ -36,7 +36,18 @@ fn render_buffer_sized(
     let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
     terminal
         .draw(|f| {
-            draw_agent_graph(f, f.area(), &nodes, &edges, use_nerd_font, tick, sessions);
+            draw_agent_graph(
+                f,
+                f.area(),
+                &nodes,
+                &edges,
+                GraphRenderOptions {
+                    use_nerd_font,
+                    tick,
+                    sessions,
+                    theme: &crate::tui::theme::Theme::dark(),
+                },
+            );
         })
         .unwrap();
     terminal.backend().buffer().clone()

--- a/src/tui/agent_graph/render_tests.rs
+++ b/src/tui/agent_graph/render_tests.rs
@@ -5,7 +5,7 @@ use ratatui::{
 };
 use uuid::Uuid;
 
-use super::draw_agent_graph;
+use super::{GraphRenderOptions, draw_agent_graph};
 use crate::session::types::{Session, SessionStatus};
 use crate::tui::agent_graph::model::build_graph;
 
@@ -32,7 +32,18 @@ fn render_buffer(
     let mut terminal = Terminal::new(TestBackend::new(120, 40)).unwrap();
     terminal
         .draw(|f| {
-            draw_agent_graph(f, f.area(), &nodes, &edges, use_nerd_font, tick, sessions);
+            draw_agent_graph(
+                f,
+                f.area(),
+                &nodes,
+                &edges,
+                GraphRenderOptions {
+                    use_nerd_font,
+                    tick,
+                    sessions,
+                    theme: &crate::tui::theme::Theme::dark(),
+                },
+            );
         })
         .unwrap();
     terminal.backend().buffer().clone()
@@ -77,9 +88,14 @@ fn has_reversed_for_color(buffer: &ratatui::buffer::Buffer, fg: Color) -> bool {
 }
 
 #[test]
-fn file_style_is_neutral_color() {
-    let (color, _) = super::file_style();
-    assert_eq!(color, Color::Cyan);
+fn file_labels_use_theme_info_accent() {
+    let session = make_session_with(0, 101, SessionStatus::Running, &["src/main.rs"]);
+    let refs = vec![&session];
+    let buffer = render_buffer(&refs, 0, false);
+    assert!(buffer_has_color(
+        &buffer,
+        crate::tui::theme::Theme::dark().accent_info
+    ));
 }
 
 #[test]
@@ -87,7 +103,18 @@ fn too_small_message_contains_dimensions() {
     let mut terminal = Terminal::new(TestBackend::new(79, 23)).unwrap();
     terminal
         .draw(|f| {
-            draw_agent_graph(f, f.area(), &[], &[], false, 0, &[]);
+            draw_agent_graph(
+                f,
+                f.area(),
+                &[],
+                &[],
+                GraphRenderOptions {
+                    use_nerd_font: false,
+                    tick: 0,
+                    sessions: &[],
+                    theme: &crate::tui::theme::Theme::dark(),
+                },
+            );
         })
         .unwrap();
     let rendered = format!("{:?}", terminal.backend().buffer());

--- a/src/tui/session_switcher.rs
+++ b/src/tui/session_switcher.rs
@@ -1,5 +1,6 @@
-use crate::session::types::Session;
+use crate::session::types::{Session, SessionStatus};
 use crate::tui::icons::{self, IconId};
+use crate::tui::spinner::graph_node_frame;
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout, Rect},
@@ -63,7 +64,15 @@ impl SessionSwitcher {
     }
 
     /// Draw the switcher as a centered overlay.
-    pub fn draw(&self, f: &mut Frame, area: Rect, sessions: &[&Session], theme: &Theme) {
+    pub fn draw(
+        &self,
+        f: &mut Frame,
+        area: Rect,
+        sessions: &[&Session],
+        theme: &Theme,
+        spinner_tick: usize,
+        use_nerd_font: bool,
+    ) {
         // Overlay: 60% width, 70% height, centered
         let overlay_width = (area.width as f32 * 0.6).max(40.0) as u16;
         let overlay_height = (area.height as f32 * 0.7).max(10.0) as u16;
@@ -105,7 +114,8 @@ impl SessionSwitcher {
                 "  ".to_string()
             };
 
-            let status_symbol = session.status.symbol();
+            let status_symbol =
+                session_switcher_status_symbol(session.status, spinner_tick, use_nerd_font);
             let label = if let Some(num) = session.issue_number {
                 format!(
                     "#{} {}",
@@ -157,6 +167,26 @@ impl SessionSwitcher {
             Span::raw(" Close"),
         ]);
         f.render_widget(Paragraph::new(footer), chunks[1]);
+    }
+}
+
+fn session_switcher_status_symbol(
+    status: SessionStatus,
+    spinner_tick: usize,
+    use_nerd_font: bool,
+) -> String {
+    if matches!(
+        status,
+        SessionStatus::Running
+            | SessionStatus::Spawning
+            | SessionStatus::Retrying
+            | SessionStatus::GatesRunning
+            | SessionStatus::CiFix
+            | SessionStatus::ConflictFix
+    ) {
+        graph_node_frame(spinner_tick, use_nerd_font).to_string()
+    } else {
+        status.symbol().to_string()
     }
 }
 
@@ -301,5 +331,33 @@ mod tests {
         };
         sw.move_down(3);
         assert_eq!(sw.selected_index, 2);
+    }
+
+    #[test]
+    fn active_status_symbol_uses_braille_spinner_when_nerd_font_enabled() {
+        assert_eq!(
+            session_switcher_status_symbol(SessionStatus::Running, 3, true),
+            "⠸"
+        );
+        assert_eq!(
+            session_switcher_status_symbol(SessionStatus::Spawning, 0, true),
+            "⠋"
+        );
+    }
+
+    #[test]
+    fn active_status_symbol_uses_ascii_spinner_without_nerd_font() {
+        assert_eq!(
+            session_switcher_status_symbol(SessionStatus::Running, 1, false),
+            "/"
+        );
+    }
+
+    #[test]
+    fn terminal_status_symbol_keeps_status_icon() {
+        assert_eq!(
+            session_switcher_status_symbol(SessionStatus::Completed, 3, true),
+            SessionStatus::Completed.symbol().to_string()
+        );
     }
 }

--- a/src/tui/snapshot_tests/agent_graph.rs
+++ b/src/tui/snapshot_tests/agent_graph.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 
 use crate::session::types::{Session, SessionStatus};
 use crate::tui::agent_graph::model::build_graph;
-use crate::tui::agent_graph::render::draw_agent_graph;
+use crate::tui::agent_graph::render::{GraphRenderOptions, draw_agent_graph};
 use crate::tui::snapshot_tests::{fixed_end, fixed_start};
 
 fn make_session(
@@ -77,7 +77,18 @@ fn render_with(
     let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
     terminal
         .draw(|f| {
-            draw_agent_graph(f, f.area(), &nodes, &edges, use_nerd_font, tick, &refs);
+            draw_agent_graph(
+                f,
+                f.area(),
+                &nodes,
+                &edges,
+                GraphRenderOptions {
+                    use_nerd_font,
+                    tick,
+                    sessions: &refs,
+                    theme: &crate::tui::theme::Theme::dark(),
+                },
+            );
         })
         .unwrap();
     terminal

--- a/src/tui/snapshot_tests/agent_personalities.rs
+++ b/src/tui/snapshot_tests/agent_personalities.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 use crate::session::role::Role;
 use crate::session::types::{Session, SessionStatus};
 use crate::tui::agent_graph::model::build_graph;
-use crate::tui::agent_graph::render::draw_agent_graph;
+use crate::tui::agent_graph::render::{GraphRenderOptions, draw_agent_graph};
 use crate::tui::snapshot_tests::{fixed_end, fixed_start};
 
 /// Build a session with an explicit role override (bypasses `derive_role`).
@@ -50,7 +50,18 @@ fn render_for_role(
     let mut terminal = Terminal::new(TestBackend::new(80, 24)).unwrap();
     terminal
         .draw(|f| {
-            draw_agent_graph(f, f.area(), &nodes, &edges, use_nerd_font, 0, &refs);
+            draw_agent_graph(
+                f,
+                f.area(),
+                &nodes,
+                &edges,
+                GraphRenderOptions {
+                    use_nerd_font,
+                    tick: 0,
+                    sessions: &refs,
+                    theme: &crate::tui::theme::Theme::dark(),
+                },
+            );
         })
         .unwrap();
     terminal

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -159,9 +159,12 @@ pub fn draw(f: &mut Frame, app: &mut App) {
                     chunks[1],
                     &nodes,
                     &edges,
-                    crate::icon_mode::use_nerd_font(),
-                    spinner_tick,
-                    &sessions,
+                    agent_graph::render::GraphRenderOptions {
+                        use_nerd_font: crate::icon_mode::use_nerd_font(),
+                        tick: spinner_tick,
+                        sessions: &sessions,
+                        theme: &theme,
+                    },
                 );
             } else {
                 app.panel_view.draw_with_claims(
@@ -342,7 +345,14 @@ pub fn draw(f: &mut Frame, app: &mut App) {
             );
             if let Some(ref sw) = app.screen_state.session_switcher {
                 let sessions = app.pool.all_sessions();
-                sw.draw(f, chunks[1], &sessions, &theme);
+                sw.draw(
+                    f,
+                    chunks[1],
+                    &sessions,
+                    &theme,
+                    spinner_tick,
+                    crate::icon_mode::use_nerd_font(),
+                );
             }
         }
         TuiMode::AdaptWizard => {


### PR DESCRIPTION
## Summary
- apply the active theme to agent graph frames, labels, and placeholder states
- use the shared braille/ASCII loading spinner for active sessions in the session switcher
- update graph rendering tests and snapshots for the themed render signature

## Testing
- cargo test session_switcher
- cargo test agent_graph
- cargo fmt --check
- cargo check
- bash scripts/check-file-size.sh