### PR TITLE
chore(templates): silence dead-code warnings (post-#703)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,9 @@ mod review;
 mod session;
 mod settings;
 mod state;
+// Bin entry never reaches into templates directly; symbols are exercised
+// through provider trait defaults and via the lib (see `src/lib.rs`).
+#[allow(dead_code)]
 mod templates;
 mod tui;
 mod updater;

--- a/src/templates/manifest.rs
+++ b/src/templates/manifest.rs
@@ -6,6 +6,9 @@
 
 #![deny(clippy::unwrap_used)]
 #![deny(clippy::expect_used)]
+// Manifest fields/methods are populated for #706 (sync-templates CLI) and
+// downstream consumers; load() exercises them via serde at parse time.
+#![allow(dead_code)]
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};

--- a/src/templates/renderer/mod.rs
+++ b/src/templates/renderer/mod.rs
@@ -16,6 +16,7 @@ use crate::templates::TemplateError;
 use crate::templates::provider_rules::TemplateProviderRules;
 
 pub(crate) const MAX_INCLUDE_DEPTH: usize = 8;
+#[cfg(test)]
 pub(crate) const SOURCE_LABEL: &str = "<template>";
 
 pub(crate) use tokenize::tokenize;
@@ -148,6 +149,7 @@ fn expand(
     }
 }
 
+#[cfg(test)]
 pub(crate) fn render(
     input: &str,
     rules: &dyn TemplateProviderRules,


### PR DESCRIPTION
## Summary

- `mod templates;` in `src/main.rs` re-declared the module for the bin entry, which never reaches into renderer/manifest internals directly (provider trait defaults + lib tests do). Gate bin's view with `#[allow(dead_code)]`.
- Apply `#![allow(dead_code)]` to `src/templates/manifest.rs` since its fields are deserialized by serde but not yet read by code (consumers land in #706 sync-templates).
- Mark `SOURCE_LABEL` and `render` in `src/templates/renderer/mod.rs` as `#[cfg(test)]` — both reachable only from the test-only `render_str` helper.

Went from 30 dead-code warnings on `cargo build` to 0. CI behaviour unchanged (project preflight already runs `-A dead_code`).

Pure mechanical cleanup. No production logic touched. Orphaned commit from PR #730 that landed after the merge; this PR rebases it onto current main.

## Test plan

- [x] `cargo build` — 0 warnings
- [x] `cargo test --quiet` — green
- [x] `cargo clippy -- -D warnings -A dead_code` — clean
- [x] `cargo fmt --check` — clean
