### PR TITLE
refactor(templates): move regen_claude_baselines from tests to examples

### DIFF
--- a/.maestro/templates/README.md
+++ b/.maestro/templates/README.md
@@ -76,6 +76,25 @@ delegate their `subagent_list()` method to that shared helper.
 - Commands without a canonical spec (`create-subagent.md`, `release.md`, etc.) remain
   hand-maintained for now.
 
+### Regenerating Claude baselines
+
+After editing a canonical spec under `.maestro/templates/commands/` or a shared fragment
+under `.maestro/templates/core/`, regenerate the rendered `.claude/commands/*.md`
+artifacts with:
+
+```sh
+cargo run --example regen_templates
+```
+
+The example writes the four canonical commands (`implement`, `pushup`, `plan-feature`,
+`simplify`) into the directory reported by `ClaudeRules::target_dir()` (`.claude/commands/`).
+Confirm the regeneration with `cargo test --test templates_render` — the byte-identical
+regression tests pass when the rendered output matches the canonical render.
+
+> The dedicated `maestro sync-templates` CLI (forward-reference `#G`) will eventually
+> replace this example with a provider-aware command. Until that lands, the example is
+> the regen path.
+
 ## Forward-reference legend
 
 Letter codes (`#A`, `#B`, `#G`) reference work items in the approved

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -673,10 +673,14 @@ maestro/
 ├── benches/                               # Criterion benchmark crates
 │   ├── parser.rs                          # Benchmark: stream-json parser throughput  [Issue #19]
 │   └── turboquant.rs                      # Benchmark: TurboQuant quantization pipeline throughput
+├── examples/                              # Cargo examples (`cargo run --example <name>`) — dev-only utilities not shipped in the binary
+│   ├── regen_templates.rs                 # Rewrites `.claude/commands/*.md` from canonical sources in `.maestro/templates/`; run with `cargo run --example regen_templates`  [Issue #729]
+│   └── multi-agent/                       # Multi-agent example configuration
+│       └── maestro.toml                   # Example maestro.toml for a multi-agent setup
 ├── tests/                                 # Cargo integration tests (run as a separate binary, full crate access)
 │   ├── settings_caveman.rs                # Integration tests for FsSettingsStore against real tempfiles: read/write/toggle round-trips for caveman mode, missing-key defaults, malformed JSON handling  [Issue #490]
 │   ├── subagent_manifest_drift.rs         # Drift guard: set-difference between `.claude/agents/subagent-*.md` on disk and `[[subagents]]` slugs in `manifest.toml`; fails with a diff line on "missing from manifest" or "stale in manifest"; 5 unit tests + 1 live-repo integration test  [Issue #728]
-│   ├── templates_render.rs                # 5 byte-identical regression tests asserting `.claude/commands/*.md` matches rendered output from `.maestro/templates/`; 1 `#[ignore]` regeneration helper; enforces drift detection in CI  [Issue #703]
+│   ├── templates_render.rs                # 5 byte-identical regression tests asserting `.claude/commands/*.md` matches rendered output from `.maestro/templates/`; enforces drift detection in CI  [Issue #703, #729]
 │   ├── fixtures/                          # Static test fixtures for integration and unit tests
 │   │   └── state/
 │   │       └── v0.json                    # Pre-version state-file fixture (no `version` key); used by state migration tests to assert that version=0 loads and migrates to CURRENT_STATE_VERSION=1  [Issue #665]

--- a/examples/regen_templates.rs
+++ b/examples/regen_templates.rs
@@ -1,0 +1,38 @@
+//! Regenerates Claude provider command baselines under `.claude/commands/`
+//! from the canonical sources in `.maestro/templates/commands/`.
+//!
+//! Run from the repo root:
+//!
+//! ```text
+//! cargo run --example regen_templates
+//! ```
+//!
+//! The `tests/templates_render.rs::renders_*_byte_identical` tests are the
+//! post-condition: if the example writes bytes that differ from what the
+//! render engine produces, those tests fail on the next `cargo test` run.
+
+use anyhow::Context;
+use maestro::agent_provider::{AgentProvider, ClaudeProvider};
+use maestro::templates::render_for_provider;
+
+const COMMANDS: &[&str] = &["implement", "pushup", "plan-feature", "simplify"];
+
+fn main() -> anyhow::Result<()> {
+    let provider = ClaudeProvider::default();
+    let Some(target_dir) = provider.template_rules().target_dir() else {
+        anyhow::bail!(
+            "provider `{}` has no target_dir; nothing to regenerate",
+            provider.id()
+        );
+    };
+    std::fs::create_dir_all(target_dir)
+        .with_context(|| format!("create_dir_all `{}`", target_dir.display()))?;
+    for command in COMMANDS {
+        let rendered = render_for_provider(&provider, command)
+            .with_context(|| format!("render `{command}`"))?;
+        let path = target_dir.join(format!("{command}.md"));
+        std::fs::write(&path, &rendered).with_context(|| format!("write `{}`", path.display()))?;
+        println!("wrote {} ({} bytes)", path.display(), rendered.len());
+    }
+    Ok(())
+}

--- a/tests/templates_render.rs
+++ b/tests/templates_render.rs
@@ -250,22 +250,3 @@ fn http_generic_skill_link_inlines_skill_body() {
         "expected inlined skill body in HTTP-generic simplify render"
     );
 }
-
-/// Regeneration helper for the #703 cutover. Not part of the default test
-/// run — invoke explicitly:
-///
-/// ```text
-/// cargo test --test templates_render -- --ignored regenerate_claude_baselines --nocapture
-/// ```
-///
-/// After this writes the baselines, the byte-identical tests above pass.
-#[test]
-#[ignore = "manual regeneration of generated artifacts under .claude/commands/"]
-fn regenerate_claude_baselines() {
-    for command in ["implement", "pushup", "plan-feature", "simplify"] {
-        let rendered = render(command);
-        let path = format!(".claude/commands/{command}.md");
-        std::fs::write(&path, &rendered).unwrap_or_else(|e| panic!("write `{path}`: {e}"));
-        println!("wrote {path} ({} bytes)", rendered.len());
-    }
-}


### PR DESCRIPTION
## Summary

- Move the `#[ignore]`-guarded `regenerate_claude_baselines` helper out of `tests/templates_render.rs` into `examples/regen_templates.rs`, invoked via `cargo run --example regen_templates`. `tests/` no longer mutates the workspace.
- Document the new regen command in `.maestro/templates/README.md` under the post-#703 cutover policy.
- Drive the write loop off `provider.template_rules().target_dir()` so the example fails fast on providers (`CodexRules`, `HttpGenericRules`) that have no on-disk baseline.

## Simplifications

- Replaced `unwrap_or_else(|e| panic!)` (old helper) with `anyhow::Context` at the example boundary — Rust guardrails §2.
- Dropped redundant `Path::new(target_dir)` wrapper after the architect simplify pass — `target_dir` is already `&Path`.

Closes #729

## Test plan

- [x] `cargo test --quiet` (4672 passed, 7 ignored — confirms the deleted `regenerate_claude_baselines` is gone)
- [x] `cargo test --test templates_render` (14 passed, post-regen)
- [x] `cargo run --example regen_templates` writes byte-identical baselines (no `.claude/commands/` diff)
- [x] `cargo fmt --check`
