### PR TITLE
fix: prevent agent graph freeze after completion

### DIFF
--- a/src/tui/agent_graph/empty_state.rs
+++ b/src/tui/agent_graph/empty_state.rs
@@ -46,7 +46,7 @@ pub(super) fn draw_single_agent_empty_state(
     let activity = session
         .map(|s| s.current_activity.trim())
         .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| {
+        .unwrap_or({
             if is_terminal {
                 "Session finished"
             } else {

--- a/src/tui/agent_graph/empty_state.rs
+++ b/src/tui/agent_graph/empty_state.rs
@@ -36,6 +36,7 @@ pub(super) fn draw_single_agent_empty_state(
         NodeKind::Agent { status } => status,
         NodeKind::File => SessionStatus::Queued,
     };
+    let is_terminal = status.is_terminal();
     let role = session.map(|s| s.role).unwrap_or_default();
     let status_style = Style::default()
         .fg(theme.status_color(status))
@@ -45,8 +46,18 @@ pub(super) fn draw_single_agent_empty_state(
     let activity = session
         .map(|s| s.current_activity.trim())
         .filter(|s| !s.is_empty())
-        .unwrap_or("Waiting for output");
-    let frame = graph_node_frame(options.tick, options.use_nerd_font);
+        .unwrap_or_else(|| {
+            if is_terminal {
+                "Session finished"
+            } else {
+                "Waiting for output"
+            }
+        });
+    let frame = if is_terminal {
+        terminal_status_marker(status, options.use_nerd_font).to_string()
+    } else {
+        graph_node_frame(options.tick, options.use_nerd_font).to_string()
+    };
     let phase = session
         .map(|s| phase_label(s.status, s.is_thinking, &s.current_activity))
         .unwrap_or_else(|| status.label().to_ascii_lowercase());
@@ -92,17 +103,23 @@ pub(super) fn draw_single_agent_empty_state(
     let sprite_para = Paragraph::new(sprite).alignment(Alignment::Center);
     f.render_widget(sprite_para, rows[0]);
 
+    let status_label = if is_terminal { "Status" } else { "Phase" };
+    let footer = if is_terminal {
+        "Press [g] for panels or [q] to quit"
+    } else {
+        "Waiting for first file edit"
+    };
     let phase_lines = vec![
         Line::from(vec![
             Span::styled(format!("{frame} "), status_style),
-            Span::styled(format!("Phase: {phase}"), status_style),
+            Span::styled(format!("{status_label}: {phase}"), status_style),
             Span::styled("  ·  ", secondary),
             Span::styled(
                 truncate_chars(activity, inner.width.saturating_sub(20) as usize),
                 secondary,
             ),
         ]),
-        Line::styled("Waiting for first file edit", secondary),
+        Line::styled(footer, secondary),
     ];
     f.render_widget(
         Paragraph::new(phase_lines).alignment(Alignment::Center),
@@ -158,6 +175,14 @@ fn phase_label(status: SessionStatus, is_thinking: bool, current_activity: &str)
         AnimationPhase::Idle if current_activity.trim().is_empty() => "waiting for output".into(),
         AnimationPhase::Idle => "running".into(),
         AnimationPhase::None => status.label().to_ascii_lowercase(),
+    }
+}
+
+fn terminal_status_marker(status: SessionStatus, use_nerd_font: bool) -> &'static str {
+    if use_nerd_font {
+        status.nerd_symbol()
+    } else {
+        status.ascii_symbol()
     }
 }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -145,11 +145,14 @@ async fn event_loop(
     spawn_version_check(app.data_tx.clone());
 
     loop {
-        terminal.draw(|f| ui::draw(f, app))?;
-
+        // Apply session stream updates before drawing. In particular, a
+        // Completed event must be visible before completion follow-up work
+        // can run gates/git operations on the UI thread.
         while let Ok(evt) = app.event_rx.try_recv() {
             app.handle_session_event(evt);
         }
+
+        terminal.draw(|f| ui::draw(f, app))?;
 
         app.check_completions().await?;
 

--- a/src/tui/snapshot_tests/agent_graph_dispatcher.rs
+++ b/src/tui/snapshot_tests/agent_graph_dispatcher.rs
@@ -1,7 +1,7 @@
 use insta::assert_snapshot;
 
 use crate::config::Config;
-use crate::session::types::{Session, SessionStatus};
+use crate::session::types::{ActivityEntry, Session, SessionStatus};
 use crate::tui::app::TuiMode;
 use crate::tui::snapshot_tests::{fixed_end, fixed_start, test_terminal};
 use crate::tui::{make_test_app, ui};
@@ -47,6 +47,28 @@ fn two_agent_sessions() -> (Session, Session) {
     (s1, s2)
 }
 
+fn completed_single_agent_no_files() -> Session {
+    use uuid::Uuid;
+
+    let mut s = Session::new(
+        "Complete no-file task".to_string(),
+        "claude-opus-4-5".to_string(),
+        "orchestrator".to_string(),
+        Some(694),
+        None,
+    );
+    s.id = Uuid::from_u128(694);
+    s.status = SessionStatus::Completed;
+    s.started_at = Some(fixed_start());
+    s.finished_at = Some(fixed_end());
+    s.current_activity = "Done".to_string();
+    s.activity_log = vec![ActivityEntry {
+        timestamp: fixed_end(),
+        message: "Session completed".to_string(),
+    }];
+    s
+}
+
 fn scrub_noise(app: &mut crate::tui::app::App) {
     app.show_mascot = false;
     app.show_activity_log = false;
@@ -84,6 +106,41 @@ fn agent_graph_dispatcher_toggle_on_renders_graph() {
         "toggle ON must render the graph canvas block title"
     );
     assert_snapshot!(t.backend());
+}
+
+#[test]
+fn agent_graph_dispatcher_completed_empty_agent_shows_terminal_state() {
+    let mut app = make_test_app("dispatcher-completed-empty-agent");
+    app.config = Some(make_config(true));
+
+    app.pool.enqueue(completed_single_agent_no_files());
+    app.tui_mode = TuiMode::AgentGraph;
+    scrub_noise(&mut app);
+
+    let mut t = test_terminal();
+    t.draw(|f| ui::draw(f, &mut app)).unwrap();
+
+    let output = format!("{}", t.backend());
+    assert!(
+        output.contains("Agent Graph") && output.contains("agent graph"),
+        "Agent Graph shell and graph block must remain visible"
+    );
+    assert!(
+        output.contains("COMPLETED") && output.contains("Status: completed"),
+        "completed status must be visible while Agent Graph is focused"
+    );
+    assert!(
+        output.contains("Session completed"),
+        "completed graph state must keep recent activity visible"
+    );
+    assert!(
+        output.contains("Press [g] for panels"),
+        "completed graph state must expose a clear way back to panels"
+    );
+    assert!(
+        !output.contains("Waiting for first file edit"),
+        "terminal graph state must not keep showing the live waiting affordance"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Drain pending session stream events before drawing and completion follow-up checks so completed state is visible immediately.
- Render a terminal single-agent Agent Graph state with completed status, recent activity, and a clear panels/quit affordance.
- Add regression coverage for a completed single-agent graph with no file nodes.

Closes #694

## Test plan

- [x] cargo test --quiet
- [x] cargo clippy -- -D warnings -A dead_code
- [x] cargo fmt --check
- [x] cargo test agent_graph_dispatcher
