### PR TITLE
feat: add L2 per-issue orchestrator state machines

### DIFF
--- a/src/integration_tests/mod.rs
+++ b/src/integration_tests/mod.rs
@@ -16,6 +16,10 @@ mod init;
 #[cfg(test)]
 mod milestone_health_wizard;
 #[cfg(test)]
+mod orchestration_mock_task;
+#[cfg(test)]
+mod orchestration_pipeline;
+#[cfg(test)]
 mod session_lifecycle;
 #[cfg(test)]
 mod stream_parsing;

--- a/src/integration_tests/orchestration_mock_task.rs
+++ b/src/integration_tests/orchestration_mock_task.rs
@@ -1,0 +1,102 @@
+use crate::orchestration::{SubagentError, SubagentResult, TeamRole};
+use std::collections::VecDeque;
+use std::sync::Mutex;
+
+#[derive(Debug, Clone)]
+pub(crate) struct MockResponse {
+    pub role: TeamRole,
+    pub result: Result<SubagentResult, SubagentError>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct MockTaskQueue {
+    responses: Mutex<VecDeque<MockResponse>>,
+}
+
+impl MockTaskQueue {
+    pub(crate) fn new(responses: Vec<MockResponse>) -> Self {
+        Self {
+            responses: Mutex::new(responses.into()),
+        }
+    }
+
+    pub(crate) fn dispatch(
+        &self,
+        role: TeamRole,
+        _instructions: &str,
+    ) -> Result<SubagentResult, SubagentError> {
+        let mut responses = self
+            .responses
+            .lock()
+            .map_err(|_| SubagentError::Other("mock queue lock poisoned".into()))?;
+        let response = responses
+            .pop_front()
+            .ok_or_else(|| SubagentError::Other("mock queue exhausted".into()))?;
+        if response.role != role {
+            return Err(SubagentError::ResultShapeMismatch {
+                role,
+                expected: format!("{:?}", role.allowed_results()),
+                got: format!("response for {:?}", response.role),
+            });
+        }
+        response.result
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.responses.lock().map(|r| r.is_empty()).unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::orchestration::ReviewVerdict;
+
+    fn code_change() -> SubagentResult {
+        SubagentResult::CodeChange {
+            files_touched: vec!["src/lib.rs".into()],
+            summary: "implemented".into(),
+            commit_sha: None,
+        }
+    }
+
+    #[test]
+    fn mock_queue_returns_canned_result() {
+        let queue = MockTaskQueue::new(vec![MockResponse {
+            role: TeamRole::Implementer,
+            result: Ok(code_change()),
+        }]);
+        assert!(matches!(
+            queue.dispatch(TeamRole::Implementer, "do work"),
+            Ok(SubagentResult::CodeChange { .. })
+        ));
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn mock_queue_surfaces_failure() {
+        let queue = MockTaskQueue::new(vec![MockResponse {
+            role: TeamRole::Reviewer,
+            result: Err(SubagentError::Provider("provider down".into())),
+        }]);
+        assert!(matches!(
+            queue.dispatch(TeamRole::Reviewer, "review"),
+            Err(SubagentError::Provider(message)) if message == "provider down"
+        ));
+    }
+
+    #[test]
+    fn mock_queue_rejects_unexpected_role() {
+        let queue = MockTaskQueue::new(vec![MockResponse {
+            role: TeamRole::Reviewer,
+            result: Ok(SubagentResult::ReviewFindings {
+                verdict: ReviewVerdict::Approved,
+                findings: vec![],
+            }),
+        }]);
+        assert!(matches!(
+            queue.dispatch(TeamRole::Implementer, "implement"),
+            Err(SubagentError::ResultShapeMismatch { .. })
+        ));
+    }
+}

--- a/src/integration_tests/orchestration_pipeline.rs
+++ b/src/integration_tests/orchestration_pipeline.rs
@@ -1,0 +1,47 @@
+use crate::integration_tests::orchestration_mock_task::{MockResponse, MockTaskQueue};
+use crate::orchestration::{
+    NextStep, Primitive, ReviewVerdict, SubagentResult, TeamRole, make_machine,
+};
+
+#[test]
+fn pipeline_machine_runs_end_to_end_with_mock_task_queue() {
+    let queue = MockTaskQueue::new(vec![
+        MockResponse {
+            role: TeamRole::Implementer,
+            result: Ok(SubagentResult::CodeChange {
+                files_touched: vec!["src/orchestration/primitives/pipeline.rs".into()],
+                summary: "implemented primitive state machine".into(),
+                commit_sha: None,
+            }),
+        },
+        MockResponse {
+            role: TeamRole::Reviewer,
+            result: Ok(SubagentResult::ReviewFindings {
+                verdict: ReviewVerdict::Approved,
+                findings: vec![],
+            }),
+        },
+        MockResponse {
+            role: TeamRole::Docs,
+            result: Ok(SubagentResult::DocsChange {
+                files_touched: vec!["README.md".into()],
+                summary: "documented orchestration behavior".into(),
+            }),
+        },
+    ]);
+
+    let mut machine = make_machine(Primitive::Pipeline, 662);
+
+    loop {
+        match machine.next() {
+            NextStep::Dispatch { role, instructions } => {
+                let result = queue.dispatch(role, &instructions);
+                machine.advance(role, result);
+            }
+            NextStep::Done { .. } => break,
+            NextStep::Fail { reason } => panic!("pipeline failed: {reason}"),
+        }
+    }
+
+    assert!(queue.is_empty());
+}

--- a/src/orchestration/contracts.rs
+++ b/src/orchestration/contracts.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use thiserror::Error;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "kebab-case")]
 pub enum SubagentResult {
     CodeChange {
@@ -42,7 +42,7 @@ pub enum ReviewVerdict {
     Comment,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Finding {
     pub file: Option<PathBuf>,
     pub line: Option<u32>,
@@ -58,7 +58,7 @@ pub enum FindingSeverity {
     Error,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct NewIssueDraft {
     pub title: String,
     pub body: String,

--- a/src/orchestration/mod.rs
+++ b/src/orchestration/mod.rs
@@ -8,7 +8,9 @@ pub(crate) mod builtins;
 pub mod contracts;
 pub mod dag;
 pub mod loader;
+pub mod orchestrator;
 pub mod preflight;
+pub mod primitives;
 pub mod run;
 pub mod scheduler;
 pub mod team;
@@ -21,6 +23,10 @@ pub use contracts::{
 };
 #[allow(unused_imports)]
 pub use loader::Loader;
+#[allow(unused_imports)]
+pub use orchestrator::build_system_prompt;
+#[allow(unused_imports)]
+pub use primitives::{NextStep, PrimitiveMachine, PrimitiveOutput, make_machine};
 #[allow(unused_imports)]
 pub use team::{ResolvedTeam, RoleBinding, RoleOverride, SourceTier, TeamConfig};
 #[allow(unused_imports)]

--- a/src/orchestration/orchestrator.rs
+++ b/src/orchestration/orchestrator.rs
@@ -1,0 +1,101 @@
+//! L2 per-issue orchestrator prompt assembly.
+
+#![allow(dead_code)]
+
+use crate::orchestration::team::ResolvedTeam;
+use crate::orchestration::types::Primitive;
+use crate::provider::types::Issue;
+
+pub fn build_system_prompt(team: &ResolvedTeam, issue: &Issue) -> String {
+    let primitive = primitive_name(team.primitive);
+    let tools = if team.primitive == Primitive::Pipeline {
+        "Task, GhPrCreate, ReportFailure"
+    } else {
+        "Task, ReportFailure"
+    };
+
+    format!(
+        "You are Maestro L2 for issue #{}.\n\
+Primitive: {primitive}.\n\
+Team: {}.\n\
+Allowed tools: {tools}.\n\
+Forbidden: Read, Edit, Write, Bash, Grep.\n\
+Do not inspect files or the issue body. Delegate with Task(role, instructions) only.\n\
+Pass only concise structured summaries between roles. ReportFailure on blocked or invalid results.",
+        issue.number, team.name
+    )
+}
+
+fn primitive_name(primitive: Primitive) -> &'static str {
+    match primitive {
+        Primitive::Pipeline => "pipeline",
+        Primitive::FanOut => "fan-out",
+        Primitive::SinglePass => "single-pass",
+        Primitive::VerdictOnly => "verdict-only",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::orchestration::team::{ResolvedTeam, RoleBinding, SourceTier};
+    use crate::orchestration::types::{Primitive, TeamRole};
+    use std::collections::HashMap;
+
+    fn issue() -> Issue {
+        Issue {
+            number: 662,
+            title: "L2 orchestrator".into(),
+            body: "SECRET ISSUE BODY".into(),
+            labels: vec![],
+            state: "open".into(),
+            html_url: "https://example.test/issues/662".into(),
+            milestone: None,
+            assignees: vec![],
+        }
+    }
+
+    fn team(primitive: Primitive) -> ResolvedTeam {
+        ResolvedTeam {
+            name: "default-coder".into(),
+            primitive,
+            min_agents: vec!["claude".into()],
+            bindings: HashMap::from([(
+                TeamRole::Reviewer,
+                RoleBinding {
+                    agent: "claude".into(),
+                    mode: None,
+                    model_override: None,
+                    prompt_addendum: None,
+                    fallback_agent: None,
+                },
+            )]),
+            source_tier: SourceTier::BuiltIn,
+        }
+    }
+
+    #[test]
+    fn pipeline_prompt_snapshot() {
+        let prompt = build_system_prompt(&team(Primitive::Pipeline), &issue());
+        insta::assert_snapshot!(prompt, @r###"
+You are Maestro L2 for issue #662.
+Primitive: pipeline.
+Team: default-coder.
+Allowed tools: Task, GhPrCreate, ReportFailure.
+Forbidden: Read, Edit, Write, Bash, Grep.
+Do not inspect files or the issue body. Delegate with Task(role, instructions) only.
+Pass only concise structured summaries between roles. ReportFailure on blocked or invalid results.
+"###);
+    }
+
+    #[test]
+    fn prompt_includes_expected_bounds() {
+        let prompt = build_system_prompt(&team(Primitive::SinglePass), &issue());
+        assert!(prompt.contains("single-pass"));
+        assert!(prompt.contains("#662"));
+        assert!(prompt.contains("Allowed tools: Task, ReportFailure."));
+        assert!(!prompt.contains("GhPrCreate"));
+        assert!(prompt.contains("Forbidden: Read, Edit, Write, Bash, Grep."));
+        assert!(!prompt.contains("SECRET ISSUE BODY"));
+    }
+}

--- a/src/orchestration/primitives/fan_out.rs
+++ b/src/orchestration/primitives/fan_out.rs
@@ -1,0 +1,183 @@
+use super::{
+    MachineState, NextStep, PrimitiveMachine, PrimitiveOutput, done, fail, malformed,
+    role_mismatch, subagent_failure,
+};
+use crate::orchestration::contracts::{SubagentError, SubagentResult};
+use crate::orchestration::types::TeamRole;
+use std::collections::VecDeque;
+
+#[derive(Debug, Clone)]
+pub struct FanOutMachine {
+    issue_number: u64,
+    state: MachineState,
+    queue: VecDeque<TeamRole>,
+    outstanding: Vec<TeamRole>,
+    results: Vec<(TeamRole, SubagentResult)>,
+}
+
+impl FanOutMachine {
+    pub fn new(issue_number: u64) -> Self {
+        Self {
+            issue_number,
+            state: MachineState::Dispatching,
+            queue: VecDeque::from([TeamRole::Implementer, TeamRole::Reviewer, TeamRole::Docs]),
+            outstanding: Vec::new(),
+            results: Vec::new(),
+        }
+    }
+}
+
+impl PrimitiveMachine for FanOutMachine {
+    fn next(&mut self) -> NextStep {
+        match &self.state {
+            MachineState::Dispatching => {
+                if let Some(role) = self.queue.pop_front() {
+                    self.outstanding.push(role);
+                    return NextStep::Dispatch {
+                        role,
+                        instructions: format!(
+                            "Contribute independently to issue #{}. Return only your structured result.",
+                            self.issue_number
+                        ),
+                    };
+                }
+                if let Some(role) = self.outstanding.first() {
+                    return NextStep::Dispatch {
+                        role: *role,
+                        instructions: format!(
+                            "Awaiting existing {role:?} task for issue #{}.",
+                            self.issue_number
+                        ),
+                    };
+                }
+                let output = PrimitiveOutput::FanOut {
+                    results: self.results.clone(),
+                };
+                self.state = MachineState::Done(output.clone());
+                NextStep::Done { output }
+            }
+            MachineState::Waiting(role) => {
+                fail(&format!("unexpected fan-out waiting state: {role:?}"))
+            }
+            MachineState::Done(output) => done(output),
+            MachineState::Failed(reason) => fail(reason),
+        }
+    }
+
+    fn advance(&mut self, role: TeamRole, result: Result<SubagentResult, SubagentError>) {
+        if !matches!(self.state, MachineState::Dispatching) {
+            self.state = MachineState::Failed("advance called after terminal state".into());
+            return;
+        }
+        let Some(position) = self
+            .outstanding
+            .iter()
+            .position(|outstanding| *outstanding == role)
+        else {
+            let expected = self.outstanding.first().copied().unwrap_or(role);
+            self.state = MachineState::Failed(role_mismatch(expected, role));
+            return;
+        };
+        let result = match result {
+            Ok(result) => result,
+            Err(err) => {
+                self.state = MachineState::Failed(subagent_failure(role, err));
+                return;
+            }
+        };
+        let valid = matches!(
+            (&role, &result),
+            (TeamRole::Implementer, SubagentResult::CodeChange { .. })
+                | (TeamRole::Reviewer, SubagentResult::ReviewFindings { .. })
+                | (TeamRole::Reviewer, SubagentResult::Generic { .. })
+                | (TeamRole::Docs, SubagentResult::DocsChange { .. })
+        );
+        if !valid {
+            self.state = MachineState::Failed(malformed(role, "role-compatible result", &result));
+            return;
+        }
+        self.outstanding.remove(position);
+        self.results.push((role, result));
+        self.state = MachineState::Dispatching;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::orchestration::contracts::ReviewVerdict;
+
+    fn result_for(role: TeamRole) -> SubagentResult {
+        match role {
+            TeamRole::Implementer => SubagentResult::CodeChange {
+                files_touched: vec![],
+                summary: "code".into(),
+                commit_sha: None,
+            },
+            TeamRole::Reviewer => SubagentResult::ReviewFindings {
+                verdict: ReviewVerdict::Approved,
+                findings: vec![],
+            },
+            TeamRole::Docs => SubagentResult::DocsChange {
+                files_touched: vec![],
+                summary: "docs".into(),
+            },
+            _ => SubagentResult::Generic {
+                json: serde_json::json!({}),
+            },
+        }
+    }
+
+    #[test]
+    fn fan_out_success_path() {
+        let mut machine = FanOutMachine::new(2);
+        for role in [TeamRole::Implementer, TeamRole::Reviewer, TeamRole::Docs] {
+            assert!(
+                matches!(machine.next(), NextStep::Dispatch { role: actual, .. } if actual == role)
+            );
+            machine.advance(role, Ok(result_for(role)));
+        }
+        assert!(matches!(machine.next(), NextStep::Done { .. }));
+    }
+
+    #[test]
+    fn fan_out_can_dispatch_all_roles_before_advancing() {
+        let mut machine = FanOutMachine::new(2);
+        let mut dispatched = Vec::new();
+        for _ in 0..3 {
+            match machine.next() {
+                NextStep::Dispatch { role, .. } => dispatched.push(role),
+                other => panic!("unexpected step {other:?}"),
+            }
+        }
+        assert_eq!(
+            dispatched,
+            vec![TeamRole::Implementer, TeamRole::Reviewer, TeamRole::Docs]
+        );
+        for role in dispatched {
+            machine.advance(role, Ok(result_for(role)));
+        }
+        assert!(matches!(machine.next(), NextStep::Done { .. }));
+    }
+
+    #[test]
+    fn fan_out_failure_path() {
+        let mut machine = FanOutMachine::new(2);
+        let _ = machine.next();
+        machine.advance(
+            TeamRole::Implementer,
+            Err(SubagentError::Malformed("bad json".into())),
+        );
+        assert!(matches!(machine.next(), NextStep::Fail { reason } if reason.contains("bad json")));
+    }
+
+    #[test]
+    fn fan_out_malformed_result_path() {
+        let mut machine = FanOutMachine::new(2);
+        let _ = machine.next();
+        machine.advance(TeamRole::Implementer, Ok(result_for(TeamRole::Reviewer)));
+        assert!(
+            matches!(machine.next(), NextStep::Fail { reason } if reason.contains("malformed"))
+        );
+    }
+}

--- a/src/orchestration/primitives/mod.rs
+++ b/src/orchestration/primitives/mod.rs
@@ -1,0 +1,144 @@
+//! Per-issue primitive state machines for L2 orchestration.
+
+mod fan_out;
+mod pipeline;
+mod single_pass;
+mod verdict_only;
+
+use crate::orchestration::contracts::{NewIssueDraft, SubagentError, SubagentResult};
+use crate::orchestration::types::{Primitive, TeamRole};
+
+pub use fan_out::FanOutMachine;
+pub use pipeline::PipelineMachine;
+pub use single_pass::SinglePassMachine;
+pub use verdict_only::VerdictOnlyMachine;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum NextStep {
+    Dispatch {
+        role: TeamRole,
+        instructions: String,
+    },
+    Done {
+        output: PrimitiveOutput,
+    },
+    Fail {
+        reason: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum PrimitiveOutput {
+    Pipeline {
+        code_summary: String,
+        review_summary: String,
+        docs_summary: String,
+    },
+    FanOut {
+        results: Vec<(TeamRole, SubagentResult)>,
+    },
+    SinglePass {
+        role: TeamRole,
+        result: SubagentResult,
+    },
+    Verdict {
+        decision: String,
+        rationale: String,
+        new_issues: Vec<NewIssueDraft>,
+    },
+}
+
+pub trait PrimitiveMachine {
+    fn next(&mut self) -> NextStep;
+    fn advance(&mut self, role: TeamRole, result: Result<SubagentResult, SubagentError>);
+}
+
+pub fn make_machine(primitive: Primitive, issue_number: u64) -> Box<dyn PrimitiveMachine> {
+    match primitive {
+        Primitive::Pipeline => Box::new(PipelineMachine::new(issue_number)),
+        Primitive::FanOut => Box::new(FanOutMachine::new(issue_number)),
+        Primitive::SinglePass => Box::new(SinglePassMachine::new(issue_number)),
+        Primitive::VerdictOnly => Box::new(VerdictOnlyMachine::new(issue_number)),
+    }
+}
+
+#[derive(Debug, Clone)]
+enum MachineState {
+    Dispatching,
+    Waiting(TeamRole),
+    Done(PrimitiveOutput),
+    Failed(String),
+}
+
+impl MachineState {
+    fn next_terminal(
+        &self,
+        waiting_instructions: impl FnOnce(TeamRole) -> String,
+    ) -> Option<NextStep> {
+        match self {
+            Self::Waiting(role) => Some(dispatch(*role, waiting_instructions(*role))),
+            Self::Done(output) => Some(done(output)),
+            Self::Failed(reason) => Some(fail(reason)),
+            Self::Dispatching => None,
+        }
+    }
+
+    fn take_waiting(&mut self, role: TeamRole) -> bool {
+        match self {
+            Self::Waiting(expected) if *expected == role => true,
+            Self::Waiting(expected) => {
+                *self = Self::Failed(role_mismatch(*expected, role));
+                false
+            }
+            Self::Done(_) | Self::Failed(_) | Self::Dispatching => {
+                *self = Self::Failed("advance called while not waiting".into());
+                false
+            }
+        }
+    }
+}
+
+fn dispatch(role: TeamRole, instructions: impl Into<String>) -> NextStep {
+    NextStep::Dispatch {
+        role,
+        instructions: instructions.into(),
+    }
+}
+
+fn done(output: &PrimitiveOutput) -> NextStep {
+    NextStep::Done {
+        output: output.clone(),
+    }
+}
+
+fn fail(reason: &str) -> NextStep {
+    NextStep::Fail {
+        reason: reason.to_string(),
+    }
+}
+
+fn role_mismatch(expected: TeamRole, got: TeamRole) -> String {
+    format!("expected result for {expected:?}, got {got:?}")
+}
+
+fn subagent_failure(role: TeamRole, err: SubagentError) -> String {
+    format!("{role:?} failed: {err}")
+}
+
+fn malformed(role: TeamRole, expected: &str, got: &SubagentResult) -> String {
+    format!("{role:?} returned malformed result: expected {expected}, got {got:?}")
+}
+
+fn review_summary(result: &SubagentResult) -> Option<String> {
+    match result {
+        SubagentResult::ReviewFindings { verdict, findings } => {
+            let notes = findings
+                .iter()
+                .map(|finding| finding.note.as_str())
+                .collect::<Vec<_>>()
+                .join("; ");
+            Some(format!("{verdict:?}: {notes}"))
+        }
+        _ => None,
+    }
+}

--- a/src/orchestration/primitives/pipeline.rs
+++ b/src/orchestration/primitives/pipeline.rs
@@ -1,0 +1,217 @@
+use super::{
+    MachineState, NextStep, PrimitiveMachine, PrimitiveOutput, dispatch, malformed, review_summary,
+    subagent_failure,
+};
+use crate::orchestration::contracts::{ReviewVerdict, SubagentError, SubagentResult};
+use crate::orchestration::types::TeamRole;
+
+#[derive(Debug, Clone)]
+pub struct PipelineMachine {
+    issue_number: u64,
+    state: MachineState,
+    code_summary: Option<String>,
+    review_summary: Option<String>,
+}
+
+impl PipelineMachine {
+    pub fn new(issue_number: u64) -> Self {
+        Self {
+            issue_number,
+            state: MachineState::Dispatching,
+            code_summary: None,
+            review_summary: None,
+        }
+    }
+}
+
+impl PrimitiveMachine for PipelineMachine {
+    fn next(&mut self) -> NextStep {
+        if let Some(step) = self.state.next_terminal(|role| {
+            format!(
+                "Awaiting existing {role:?} task for issue #{}.",
+                self.issue_number
+            )
+        }) {
+            return step;
+        }
+
+        match &self.state {
+            MachineState::Dispatching if self.code_summary.is_none() => {
+                self.state = MachineState::Waiting(TeamRole::Implementer);
+                dispatch(
+                    TeamRole::Implementer,
+                    format!(
+                        "Implement issue #{} and return CodeChange.",
+                        self.issue_number
+                    ),
+                )
+            }
+            MachineState::Dispatching if self.review_summary.is_none() => {
+                self.state = MachineState::Waiting(TeamRole::Reviewer);
+                let summary = self
+                    .code_summary
+                    .as_deref()
+                    .unwrap_or("code change complete");
+                dispatch(
+                    TeamRole::Reviewer,
+                    format!(
+                        "Review issue #{} using this summary only: {summary}. Return ReviewFindings.",
+                        self.issue_number
+                    ),
+                )
+            }
+            MachineState::Dispatching => {
+                self.state = MachineState::Waiting(TeamRole::Docs);
+                let code = self
+                    .code_summary
+                    .as_deref()
+                    .unwrap_or("code change complete");
+                let review = self.review_summary.as_deref().unwrap_or("review complete");
+                dispatch(
+                    TeamRole::Docs,
+                    format!(
+                        "Update docs for issue #{} using summaries only. Code: {code}. Review: {review}. Return DocsChange.",
+                        self.issue_number
+                    ),
+                )
+            }
+            MachineState::Waiting(_) | MachineState::Done(_) | MachineState::Failed(_) => {
+                unreachable!("terminal states returned above")
+            }
+        }
+    }
+
+    fn advance(&mut self, role: TeamRole, result: Result<SubagentResult, SubagentError>) {
+        if !self.state.take_waiting(role) {
+            return;
+        }
+        let result = match result {
+            Ok(result) => result,
+            Err(err) => {
+                self.state = MachineState::Failed(subagent_failure(role, err));
+                return;
+            }
+        };
+        match (role, result) {
+            (
+                TeamRole::Implementer,
+                SubagentResult::CodeChange {
+                    summary,
+                    files_touched: _,
+                    commit_sha: _,
+                },
+            ) => {
+                self.code_summary = Some(summary);
+                self.state = MachineState::Dispatching;
+            }
+            (
+                TeamRole::Reviewer,
+                result @ SubagentResult::ReviewFindings {
+                    verdict,
+                    findings: _,
+                },
+            ) => {
+                if verdict == ReviewVerdict::RequestChanges {
+                    self.state = MachineState::Failed("review requested changes".into());
+                } else if let Some(summary) = review_summary(&result) {
+                    self.review_summary = Some(summary);
+                    self.state = MachineState::Dispatching;
+                }
+            }
+            (
+                TeamRole::Docs,
+                SubagentResult::DocsChange {
+                    summary,
+                    files_touched: _,
+                },
+            ) => {
+                self.state = MachineState::Done(PrimitiveOutput::Pipeline {
+                    code_summary: self.code_summary.clone().unwrap_or_default(),
+                    review_summary: self.review_summary.clone().unwrap_or_default(),
+                    docs_summary: summary,
+                });
+            }
+            (role, got) => {
+                self.state = MachineState::Failed(malformed(role, role.allowed_results()[0], &got));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn code(summary: &str) -> SubagentResult {
+        SubagentResult::CodeChange {
+            files_touched: vec!["src/lib.rs".into()],
+            summary: summary.into(),
+            commit_sha: None,
+        }
+    }
+
+    fn review(verdict: ReviewVerdict) -> SubagentResult {
+        SubagentResult::ReviewFindings {
+            verdict,
+            findings: vec![],
+        }
+    }
+
+    fn docs(summary: &str) -> SubagentResult {
+        SubagentResult::DocsChange {
+            files_touched: vec!["README.md".into()],
+            summary: summary.into(),
+        }
+    }
+
+    #[test]
+    fn pipeline_success_path() {
+        let mut machine = PipelineMachine::new(662);
+        assert!(matches!(
+            machine.next(),
+            NextStep::Dispatch {
+                role: TeamRole::Implementer,
+                ..
+            }
+        ));
+        machine.advance(TeamRole::Implementer, Ok(code("implemented")));
+        assert!(matches!(
+            machine.next(),
+            NextStep::Dispatch {
+                role: TeamRole::Reviewer,
+                ..
+            }
+        ));
+        machine.advance(TeamRole::Reviewer, Ok(review(ReviewVerdict::Approved)));
+        assert!(matches!(
+            machine.next(),
+            NextStep::Dispatch {
+                role: TeamRole::Docs,
+                ..
+            }
+        ));
+        machine.advance(TeamRole::Docs, Ok(docs("documented")));
+        assert!(matches!(machine.next(), NextStep::Done { .. }));
+    }
+
+    #[test]
+    fn pipeline_failure_path() {
+        let mut machine = PipelineMachine::new(662);
+        let _ = machine.next();
+        machine.advance(
+            TeamRole::Implementer,
+            Err(SubagentError::Provider("boom".into())),
+        );
+        assert!(matches!(machine.next(), NextStep::Fail { reason } if reason.contains("boom")));
+    }
+
+    #[test]
+    fn pipeline_malformed_result_path() {
+        let mut machine = PipelineMachine::new(662);
+        let _ = machine.next();
+        machine.advance(TeamRole::Implementer, Ok(review(ReviewVerdict::Approved)));
+        assert!(
+            matches!(machine.next(), NextStep::Fail { reason } if reason.contains("malformed"))
+        );
+    }
+}

--- a/src/orchestration/primitives/single_pass.rs
+++ b/src/orchestration/primitives/single_pass.rs
@@ -1,0 +1,121 @@
+use super::{
+    MachineState, NextStep, PrimitiveMachine, PrimitiveOutput, dispatch, malformed,
+    subagent_failure,
+};
+use crate::orchestration::contracts::{SubagentError, SubagentResult};
+use crate::orchestration::types::TeamRole;
+
+#[derive(Debug, Clone)]
+pub struct SinglePassMachine {
+    issue_number: u64,
+    state: MachineState,
+}
+
+impl SinglePassMachine {
+    pub fn new(issue_number: u64) -> Self {
+        Self {
+            issue_number,
+            state: MachineState::Dispatching,
+        }
+    }
+}
+
+impl PrimitiveMachine for SinglePassMachine {
+    fn next(&mut self) -> NextStep {
+        if let Some(step) = self.state.next_terminal(|role| {
+            format!(
+                "Awaiting existing {role:?} task for issue #{}.",
+                self.issue_number
+            )
+        }) {
+            return step;
+        }
+
+        match &self.state {
+            MachineState::Dispatching => {
+                self.state = MachineState::Waiting(TeamRole::Reviewer);
+                dispatch(
+                    TeamRole::Reviewer,
+                    format!(
+                        "Perform a single-pass review for issue #{}.",
+                        self.issue_number
+                    ),
+                )
+            }
+            MachineState::Waiting(_) | MachineState::Done(_) | MachineState::Failed(_) => {
+                unreachable!("terminal states returned above")
+            }
+        }
+    }
+
+    fn advance(&mut self, role: TeamRole, result: Result<SubagentResult, SubagentError>) {
+        if !self.state.take_waiting(role) {
+            return;
+        }
+        match result {
+            Ok(result @ SubagentResult::ReviewFindings { .. })
+            | Ok(result @ SubagentResult::Generic { .. }) => {
+                self.state = MachineState::Done(PrimitiveOutput::SinglePass { role, result });
+            }
+            Ok(got) => {
+                self.state =
+                    MachineState::Failed(malformed(role, "review-findings or generic", &got));
+            }
+            Err(err) => self.state = MachineState::Failed(subagent_failure(role, err)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::orchestration::contracts::ReviewVerdict;
+
+    fn review() -> SubagentResult {
+        SubagentResult::ReviewFindings {
+            verdict: ReviewVerdict::Comment,
+            findings: vec![],
+        }
+    }
+
+    #[test]
+    fn single_pass_success_path() {
+        let mut machine = SinglePassMachine::new(1);
+        assert!(matches!(
+            machine.next(),
+            NextStep::Dispatch {
+                role: TeamRole::Reviewer,
+                ..
+            }
+        ));
+        machine.advance(TeamRole::Reviewer, Ok(review()));
+        assert!(matches!(machine.next(), NextStep::Done { .. }));
+    }
+
+    #[test]
+    fn single_pass_failure_path() {
+        let mut machine = SinglePassMachine::new(1);
+        let _ = machine.next();
+        machine.advance(
+            TeamRole::Reviewer,
+            Err(SubagentError::SubagentReported("nope".into())),
+        );
+        assert!(matches!(machine.next(), NextStep::Fail { reason } if reason.contains("nope")));
+    }
+
+    #[test]
+    fn single_pass_malformed_result_path() {
+        let mut machine = SinglePassMachine::new(1);
+        let _ = machine.next();
+        machine.advance(
+            TeamRole::Reviewer,
+            Ok(SubagentResult::DocsChange {
+                files_touched: vec![],
+                summary: "wrong".into(),
+            }),
+        );
+        assert!(
+            matches!(machine.next(), NextStep::Fail { reason } if reason.contains("malformed"))
+        );
+    }
+}

--- a/src/orchestration/primitives/verdict_only.rs
+++ b/src/orchestration/primitives/verdict_only.rs
@@ -1,0 +1,126 @@
+use super::{
+    MachineState, NextStep, PrimitiveMachine, PrimitiveOutput, dispatch, malformed,
+    subagent_failure,
+};
+use crate::orchestration::contracts::{SubagentError, SubagentResult};
+use crate::orchestration::types::TeamRole;
+
+#[derive(Debug, Clone)]
+pub struct VerdictOnlyMachine {
+    issue_number: u64,
+    state: MachineState,
+}
+
+impl VerdictOnlyMachine {
+    pub fn new(issue_number: u64) -> Self {
+        Self {
+            issue_number,
+            state: MachineState::Dispatching,
+        }
+    }
+}
+
+impl PrimitiveMachine for VerdictOnlyMachine {
+    fn next(&mut self) -> NextStep {
+        if let Some(step) = self.state.next_terminal(|role| {
+            format!(
+                "Awaiting existing {role:?} task for issue #{}.",
+                self.issue_number
+            )
+        }) {
+            return step;
+        }
+
+        match &self.state {
+            MachineState::Dispatching => {
+                self.state = MachineState::Waiting(TeamRole::Triager);
+                dispatch(
+                    TeamRole::Triager,
+                    format!(
+                        "Produce a verdict for issue #{} without code changes.",
+                        self.issue_number
+                    ),
+                )
+            }
+            MachineState::Waiting(_) | MachineState::Done(_) | MachineState::Failed(_) => {
+                unreachable!("terminal states returned above")
+            }
+        }
+    }
+
+    fn advance(&mut self, role: TeamRole, result: Result<SubagentResult, SubagentError>) {
+        if !self.state.take_waiting(role) {
+            return;
+        }
+        match result {
+            Ok(SubagentResult::Verdict {
+                decision,
+                rationale,
+                new_issues,
+            }) => {
+                self.state = MachineState::Done(PrimitiveOutput::Verdict {
+                    decision,
+                    rationale,
+                    new_issues,
+                });
+            }
+            Ok(got) => self.state = MachineState::Failed(malformed(role, "verdict", &got)),
+            Err(err) => self.state = MachineState::Failed(subagent_failure(role, err)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn verdict() -> SubagentResult {
+        SubagentResult::Verdict {
+            decision: "promote".into(),
+            rationale: "clear value".into(),
+            new_issues: vec![],
+        }
+    }
+
+    #[test]
+    fn verdict_only_success_path() {
+        let mut machine = VerdictOnlyMachine::new(3);
+        assert!(matches!(
+            machine.next(),
+            NextStep::Dispatch {
+                role: TeamRole::Triager,
+                ..
+            }
+        ));
+        machine.advance(TeamRole::Triager, Ok(verdict()));
+        assert!(matches!(machine.next(), NextStep::Done { .. }));
+    }
+
+    #[test]
+    fn verdict_only_failure_path() {
+        let mut machine = VerdictOnlyMachine::new(3);
+        let _ = machine.next();
+        machine.advance(
+            TeamRole::Triager,
+            Err(SubagentError::Timeout { seconds: 1 }),
+        );
+        assert!(
+            matches!(machine.next(), NextStep::Fail { reason } if reason.contains("timed out"))
+        );
+    }
+
+    #[test]
+    fn verdict_only_malformed_result_path() {
+        let mut machine = VerdictOnlyMachine::new(3);
+        let _ = machine.next();
+        machine.advance(
+            TeamRole::Triager,
+            Ok(SubagentResult::Generic {
+                json: serde_json::json!({}),
+            }),
+        );
+        assert!(
+            matches!(machine.next(), NextStep::Fail { reason } if reason.contains("malformed"))
+        );
+    }
+}

--- a/src/tui/widgets/ci_monitor.rs
+++ b/src/tui/widgets/ci_monitor.rs
@@ -49,6 +49,7 @@ impl<'a> CiMonitorWidget<'a> {
     /// When `true` (default), render an `[e] Error Review` hint line below
     /// the summary row whenever `summary.failed > 0` (#695). Tests use
     /// `false` to assert summary-only output.
+    #[allow(dead_code)]
     pub fn show_action_hint(mut self, show: bool) -> Self {
         self.show_action_hint = show;
         self


### PR DESCRIPTION
## Summary

- Adds L2 system-prompt assembly bounded to Task-style delegation.
- Adds primitive state machines for pipeline, fan-out, single-pass, and verdict-only workflows.
- Covers primitive dispatch and mock-task orchestration paths with focused tests.

Closes #662

## Test plan

- [x] cargo test orchestration --all-targets
- [x] cargo fmt --check
