### PR TITLE
feat(templates): author canonical command specs (implement, pushup, plan-feature, simplify)

### DIFF
--- a/.maestro/templates/README.md
+++ b/.maestro/templates/README.md
@@ -18,8 +18,11 @@ directly. The canonical-vs-rendered split exists so cross-provider rules
 │   ├── premises.md
 │   ├── tdd-cycle.md
 │   └── dependency-graph.md
-└── commands/              ← canonical command specs (populated in #C)
-    └── .gitkeep
+└── commands/              ← canonical command specs (Issue #702)
+    ├── implement.md
+    ├── pushup.md
+    ├── plan-feature.md
+    └── simplify.md
 ```
 
 > Authoritative project layout lives in `directory-tree.md` at the repo root.
@@ -27,15 +30,14 @@ directly. The canonical-vs-rendered split exists so cross-provider rules
 
 ## Forward-reference legend
 
-Letter codes (`#A`, `#B`, `#C`, `#G`) reference work items in the approved
-plan `we-need-to-standardize-zippy-wave.md`. They are placeholders until the
-follow-up GitHub issues are filed; replace with concrete `#NNN` numbers as
-each lands.
+Letter codes (`#A`, `#B`, `#G`) reference work items in the approved
+plan `we-need-to-standardize-zippy-wave.md`. `#A`, `#B`, and `#C` have
+landed; replace `#G` with a concrete `#NNN` number when that issue is filed.
 
-| Code | Scope |
-|------|-------|
-| #A   | This issue (#700) — L0 scaffold |
-| #B   | Render engine — resolves placeholders into per-provider output |
-| #C   | Canonical command specs — populates `commands/` |
-| #G   | `maestro sync-templates` CLI — re-renders from canonical sources |
+| Code | Issue | Scope |
+|------|-------|-------|
+| #A   | #700  | L0 scaffold — canonical templates directory |
+| #B   | #701  | Render engine — resolves placeholders into per-provider output |
+| #C   | #702  | Canonical command specs — populated `commands/` with implement, pushup, plan-feature, simplify |
+| #G   | TBD   | `maestro sync-templates` CLI — re-renders from canonical sources |
 

--- a/.maestro/templates/commands/implement.md
+++ b/.maestro/templates/commands/implement.md
@@ -1,0 +1,489 @@
+---
+command: implement
+version: 1.0.0
+description: Fetch a GitHub issue and implement it following the enforced TDD harness.
+placeholders:
+  - HOOK_GATE
+  - INCLUDE
+  - INVOKE_SUBAGENT
+includes:
+  - core/premises.md
+  - core/tdd-cycle.md
+source_provenance:
+  ported_from: .claude/commands/implement.md
+  ported_at: 2026-05-13
+---
+
+# Implement Issue
+
+Fetch a GitHub issue and implement it following the enforced TDD harness.
+
+**Usage:** `/implement #123` or `/implement 123 --english --orchestrator`
+
+{{INCLUDE path="core/premises.md"}}
+
+---
+
+## Arguments
+
+`$ARGUMENTS` contains the issue number and optional flags.
+
+### Supported Flags
+
+| Flag | Short | Purpose |
+|------|-------|---------|
+| `--english` | `-e` | Set language to English |
+| `--portuguese` | `-pt` | Set language to Português do Brasil |
+| `--spanish` | `-s` | Set language to Español |
+| `--orchestrator` | `-o` | Use Subagents Orchestrator mode |
+| `--vibe-coding` | `-vc` | Use Vibe Coding mode |
+| `--continue` | — | Step 5 idempotency: continue on existing branch (skip prompt) |
+| `--restart` | — | Step 5 idempotency: delete existing branch and start fresh (skip prompt; still requires inner `RESTART` confirmation if interactive) |
+| `--dirty-tree-action=stash\|abort\|ask` | — | Pre-check Gate 6: how to handle a dirty working tree. Pass-through to the gate hook. |
+| `--auto-comment` | — | Step 4 DOR remediation: auto-post the gatekeeper-drafted comment + `needs-info` label. Default: print the proposed action and STOP for human review. |
+
+`--training` / `-t` is explicitly rejected — Training mode is for provider-configuration directories, not implementation.
+
+`--continue` and `--restart` are mutually exclusive — passing both is an error.
+
+---
+
+## Instructions
+
+### Step 0: Parse arguments
+
+Extract from `$ARGUMENTS`:
+1. **Issue number**: first `\d+` with optional `#` prefix. Export as `$ISSUE_NUMBER` for downstream steps.
+2. **Language flag** (if present).
+3. **Mode flag** (if present).
+4. **Idempotency flag** (`--continue` or `--restart`, if present). Reject with exit 1 if both are passed.
+5. **Dirty-tree action** (`--dirty-tree-action=...`, if present) — captured for pass-through to the pre-check hook in Step 2.
+6. **Auto-comment opt-in** (`--auto-comment`, if present) — export `AUTO_COMMENT=1` for Step 4 DOR auto-remediation.
+
+```bash
+export ISSUE_NUMBER="<n>"  # substitute the parsed number
+```
+
+All subsequent gate commands in this file reference `$ISSUE_NUMBER`, not bare `<n>`.
+
+If `--training` or `-t` is detected, output:
+
+```
+Training mode is for configuring provider agents, skills, and commands.
+/implement is for building features from GitHub issues.
+Drop --training, or use a free-form prompt for provider configuration.
+```
+
+and exit 0 (not an error).
+
+If no issue number found, ask: "Which issue should I implement?"
+
+### Step 1: Language and mode selection
+
+If flags provided, honor them. Otherwise, ask the user.
+
+### Step 2: Pre-check hook (GATE — MANDATORY)
+
+Run the mechanical pre-check hook. Abort on non-zero exit, printing stderr verbatim. Pass through `--dirty-tree-action=...` from Step 0 if the user supplied it.
+
+```bash
+{{HOOK_GATE script="implement-gates.sh" args="$ISSUE_NUMBER ${DIRTY_TREE_ACTION:+--dirty-tree-action=$DIRTY_TREE_ACTION}"}}
+```
+
+The hook prints `gate log dir: /tmp/maestro-$ISSUE_NUMBER-<ts>` on success AND writes the same path to a sentinel file. The sentinel allows subsequent shell calls to recover `GATE_LOG_DIR` without relying on env-var persistence (each fresh shell loses `export`).
+
+The resolution chain (symlink-attack hardening on multi-user Linux) is `$XDG_RUNTIME_DIR` → `$HOME/.cache/maestro` → `${TMPDIR:-/tmp}`. The hook prints the chosen path as `sentinel: <path>` on stdout.
+
+Recovery pattern for any later step (walks the same chain):
+
+```bash
+GATE_LOG_DIR=""
+for candidate in \
+  "${XDG_RUNTIME_DIR:-}/maestro-current-gate-dir" \
+  "${HOME}/.cache/maestro/maestro-current-gate-dir" \
+  "/tmp/maestro-current-gate-dir"; do
+  if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+    GATE_LOG_DIR=$(cat "$candidate")
+    break
+  fi
+done
+```
+
+The sentinel file is overwritten on the next `/implement` run, so it always points at the current gate session.
+
+**Non-TTY behavior of the hook:** the gate hook detects no-TTY (`! -t 0`) and refuses to prompt for the dirty-tree action. If the tree is dirty and `--dirty-tree-action=` is not passed, the hook prints an actionable message and exits 6. Re-run the slash command with `--dirty-tree-action=stash` (auto-stash) or `--dirty-tree-action=abort` (clean fail) to unblock.
+
+Exit codes:
+- `0` — proceed.
+- `1` — generic failure (gh missing, not authed, not in repo, closed issue). Abort with the hook's stderr.
+- `2` — baseline cargo test failing. Abort — fix the baseline before starting.
+- `6` — dirty tree, user chose abort. Abort cleanly.
+- `7+` — preflight failure. Abort with its stderr.
+
+### Step 3: Read cached issue JSON and summary
+
+The hook has cached the issue JSON at `$GATE_LOG_DIR/issue.json` and a condensed
+DOR summary at `$GATE_LOG_DIR/issue-summary.md`. Read them directly — no second
+`gh` call. Prefer `issue-summary.md` for downstream subagents that only need the
+issue requirements; keep `issue.json` for mechanical gates and fallback checks
+that need labels, state, comments, or other structured fields.
+
+```bash
+cat "$GATE_LOG_DIR/issue.json"
+cat "$GATE_LOG_DIR/issue-summary.md"
+```
+
+### Step 4: Gatekeeper (GATE — MANDATORY)
+
+Run the mechanical DOR lint first. It writes `$GATE_LOG_DIR/dor-lint.json` and
+always exits 0; the JSON verdict decides whether the subagent can be skipped.
+
+```bash
+scripts/dor-lint.sh "$GATE_LOG_DIR/issue.json" >/dev/null
+
+lint_passed=$(jq -r .passed "$GATE_LOG_DIR/dor-lint.json")
+all_blockers_closed=$(jq -r '.blocker_states | to_entries | all(.value == "CLOSED")' "$GATE_LOG_DIR/dor-lint.json")
+contract_required=$(jq -r '.reasons | index("contract validation required") != null' "$GATE_LOG_DIR/dor-lint.json")
+
+if [ "$lint_passed" = "true" ] && \
+   [ "$all_blockers_closed" = "true" ] && \
+   [ "$contract_required" = "false" ]; then
+  python3 - "$GATE_LOG_DIR/dor-lint.json" "$GATE_LOG_DIR/gatekeeper.json" <<'PY'
+import json
+import sys
+
+lint = json.load(open(sys.argv[1]))
+task_map = {
+    "feature": "implementation",
+    "bug": "implementation",
+    "trivial": "implementation",
+    "docs": "docs",
+    "refactor": "refactor",
+}
+report = {
+    "report_version": 1,
+    "status": "PASS",
+    "task_type": task_map.get(lint.get("task_type"), "implementation"),
+    "dor": {"passed": True, "missing_sections": [], "weak_sections": []},
+    "blockers": {"passed": True, "open": []},
+    "contracts": {"passed": True, "missing": []},
+    "remediation": {"comment_body": "", "labels_to_add": []},
+    "reasons": [],
+}
+json.dump(report, open(sys.argv[2], "w"), separators=(",", ":"))
+open(sys.argv[2], "a").write("\n")
+PY
+  task_type=$(jq -r .task_type "$GATE_LOG_DIR/gatekeeper.json")
+  echo "Gatekeeper fast-path PASS (task_type: $task_type)"
+  export TASK_TYPE="$task_type"
+else
+  echo "DOR lint did not qualify for fast-path; invoking subagent-gatekeeper."
+fi
+```
+
+If the fast path did not write `$GATE_LOG_DIR/gatekeeper.json`, invoke the gatekeeper subagent:
+
+{{INVOKE_SUBAGENT name="gatekeeper" prompt="Classify issue $ISSUE_NUMBER (DOR, blockers, contracts, task_type). Return the structured JSON gatekeeper report."}}
+
+The subagent's response will contain a fenced `json gatekeeper` code block. Pipe its full response through the parser:
+
+```bash
+if [ ! -f "$GATE_LOG_DIR/gatekeeper.json" ]; then
+  echo "$SUBAGENT_RESPONSE" | python3 scripts/parse_gatekeeper_report.py > "$GATE_LOG_DIR/gatekeeper.json"
+fi
+```
+
+Then branch on the parsed report:
+
+```bash
+status=$(jq -r .status "$GATE_LOG_DIR/gatekeeper.json")
+task_type=$(jq -r .task_type "$GATE_LOG_DIR/gatekeeper.json")
+
+if [ "$status" = "FAIL" ]; then
+  dor_passed=$(jq -r .dor.passed "$GATE_LOG_DIR/gatekeeper.json")
+  if [ "$dor_passed" = "false" ]; then
+    comment_body=$(jq -r .remediation.comment_body "$GATE_LOG_DIR/gatekeeper.json")
+    labels_csv=$(jq -r '.remediation.labels_to_add | join(", ")' "$GATE_LOG_DIR/gatekeeper.json")
+
+    if [ "${AUTO_COMMENT:-0}" = "1" ]; then
+      gh issue comment "$ISSUE_NUMBER" --body "$comment_body"
+      for label in $(jq -r '.remediation.labels_to_add[]' "$GATE_LOG_DIR/gatekeeper.json"); do
+        gh issue edit "$ISSUE_NUMBER" --add-label "$label"
+      done
+      echo "Gatekeeper FAIL: DOR auto-remediation posted (--auto-comment)." >&2
+    else
+      echo "Gatekeeper FAIL: DOR not satisfied." >&2
+      echo "Proposed remediation (NOT posted; re-run with --auto-comment to post):" >&2
+      echo "" >&2
+      echo "  Issue:  #$ISSUE_NUMBER" >&2
+      echo "  Labels: $labels_csv" >&2
+      echo "  Comment body:" >&2
+      echo "  ----" >&2
+      printf '%s\n' "$comment_body" | sed 's/^/  /' >&2
+      echo "  ----" >&2
+    fi
+  fi
+  echo "Gatekeeper FAIL:" >&2
+  jq -r '.reasons[]' "$GATE_LOG_DIR/gatekeeper.json" | while read -r r; do
+    echo "  - $r" >&2
+  done
+  exit 5
+fi
+
+echo "Gatekeeper PASS (task_type: $task_type)"
+export TASK_TYPE="$task_type"
+```
+
+Exit code `5` is reserved for gatekeeper failure.
+
+### Step 5: Branch selection with idempotency
+
+Check for an existing branch matching `feat/issue-${ISSUE_NUMBER}-*`:
+
+```bash
+existing=$(git branch --list "feat/issue-${ISSUE_NUMBER}-*" | head -1 | sed 's/^[ *]*//')
+```
+
+**If empty:** derive a slug from the issue title and create a new branch:
+
+```bash
+slug=$(jq -r .title "$GATE_LOG_DIR/issue.json" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | sed 's/^-//;s/-$//' | cut -c -40)
+git checkout -b "feat/issue-${ISSUE_NUMBER}-${slug}"
+```
+
+**If non-empty:** resolve the idempotency choice using the flags from Step 0, falling back to a TTY prompt when running interactively.
+
+```
+Branch `<existing>` already exists.
+
+Recent commits on that branch:
+<git log main..HEAD --oneline -5>
+```
+
+Resolution rules (in order):
+
+1. If `--continue` was passed → take the **(C)ontinue** path below.
+2. If `--restart` was passed → take the **(R)estart** path below (the inner `RESTART` typed confirmation is also waived under `--restart`, since the user already chose this path explicitly).
+3. If neither flag was passed AND stdin is a TTY → fire the interactive prompt:
+
+   ```
+     (C)ontinue on this branch
+     (R)estart — delete branch and start over
+     (A)bort
+
+   Choice [C/R/A]:
+   ```
+
+4. If neither flag was passed AND stdin is **not** a TTY → default to **(A)bort** with this message:
+
+   ```
+   Branch `<existing>` already exists and stdin is not interactive.
+   Re-run with `/implement #<N> --continue` (resume) or `/implement #<N> --restart` (start over).
+   ```
+
+   Exit cleanly (no error code; the user's next invocation drives the choice).
+
+Handle each choice:
+
+**(C)ontinue:**
+- `git checkout <existing>`.
+- Re-invoke the gatekeeper (idempotent).
+- When delegating to architect/QA in Step 6, prepend the resumption context prompt:
+
+  > **Context for resumption:** This branch already has commits. Here is the history since `main`:
+  >
+  > ```
+  > $(git log --oneline main..HEAD)
+  > ```
+  >
+  > Before producing a full blueprint, inspect these commits. If the work described by the issue appears substantially done (architecture scaffolded, tests present, or implementation in place), return a **minimal response** acknowledging the existing state and listing only what remains. Do not duplicate work already in the branch. If the branch diverges from what you would design (e.g., different module layout, different abstractions), flag the divergence and recommend either reconciling or restarting — do not silently layer a conflicting plan on top.
+
+- **Divergence handling:** if the architect or QA subagent flags divergence, the orchestrator presents a secondary prompt — but only when stdin is a TTY:
+
+  ```
+  Architect detected divergence between the existing branch and the
+  issue's requirements:
+
+  <architect's divergence summary>
+
+    (R)econcile — continue and let subagents bridge the gap
+    (S)witch to Restart — delete and start over
+    (A)bort — inspect manually
+
+  Choice [R/S/A]:
+  ```
+
+  - **(R)econcile**: proceed with Step 6's subagent sequence, trusting the architect/QA to bridge the gap via follow-up edits.
+  - **(S)witch to Restart**: fall through to the Restart flow below (typed `RESTART` confirmation, branch deletion).
+  - **(A)bort**: exit cleanly, tell the user to inspect manually.
+
+  **Non-TTY default:** emit the divergence summary to the user, default to **(A)bort**, and instruct: `Re-run with /implement #<N> --restart` to take the Switch-to-Restart path explicitly, or fix the divergence manually then re-run with `--continue`. Do not silently reconcile — divergence is exactly the case the human should adjudicate.
+
+**(R)estart:**
+- If reached via the interactive prompt, require typed `RESTART` confirmation. If reached via `--restart`, the flag itself is the confirmation — skip the typed gate.
+- `git checkout main && git branch -D "$existing"`.
+- If the branch was pushed AND stdin is a TTY, prompt about remote deletion (default no). If non-TTY, skip remote deletion (safer default; user can prune manually).
+- Create fresh branch.
+
+**(A)bort:**
+- Exit cleanly. Tell the user to `git checkout <branch>` manually to inspect.
+
+If the user is already on the matching branch, skip the prompt and use Continue semantics.
+
+### Step 6: Orchestrator-mode subagent sequence
+
+Vibe mode skips 6a and 6c. All gates use `bash` (not `sh`) — `${PIPESTATUS[0]}` requires it.
+
+The TDD cycle below is non-negotiable. The full canonical fragment:
+
+{{INCLUDE path="core/tdd-cycle.md"}}
+
+#### 6a. Architect → blueprint
+
+Orchestrator mode only. Invoke the architect subagent with the condensed issue
+summary from `$GATE_LOG_DIR/issue-summary.md` and the architecture blueprint
+request. If Step 5 chose Continue, prepend the resumption context prompt.
+
+{{INVOKE_SUBAGENT name="architect" prompt="Produce architecture blueprint for issue $ISSUE_NUMBER using $GATE_LOG_DIR/issue-summary.md; on Continue, prepend resumption context."}}
+
+#### 6b. `/validate-contracts` (if architect blueprint touches API endpoints)
+
+Skip if no endpoints.
+
+#### 6c. QA → test blueprint
+
+Orchestrator mode only. Invoke the QA subagent with the architect's blueprint. If Step 5 chose Continue, prepend the resumption context prompt.
+
+{{INVOKE_SUBAGENT name="qa" prompt="Produce test blueprint from architect's blueprint for issue $ISSUE_NUMBER; on Continue, prepend resumption context."}}
+
+#### 6d. Write tests from QA blueprint
+
+You (the orchestrator) write tests. No subagent.
+
+#### 6d-bis. Binding-gate selection (CI / non-Rust tasks)
+
+For most tasks `cargo test` is the binding RED/GREEN gate. For tasks where the artifact under test isn't Rust source — workflow YAML, shell scripts, slash-command spec edits, pure deletions — `cargo test` is a regression guard and the binding gate is the tool that actually validates the changed artifact.
+
+| Artifact under test | Binding RED/GREEN gate | Regression guard |
+|---|---|---|
+| Rust source (`src/**`, `tests/**`) | `cargo test --quiet` | — |
+| Workflow YAML (`.github/workflows/**`) | `actionlint` (wired into `ci.yml`) | `cargo test --quiet` |
+| Shell scripts (`scripts/**`) | `bash -n` + `shellcheck` on changed files | `cargo test --quiet` |
+| Docs (`*.md`, `directory-tree.md`) | none (skipped) | `cargo test --quiet` |
+
+For CI / non-Rust tasks the orchestrator runs the binding gate before and after implementation, and `cargo test` as a regression-only check. The 6e/6g `cargo test` blocks below remain the default; substitute the appropriate gate when the gatekeeper's advisory or the issue body indicates a non-Rust binding gate.
+
+#### 6e. RED checkpoint (GATE)
+
+Skipped if `TASK_TYPE` is `docs` or `refactor`.
+
+```bash
+if [ "$TASK_TYPE" != "docs" ] && [ "$TASK_TYPE" != "refactor" ]; then
+  cargo test --quiet 2>&1 | tee "$GATE_LOG_DIR/red.log"
+  red_exit=${PIPESTATUS[0]}
+  if [ $red_exit -eq 0 ]; then
+    echo "RED GATE FAILED — cargo test passed, but implementation has not started." >&2
+    echo "Write a failing test for the new behavior before implementing." >&2
+    exit 3
+  fi
+fi
+```
+
+Exit code `3` reserved for RED failure.
+
+#### 6f. Implement
+
+You (the orchestrator) write the minimum code to make the failing test pass.
+
+#### 6g. GREEN checkpoint (GATE)
+
+Skipped only if `TASK_TYPE` is `docs`.
+
+```bash
+if [ "$TASK_TYPE" != "docs" ]; then
+  cargo test --quiet 2>&1 | tee "$GATE_LOG_DIR/green.log"
+  green_exit=${PIPESTATUS[0]}
+  if [ $green_exit -ne 0 ]; then
+    echo "GREEN GATE FAILED — tests still failing after implementation." >&2
+    echo "See $GATE_LOG_DIR/green.log" >&2
+    exit 4
+  fi
+fi
+```
+
+Exit code `4` reserved for GREEN failure.
+
+#### 6h. Refactor (if needed)
+
+Refactor while tests stay green. Re-run the GREEN checkpoint after:
+
+```bash
+cargo test --quiet 2>&1 | tee "$GATE_LOG_DIR/green-refactor.log"
+[ ${PIPESTATUS[0]} -eq 0 ] || { echo "Refactor broke tests"; exit 4; }
+```
+
+#### 6i. Security review
+
+Both modes. Invoke the security analyst against the newly-written code.
+
+{{INVOKE_SUBAGENT name="security-analyst" prompt="Review newly-written code for issue $ISSUE_NUMBER against OWASP Top 10, secrets handling, and input validation."}}
+
+#### 6j. Documentation
+
+Both modes. Mandatory at task end.
+
+{{INVOKE_SUBAGENT name="docs-analyst" prompt="Update documentation and directory-tree.md for issue $ISSUE_NUMBER."}}
+
+### Step 7: Handoff
+
+Print a summary:
+
+```
+Implementation complete for Issue #$ISSUE_NUMBER: $TITLE
+
+Gates passed:
+  - Pre-check hook (ok)
+  - Gatekeeper (task_type: $TASK_TYPE)
+  - RED checkpoint (verified failing → passing)   # omit if task_type is docs/refactor
+  - GREEN checkpoint (all tests pass)              # omit if task_type is docs
+
+Logs: $GATE_LOG_DIR
+
+Next: run /pushup to commit, push, create PR, and close the issue.
+```
+
+---
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success — also returned when `--training` is passed (wrong-tool message, not a failure) |
+| 1 | Generic failure (gh missing, not authed, not in repo, closed issue) |
+| 2 | Baseline cargo test failing |
+| 3 | RED gate failed |
+| 4 | GREEN gate failed |
+| 5 | Gatekeeper FAIL (DOR, blockers, contracts) |
+| 6 | Dirty tree, user declined stash |
+| 7+ | Preflight failure (reserved for CI-gates spec) |
+
+---
+
+## Error Handling
+
+- If `gh` CLI not installed → hook exits 1 with install hint.
+- If `gh` not authenticated → hook exits 1 with `gh auth login` hint.
+- If issue closed → hook exits 1. Re-open first or pick a different issue.
+- If dirty tree → prompt (S)tash/(A)bort.
+- If baseline fails → exit 2. Fix baseline first.
+- If gatekeeper FAILs with DOR missing → proposed remediation printed to stderr for human review, exit 5. Re-run with `--auto-comment` to auto-post the comment and apply `needs-info` label.
+- If blockers open → exit 5. Wait for blockers to close.
+- If RED/GREEN fails → exit 3/4. Actionable error with log path.
+
+---
+
+## Do Not
+
+- Run `/implement` for the same issue concurrently in two sessions.
+- Bypass the hook by invoking subagents directly.
+- Skip the RED gate for `implementation` task types — write the failing test first.

--- a/.maestro/templates/commands/plan-feature.md
+++ b/.maestro/templates/commands/plan-feature.md
@@ -1,0 +1,110 @@
+---
+command: plan-feature
+version: 1.0.0
+description: Plan a feature across the project, creating API contracts first, then milestones and issues with dependency tracking.
+placeholders:
+  - INCLUDE
+  - SUBAGENT_LIST
+includes:
+  - core/premises.md
+  - core/dependency-graph.md
+source_provenance:
+  ported_from: .claude/commands/plan-feature.md
+  ported_at: 2026-05-13
+---
+
+# Plan Feature
+
+Plan a feature across your project, creating API contracts first, then milestones and issues with dependency tracking.
+
+**Usage:** `/plan-feature <description>` or `/plan-feature`
+
+{{INCLUDE path="core/premises.md"}}
+
+---
+
+## Arguments
+
+`$ARGUMENTS` contains the user's natural language description of the feature.
+
+If no arguments, ask: "Describe the feature you want to build."
+
+---
+
+## Instructions
+
+### Phase 1: ANALYZE — Understand the Feature
+
+1. **Parse the description** to identify:
+   - Feature goals
+   - Which systems/modules are involved
+   - What data flows exist (APIs, events, etc.)
+
+2. **Explore the codebase** to find:
+   - Existing models, services, and components related to the feature
+   - Existing API endpoints or contracts
+   - Architecture patterns already in use
+
+   Available subagents for delegation: {{SUBAGENT_LIST}}
+
+3. **Present analysis** to the user with what exists vs. what's needed
+
+### Phase 2: CONTRACTS FIRST — Create API Schemas
+
+For every API endpoint identified:
+1. Check if a contract already exists in `docs/api-contracts/`
+2. If not, create one following `api-contract-v1` format
+3. Present contracts to user for review
+
+### Phase 3: MILESTONES — Create if Needed
+
+If the feature is large enough for a milestone:
+```bash
+gh api repos/<owner>/<repo>/milestones -f title="..." -f state=open -f description="..."
+```
+
+### Phase 4: ISSUES — Create with Traceability
+
+Every issue MUST contain:
+1. **Context** — Why this issue exists
+2. **API Contract** reference (if endpoint involved)
+3. **Requirements** — What to build
+4. **TDD Checklist** — Tests to write
+5. **Acceptance Criteria** — Checkbox list
+6. **Dependencies** — What blocks this / what this blocks
+
+Create in dependency order:
+1. Contract/schema issues first
+2. Foundation issues (blocked by contracts)
+3. Feature issues (blocked by foundation)
+4. Capstone issue (blocked by all)
+
+### Phase 5: DEPENDENCY GRAPH — Present Final Plan
+
+Output:
+```
+## Implementation Order
+
+### Phase 1: Foundation
+- #XX: <title>
+
+### Phase 2: Core Features (parallelizable)
+- #XX: <title> (blocked by #YY)
+- #XX: <title> (blocked by #YY)
+
+### Phase 3: Integration
+- #XX: <title> (blocked by all above)
+```
+
+The dependency-graph format and per-issue `## Blocked By` rules are canonical:
+
+{{INCLUDE path="core/dependency-graph.md"}}
+
+---
+
+## Error Handling
+
+- If `gh` CLI fails → suggest `gh auth login`
+- If description is too vague → ask clarifying questions
+- If contract already exists → reuse it
+- If milestone exists → reuse it

--- a/.maestro/templates/commands/pushup.md
+++ b/.maestro/templates/commands/pushup.md
@@ -1,0 +1,203 @@
+---
+command: pushup
+version: 1.0.0
+description: Commit semantically, push, create PR, link issue, and complete tasks.
+placeholders:
+  - INCLUDE
+includes:
+  - core/premises.md
+  - core/dependency-graph.md
+source_provenance:
+  ported_from: .claude/commands/pushup.md
+  ported_at: 2026-05-13
+---
+
+# Push Up
+
+Commit semantically, push, create PR, link issue, and complete tasks.
+
+**Usage:** `/pushup` or `/pushup #123` (where #123 is the issue number)
+
+{{INCLUDE path="core/premises.md"}}
+
+---
+
+## Instructions
+
+This command automates the end-of-feature workflow. Execute ALL steps in order.
+
+### Step 1: Determine the Issue
+
+If `$ARGUMENTS` contains an issue number (e.g., `#123` or `123`), use that.
+
+Otherwise, detect the issue from:
+1. The current branch name (e.g., `feat/issue-123-description` → issue #123)
+2. Recent commit messages mentioning an issue
+3. If not found, ask the user: "Which issue does this PR close? (e.g., #123)"
+
+### Step 2: Semantic Commit
+
+1. Run `git status` to see all changes
+2. Run `git diff --staged` and `git diff` to understand what changed
+3. Run `git log --oneline -5` to match the repo's commit style
+4. Stage all relevant files (avoid secrets, .env, credentials)
+5. Ensure a gate log directory exists for editable drafts:
+
+```bash
+: "${GATE_LOG_DIR:=$(mktemp -d)}"
+export GATE_LOG_DIR
+```
+
+6. Generate the mechanical commit draft:
+
+```bash
+scripts/commit-helper.sh <issue-number>
+```
+
+The helper chooses the Conventional Commits prefix from issue labels, writes
+`$GATE_LOG_DIR/commit-draft.txt`, and includes `Closes #<issue-number>`.
+
+7. Fill in only the first-line subject placeholder. Keep the helper-selected
+   prefix and `Closes #<issue-number>` body unchanged. Use the existing HEREDOC
+   pattern to overwrite the draft, then commit from the draft file:
+
+```bash
+cat > "$GATE_LOG_DIR/commit-draft.txt" <<'EOF'
+<prefix>: <filled subject>
+
+Closes #<issue-number>
+EOF
+git commit -F "$GATE_LOG_DIR/commit-draft.txt"
+```
+
+### Step 3: Push to Remote
+
+1. Check if the current branch tracks a remote branch: `git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null`
+2. If no upstream exists, push with `-u`: `git push -u origin <branch-name>`
+3. If upstream exists, push normally: `git push`
+
+### Step 4: Create Pull Request
+
+1. Check if a PR already exists for this branch: `gh pr view --json number 2>/dev/null`
+2. If NO existing PR, create one:
+   - Title: use the commit subject exactly
+   - Body: generate a skeleton, then fill in only 1-3 summary bullets
+
+```
+commit_subject="$(git log -1 --pretty=%s)"
+: "${GATE_LOG_DIR:=$(mktemp -d)}"
+export GATE_LOG_DIR
+scripts/pr-skeleton.sh <issue-number> "$commit_subject"
+# Edit only $GATE_LOG_DIR/pr-draft.md summary bullets; keep Closes and Test plan.
+gh pr create --title "$commit_subject" --body-file "$GATE_LOG_DIR/pr-draft.md"
+```
+
+3. If PR already exists, update it if needed after regenerating/filling the body:
+   `gh pr edit <pr-number> --body-file "$GATE_LOG_DIR/pr-draft.md"`
+
+4. **Surface the new PR to a running maestro TUI for auto-review.** After a successful `gh pr create`, write a single-line JSON marker to `~/.maestro/last-pr-created`. A running maestro instance polls this file once per `check_completions` tick; on a fresh write it enqueues `TuiCommand::PrCreated` and triggers `/review`.
+
+The write must be atomic (write to `.tmp`, then `mv`) so the consumer never reads a partially-written line. The maestro reader also refuses to follow a symlink at this path and validates `owner` and `repo` against argv-injection.
+
+```bash
+mkdir -p "$HOME/.maestro"
+ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+marker="$HOME/.maestro/last-pr-created"
+printf '{"pr_number":%d,"owner":"%s","repo":"%s","ts":"%s"}\n' \
+  "<pr-number>" "<owner>" "<repo>" "$ts" \
+  > "${marker}.tmp"
+mv "${marker}.tmp" "$marker"
+```
+
+The marker is consumed-once: maestro deletes it after dispatching the review. If the marker is malformed or fails the owner/repo guard, maestro logs a Warn entry and deletes it.
+
+### Step 5: Link Issue to PR
+
+The `Closes #<issue-number>` in the PR body automatically links the issue.
+
+Additionally, add the issue as a linked reference:
+```bash
+gh pr edit <pr-number> --add-label "closes-issue"
+```
+
+If the repo doesn't have that label, skip this step (don't fail).
+
+### Step 6: Update Milestone Dependency Graph (MANDATORY — runs BEFORE issue close)
+
+Update the milestone's dependency graph to mark this issue with ✅. **This step runs before the issue close so that a failure here leaves the issue open and `/pushup` can be safely re-run** — closing the issue first would orphan the milestone graph if this step blew up.
+
+1. Fetch the issue's milestone:
+```bash
+MILESTONE=$(gh issue view <issue-number> --json milestone --jq '.milestone.number')
+```
+
+2. If the issue has no milestone, log that no milestone graph exists and continue to Step 6.5.
+
+3. If the issue has a milestone, run the mechanical updater and treat its exit code as the gate:
+```bash
+python3 scripts/update-milestone-graph.py --milestone "$MILESTONE" --issue "<issue-number>"
+```
+
+The script handles idempotency, anchored bullet replacement, level-header roll-up, `Sequence:` token-boundary rewrites, PATCH, and post-PATCH verification. A re-run where the issue is already stamped exits 0 with an "already marked" log line.
+
+**This step is NON-NEGOTIABLE.** Every closed issue MUST be reflected in the milestone graph. If it fails, **STOP** — do not proceed to Step 6.5 (issue close).
+
+The full canonical rules for milestone graph updates after issue closure:
+
+{{INCLUDE path="core/dependency-graph.md"}}
+
+### Step 6.5: Complete Tasks (issue close + checks)
+
+Runs AFTER the milestone graph is correctly stamped. If this step fails after Step 6 succeeded, the milestone graph is correctly stamped but the issue stays open — re-run `/pushup` or close manually. **This partial state is recoverable** (running `/pushup` again will idempotently re-detect the milestone is already stamped via Step 6.3 and skip straight to closing the issue).
+
+1. **On the Issue:** Add a comment and close it idempotently. A previous `/pushup` run may have already closed the issue (e.g., it failed mid-Step-6 and the user re-ran); the close step must NOT fail in that case.
+
+```bash
+issue_state=$(gh issue view <issue-number> --json state --jq '.state' 2>/dev/null || echo "ERROR")
+if [ "$issue_state" = "CLOSED" ]; then
+  echo "/pushup: issue #<issue-number> is already CLOSED — skipping comment + close (idempotent re-run)"
+elif [ "$issue_state" = "ERROR" ]; then
+  echo "/pushup: failed to read issue state; aborting close (will retry on next /pushup)" >&2
+  exit 1
+else
+  gh issue comment <issue-number> --body "Completed in PR #<pr-number>"
+  gh issue close <issue-number>
+fi
+```
+
+2. **On the PR:** Verify all checks pass (informational only, don't block):
+```bash
+gh pr checks <pr-number> 2>/dev/null || echo "No checks configured or still running"
+```
+
+### Step 7: Summary
+
+Print a final summary:
+
+```
+Push Up Complete
+
+  Commit:  <commit-hash> (<commit-type>: <short-message>)
+  Branch:  <branch-name>
+  PR:      #<pr-number> - <pr-title> (<pr-url>)
+  Issue:   #<issue-number> - Closed
+```
+
+---
+
+## Error Handling
+
+- If `gh` CLI is not installed, tell the user to install it: `brew install gh`
+- If not authenticated, tell user to run: `gh auth login`
+- If there are no changes to commit, skip to Step 3 (push any unpushed commits)
+- If push fails, show the error and stop (don't create PR with stale code)
+- If on `main` or `master` branch, WARN the user and ask for confirmation before proceeding
+
+---
+
+## Safety Checks
+
+- NEVER force push
+- NEVER push to `main` or `master` without explicit user confirmation
+- NEVER commit files matching: `.env*`, `credentials*`, `*.key`, `*.pem`, `*.p12`
+- Always show the user what will be committed before committing

--- a/.maestro/templates/commands/simplify.md
+++ b/.maestro/templates/commands/simplify.md
@@ -1,0 +1,118 @@
+---
+command: simplify
+version: 1.0.0
+description: Review changed code for reuse, quality, and efficiency; remove duplication, dead code, and over-abstraction without breaking tests.
+placeholders:
+  - INCLUDE
+  - INVOKE_SUBAGENT
+  - SKILL
+includes:
+  - core/premises.md
+  - core/tdd-cycle.md
+source_provenance:
+  ported_from: new
+  ported_at: 2026-05-13
+---
+
+# Simplify
+
+Review the working-tree diff against the project's design philosophy and remove what does not earn its place.
+
+**Usage:** `/simplify` (defaults to `main..HEAD`) or `/simplify <base-ref>`
+
+{{INCLUDE path="core/premises.md"}}
+
+---
+
+## When to Use
+
+- After a feature is GREEN but before `/pushup`.
+- After a large refactor, to confirm no new coupling or duplication slipped in.
+- When the diff "feels long" — the heuristic is wrong more often than right, and a structured pass catches what intuition misses.
+
+## Non-Goals
+
+- This is NOT a security review (that is handled by `security-analyst` in `/implement` step 6i).
+- This is NOT a test-coverage review (that is handled by `qa`).
+- This does NOT introduce new abstractions; it removes premature ones.
+
+## Design Principles (the rubric)
+
+Three lenses, applied in order:
+
+1. **ETC (Easy To Change)** — would this be easy to change if the next requirement shifted? Each binding to a concrete implementation is a coupling point; flag it.
+2. **Law of Demeter** — count the dots. Method chains like `app.pool.sessions[0].status.label()` are a code smell. Push behaviour into the owner, not the caller.
+3. **Object Calisthenics (5-7 of 9)** — aspirational compass, not dogma. Score the diff:
+   - One level of indentation per method
+   - No `else` keyword (early returns / match)
+   - Wrap primitives that carry domain meaning
+   - First-class collections (`SessionPool` wraps `Vec<Session>`)
+   - One dot per line
+   - No abbreviations
+   - Keep entities small (< 100 lines per impl, < 500 lines per file)
+   - Two instance variables or fewer
+   - No getters/setters — expose behaviour
+
+   Flag any score below 5/9 as a design smell worth fixing now.
+
+## Workflow
+
+### Step 1: Scope the diff
+
+`git diff --stat <base>..HEAD` to see what changed. If the diff touches more than ~15 files or ~800 lines, recommend splitting the review by directory.
+
+### Step 2: Mechanical rot checks
+
+Run, in order:
+
+- `cargo fmt --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test --quiet`
+
+If any of these fail, **STOP** — simplify is for clean diffs, not broken ones. Fix the basics first.
+
+### Step 3: Quality skills pass
+
+Apply the {{SKILL name="project-patterns"}} skill to the changed files. Look for:
+
+- Naming inconsistent with the existing module
+- New `unwrap()`/`expect()` introduced (forbidden per Rust guardrails §2)
+- New `println!`/`dbg!` (use `tracing` — Rust guardrails §11)
+- Files crossing 500 LOC
+- Functions crossing one indent level
+
+### Step 4: Architect review
+
+{{INVOKE_SUBAGENT name="architect" prompt="Review the diff <base>..HEAD against ETC, Demeter, and Object Calisthenics 5-7/9. Flag duplications, dead code, over-abstraction, and Demeter violations. Return a blueprint, not code."}}
+
+The architect's response is a list of recommendations, not edits. You (the orchestrator) decide which to apply.
+
+### Step 5: Apply edits, tests green
+
+Each recommendation is a small TDD cycle:
+
+{{INCLUDE path="core/tdd-cycle.md"}}
+
+After each edit, re-run `cargo test --quiet`. If a simplification breaks a test, **the test is the spec** — either the simplification was wrong, or the test was over-fitted to the old shape. Decide explicitly which.
+
+### Step 6: Document the trade-off
+
+For every non-trivial change (renaming a type, collapsing two functions, removing a layer), append a one-line entry to the PR body under `## Simplifications`:
+
+```
+- Collapsed `SessionStatus::label()` + `SessionStatus::short_label()` into one method (Demeter, ETC).
+```
+
+This makes the review's intent visible to PR reviewers.
+
+## Error Handling
+
+- If `cargo test` fails before starting → STOP, fix baseline (same Gate 2 as `/implement`).
+- If the architect flags more than ~5 issues → split into a fresh issue and run `/implement` on it. `/simplify` is for low-risk passes, not full refactors.
+- If a simplification cannot keep tests green → revert it and document the constraint in the PR body.
+
+## Do Not
+
+- Introduce new abstractions during simplify.
+- Touch files outside the diff under review.
+- Skip the mechanical rot checks (Step 2) — they're cheap and catch 80% of issues.

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-05-13 14:00 (UTC)
+> Last updated: 2026-05-13 15:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -90,8 +90,11 @@ maestro/
 │       │   ├── premises.md                # Ported from .claude/CLAUDE.md § CRITICAL PREMISES
 │       │   ├── tdd-cycle.md               # Ported from .claude/CLAUDE.md § 5 (TDD mandate and Orchestrator flow)
 │       │   └── dependency-graph.md        # Ported from .claude/CLAUDE.md § 4 (dependency-graph mandate)
-│       └── commands/                      # Canonical command specs (populated in #C)
-│           └── .gitkeep
+│       └── commands/                      # Canonical command specs (Issue #702)
+│           ├── implement.md               # Canonical port of .claude/commands/implement.md (489 lines)  [Issue #702]
+│           ├── pushup.md                  # Canonical port of .claude/commands/pushup.md (203 lines)  [Issue #702]
+│           ├── plan-feature.md            # Canonical port of .claude/commands/plan-feature.md (110 lines)  [Issue #702]
+│           └── simplify.md               # New canonical spec (no .claude/commands/ ancestor) (118 lines)  [Issue #702]
 ├── build.rs                               # Build script: generates man page (maestro.1) and shell completions (bash, zsh, fish) into OUT_DIR at build time using clap_mangen and clap_complete  [Issue #18]
 ├── src/
 │   ├── lib.rs                             # Library facade; exposes session::parser and session::types for benchmark crates; pub mod icon_mode and pub mod icons added so shared icon modules are accessible as library crate items; pub mod templates declared (Issue #701); agent_graph_spike module removed; the now-removed ADR-002 spike's #[cfg(feature = "spike")] pub mod agent_personalities block was cleaned up in issue #536  [Issue #307, #308, #526, #536, #539, #701]
@@ -542,7 +545,7 @@ maestro/
 │   │       ├── text_input.rs              # Single-line text input widget with cursor support
 │   │       └── toggle.rs                 # Boolean toggle widget for settings and forms; draw() routes through icons::get(IconId::CheckboxOn/Off) instead of hardcoded literals, eliminating the DRY drift that caused blank indicators on iTerm2 + some Nerd Font installs  [Issue #433]
 │   ├── integration_tests/                 # End-to-end integration test suite (no external deps, all mocked)  [Issue #15]
-│   │   ├── mod.rs                         # Module declarations; shared helpers: make_pool(), make_pool_with_worktree(), make_session(), make_session_with_issue(), make_gh_issue(); mod milestone_health_wizard, wip_backup, orchestration_*, adapt_pipeline, doctor_run_health_check, orchestration_smoke, and templates_render registered  [Issue #500, #562, #663, #665, #701]
+│   │   ├── mod.rs                         # Module declarations; shared helpers: make_pool(), make_pool_with_worktree(), make_session(), make_session_with_issue(), make_gh_issue(); mod milestone_health_wizard, wip_backup, orchestration_*, adapt_pipeline, doctor_run_health_check, orchestration_smoke, templates_render, and canonical_command_specs registered  [Issue #500, #562, #663, #665, #701, #702]
 │   │   ├── adapt_pipeline.rs              # Integration tests for the adapt pipeline
 │   │   ├── completion_pipeline.rs         # 9 tests: label transitions and PR creation
 │   │   ├── concurrent_sessions.rs         # 6 tests: max_concurrent enforcement
@@ -559,7 +562,13 @@ maestro/
 │   │   ├── upgrade.rs                     # End-to-end upgrade flow tests: version check, banner states, installer backup/swap, restart command construction  [Issue #118]
 │   │   ├── wip_backup.rs                  # Pipeline-level regression tests for the WIP backup commit step (Issue #562): real git in tempdir; covers backup_wip creates sentinel commit, amend_clean_and_push amends on success, head_is_wip_backup detects sentinel vs clean commit, gate failure leaves WIP commit in place, flag-injection rejected in commit_and_push  [Issue #562]
 │   │   ├── worktree_lifecycle.rs          # 8 tests: worktree create/cleanup and health monitoring
-│   │   └── templates_render.rs            # 11 integration tests for the template render engine using tempdir fixtures; covers literal pass-through, provider placeholder expansion, sandbox escape rejection, include-cycle detection, and manifest-missing error path  [Issue #701]
+│   │   ├── templates_render.rs            # 11 integration tests for the template render engine using tempdir fixtures; covers literal pass-through, provider placeholder expansion, sandbox escape rejection, include-cycle detection, and manifest-missing error path  [Issue #701]
+│   │   ├── canonical_command_specs.rs     # 15-invariant test suite for canonical command specs; verifies structural integrity of all four commands/ files (front-matter, placeholder coverage, include directives, section headings); 4 insta snapshots via tokenize()  [Issue #702]
+│   │   └── snapshots/                     # Insta snapshot files for canonical_command_specs tests  [Issue #702]
+│   │       ├── maestro__integration_tests__canonical_command_specs__snapshot_tokenize_implement.snap
+│   │       ├── maestro__integration_tests__canonical_command_specs__snapshot_tokenize_plan_feature.snap
+│   │       ├── maestro__integration_tests__canonical_command_specs__snapshot_tokenize_pushup.snap
+│   │       └── maestro__integration_tests__canonical_command_specs__snapshot_tokenize_simplify.snap
 │   ├── changelog/                         # CHANGELOG.md parser and model
 │   │   ├── mod.rs                         # Module facade; re-exports ChangelogParser and related types
 │   │   └── parser.rs                      # ChangelogParser: parses Keep a Changelog formatted CHANGELOG.md; used by release notes screen
@@ -704,6 +713,7 @@ maestro/
 | `.claude/worktrees/` | Worktree checkouts managed by maestro |
 | `.maestro/templates/` | Canonical template sources for the render engine; never edit rendered outputs under `.claude/commands/` directly  [Issue #700] |
 | `.maestro/templates/core/` | Shared fragments (premises, TDD cycle, dependency-graph mandate) included by every command spec |
+| `.maestro/templates/commands/` | Canonical command specs; four files ported/created in Issue #702: `implement.md`, `pushup.md`, `plan-feature.md`, `simplify.md` |
 | `.maestro/templates/manifest.toml` | Structured TOML manifest consumed by `src/templates/manifest.rs`; sections: `[meta]` (schema version), `[placeholders.*]` (vocabulary), `[providers.*]` (per-provider capability flags); rewritten from comment-skeleton to typed TOML in Issue #701 |
 | `build.rs` | Build script: generates `maestro.1` man page and bash/zsh/fish completions into `OUT_DIR` at build time (Issue #18) |
 | `docs/` | Project documentation |
@@ -926,7 +936,7 @@ maestro/
 | `src/tui/snapshot_tests/turboquant_dashboard.rs` | 3 snapshot tests for `TurboQuantDashboard`: projections-only, mixed actual+projections, empty sessions (Issue #346) |
 | `src/tui/snapshot_tests/snapshots/` | Committed `.snap` files — insta ground-truth for TUI rendering regressions; includes 4 agent_graph baselines (`80x24`, `100x30`, `120x40`, original `single_agent_card`) added in Issue #526; the `single_agent_card` snap was retired in Issue #543 in favor of `single_agent_with_files_as_graph` + `falls_back_when_single_agent_has_no_files` (the fallback was narrowed to no-edges only); 2 agent_graph_dispatcher baselines (`toggle_on_renders_graph`, `toggle_off_renders_panels`) added in Issue #527; 11 agent_personalities snapshots added in Issue #539; several existing agent_graph snaps re-baselined in #539 (nodes now render as sprites/abbrevs); 12 activity_log_dispatch snapshots added in Issue #543 (chip renders per role × mode, guard cases, multi-dispatch composition); 2 completion_overlay snapshots added in Issue #560 (`completion_overlay_success_modal_80x24` and `completion_overlay_failed_gates_modal_80x24`) |
 | `src/integration_tests/` | End-to-end integration test suite; MockGitHubClient and MockWorktreeManager; no external process dependencies (Issue #15) |
-| `src/integration_tests/mod.rs` | Module declarations and shared helpers: `make_pool()`, `make_pool_with_worktree()`, `make_session()`, `make_session_with_issue()`, `make_gh_issue()` |
+| `src/integration_tests/mod.rs` | Module declarations and shared helpers: `make_pool()`, `make_pool_with_worktree()`, `make_session()`, `make_session_with_issue()`, `make_gh_issue()`; `mod canonical_command_specs` registered in Issue #702 |
 | `src/integration_tests/doctor_run_health_check.rs` | Smoke tests for `run_health_check` library function (Issue #663) |
 | `src/integration_tests/orchestration_dispatch.rs` | End-to-end L1 dispatch tests with `FakeProvider`; exercises `dispatch_subagent()` path (Issue #663) |
 | `src/integration_tests/session_lifecycle.rs` | 11 tests covering enqueue, promote, and complete session lifecycle via `handle_event()` |
@@ -936,6 +946,8 @@ maestro/
 | `src/integration_tests/gate_failure_retention.rs` | 8 tests covering gate-failure worktree retention; 3 new pipeline tests added in #560 verify `worktree_path` is persisted on the session at `FailedGates` transition; uses real `git worktree` commands so the #558 regression (force-remove on gate failure) is guarded end-to-end (Issues #558, #560) |
 | `src/integration_tests/worktree_lifecycle.rs` | 8 tests covering worktree create/cleanup and health monitoring |
 | `src/integration_tests/upgrade.rs` | End-to-end upgrade flow tests: version check, banner state transitions, installer backup/swap, `RestartCommand` construction (Issue #118) |
+| `src/integration_tests/canonical_command_specs.rs` | 15-invariant test suite for canonical command specs; verifies structural integrity of all four `.maestro/templates/commands/` files (front-matter, placeholder coverage, include directives, section headings); 4 insta snapshots via `tokenize()` (Issue #702) |
+| `src/integration_tests/snapshots/` | Insta snapshot files for `canonical_command_specs` tests: `snapshot_tokenize_implement`, `snapshot_tokenize_plan_feature`, `snapshot_tokenize_pushup`, `snapshot_tokenize_simplify` (Issue #702) |
 | `src/turboquant/` | Vector quantization for context compression (Issues #242-253, #343-345, #347) |
 | `src/turboquant/types.rs` | `QuantStrategy` enum; `TurboQuantConfig` with three v0.14.0 budget fields (`fork_handoff_budget`, `system_prompt_budget`, `knowledge_budget`); `QuantResult`; `CompressionMetrics` |
 | `src/turboquant/polar.rs` | PolarQuant — recursive polar decomposition; preserves cosine distance |

--- a/src/integration_tests/canonical_command_specs.rs
+++ b/src/integration_tests/canonical_command_specs.rs
@@ -1,0 +1,396 @@
+//! Invariant tests for canonical command specs under `.maestro/templates/commands/`.
+//!
+//! Validates structural and semantic invariants for the four canonical specs
+//! authored in issue #702. These tests read the real project filesystem via
+//! `CARGO_MANIFEST_DIR` — RED phase fails with descriptive `panic!` messages
+//! while the files are absent; GREEN phase passes once they are authored.
+
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
+
+use crate::templates::{PlaceholderKind, TemplateError, Token, render_str, tokenize};
+
+const SLUGS: &[&str] = &["implement", "pushup", "plan-feature", "simplify"];
+
+fn project_root() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn read_canonical(slug: &str) -> Result<String, String> {
+    let path = project_root()
+        .join(".maestro/templates/commands")
+        .join(format!("{slug}.md"));
+    std::fs::read_to_string(&path).map_err(|e| {
+        format!(
+            "cannot read canonical file {slug}.md at {}: {e}",
+            path.display()
+        )
+    })
+}
+
+fn split_frontmatter<'a>(content: &'a str, slug: &str) -> (&'a str, &'a str) {
+    assert!(
+        content.starts_with("---\n"),
+        "{slug}: file must start with '---\\n' frontmatter fence"
+    );
+    let after_open = &content[4..];
+    let close_pos = after_open.find("\n---\n").unwrap_or_else(|| {
+        panic!("{slug}: no closing '---' frontmatter fence found");
+    });
+    let fm_text = &after_open[..close_pos];
+    let body_start = close_pos + "\n---\n".len();
+    let body = if body_start <= after_open.len() {
+        &after_open[body_start..]
+    } else {
+        ""
+    };
+    (fm_text, body)
+}
+
+#[derive(Debug, Default)]
+struct Frontmatter {
+    command: String,
+    version: String,
+    description: String,
+    placeholders: Vec<String>,
+    includes: Vec<String>,
+    ported_from: String,
+}
+
+fn parse_frontmatter(fm_text: &str, slug: &str) -> Frontmatter {
+    let mut fm = Frontmatter::default();
+    let mut in_placeholders = false;
+    let mut in_includes = false;
+    let mut in_provenance = false;
+
+    for line in fm_text.lines() {
+        if line.starts_with("  - ") {
+            let val = line[4..].trim().trim_matches('"').to_string();
+            if in_placeholders {
+                fm.placeholders.push(val);
+                continue;
+            }
+            if in_includes {
+                fm.includes.push(val);
+                continue;
+            }
+        }
+
+        if !line.starts_with("  ") {
+            in_placeholders = false;
+            in_includes = false;
+            in_provenance = false;
+        }
+
+        if let Some(rest) = line.strip_prefix("command:") {
+            fm.command = rest.trim().trim_matches('"').to_string();
+        } else if let Some(rest) = line.strip_prefix("version:") {
+            fm.version = rest.trim().trim_matches('"').to_string();
+        } else if let Some(rest) = line.strip_prefix("description:") {
+            fm.description = rest.trim().trim_matches('"').to_string();
+        } else if line.starts_with("placeholders:") {
+            let rest = line["placeholders:".len()..].trim();
+            if rest != "[]" {
+                in_placeholders = true;
+            }
+        } else if line.starts_with("includes:") {
+            let rest = line["includes:".len()..].trim();
+            if rest != "[]" {
+                in_includes = true;
+            }
+        } else if line.starts_with("source_provenance:") {
+            in_provenance = true;
+        } else if in_provenance {
+            if let Some(rest) = line.strip_prefix("  ported_from:") {
+                fm.ported_from = rest.trim().trim_matches('"').to_string();
+            }
+        }
+    }
+    assert!(
+        !fm.command.is_empty(),
+        "{slug}: frontmatter missing 'command:' field"
+    );
+    fm
+}
+
+fn placeholder_tokens(body: &str, slug: &str) -> Vec<Token> {
+    tokenize(body, slug)
+        .unwrap_or_else(|e| panic!("{slug}: tokenize failed: {e}"))
+        .into_iter()
+        .filter(|t| matches!(t, Token::Placeholder { .. }))
+        .collect()
+}
+
+// ── Invariants 1 & 2: frontmatter fences and parse ───────────────────────────
+
+#[test]
+fn canonical_files_have_valid_frontmatter_fences() {
+    for slug in SLUGS {
+        let content = read_canonical(slug).unwrap_or_else(|e| panic!("{e}"));
+        let (fm_text, _body) = split_frontmatter(&content, slug);
+        let _fm = parse_frontmatter(fm_text, slug);
+    }
+}
+
+// ── Invariant 3: command field matches filename ──────────────────────────────
+
+#[test]
+fn canonical_command_field_matches_filename_stem() {
+    for slug in SLUGS {
+        let content = read_canonical(slug).unwrap_or_else(|e| panic!("{e}"));
+        let (fm_text, _) = split_frontmatter(&content, slug);
+        let fm = parse_frontmatter(fm_text, slug);
+        assert_eq!(
+            fm.command, *slug,
+            "{slug}: command: field '{}' does not match filename stem",
+            fm.command
+        );
+    }
+}
+
+// ── Invariant 4: version is N.N.N semver ─────────────────────────────────────
+
+#[test]
+fn canonical_version_field_is_semver() {
+    for slug in SLUGS {
+        let content = read_canonical(slug).unwrap_or_else(|e| panic!("{e}"));
+        let (fm_text, _) = split_frontmatter(&content, slug);
+        let fm = parse_frontmatter(fm_text, slug);
+        let parts: Vec<&str> = fm.version.splitn(3, '.').collect();
+        assert_eq!(
+            parts.len(),
+            3,
+            "{slug}: version '{}' is not N.N.N semver",
+            fm.version
+        );
+        for part in &parts {
+            assert!(
+                part.parse::<u32>().is_ok(),
+                "{slug}: version component '{}' in '{}' is not a number",
+                part,
+                fm.version
+            );
+        }
+    }
+}
+
+// ── Invariant 5: frontmatter placeholders == body placeholders ───────────────
+
+#[test]
+fn frontmatter_placeholders_match_body_placeholders() {
+    for slug in SLUGS {
+        let content = read_canonical(slug).unwrap_or_else(|e| panic!("{e}"));
+        let (fm_text, body) = split_frontmatter(&content, slug);
+        let fm = parse_frontmatter(fm_text, slug);
+
+        let tokens = placeholder_tokens(body, slug);
+        let mut body_names: Vec<String> = tokens
+            .iter()
+            .filter_map(|t| match t {
+                Token::Placeholder { name, .. } => Some(name.clone()),
+                _ => None,
+            })
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
+        body_names.sort();
+
+        let mut fm_names = fm.placeholders.clone();
+        fm_names.sort();
+
+        assert_eq!(
+            fm_names, body_names,
+            "{slug}: frontmatter placeholders {fm_names:?} != body placeholders {body_names:?}"
+        );
+    }
+}
+
+// ── Invariants 6 & 7: known kinds + required args ────────────────────────────
+
+#[test]
+fn all_placeholder_names_are_known_kinds_with_required_args() {
+    for slug in SLUGS {
+        let content = read_canonical(slug).unwrap_or_else(|e| panic!("{e}"));
+        let (_, body) = split_frontmatter(&content, slug);
+        let tokens = placeholder_tokens(body, slug);
+
+        for tok in &tokens {
+            if let Token::Placeholder { name, args, .. } = tok {
+                let kind = PlaceholderKind::from_name(name)
+                    .unwrap_or_else(|| panic!("{slug}: unknown placeholder kind '{name}'"));
+                for required in kind.required_args() {
+                    assert!(
+                        args.contains_key(*required),
+                        "{slug}: placeholder '{name}' missing required arg '{required}'"
+                    );
+                }
+            }
+        }
+    }
+}
+
+// ── Invariants 8, 9, 10: includes match and resolve under core/ ──────────────
+
+#[test]
+fn frontmatter_includes_match_body_and_resolve_under_core() {
+    for slug in SLUGS {
+        let content = read_canonical(slug).unwrap_or_else(|e| panic!("{e}"));
+        let (fm_text, body) = split_frontmatter(&content, slug);
+        let fm = parse_frontmatter(fm_text, slug);
+
+        let tokens = placeholder_tokens(body, slug);
+        let mut body_includes: Vec<String> = tokens
+            .iter()
+            .filter_map(|t| match t {
+                Token::Placeholder { name, args, .. } if name == "INCLUDE" => {
+                    args.get("path").cloned()
+                }
+                _ => None,
+            })
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
+        body_includes.sort();
+
+        let mut fm_includes = fm.includes.clone();
+        fm_includes.sort();
+
+        assert_eq!(
+            fm_includes, body_includes,
+            "{slug}: frontmatter includes {fm_includes:?} != body includes {body_includes:?}"
+        );
+
+        for inc_path in &body_includes {
+            let resolved = project_root().join(".maestro/templates").join(inc_path);
+            assert!(
+                resolved.exists(),
+                "{slug}: INCLUDE path '{inc_path}' does not resolve to existing file at {}",
+                resolved.display()
+            );
+            assert!(
+                !inc_path.starts_with("commands/"),
+                "{slug}: INCLUDE path '{inc_path}' starts with 'commands/' — only 'core/' is allowed"
+            );
+        }
+    }
+}
+
+// ── Invariant 11: no raw .claude/commands or .claude/agents in body ──────────
+
+#[test]
+fn body_contains_no_raw_claude_paths() {
+    for slug in SLUGS {
+        let content = read_canonical(slug).unwrap_or_else(|e| panic!("{e}"));
+        let (_, body) = split_frontmatter(&content, slug);
+        assert!(
+            !body.contains(".claude/commands/"),
+            "{slug}: body contains raw '.claude/commands/' path — must go through a placeholder"
+        );
+        assert!(
+            !body.contains(".claude/agents/"),
+            "{slug}: body contains raw '.claude/agents/' path — must go through a placeholder"
+        );
+    }
+}
+
+// ── Invariants 12, 13, 15: tokenize ok, NullRules fails closed, prompts cap ──
+
+#[test]
+fn tokenize_ok_null_render_fails_closed_prompts_under_cap() {
+    let null = crate::templates::null_rules();
+    for slug in SLUGS {
+        let content = read_canonical(slug).unwrap_or_else(|e| panic!("{e}"));
+        let (_, body) = split_frontmatter(&content, slug);
+
+        let tokens =
+            tokenize(body, slug).unwrap_or_else(|e| panic!("{slug}: tokenize returned Err: {e}"));
+
+        for tok in &tokens {
+            if let Token::Placeholder { name, args, .. } = tok {
+                if let Some(prompt) = args.get("prompt") {
+                    assert!(
+                        prompt.len() <= 200,
+                        "{slug}: placeholder '{name}' prompt= is {} bytes (max 200): {:?}",
+                        prompt.len(),
+                        &prompt[..prompt.len().min(60)]
+                    );
+                }
+            }
+        }
+
+        let has_placeholder = tokens
+            .iter()
+            .any(|t| matches!(t, Token::Placeholder { .. }));
+        if has_placeholder {
+            let result = render_str(body, null);
+            assert!(
+                matches!(result, Err(TemplateError::UnsupportedByProvider { .. })),
+                "{slug}: render with NullRules should be Err(UnsupportedByProvider), got {result:?}"
+            );
+        }
+    }
+}
+
+// ── Invariant 14: source_provenance.ported_from is valid ─────────────────────
+
+#[test]
+fn source_provenance_ported_from_is_valid() {
+    for slug in SLUGS {
+        let content = read_canonical(slug).unwrap_or_else(|e| panic!("{e}"));
+        let (fm_text, _) = split_frontmatter(&content, slug);
+        let fm = parse_frontmatter(fm_text, slug);
+
+        assert!(
+            !fm.ported_from.is_empty(),
+            "{slug}: frontmatter missing 'ported_from' under source_provenance"
+        );
+
+        if fm.ported_from != "new" {
+            let source = project_root().join(&fm.ported_from);
+            assert!(
+                source.exists(),
+                "{slug}: ported_from '{}' does not point to an existing file",
+                fm.ported_from
+            );
+        }
+    }
+}
+
+// ── Tokenize snapshots ───────────────────────────────────────────────────────
+
+fn snapshot_tokens(slug: &str) -> Vec<(String, Vec<(String, String)>)> {
+    let content = read_canonical(slug).unwrap_or_else(|e| panic!("{e}"));
+    let (_, body) = split_frontmatter(&content, slug);
+    let tokens = tokenize(body, slug).unwrap_or_else(|e| panic!("{slug}: tokenize failed: {e}"));
+    tokens
+        .into_iter()
+        .filter_map(|t| match t {
+            Token::Placeholder { name, args, .. } => {
+                let mut sorted_args: Vec<(String, String)> = args.into_iter().collect();
+                sorted_args.sort_by(|a, b| a.0.cmp(&b.0));
+                Some((name, sorted_args))
+            }
+            Token::Text(_) => None,
+        })
+        .collect()
+}
+
+#[test]
+fn snapshot_tokenize_implement() {
+    insta::assert_debug_snapshot!(snapshot_tokens("implement"));
+}
+
+#[test]
+fn snapshot_tokenize_pushup() {
+    insta::assert_debug_snapshot!(snapshot_tokens("pushup"));
+}
+
+#[test]
+fn snapshot_tokenize_plan_feature() {
+    insta::assert_debug_snapshot!(snapshot_tokens("plan-feature"));
+}
+
+#[test]
+fn snapshot_tokenize_simplify() {
+    insta::assert_debug_snapshot!(snapshot_tokens("simplify"));
+}

--- a/src/integration_tests/mod.rs
+++ b/src/integration_tests/mod.rs
@@ -6,6 +6,8 @@
 #[cfg(test)]
 mod adapt_pipeline;
 #[cfg(test)]
+mod canonical_command_specs;
+#[cfg(test)]
 mod completion_pipeline;
 #[cfg(test)]
 mod concurrent_sessions;

--- a/src/integration_tests/snapshots/maestro__integration_tests__canonical_command_specs__snapshot_tokenize_implement.snap
+++ b/src/integration_tests/snapshots/maestro__integration_tests__canonical_command_specs__snapshot_tokenize_implement.snap
@@ -1,0 +1,103 @@
+---
+source: src/integration_tests/canonical_command_specs.rs
+assertion_line: 381
+expression: "snapshot_tokens(\"implement\")"
+---
+[
+    (
+        "INCLUDE",
+        [
+            (
+                "path",
+                "core/premises.md",
+            ),
+        ],
+    ),
+    (
+        "HOOK_GATE",
+        [
+            (
+                "args",
+                "$ISSUE_NUMBER ${DIRTY_TREE_ACTION:+--dirty-tree-action=$DIRTY_TREE_ACTION}",
+            ),
+            (
+                "script",
+                "implement-gates.sh",
+            ),
+        ],
+    ),
+    (
+        "INVOKE_SUBAGENT",
+        [
+            (
+                "name",
+                "gatekeeper",
+            ),
+            (
+                "prompt",
+                "Classify issue $ISSUE_NUMBER (DOR, blockers, contracts, task_type). Return the structured JSON gatekeeper report.",
+            ),
+        ],
+    ),
+    (
+        "INCLUDE",
+        [
+            (
+                "path",
+                "core/tdd-cycle.md",
+            ),
+        ],
+    ),
+    (
+        "INVOKE_SUBAGENT",
+        [
+            (
+                "name",
+                "architect",
+            ),
+            (
+                "prompt",
+                "Produce architecture blueprint for issue $ISSUE_NUMBER using $GATE_LOG_DIR/issue-summary.md; on Continue, prepend resumption context.",
+            ),
+        ],
+    ),
+    (
+        "INVOKE_SUBAGENT",
+        [
+            (
+                "name",
+                "qa",
+            ),
+            (
+                "prompt",
+                "Produce test blueprint from architect's blueprint for issue $ISSUE_NUMBER; on Continue, prepend resumption context.",
+            ),
+        ],
+    ),
+    (
+        "INVOKE_SUBAGENT",
+        [
+            (
+                "name",
+                "security-analyst",
+            ),
+            (
+                "prompt",
+                "Review newly-written code for issue $ISSUE_NUMBER against OWASP Top 10, secrets handling, and input validation.",
+            ),
+        ],
+    ),
+    (
+        "INVOKE_SUBAGENT",
+        [
+            (
+                "name",
+                "docs-analyst",
+            ),
+            (
+                "prompt",
+                "Update documentation and directory-tree.md for issue $ISSUE_NUMBER.",
+            ),
+        ],
+    ),
+]

--- a/src/integration_tests/snapshots/maestro__integration_tests__canonical_command_specs__snapshot_tokenize_plan_feature.snap
+++ b/src/integration_tests/snapshots/maestro__integration_tests__canonical_command_specs__snapshot_tokenize_plan_feature.snap
@@ -1,0 +1,29 @@
+---
+source: src/integration_tests/canonical_command_specs.rs
+assertion_line: 391
+expression: "snapshot_tokens(\"plan-feature\")"
+---
+[
+    (
+        "INCLUDE",
+        [
+            (
+                "path",
+                "core/premises.md",
+            ),
+        ],
+    ),
+    (
+        "SUBAGENT_LIST",
+        [],
+    ),
+    (
+        "INCLUDE",
+        [
+            (
+                "path",
+                "core/dependency-graph.md",
+            ),
+        ],
+    ),
+]

--- a/src/integration_tests/snapshots/maestro__integration_tests__canonical_command_specs__snapshot_tokenize_pushup.snap
+++ b/src/integration_tests/snapshots/maestro__integration_tests__canonical_command_specs__snapshot_tokenize_pushup.snap
@@ -1,0 +1,25 @@
+---
+source: src/integration_tests/canonical_command_specs.rs
+assertion_line: 386
+expression: "snapshot_tokens(\"pushup\")"
+---
+[
+    (
+        "INCLUDE",
+        [
+            (
+                "path",
+                "core/premises.md",
+            ),
+        ],
+    ),
+    (
+        "INCLUDE",
+        [
+            (
+                "path",
+                "core/dependency-graph.md",
+            ),
+        ],
+    ),
+]

--- a/src/integration_tests/snapshots/maestro__integration_tests__canonical_command_specs__snapshot_tokenize_simplify.snap
+++ b/src/integration_tests/snapshots/maestro__integration_tests__canonical_command_specs__snapshot_tokenize_simplify.snap
@@ -1,0 +1,47 @@
+---
+source: src/integration_tests/canonical_command_specs.rs
+assertion_line: 396
+expression: "snapshot_tokens(\"simplify\")"
+---
+[
+    (
+        "INCLUDE",
+        [
+            (
+                "path",
+                "core/premises.md",
+            ),
+        ],
+    ),
+    (
+        "SKILL",
+        [
+            (
+                "name",
+                "project-patterns",
+            ),
+        ],
+    ),
+    (
+        "INVOKE_SUBAGENT",
+        [
+            (
+                "name",
+                "architect",
+            ),
+            (
+                "prompt",
+                "Review the diff <base>..HEAD against ETC, Demeter, and Object Calisthenics 5-7/9. Flag duplications, dead code, over-abstraction, and Demeter violations. Return a blueprint, not code.",
+            ),
+        ],
+    ),
+    (
+        "INCLUDE",
+        [
+            (
+                "path",
+                "core/tdd-cycle.md",
+            ),
+        ],
+    ),
+]

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -23,6 +23,9 @@ pub(crate) use manifest::{ManifestMeta, ManifestPlaceholder, ManifestProvider};
 #[cfg(test)]
 pub(crate) use provider_rules::NullRules;
 pub use provider_rules::{TemplateProviderRules, null_rules};
+#[cfg(test)]
+#[allow(unused_imports)]
+pub(crate) use renderer::{PlaceholderKind, Token, tokenize};
 
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
## Summary

- Author 4 canonical command specs under `.maestro/templates/commands/` (`implement.md`, `pushup.md`, `plan-feature.md`, `simplify.md`) using the placeholder DSL from #701; `simplify.md` is new (ETC/Demeter/Calisthenics rubric)
- Add 13 invariant tests + 4 insta snapshots in `src/integration_tests/canonical_command_specs.rs` validating frontmatter schema, placeholder vocabulary, INCLUDE sandbox, and `NullRules` fail-closed contract
- Re-export `PlaceholderKind`/`Token`/`tokenize` from `crate::templates` under `#[cfg(test)]`; update `directory-tree.md` and `.maestro/templates/README.md` forward-reference legend

Closes #702

## Test plan

- [x] cargo test --quiet (4623 passed, 13 new invariant tests + 4 snapshots)
- [x] cargo clippy -- -D warnings -A dead_code
- [x] cargo fmt --check
- [x] manual verification: tokenize() succeeds on all 4 canonical files; NullRules returns UnsupportedByProvider; INCLUDE paths resolve to existing core/ fragments
