### PR TITLE
chore(init): scaffold .maestro/templates + canonical-vs-rendered docs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -205,6 +205,18 @@ subagent-security-analyst → Security review
 subagent-docs-analyst → Documentation
 ```
 
+### 6. CANONICAL TEMPLATES — DO NOT EDIT RENDERED FILES
+
+`.maestro/templates/` is the canonical source for slash commands. The orchestrator and contributors MUST:
+
+- Edit canonical files under `.maestro/templates/commands/` and `.maestro/templates/core/`, **never** edit rendered `.claude/commands/*.md` directly (those carry an `AUTO-GENERATED` banner).
+- Run `maestro sync-templates` after every canonical edit; commit the regenerated artifacts.
+- CI runs `maestro sync-templates --check` and rejects PRs with drift.
+
+`maestro init` scaffolds the same `.maestro/templates/` reference tree into newly initialized projects (embedded under `template/.maestro/templates/`; a drift test guards the mirror).
+
+See `docs/templates.md` for the placeholder vocabulary, per-provider quirks, and the "how to add a new command" walkthrough.
+
 ---
 
 ## FIRST ACTIONS: Language and Mode Selection

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-05-15 18:00 (UTC)
+> Last updated: 2026-05-15 20:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -110,7 +110,7 @@ maestro/
 │   │   ├── clean.rs                       # cmd_clean(): prune orphaned worktrees and stale log files
 │   │   ├── dashboard.rs                   # cmd_dashboard(): launch the TUI dashboard
 │   │   ├── doctor.rs                      # cmd_doctor(): run preflight checks and print report; `pub async fn run_health_check(agent_ids: &[String]) -> Vec<AgentHealthCheck>` library entry point for orchestration pre-flight  [Issue #663]
-│   │   ├── init.rs                        # cmd_init(): scaffold maestro.toml; delegates to src/init/; accepts --reset flag  [Issue #505]
+│   │   ├── init.rs                        # cmd_init(): scaffold maestro.toml; delegates to src/init/; accepts --reset flag; calls scaffold_templates_and_report(project_root) after Fresh and Merged writes to drop .maestro/templates/ mirror  [Issue #505, #708]
 │   │   ├── logs.rs                        # cmd_logs(): stream or tail session log files
 │   │   ├── queue.rs                       # cmd_queue(): interactive work-queue management
 │   │   ├── resume.rs                      # cmd_resume(): re-attach to a paused session
@@ -193,12 +193,14 @@ maestro/
 │   │   ├── scaffolder.rs                  # Scaffold phase: ProjectScaffolder trait, ClaudeScaffolder impl, write_scaffold_files(); generates project files from adapt plan  [Issue #371]
 │   │   ├── prompts.rs                     # Claude prompt builders for analyzer, planner, and scaffold phases  [Issue #371]
 │   │   └── knowledge.rs                   # Knowledge-base compression (Phase 2.6): consumes AdaptReport + ProjectProfile; produces KnowledgeBase (six token-budgeted sections); write_knowledge_file() writes .maestro/knowledge.md; auto-loaded by SessionPool::try_promote as a system-prompt component; 1 MiB size cap, symlink rejection, TOCTOU-safe load, envelope-wrapped injection  [Issue #347]
-│   ├── init/                              # Project tech-stack auto-detection used by `maestro init --reset` and the Settings TUI action  [Issue #505]
-│   │   ├── mod.rs                         # Module facade; RenderOutcome enum (Fresh | Merged); render_or_merge() top-level orchestration used by CLI and TUI
+│   ├── init/                              # Project tech-stack auto-detection used by `maestro init --reset` and the Settings TUI action; includes template scaffolding since #708  [Issue #505, #708]
+│   │   ├── mod.rs                         # Module facade; RenderOutcome enum (Fresh | Merged); render_or_merge() top-level orchestration used by CLI and TUI; re-exports scaffold_templates_and_report()  [Issue #505, #708]
 │   │   ├── detector.rs                    # DetectedStack enum (Rust, Node, Python, Go); ProjectDetector trait; FsProjectDetector probes marker files (Cargo.toml, package.json, pyproject.toml/requirements.txt/setup.py, go.mod); FakeProjectDetector for tests
 │   │   ├── walk.rs                        # find_project_root(): walks ancestors looking for known marker files
 │   │   ├── template.rs                    # StackDefaults per stack (language, build_command, test_command, run_command); render_template() produces a complete maestro.toml string including [views]\nagent_graph_enabled = true (default-on since v0.25.1 #710)  [Issue #505, #710]
 │   │   ├── template_tests.rs              # Sibling test module extracted from template.rs to stay under the 400-LOC cap (attached via #[cfg(test)] #[path]); covers render_template output for all DetectedStack variants  [Issue #710]
+│   │   ├── scaffold.rs                    # Scaffolder trait + FsScaffolder impl; scaffold_templates_dir() writes template/.maestro/templates/ mirror into the project root; template_relative_paths() enumerates embedded paths; files embedded via include_bytes! at build time — works for `cargo install` binaries; idempotent: reports Created / Skipped per file; path-traversal hardening rejects any relative path escaping the target dir  [Issue #708]
+│   │   ├── scaffold_tests.rs              # Sibling unit tests for scaffold.rs (attached via #[cfg(test)] #[path]); covers fresh write, idempotency (Skipped), and path-traversal rejection  [Issue #708]
 │   │   └── merge.rs                       # MergeReport; merge_toml() merges detected defaults into an existing TOML string — adds missing keys, never overwrites user-set keys
 │   ├── templates/                         # Canonical command-template render engine  [Issue #701]
 │   │   ├── mod.rs                         # Public API: `render_for_provider(provider, command)` + `render_command_in(root, provider, command)` + `render_command_for_rules(root, rules, command)`; sandbox-validates the `command` parameter before path traversal; the third entry point allows sync-templates to render with a `&'static dyn TemplateProviderRules` directly (no provider instantiation)
@@ -620,6 +622,7 @@ maestro/
 │   ├── layers-debt.txt                    # Layer-boundary debt notes
 │   ├── RUST-GUARDRAILS.md                 # Rust coding policy and guardrails (single source of truth)
 │   ├── tech-debt-catalog.md               # Automated tech-debt catalog (generated by maestro adapt)
+│   ├── templates.md                       # Developer guide for the canonical templates layer: placeholder vocabulary, how to add commands/providers, drift detection, per-provider quirks, maestro init scaffolding, troubleshooting  [Issue #708]
 │   ├── teams/                             # Team orchestration preset documentation (v0.27.0+)  [Issue #665]
 │   │   ├── README.md                      # Preset overview, three-tier resolution model, five built-ins table, CLI surface, headless launch semantics, and state migration guide
 │   │   ├── default-coder.md               # `default-coder` pipeline preset — implementer → reviewer → docs; customisation examples
@@ -638,19 +641,32 @@ maestro/
 │           └── 2026-05-05-orchestration-wizard-design.md  # Orchestration wizard design spec — locked decisions, architecture layers, data model, CLI surface  [Issue #665]
 ├── template/
 │   ├── README-TEMPLATE.md                 # Template usage instructions
-│   └── .claude/                           # Reproducible template for new projects
-│       ├── CLAUDE.md
-│       ├── agents/                        # Template copies of all subagents
-│       ├── commands/
-│       │   ├── implement.md
-│       │   └── validate-contracts.md
-│       ├── hooks/
-│       │   └── README.md
-│       ├── settings.json
-│       └── skills/                        # Template copies of core skills
-│           ├── api-contract-validation/
-│           ├── project-patterns/
-│           └── security-patterns/
+│   ├── .claude/                           # Reproducible template for new projects
+│   │   ├── CLAUDE.md                      # Template CLAUDE.md; §4 (canonical templates rule) added in #708
+│   │   ├── agents/                        # Template copies of all subagents
+│   │   ├── commands/
+│   │   │   ├── implement.md
+│   │   │   └── validate-contracts.md
+│   │   ├── hooks/
+│   │   │   └── README.md
+│   │   ├── settings.json
+│   │   └── skills/                        # Template copies of core skills
+│   │       ├── api-contract-validation/
+│   │       ├── project-patterns/
+│   │       └── security-patterns/
+│   └── .maestro/
+│       └── templates/                     # Byte-mirror of canonical .maestro/templates/ for scaffolding; embedded via include_bytes! in src/init/scaffold.rs; kept in sync by tests/template_mirror_drift.rs; fix drift with: cp -a .maestro/templates/. template/.maestro/templates/  [Issue #708]
+│           ├── README.md
+│           ├── manifest.toml
+│           ├── core/
+│           │   ├── premises.md
+│           │   ├── tdd-cycle.md
+│           │   └── dependency-graph.md
+│           └── commands/
+│               ├── implement.md
+│               ├── pushup.md
+│               ├── plan-feature.md
+│               └── simplify.md
 ├── scripts/                               # Project-level shell scripts and config for architecture, file-size, coverage, and workflow automation
 │   ├── allowlist-large-files.txt          # Allowlist for large files exempted from size checks; src/tui/screens/milestone_health/state/tests/mod.rs added (deadline 2026-07-22, pending at(step) helper)  [Issue #500]
 │   ├── architecture-layers.yml            # Layer dependency rules for check-layers.sh
@@ -690,6 +706,7 @@ maestro/
 ├── tests/                                 # Cargo integration tests (run as a separate binary, full crate access)
 │   ├── settings_caveman.rs                # Integration tests for FsSettingsStore against real tempfiles: read/write/toggle round-trips for caveman mode, missing-key defaults, malformed JSON handling  [Issue #490]
 │   ├── subagent_manifest_drift.rs         # Drift guard: set-difference between `.claude/agents/subagent-*.md` on disk and `[[subagents]]` slugs in `manifest.toml`; fails with a diff line on "missing from manifest" or "stale in manifest"; 5 unit tests + 1 live-repo integration test  [Issue #728]
+│   ├── template_mirror_drift.rs           # Drift guard: asserts byte-equality between every file in `.maestro/templates/` and its mirror under `template/.maestro/templates/`; fails CI when the mirror is stale; fix with: cp -a .maestro/templates/. template/.maestro/templates/  [Issue #708]
 │   ├── templates_render.rs                # 5 byte-identical regression tests asserting `.claude/commands/*.md` matches rendered output from `.maestro/templates/`; enforces drift detection in CI  [Issue #703, #729]
 │   ├── fixtures/                          # Static test fixtures for integration and unit tests
 │   │   └── state/
@@ -744,6 +761,9 @@ maestro/
 | `docs/FOLLOW-UPS.md` | Pending hardening and security follow-up items (non-blocking; file as issues before next release) |
 | `docs/RUST-GUARDRAILS.md` | Rust coding policy — single source of truth; amend via PR |
 | `docs/tech-debt-catalog.md` | Tech-debt catalog generated by `maestro adapt` |
+| `docs/templates.md` | Canonical templates developer guide — placeholder vocabulary, add commands/providers, drift detection, `maestro init` scaffolding (Issue #708) |
+| `tests/template_mirror_drift.rs` | Drift guard asserting byte-equality between `.maestro/templates/` and `template/.maestro/templates/` (Issue #708) |
+| `template/.maestro/templates/` | Byte-mirror of canonical templates embedded by `src/init/scaffold.rs` via `include_bytes!`; kept in sync by `tests/template_mirror_drift.rs` (Issue #708) |
 | `docs/teams/` | Team orchestration preset documentation (v0.27.0+) |
 | `docs/teams/README.md` | Preset overview, three-tier resolution, five built-ins, CLI surface, headless launch, state migration |
 | `docs/superpowers/specs/2026-05-05-orchestration-wizard-design.md` | Orchestration wizard design spec — locked decisions, architecture, data model |

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,0 +1,162 @@
+# Canonical Templates
+
+`.maestro/templates/` is the **canonical, agent-agnostic source** for maestro
+slash commands. Provider-specific rendered artifacts (e.g. `.claude/commands/`)
+are generated from this tree by `maestro sync-templates` and **must not be
+edited directly** — they carry an `AUTO-GENERATED` banner and CI rejects PRs
+that drift.
+
+This guide covers the placeholder vocabulary, how to add new commands and
+providers, drift-detection behavior in CI, per-provider quirks, and common
+troubleshooting paths.
+
+---
+
+## Why this layer exists
+
+Before the templates layer (issues #700-#706), every slash-command file had
+to be authored separately per provider directory (`.claude/commands/*.md`).
+That meant:
+
+- Premises like the TDD cycle and DOR rules had to be duplicated and stayed
+  in sync by convention.
+- New providers (Codex, HTTP-generic) needed every command re-authored.
+- Edits to a single rule (e.g., "skip RED gate for docs tasks") had to be
+  applied N times — and silently drifted.
+
+The canonical layer fixes all three:
+
+- **Single-source authoring** — write the spec once under
+  `.maestro/templates/`. The render engine emits per-provider artifacts.
+- **Agent-agnostic vocabulary** — `{{INVOKE_SUBAGENT}}` becomes a `Task`
+  call for Claude, an inline expansion for Codex, or a runtime injection
+  for an HTTP provider.
+- **Drift-detected** — `maestro sync-templates --check` fails CI when a
+  rendered artifact diverges from what the canonical spec would produce.
+
+For the layout of `.maestro/templates/`, refer to `directory-tree.md` at
+the repo root — never duplicate the tree here.
+
+---
+
+## Placeholder vocabulary
+
+The renderer's placeholder vocabulary is hard-coded. The
+`.maestro/templates/manifest.toml` file declares per-placeholder validation
+hints used by tooling but does **not** define new placeholders.
+
+| Placeholder         | Purpose                                                   | Required args              |
+| ------------------- | --------------------------------------------------------- | -------------------------- |
+| `{{INVOKE_SUBAGENT}}` | Render the canonical instruction for spawning a subagent. | `name`, `prompt`           |
+| `{{HOOK_GATE}}`     | Render a bash invocation for a pre-/post-step gate hook.  | `script`, `args`           |
+| `{{INCLUDE}}`       | Inline a shared core fragment from the templates root.    | `path` (max depth 8)       |
+| `{{SUBAGENT_LIST}}` | Render the active subagent registry for the target provider. | _(none)_                |
+| `{{SKILL}}`         | Reference a skill knowledge base.                         | `name`                     |
+
+The canonical declarations live in
+`.maestro/templates/manifest.toml`. Argument enforcement is implemented in
+`src/templates/manifest.rs` and the renderer in
+`src/commands/sync_templates/`.
+
+---
+
+## How to add a new command
+
+1. Create the canonical file under `.maestro/templates/commands/<name>.md`.
+   Front-matter is plain Markdown; placeholders use `{{...}}` syntax.
+2. Register the command in the renderer's command registry (see
+   `src/commands/sync_templates/`) so it is picked up by the sync flow.
+3. Add a byte-identical regression assertion in `tests/templates_render.rs`
+   so any unintentional change to the rendered output is caught.
+4. Run `maestro sync-templates` to regenerate the provider artifacts; commit
+   both the canonical source and the rendered outputs in the same PR.
+5. CI runs `maestro sync-templates --check` and `cargo test`; both must pass.
+
+---
+
+## How to add a new provider
+
+1. Implement the provider's rendering rules in
+   `src/templates/provider_rules/<provider>.rs`.
+2. Add a `[providers.<name>]` block to `.maestro/templates/manifest.toml`
+   with `display_name`, `target_dir`, and `inline_skills`.
+3. Wire the provider into the renderer registry so `sync-templates` invokes
+   it for every command.
+4. Choose the right strategy for your provider:
+   - **Byte-identical** — emit the same text verbatim into a provider
+     directory (the Claude Code pattern).
+   - **Inline-expansion** — replace `{{SKILL}}` / `{{INCLUDE}}` with the
+     expanded text (the Codex CLI pattern; no separate skill dir at the
+     destination).
+   - **Runtime-only** — never write to disk; inject the canonical text into
+     the L2 prompt at build time (the HTTP-generic pattern).
+5. Add per-provider tests under `tests/templates_render.rs` confirming the
+   rendered output for at least one command.
+
+---
+
+## Drift detection in CI
+
+CI defends three layers:
+
+- **`maestro sync-templates --check`** — re-renders every command into a
+  temp directory and diffs against the committed provider artifacts. Any
+  drift fails the run. Re-run `maestro sync-templates` locally and commit
+  the regenerated files.
+- **`tests/templates_render.rs`** — byte-identical regression checks against
+  hand-frozen snapshots; catches subtle whitespace or banner changes.
+- **`tests/template_mirror_drift.rs`** (NEW in #708) — guards the
+  `template/.maestro/templates/` scaffolding mirror. The `maestro init`
+  scaffolder embeds the mirror via `include_bytes!`; the test asserts the
+  mirror is byte-equal to the canonical `.maestro/templates/`. Fix with
+  `cp -a .maestro/templates/. template/.maestro/templates/`.
+
+---
+
+## Per-provider quirks
+
+- **Claude Code** — Byte-identical pass-through. Rendered files live under
+  `.claude/commands/<name>.md` and carry an
+  `AUTO-GENERATED by maestro sync-templates` banner.
+- **Codex CLI** — Inline expansion of `{{SKILL}}` and `{{INCLUDE}}` at
+  render time. No skill directory at the destination, so users don't need
+  to install a parallel skills tree.
+- **HTTP generic** — Runtime-only injection at L2 prompt build (no
+  on-disk artifacts). The renderer prepares the canonical text; the L2
+  orchestrator stitches it into the system prompt for each role.
+
+---
+
+## `maestro init` scaffolding (since #708)
+
+`maestro init` mirrors `.maestro/templates/` into newly initialized
+projects so the scaffolded project ships with a working canonical tree
+out of the box.
+
+- Embedded source: `template/.maestro/templates/` (kept byte-equal to
+  `.maestro/templates/` by `tests/template_mirror_drift.rs`).
+- Embedded via `include_bytes!` at build time — no runtime path lookup,
+  so installed binaries via `cargo install` work in any project.
+- Idempotent: re-running `maestro init` reports per-file `Created` /
+  `Skipped` and never overwrites user-edited templates.
+
+---
+
+## Troubleshooting
+
+- **"Unresolved placeholder `{{X}}`"** — the canonical file references a
+  placeholder the renderer does not know. Either you typed it wrong or
+  you need to add it to the vocabulary (see `src/templates/manifest.rs`).
+- **"Drift detected by CI"** — re-run `maestro sync-templates` locally,
+  commit the regenerated files. Do NOT edit the rendered files manually.
+- **"Byte-identical mismatch"** — usually trailing whitespace or a stale
+  `AUTO-GENERATED` banner; regenerate via `maestro sync-templates`.
+- **"`maestro init` did not drop `.maestro/templates/`"** — verify you
+  are on a binary that includes #708 (`maestro --version` ≥ 0.27). If
+  the directory already existed, every file is reported as `Skipped` —
+  intended idempotency.
+- **"Mirror tree drift between `.maestro/templates/` and
+  `template/.maestro/templates/`"** — fix with
+  `cp -a .maestro/templates/. template/.maestro/templates/` and commit.
+  The drift test (`tests/template_mirror_drift.rs`) will pass once both
+  trees are byte-equal.

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -9,7 +9,10 @@ use std::path::Path;
 
 use crate::init::{
     FsProjectDetector, ProjectDetector, RenderOutcome, render_or_merge,
-    render_or_merge_with_provider, template::ProviderTemplate, walk::find_project_root,
+    render_or_merge_with_provider,
+    scaffold::{FsScaffolder, ScaffoldAction, scaffold_templates_dir},
+    template::ProviderTemplate,
+    walk::find_project_root,
 };
 use crate::provider::{detect_provider_from_remote, types::ProviderKind};
 
@@ -154,6 +157,7 @@ pub fn cmd_init_inner_with_options(
                     target.display()
                 );
             }
+            scaffold_templates_and_report(project_root)?;
         }
         RenderOutcome::Merged { stacks, report } => {
             std::fs::write(&target, &report.merged_toml)
@@ -169,10 +173,26 @@ pub fn cmd_init_inner_with_options(
                 report.keys_added.len(),
                 report.keys_preserved.len()
             );
+            scaffold_templates_and_report(project_root)?;
         }
     }
 
     Ok(0)
+}
+
+/// Scaffold `.maestro/templates/` next to the project root and print a
+/// one-line summary. Idempotent: pre-existing files are reported as Skipped.
+fn scaffold_templates_and_report(project_root: &Path) -> Result<()> {
+    let scaffolder = FsScaffolder::new(project_root.to_path_buf());
+    let report = scaffold_templates_dir(&scaffolder)?;
+    let created = report.count(ScaffoldAction::Created);
+    let skipped = report.count(ScaffoldAction::Skipped);
+    if created > 0 || skipped > 0 {
+        println!(
+            "Scaffolded .maestro/templates/: {created} created, {skipped} skipped (already present)."
+        );
+    }
+    Ok(())
 }
 
 fn provider_template_from_options(options: InitOptions<'_>) -> Result<ProviderTemplate> {

--- a/src/commands/init_tests.rs
+++ b/src/commands/init_tests.rs
@@ -1,4 +1,54 @@
 use super::*;
+use crate::init::{DetectedStack, FakeProjectDetector};
+use tempfile::TempDir;
+
+#[test]
+fn init_creates_templates_manifest_toml() {
+    // Verifies cmd_init_inner wires the scaffold step in after the
+    // maestro.toml write succeeds.
+    let dir = TempDir::new().expect("create tempdir");
+    let detector = FakeProjectDetector::new(vec![DetectedStack::Rust]);
+    let code = cmd_init_inner(false, dir.path(), &detector).expect("cmd_init_inner");
+    assert_eq!(code, 0);
+    let manifest = dir.path().join(".maestro/templates/manifest.toml");
+    assert!(
+        manifest.exists(),
+        ".maestro/templates/manifest.toml must be created by init"
+    );
+}
+
+#[test]
+fn init_manifest_toml_matches_canonical_bytes() {
+    let dir = TempDir::new().expect("create tempdir");
+    let detector = FakeProjectDetector::new(vec![DetectedStack::Rust]);
+    let code = cmd_init_inner(false, dir.path(), &detector).expect("cmd_init_inner");
+    assert_eq!(code, 0);
+
+    let written = std::fs::read(dir.path().join(".maestro/templates/manifest.toml"))
+        .expect("manifest.toml must be readable after init");
+    let canonical = include_bytes!("../../template/.maestro/templates/manifest.toml");
+    assert_eq!(
+        written.as_slice(),
+        canonical.as_slice(),
+        "scaffolded manifest.toml must be byte-equal to embedded source"
+    );
+}
+
+#[test]
+fn init_creates_all_template_files() {
+    let dir = TempDir::new().expect("create tempdir");
+    let detector = FakeProjectDetector::new(vec![DetectedStack::Rust]);
+    let code = cmd_init_inner(false, dir.path(), &detector).expect("cmd_init_inner");
+    assert_eq!(code, 0);
+
+    for rel in crate::init::scaffold::template_relative_paths() {
+        assert!(
+            dir.path().join(&rel).exists(),
+            "expected scaffolded file: {}",
+            rel.display()
+        );
+    }
+}
 
 #[test]
 fn first_origin_remote_url_prefers_fetch_url() {

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod detector;
 pub mod merge;
+pub mod scaffold;
 pub mod template;
 pub mod walk;
 

--- a/src/init/scaffold.rs
+++ b/src/init/scaffold.rs
@@ -178,7 +178,9 @@ pub fn scaffold_templates_dir(s: &dyn Scaffolder) -> Result<ScaffoldReport> {
 }
 
 /// Stable list of relative paths (under the project root) that
-/// `scaffold_templates_dir` writes.
+/// `scaffold_templates_dir` writes. Test-only — production callers
+/// consume the `ScaffoldReport` returned by `scaffold_templates_dir`.
+#[cfg(test)]
 pub fn template_relative_paths() -> Vec<PathBuf> {
     FILES
         .iter()

--- a/src/init/scaffold.rs
+++ b/src/init/scaffold.rs
@@ -1,0 +1,191 @@
+//! Scaffolds the `.maestro/templates/` reference tree into a freshly
+//! initialized project. Canonical content lives at
+//! `template/.maestro/templates/` in the repo and is embedded via
+//! `include_bytes!` at build time. Tests drive `scaffold_templates_dir`
+//! through an `InMemoryScaffolder` (see `scaffold_tests.rs`).
+
+use anyhow::{Context, Result};
+use std::io;
+use std::path::{Component, Path, PathBuf};
+
+/// Per-file outcome of a scaffold run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScaffoldAction {
+    Created,
+    Skipped,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScaffoldedFile {
+    pub path: PathBuf,
+    pub action: ScaffoldAction,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ScaffoldReport {
+    pub files: Vec<ScaffoldedFile>,
+}
+
+impl ScaffoldReport {
+    pub fn count(&self, action: ScaffoldAction) -> usize {
+        self.files.iter().filter(|f| f.action == action).count()
+    }
+}
+
+/// I/O seam — the FS implementation writes through `std::fs`; tests use an
+/// in-memory map.
+pub trait Scaffolder {
+    fn write(&self, rel_path: &Path, contents: &[u8]) -> io::Result<()>;
+    fn exists(&self, rel_path: &Path) -> bool;
+}
+
+pub struct FsScaffolder {
+    pub root: PathBuf,
+}
+
+impl FsScaffolder {
+    pub fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+}
+
+/// Reject absolute paths, drive prefixes, and any `..` traversal segments.
+/// `rel_path` MUST be a relative path with only `Normal` and `CurDir`
+/// components. Returning `InvalidInput` here ensures `FsScaffolder` cannot
+/// be coerced into writing outside `self.root` even if a future caller
+/// passes attacker-influenced input.
+fn validate_relative(rel_path: &Path) -> io::Result<()> {
+    for component in rel_path.components() {
+        match component {
+            Component::Normal(_) | Component::CurDir => {}
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "scaffolder rejects non-relative path component in {}",
+                        rel_path.display()
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+impl Scaffolder for FsScaffolder {
+    fn write(&self, rel_path: &Path, contents: &[u8]) -> io::Result<()> {
+        validate_relative(rel_path)?;
+        let abs = self.root.join(rel_path);
+        if let Some(parent) = abs.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        // create_new closes the TOCTOU between `exists()` and `write()`: if
+        // a concurrent writer wins the race, we treat the file as already
+        // present (Skipped) and do NOT clobber it.
+        match std::fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&abs)
+        {
+            Ok(mut f) => {
+                use std::io::Write;
+                f.write_all(contents)
+            }
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn exists(&self, rel_path: &Path) -> bool {
+        if validate_relative(rel_path).is_err() {
+            return false;
+        }
+        self.root.join(rel_path).exists()
+    }
+}
+
+const TEMPLATES_ROOT: &str = ".maestro/templates";
+
+struct Embedded {
+    rel_path: &'static str,
+    contents: &'static [u8],
+}
+
+const FILES: &[Embedded] = &[
+    Embedded {
+        rel_path: "README.md",
+        contents: include_bytes!("../../template/.maestro/templates/README.md"),
+    },
+    Embedded {
+        rel_path: "manifest.toml",
+        contents: include_bytes!("../../template/.maestro/templates/manifest.toml"),
+    },
+    Embedded {
+        rel_path: "core/premises.md",
+        contents: include_bytes!("../../template/.maestro/templates/core/premises.md"),
+    },
+    Embedded {
+        rel_path: "core/tdd-cycle.md",
+        contents: include_bytes!("../../template/.maestro/templates/core/tdd-cycle.md"),
+    },
+    Embedded {
+        rel_path: "core/dependency-graph.md",
+        contents: include_bytes!("../../template/.maestro/templates/core/dependency-graph.md"),
+    },
+    Embedded {
+        rel_path: "commands/.gitkeep",
+        contents: include_bytes!("../../template/.maestro/templates/commands/.gitkeep"),
+    },
+    Embedded {
+        rel_path: "commands/implement.md",
+        contents: include_bytes!("../../template/.maestro/templates/commands/implement.md"),
+    },
+    Embedded {
+        rel_path: "commands/plan-feature.md",
+        contents: include_bytes!("../../template/.maestro/templates/commands/plan-feature.md"),
+    },
+    Embedded {
+        rel_path: "commands/pushup.md",
+        contents: include_bytes!("../../template/.maestro/templates/commands/pushup.md"),
+    },
+    Embedded {
+        rel_path: "commands/simplify.md",
+        contents: include_bytes!("../../template/.maestro/templates/commands/simplify.md"),
+    },
+];
+
+/// Walk the embedded file list, write each into `s` under
+/// `.maestro/templates/`, skipping any file that already exists.
+pub fn scaffold_templates_dir(s: &dyn Scaffolder) -> Result<ScaffoldReport> {
+    let mut report = ScaffoldReport::default();
+    for embed in FILES {
+        let rel = PathBuf::from(TEMPLATES_ROOT).join(embed.rel_path);
+        if s.exists(&rel) {
+            report.files.push(ScaffoldedFile {
+                path: rel,
+                action: ScaffoldAction::Skipped,
+            });
+            continue;
+        }
+        s.write(&rel, embed.contents)
+            .with_context(|| format!("writing scaffolded template {}", rel.display()))?;
+        report.files.push(ScaffoldedFile {
+            path: rel,
+            action: ScaffoldAction::Created,
+        });
+    }
+    Ok(report)
+}
+
+/// Stable list of relative paths (under the project root) that
+/// `scaffold_templates_dir` writes.
+pub fn template_relative_paths() -> Vec<PathBuf> {
+    FILES
+        .iter()
+        .map(|f| PathBuf::from(TEMPLATES_ROOT).join(f.rel_path))
+        .collect()
+}
+
+#[cfg(test)]
+#[path = "scaffold_tests.rs"]
+mod tests;

--- a/src/init/scaffold_tests.rs
+++ b/src/init/scaffold_tests.rs
@@ -1,7 +1,7 @@
 //! Tests for `scaffold.rs`. Sibling file loaded via `#[path]` to keep
 //! `scaffold.rs` under the repo's 400-line guardrail.
 
-use super::{FsScaffolder, ScaffoldAction, ScaffoldReport, Scaffolder, scaffold_templates_dir};
+use super::{FsScaffolder, ScaffoldAction, Scaffolder, scaffold_templates_dir};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::io;

--- a/src/init/scaffold_tests.rs
+++ b/src/init/scaffold_tests.rs
@@ -1,0 +1,198 @@
+//! Tests for `scaffold.rs`. Sibling file loaded via `#[path]` to keep
+//! `scaffold.rs` under the repo's 400-line guardrail.
+
+use super::{FsScaffolder, ScaffoldAction, ScaffoldReport, Scaffolder, scaffold_templates_dir};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::io;
+use std::path::{Path, PathBuf};
+
+struct InMemoryScaffolder {
+    files: RefCell<HashMap<PathBuf, Vec<u8>>>,
+}
+
+impl InMemoryScaffolder {
+    fn new() -> Self {
+        Self {
+            files: RefCell::new(HashMap::new()),
+        }
+    }
+
+    fn with_file(path: impl Into<PathBuf>, contents: impl Into<Vec<u8>>) -> Self {
+        let s = Self::new();
+        s.files.borrow_mut().insert(path.into(), contents.into());
+        s
+    }
+
+    fn get(&self, path: &Path) -> Option<Vec<u8>> {
+        self.files.borrow().get(path).cloned()
+    }
+}
+
+impl Scaffolder for InMemoryScaffolder {
+    fn write(&self, rel_path: &Path, contents: &[u8]) -> io::Result<()> {
+        self.files
+            .borrow_mut()
+            .insert(rel_path.to_path_buf(), contents.to_vec());
+        Ok(())
+    }
+
+    fn exists(&self, rel_path: &Path) -> bool {
+        self.files.borrow().contains_key(rel_path)
+    }
+}
+
+fn expected_paths() -> Vec<PathBuf> {
+    [
+        ".maestro/templates/README.md",
+        ".maestro/templates/manifest.toml",
+        ".maestro/templates/core/premises.md",
+        ".maestro/templates/core/tdd-cycle.md",
+        ".maestro/templates/core/dependency-graph.md",
+        ".maestro/templates/commands/.gitkeep",
+        ".maestro/templates/commands/implement.md",
+        ".maestro/templates/commands/plan-feature.md",
+        ".maestro/templates/commands/pushup.md",
+        ".maestro/templates/commands/simplify.md",
+    ]
+    .iter()
+    .map(PathBuf::from)
+    .collect()
+}
+
+#[test]
+fn scaffold_writes_all_10_files_into_empty_scaffolder() {
+    let s = InMemoryScaffolder::new();
+    let report = scaffold_templates_dir(&s).expect("scaffold must not error");
+
+    let mut written: Vec<PathBuf> = report.files.iter().map(|f| f.path.clone()).collect();
+    written.sort();
+
+    let mut expected = expected_paths();
+    expected.sort();
+
+    assert_eq!(
+        written, expected,
+        "scaffolder must write exactly the 10 template files"
+    );
+}
+
+#[test]
+fn scaffold_report_has_exactly_10_entries_all_created() {
+    let s = InMemoryScaffolder::new();
+    let report = scaffold_templates_dir(&s).expect("scaffold must not error");
+
+    assert_eq!(
+        report.files.len(),
+        10,
+        "expected exactly 10 ScaffoldedFile entries"
+    );
+    assert_eq!(
+        report.count(ScaffoldAction::Created),
+        10,
+        "all 10 files must be Created on a fresh run"
+    );
+    assert_eq!(
+        report.count(ScaffoldAction::Skipped),
+        0,
+        "no files must be Skipped on a fresh run"
+    );
+}
+
+#[test]
+fn scaffold_idempotent_skips_pre_existing_file_and_preserves_content() {
+    let original_content = b"# user-edited content that must survive";
+    let manifest_path = PathBuf::from(".maestro/templates/manifest.toml");
+
+    let s = InMemoryScaffolder::with_file(manifest_path.clone(), original_content.to_vec());
+    let report = scaffold_templates_dir(&s).expect("scaffold must not error");
+
+    assert_eq!(
+        report.files.len(),
+        10,
+        "report must still contain 10 entries"
+    );
+    assert_eq!(
+        report.count(ScaffoldAction::Skipped),
+        1,
+        "exactly 1 file was pre-existing — must be Skipped"
+    );
+    assert_eq!(
+        report.count(ScaffoldAction::Created),
+        9,
+        "remaining 9 files must be Created"
+    );
+
+    let manifest_entry = report
+        .files
+        .iter()
+        .find(|f| f.path == manifest_path)
+        .expect("manifest.toml must appear in report");
+    assert_eq!(manifest_entry.action, ScaffoldAction::Skipped);
+
+    let actual = s
+        .get(&manifest_path)
+        .expect("file must still be in scaffolder");
+    assert_eq!(
+        actual, original_content,
+        "pre-existing file content must not be overwritten"
+    );
+}
+
+#[test]
+fn fs_scaffolder_rejects_absolute_path() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let s = FsScaffolder::new(tmp.path().to_path_buf());
+    let err = s
+        .write(Path::new("/tmp/escaped.txt"), b"x")
+        .expect_err("absolute path must be rejected");
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+}
+
+#[test]
+fn fs_scaffolder_rejects_parent_dir_traversal() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let s = FsScaffolder::new(tmp.path().to_path_buf());
+    let err = s
+        .write(Path::new("../escaped.txt"), b"x")
+        .expect_err("parent-dir traversal must be rejected");
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+}
+
+#[test]
+fn fs_scaffolder_create_new_skips_existing_file_silently() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let s = FsScaffolder::new(tmp.path().to_path_buf());
+    // First write succeeds.
+    s.write(Path::new("foo.txt"), b"original")
+        .expect("first write");
+    // Second write must not clobber the original.
+    s.write(Path::new("foo.txt"), b"replacement")
+        .expect("second write should be silent Ok");
+    let content = std::fs::read(tmp.path().join("foo.txt")).expect("read");
+    assert_eq!(
+        content, b"original",
+        "FsScaffolder::write must not overwrite an existing file"
+    );
+}
+
+#[test]
+fn each_embedded_file_is_non_empty_after_write() {
+    let s = InMemoryScaffolder::new();
+    let report = scaffold_templates_dir(&s).expect("scaffold must not error");
+
+    for entry in &report.files {
+        // .gitkeep is intentionally empty; every other file must have content.
+        if entry.path.ends_with(".gitkeep") {
+            continue;
+        }
+        let content = s
+            .get(&entry.path)
+            .unwrap_or_else(|| panic!("file not found in scaffolder: {}", entry.path.display()));
+        assert!(
+            !content.is_empty(),
+            "embedded file {} must not be empty — check the include_bytes! path",
+            entry.path.display()
+        );
+    }
+}

--- a/template/.claude/CLAUDE.md
+++ b/template/.claude/CLAUDE.md
@@ -33,6 +33,12 @@
 2. **GREEN** — Write minimum code to pass
 3. **REFACTOR** — Clean up, tests stay green
 
+### 4. CANONICAL TEMPLATES — DO NOT EDIT RENDERED FILES
+
+- Edit canonical files under `.maestro/templates/commands/` and `.maestro/templates/core/`.
+- Never edit rendered `.claude/commands/*.md` directly (they carry an `AUTO-GENERATED` banner).
+- Run `maestro sync-templates` after every canonical edit; commit the regenerated artifacts.
+
 ---
 
 ## FIRST ACTIONS: Language and Mode Selection

--- a/template/.maestro/templates/README.md
+++ b/template/.maestro/templates/README.md
@@ -1,0 +1,119 @@
+# Canonical Templates
+
+This directory holds **canonical**, provider-agnostic command and fragment
+sources. The render engine projects them into provider-specific outputs such as
+`.claude/commands/*.md` (Claude Code). Edit canonical sources here and re-render
+with `maestro sync-templates` — never edit the rendered files under
+`.claude/commands/*.md` directly. The canonical-vs-rendered split exists so
+cross-provider rules (premises, TDD cycle, dependency-graph mandate) live in
+exactly one place.
+
+## Layout
+
+```
+.maestro/templates/
+├── README.md              ← this file
+├── manifest.toml          ← placeholder vocabulary + subagent registry (canonical)
+├── core/                  ← shared fragments included by every spec
+│   ├── premises.md
+│   ├── tdd-cycle.md
+│   └── dependency-graph.md
+└── commands/              ← canonical command specs (Issue #702)
+    ├── implement.md
+    ├── pushup.md
+    ├── plan-feature.md
+    └── simplify.md
+```
+
+> Authoritative project layout lives in `directory-tree.md` at the repo root.
+> The snippet above is illustrative for this subtree only.
+
+## manifest.toml schema
+
+`manifest.toml` is the single source of truth for all placeholder metadata used
+by the render engine.
+
+### `[[subagents]]` — subagent registry (Issue #728)
+
+Each entry in the `[[subagents]]` TOML array declares one subagent that appears
+in the rendered `{{SUBAGENT_LIST}}` placeholder:
+
+```toml
+[[subagents]]
+slug    = "subagent-gatekeeper"
+purpose = "DOR, blockers, and API-contract gate for `/implement`"
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `slug` | string | Exact filename stem of the agent file (e.g. `subagent-gatekeeper` matches `.claude/agents/subagent-gatekeeper.md`) |
+| `purpose` | string | One-line description; rendered verbatim as the "Purpose" column in the Markdown table |
+
+**Order matters.** Rows in the rendered table follow the order of entries in
+this file (pipeline order, not alphabetical).
+
+**Drift detection.** The set of slugs in `[[subagents]]` must match the set of
+`subagent-*.md` files on disk under `.claude/agents/`. Any mismatch is caught
+at test time by `tests/subagent_manifest_drift.rs`. When you add or remove an
+agent file you must update this array.
+
+**Render path.** `src/templates/provider_rules/subagent_list.rs` reads this
+array via `Manifest::subagents()` and converts it into the Markdown table.
+The three provider rule files (`claude.rs`, `codex.rs`, `http_generic.rs`) all
+delegate their `subagent_list()` method to that shared helper.
+
+## Cutover policy (post-#703)
+
+`.maestro/templates/` is the **single source of truth** for slash-command specs.
+`.claude/commands/*.md` files that are listed as `[generated]` in `directory-tree.md`
+(`implement.md`, `pushup.md`, `plan-feature.md`, `simplify.md`) are **rendered artifacts**.
+
+- **Never edit generated files directly.** Edit the canonical source in
+  `.maestro/templates/commands/` and re-render with `maestro sync-templates`.
+- **CI enforces drift.** The `sync-templates` CI job runs
+  `cargo run --quiet -- sync-templates --check` and fails the build on any mismatch.
+  `tests/templates_render.rs` additionally contains byte-identical regression tests.
+- Commands without a canonical spec (`create-subagent.md`, `release.md`, etc.) remain
+  hand-maintained for now.
+
+### Regenerating rendered outputs
+
+After editing a canonical spec under `.maestro/templates/commands/` or a shared fragment
+under `.maestro/templates/core/`, regenerate all rendered outputs with:
+
+```sh
+maestro sync-templates
+```
+
+To regenerate only the Claude provider outputs:
+
+```sh
+maestro sync-templates --provider claude
+```
+
+To preview planned writes without touching the filesystem:
+
+```sh
+maestro sync-templates --dry-run
+```
+
+To verify that on-disk files match the canonical sources (what CI runs):
+
+```sh
+maestro sync-templates --check
+```
+
+Confirm the regeneration with `cargo test --test templates_render` — the byte-identical
+regression tests pass when the rendered output matches the canonical render.
+
+## Forward-reference legend
+
+All planned work items from `we-need-to-standardize-zippy-wave.md` have landed:
+
+| Code | Issue | Scope |
+|------|-------|-------|
+| #A   | #700  | L0 scaffold — canonical templates directory |
+| #B   | #701  | Render engine — resolves placeholders into per-provider output |
+| #C   | #702  | Canonical command specs — populated `commands/` with implement, pushup, plan-feature, simplify |
+| #G   | #706  | `maestro sync-templates` CLI — provider-aware re-render + drift detection |
+

--- a/template/.maestro/templates/commands/implement.md
+++ b/template/.maestro/templates/commands/implement.md
@@ -1,0 +1,489 @@
+---
+command: implement
+version: 1.0.0
+description: Fetch a GitHub issue and implement it following the enforced TDD harness.
+placeholders:
+  - HOOK_GATE
+  - INCLUDE
+  - INVOKE_SUBAGENT
+includes:
+  - core/premises.md
+  - core/tdd-cycle.md
+source_provenance:
+  ported_from: .claude/commands/implement.md
+  ported_at: 2026-05-13
+---
+
+# Implement Issue
+
+Fetch a GitHub issue and implement it following the enforced TDD harness.
+
+**Usage:** `/implement #123` or `/implement 123 --english --orchestrator`
+
+{{INCLUDE path="core/premises.md"}}
+
+---
+
+## Arguments
+
+`$ARGUMENTS` contains the issue number and optional flags.
+
+### Supported Flags
+
+| Flag | Short | Purpose |
+|------|-------|---------|
+| `--english` | `-e` | Set language to English |
+| `--portuguese` | `-pt` | Set language to Português do Brasil |
+| `--spanish` | `-s` | Set language to Español |
+| `--orchestrator` | `-o` | Use Subagents Orchestrator mode |
+| `--vibe-coding` | `-vc` | Use Vibe Coding mode |
+| `--continue` | — | Step 5 idempotency: continue on existing branch (skip prompt) |
+| `--restart` | — | Step 5 idempotency: delete existing branch and start fresh (skip prompt; still requires inner `RESTART` confirmation if interactive) |
+| `--dirty-tree-action=stash\|abort\|ask` | — | Pre-check Gate 6: how to handle a dirty working tree. Pass-through to the gate hook. |
+| `--auto-comment` | — | Step 4 DOR remediation: auto-post the gatekeeper-drafted comment + `needs-info` label. Default: print the proposed action and STOP for human review. |
+
+`--training` / `-t` is explicitly rejected — Training mode is for provider-configuration directories, not implementation.
+
+`--continue` and `--restart` are mutually exclusive — passing both is an error.
+
+---
+
+## Instructions
+
+### Step 0: Parse arguments
+
+Extract from `$ARGUMENTS`:
+1. **Issue number**: first `\d+` with optional `#` prefix. Export as `$ISSUE_NUMBER` for downstream steps.
+2. **Language flag** (if present).
+3. **Mode flag** (if present).
+4. **Idempotency flag** (`--continue` or `--restart`, if present). Reject with exit 1 if both are passed.
+5. **Dirty-tree action** (`--dirty-tree-action=...`, if present) — captured for pass-through to the pre-check hook in Step 2.
+6. **Auto-comment opt-in** (`--auto-comment`, if present) — export `AUTO_COMMENT=1` for Step 4 DOR auto-remediation.
+
+```bash
+export ISSUE_NUMBER="<n>"  # substitute the parsed number
+```
+
+All subsequent gate commands in this file reference `$ISSUE_NUMBER`, not bare `<n>`.
+
+If `--training` or `-t` is detected, output:
+
+```
+Training mode is for configuring provider agents, skills, and commands.
+/implement is for building features from GitHub issues.
+Drop --training, or use a free-form prompt for provider configuration.
+```
+
+and exit 0 (not an error).
+
+If no issue number found, ask: "Which issue should I implement?"
+
+### Step 1: Language and mode selection
+
+If flags provided, honor them. Otherwise, ask the user.
+
+### Step 2: Pre-check hook (GATE — MANDATORY)
+
+Run the mechanical pre-check hook. Abort on non-zero exit, printing stderr verbatim. Pass through `--dirty-tree-action=...` from Step 0 if the user supplied it.
+
+```bash
+{{HOOK_GATE script="implement-gates.sh" args="$ISSUE_NUMBER ${DIRTY_TREE_ACTION:+--dirty-tree-action=$DIRTY_TREE_ACTION}"}}
+```
+
+The hook prints `gate log dir: /tmp/maestro-$ISSUE_NUMBER-<ts>` on success AND writes the same path to a sentinel file. The sentinel allows subsequent shell calls to recover `GATE_LOG_DIR` without relying on env-var persistence (each fresh shell loses `export`).
+
+The resolution chain (symlink-attack hardening on multi-user Linux) is `$XDG_RUNTIME_DIR` → `$HOME/.cache/maestro` → `${TMPDIR:-/tmp}`. The hook prints the chosen path as `sentinel: <path>` on stdout.
+
+Recovery pattern for any later step (walks the same chain):
+
+```bash
+GATE_LOG_DIR=""
+for candidate in \
+  "${XDG_RUNTIME_DIR:-}/maestro-current-gate-dir" \
+  "${HOME}/.cache/maestro/maestro-current-gate-dir" \
+  "/tmp/maestro-current-gate-dir"; do
+  if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+    GATE_LOG_DIR=$(cat "$candidate")
+    break
+  fi
+done
+```
+
+The sentinel file is overwritten on the next `/implement` run, so it always points at the current gate session.
+
+**Non-TTY behavior of the hook:** the gate hook detects no-TTY (`! -t 0`) and refuses to prompt for the dirty-tree action. If the tree is dirty and `--dirty-tree-action=` is not passed, the hook prints an actionable message and exits 6. Re-run the slash command with `--dirty-tree-action=stash` (auto-stash) or `--dirty-tree-action=abort` (clean fail) to unblock.
+
+Exit codes:
+- `0` — proceed.
+- `1` — generic failure (gh missing, not authed, not in repo, closed issue). Abort with the hook's stderr.
+- `2` — baseline cargo test failing. Abort — fix the baseline before starting.
+- `6` — dirty tree, user chose abort. Abort cleanly.
+- `7+` — preflight failure. Abort with its stderr.
+
+### Step 3: Read cached issue JSON and summary
+
+The hook has cached the issue JSON at `$GATE_LOG_DIR/issue.json` and a condensed
+DOR summary at `$GATE_LOG_DIR/issue-summary.md`. Read them directly — no second
+`gh` call. Prefer `issue-summary.md` for downstream subagents that only need the
+issue requirements; keep `issue.json` for mechanical gates and fallback checks
+that need labels, state, comments, or other structured fields.
+
+```bash
+cat "$GATE_LOG_DIR/issue.json"
+cat "$GATE_LOG_DIR/issue-summary.md"
+```
+
+### Step 4: Gatekeeper (GATE — MANDATORY)
+
+Run the mechanical DOR lint first. It writes `$GATE_LOG_DIR/dor-lint.json` and
+always exits 0; the JSON verdict decides whether the subagent can be skipped.
+
+```bash
+scripts/dor-lint.sh "$GATE_LOG_DIR/issue.json" >/dev/null
+
+lint_passed=$(jq -r .passed "$GATE_LOG_DIR/dor-lint.json")
+all_blockers_closed=$(jq -r '.blocker_states | to_entries | all(.value == "CLOSED")' "$GATE_LOG_DIR/dor-lint.json")
+contract_required=$(jq -r '.reasons | index("contract validation required") != null' "$GATE_LOG_DIR/dor-lint.json")
+
+if [ "$lint_passed" = "true" ] && \
+   [ "$all_blockers_closed" = "true" ] && \
+   [ "$contract_required" = "false" ]; then
+  python3 - "$GATE_LOG_DIR/dor-lint.json" "$GATE_LOG_DIR/gatekeeper.json" <<'PY'
+import json
+import sys
+
+lint = json.load(open(sys.argv[1]))
+task_map = {
+    "feature": "implementation",
+    "bug": "implementation",
+    "trivial": "implementation",
+    "docs": "docs",
+    "refactor": "refactor",
+}
+report = {
+    "report_version": 1,
+    "status": "PASS",
+    "task_type": task_map.get(lint.get("task_type"), "implementation"),
+    "dor": {"passed": True, "missing_sections": [], "weak_sections": []},
+    "blockers": {"passed": True, "open": []},
+    "contracts": {"passed": True, "missing": []},
+    "remediation": {"comment_body": "", "labels_to_add": []},
+    "reasons": [],
+}
+json.dump(report, open(sys.argv[2], "w"), separators=(",", ":"))
+open(sys.argv[2], "a").write("\n")
+PY
+  task_type=$(jq -r .task_type "$GATE_LOG_DIR/gatekeeper.json")
+  echo "Gatekeeper fast-path PASS (task_type: $task_type)"
+  export TASK_TYPE="$task_type"
+else
+  echo "DOR lint did not qualify for fast-path; invoking subagent-gatekeeper."
+fi
+```
+
+If the fast path did not write `$GATE_LOG_DIR/gatekeeper.json`, invoke the gatekeeper subagent:
+
+{{INVOKE_SUBAGENT name="gatekeeper" prompt="Classify issue $ISSUE_NUMBER (DOR, blockers, contracts, task_type). Return the structured JSON gatekeeper report."}}
+
+The subagent's response will contain a fenced `json gatekeeper` code block. Pipe its full response through the parser:
+
+```bash
+if [ ! -f "$GATE_LOG_DIR/gatekeeper.json" ]; then
+  echo "$SUBAGENT_RESPONSE" | python3 scripts/parse_gatekeeper_report.py > "$GATE_LOG_DIR/gatekeeper.json"
+fi
+```
+
+Then branch on the parsed report:
+
+```bash
+status=$(jq -r .status "$GATE_LOG_DIR/gatekeeper.json")
+task_type=$(jq -r .task_type "$GATE_LOG_DIR/gatekeeper.json")
+
+if [ "$status" = "FAIL" ]; then
+  dor_passed=$(jq -r .dor.passed "$GATE_LOG_DIR/gatekeeper.json")
+  if [ "$dor_passed" = "false" ]; then
+    comment_body=$(jq -r .remediation.comment_body "$GATE_LOG_DIR/gatekeeper.json")
+    labels_csv=$(jq -r '.remediation.labels_to_add | join(", ")' "$GATE_LOG_DIR/gatekeeper.json")
+
+    if [ "${AUTO_COMMENT:-0}" = "1" ]; then
+      gh issue comment "$ISSUE_NUMBER" --body "$comment_body"
+      for label in $(jq -r '.remediation.labels_to_add[]' "$GATE_LOG_DIR/gatekeeper.json"); do
+        gh issue edit "$ISSUE_NUMBER" --add-label "$label"
+      done
+      echo "Gatekeeper FAIL: DOR auto-remediation posted (--auto-comment)." >&2
+    else
+      echo "Gatekeeper FAIL: DOR not satisfied." >&2
+      echo "Proposed remediation (NOT posted; re-run with --auto-comment to post):" >&2
+      echo "" >&2
+      echo "  Issue:  #$ISSUE_NUMBER" >&2
+      echo "  Labels: $labels_csv" >&2
+      echo "  Comment body:" >&2
+      echo "  ----" >&2
+      printf '%s\n' "$comment_body" | sed 's/^/  /' >&2
+      echo "  ----" >&2
+    fi
+  fi
+  echo "Gatekeeper FAIL:" >&2
+  jq -r '.reasons[]' "$GATE_LOG_DIR/gatekeeper.json" | while read -r r; do
+    echo "  - $r" >&2
+  done
+  exit 5
+fi
+
+echo "Gatekeeper PASS (task_type: $task_type)"
+export TASK_TYPE="$task_type"
+```
+
+Exit code `5` is reserved for gatekeeper failure.
+
+### Step 5: Branch selection with idempotency
+
+Check for an existing branch matching `feat/issue-${ISSUE_NUMBER}-*`:
+
+```bash
+existing=$(git branch --list "feat/issue-${ISSUE_NUMBER}-*" | head -1 | sed 's/^[ *]*//')
+```
+
+**If empty:** derive a slug from the issue title and create a new branch:
+
+```bash
+slug=$(jq -r .title "$GATE_LOG_DIR/issue.json" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | sed 's/^-//;s/-$//' | cut -c -40)
+git checkout -b "feat/issue-${ISSUE_NUMBER}-${slug}"
+```
+
+**If non-empty:** resolve the idempotency choice using the flags from Step 0, falling back to a TTY prompt when running interactively.
+
+```
+Branch `<existing>` already exists.
+
+Recent commits on that branch:
+<git log main..HEAD --oneline -5>
+```
+
+Resolution rules (in order):
+
+1. If `--continue` was passed → take the **(C)ontinue** path below.
+2. If `--restart` was passed → take the **(R)estart** path below (the inner `RESTART` typed confirmation is also waived under `--restart`, since the user already chose this path explicitly).
+3. If neither flag was passed AND stdin is a TTY → fire the interactive prompt:
+
+   ```
+     (C)ontinue on this branch
+     (R)estart — delete branch and start over
+     (A)bort
+
+   Choice [C/R/A]:
+   ```
+
+4. If neither flag was passed AND stdin is **not** a TTY → default to **(A)bort** with this message:
+
+   ```
+   Branch `<existing>` already exists and stdin is not interactive.
+   Re-run with `/implement #<N> --continue` (resume) or `/implement #<N> --restart` (start over).
+   ```
+
+   Exit cleanly (no error code; the user's next invocation drives the choice).
+
+Handle each choice:
+
+**(C)ontinue:**
+- `git checkout <existing>`.
+- Re-invoke the gatekeeper (idempotent).
+- When delegating to architect/QA in Step 6, prepend the resumption context prompt:
+
+  > **Context for resumption:** This branch already has commits. Here is the history since `main`:
+  >
+  > ```
+  > $(git log --oneline main..HEAD)
+  > ```
+  >
+  > Before producing a full blueprint, inspect these commits. If the work described by the issue appears substantially done (architecture scaffolded, tests present, or implementation in place), return a **minimal response** acknowledging the existing state and listing only what remains. Do not duplicate work already in the branch. If the branch diverges from what you would design (e.g., different module layout, different abstractions), flag the divergence and recommend either reconciling or restarting — do not silently layer a conflicting plan on top.
+
+- **Divergence handling:** if the architect or QA subagent flags divergence, the orchestrator presents a secondary prompt — but only when stdin is a TTY:
+
+  ```
+  Architect detected divergence between the existing branch and the
+  issue's requirements:
+
+  <architect's divergence summary>
+
+    (R)econcile — continue and let subagents bridge the gap
+    (S)witch to Restart — delete and start over
+    (A)bort — inspect manually
+
+  Choice [R/S/A]:
+  ```
+
+  - **(R)econcile**: proceed with Step 6's subagent sequence, trusting the architect/QA to bridge the gap via follow-up edits.
+  - **(S)witch to Restart**: fall through to the Restart flow below (typed `RESTART` confirmation, branch deletion).
+  - **(A)bort**: exit cleanly, tell the user to inspect manually.
+
+  **Non-TTY default:** emit the divergence summary to the user, default to **(A)bort**, and instruct: `Re-run with /implement #<N> --restart` to take the Switch-to-Restart path explicitly, or fix the divergence manually then re-run with `--continue`. Do not silently reconcile — divergence is exactly the case the human should adjudicate.
+
+**(R)estart:**
+- If reached via the interactive prompt, require typed `RESTART` confirmation. If reached via `--restart`, the flag itself is the confirmation — skip the typed gate.
+- `git checkout main && git branch -D "$existing"`.
+- If the branch was pushed AND stdin is a TTY, prompt about remote deletion (default no). If non-TTY, skip remote deletion (safer default; user can prune manually).
+- Create fresh branch.
+
+**(A)bort:**
+- Exit cleanly. Tell the user to `git checkout <branch>` manually to inspect.
+
+If the user is already on the matching branch, skip the prompt and use Continue semantics.
+
+### Step 6: Orchestrator-mode subagent sequence
+
+Vibe mode skips 6a and 6c. All gates use `bash` (not `sh`) — `${PIPESTATUS[0]}` requires it.
+
+The TDD cycle below is non-negotiable. The full canonical fragment:
+
+{{INCLUDE path="core/tdd-cycle.md"}}
+
+#### 6a. Architect → blueprint
+
+Orchestrator mode only. Invoke the architect subagent with the condensed issue
+summary from `$GATE_LOG_DIR/issue-summary.md` and the architecture blueprint
+request. If Step 5 chose Continue, prepend the resumption context prompt.
+
+{{INVOKE_SUBAGENT name="architect" prompt="Produce architecture blueprint for issue $ISSUE_NUMBER using $GATE_LOG_DIR/issue-summary.md; on Continue, prepend resumption context."}}
+
+#### 6b. `/validate-contracts` (if architect blueprint touches API endpoints)
+
+Skip if no endpoints.
+
+#### 6c. QA → test blueprint
+
+Orchestrator mode only. Invoke the QA subagent with the architect's blueprint. If Step 5 chose Continue, prepend the resumption context prompt.
+
+{{INVOKE_SUBAGENT name="qa" prompt="Produce test blueprint from architect's blueprint for issue $ISSUE_NUMBER; on Continue, prepend resumption context."}}
+
+#### 6d. Write tests from QA blueprint
+
+You (the orchestrator) write tests. No subagent.
+
+#### 6d-bis. Binding-gate selection (CI / non-Rust tasks)
+
+For most tasks `cargo test` is the binding RED/GREEN gate. For tasks where the artifact under test isn't Rust source — workflow YAML, shell scripts, slash-command spec edits, pure deletions — `cargo test` is a regression guard and the binding gate is the tool that actually validates the changed artifact.
+
+| Artifact under test | Binding RED/GREEN gate | Regression guard |
+|---|---|---|
+| Rust source (`src/**`, `tests/**`) | `cargo test --quiet` | — |
+| Workflow YAML (`.github/workflows/**`) | `actionlint` (wired into `ci.yml`) | `cargo test --quiet` |
+| Shell scripts (`scripts/**`) | `bash -n` + `shellcheck` on changed files | `cargo test --quiet` |
+| Docs (`*.md`, `directory-tree.md`) | none (skipped) | `cargo test --quiet` |
+
+For CI / non-Rust tasks the orchestrator runs the binding gate before and after implementation, and `cargo test` as a regression-only check. The 6e/6g `cargo test` blocks below remain the default; substitute the appropriate gate when the gatekeeper's advisory or the issue body indicates a non-Rust binding gate.
+
+#### 6e. RED checkpoint (GATE)
+
+Skipped if `TASK_TYPE` is `docs` or `refactor`.
+
+```bash
+if [ "$TASK_TYPE" != "docs" ] && [ "$TASK_TYPE" != "refactor" ]; then
+  cargo test --quiet 2>&1 | tee "$GATE_LOG_DIR/red.log"
+  red_exit=${PIPESTATUS[0]}
+  if [ $red_exit -eq 0 ]; then
+    echo "RED GATE FAILED — cargo test passed, but implementation has not started." >&2
+    echo "Write a failing test for the new behavior before implementing." >&2
+    exit 3
+  fi
+fi
+```
+
+Exit code `3` reserved for RED failure.
+
+#### 6f. Implement
+
+You (the orchestrator) write the minimum code to make the failing test pass.
+
+#### 6g. GREEN checkpoint (GATE)
+
+Skipped only if `TASK_TYPE` is `docs`.
+
+```bash
+if [ "$TASK_TYPE" != "docs" ]; then
+  cargo test --quiet 2>&1 | tee "$GATE_LOG_DIR/green.log"
+  green_exit=${PIPESTATUS[0]}
+  if [ $green_exit -ne 0 ]; then
+    echo "GREEN GATE FAILED — tests still failing after implementation." >&2
+    echo "See $GATE_LOG_DIR/green.log" >&2
+    exit 4
+  fi
+fi
+```
+
+Exit code `4` reserved for GREEN failure.
+
+#### 6h. Refactor (if needed)
+
+Refactor while tests stay green. Re-run the GREEN checkpoint after:
+
+```bash
+cargo test --quiet 2>&1 | tee "$GATE_LOG_DIR/green-refactor.log"
+[ ${PIPESTATUS[0]} -eq 0 ] || { echo "Refactor broke tests"; exit 4; }
+```
+
+#### 6i. Security review
+
+Both modes. Invoke the security analyst against the newly-written code.
+
+{{INVOKE_SUBAGENT name="security-analyst" prompt="Review newly-written code for issue $ISSUE_NUMBER against OWASP Top 10, secrets handling, and input validation."}}
+
+#### 6j. Documentation
+
+Both modes. Mandatory at task end.
+
+{{INVOKE_SUBAGENT name="docs-analyst" prompt="Update documentation and directory-tree.md for issue $ISSUE_NUMBER."}}
+
+### Step 7: Handoff
+
+Print a summary:
+
+```
+Implementation complete for Issue #$ISSUE_NUMBER: $TITLE
+
+Gates passed:
+  - Pre-check hook (ok)
+  - Gatekeeper (task_type: $TASK_TYPE)
+  - RED checkpoint (verified failing → passing)   # omit if task_type is docs/refactor
+  - GREEN checkpoint (all tests pass)              # omit if task_type is docs
+
+Logs: $GATE_LOG_DIR
+
+Next: run /pushup to commit, push, create PR, and close the issue.
+```
+
+---
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success — also returned when `--training` is passed (wrong-tool message, not a failure) |
+| 1 | Generic failure (gh missing, not authed, not in repo, closed issue) |
+| 2 | Baseline cargo test failing |
+| 3 | RED gate failed |
+| 4 | GREEN gate failed |
+| 5 | Gatekeeper FAIL (DOR, blockers, contracts) |
+| 6 | Dirty tree, user declined stash |
+| 7+ | Preflight failure (reserved for CI-gates spec) |
+
+---
+
+## Error Handling
+
+- If `gh` CLI not installed → hook exits 1 with install hint.
+- If `gh` not authenticated → hook exits 1 with `gh auth login` hint.
+- If issue closed → hook exits 1. Re-open first or pick a different issue.
+- If dirty tree → prompt (S)tash/(A)bort.
+- If baseline fails → exit 2. Fix baseline first.
+- If gatekeeper FAILs with DOR missing → proposed remediation printed to stderr for human review, exit 5. Re-run with `--auto-comment` to auto-post the comment and apply `needs-info` label.
+- If blockers open → exit 5. Wait for blockers to close.
+- If RED/GREEN fails → exit 3/4. Actionable error with log path.
+
+---
+
+## Do Not
+
+- Run `/implement` for the same issue concurrently in two sessions.
+- Bypass the hook by invoking subagents directly.
+- Skip the RED gate for `implementation` task types — write the failing test first.

--- a/template/.maestro/templates/commands/plan-feature.md
+++ b/template/.maestro/templates/commands/plan-feature.md
@@ -1,0 +1,110 @@
+---
+command: plan-feature
+version: 1.0.0
+description: Plan a feature across the project, creating API contracts first, then milestones and issues with dependency tracking.
+placeholders:
+  - INCLUDE
+  - SUBAGENT_LIST
+includes:
+  - core/premises.md
+  - core/dependency-graph.md
+source_provenance:
+  ported_from: .claude/commands/plan-feature.md
+  ported_at: 2026-05-13
+---
+
+# Plan Feature
+
+Plan a feature across your project, creating API contracts first, then milestones and issues with dependency tracking.
+
+**Usage:** `/plan-feature <description>` or `/plan-feature`
+
+{{INCLUDE path="core/premises.md"}}
+
+---
+
+## Arguments
+
+`$ARGUMENTS` contains the user's natural language description of the feature.
+
+If no arguments, ask: "Describe the feature you want to build."
+
+---
+
+## Instructions
+
+### Phase 1: ANALYZE — Understand the Feature
+
+1. **Parse the description** to identify:
+   - Feature goals
+   - Which systems/modules are involved
+   - What data flows exist (APIs, events, etc.)
+
+2. **Explore the codebase** to find:
+   - Existing models, services, and components related to the feature
+   - Existing API endpoints or contracts
+   - Architecture patterns already in use
+
+   Available subagents for delegation: {{SUBAGENT_LIST}}
+
+3. **Present analysis** to the user with what exists vs. what's needed
+
+### Phase 2: CONTRACTS FIRST — Create API Schemas
+
+For every API endpoint identified:
+1. Check if a contract already exists in `docs/api-contracts/`
+2. If not, create one following `api-contract-v1` format
+3. Present contracts to user for review
+
+### Phase 3: MILESTONES — Create if Needed
+
+If the feature is large enough for a milestone:
+```bash
+gh api repos/<owner>/<repo>/milestones -f title="..." -f state=open -f description="..."
+```
+
+### Phase 4: ISSUES — Create with Traceability
+
+Every issue MUST contain:
+1. **Context** — Why this issue exists
+2. **API Contract** reference (if endpoint involved)
+3. **Requirements** — What to build
+4. **TDD Checklist** — Tests to write
+5. **Acceptance Criteria** — Checkbox list
+6. **Dependencies** — What blocks this / what this blocks
+
+Create in dependency order:
+1. Contract/schema issues first
+2. Foundation issues (blocked by contracts)
+3. Feature issues (blocked by foundation)
+4. Capstone issue (blocked by all)
+
+### Phase 5: DEPENDENCY GRAPH — Present Final Plan
+
+Output:
+```
+## Implementation Order
+
+### Phase 1: Foundation
+- #XX: <title>
+
+### Phase 2: Core Features (parallelizable)
+- #XX: <title> (blocked by #YY)
+- #XX: <title> (blocked by #YY)
+
+### Phase 3: Integration
+- #XX: <title> (blocked by all above)
+```
+
+The dependency-graph format and per-issue `## Blocked By` rules are canonical:
+
+{{INCLUDE path="core/dependency-graph.md"}}
+
+---
+
+## Error Handling
+
+- If `gh` CLI fails → suggest `gh auth login`
+- If description is too vague → ask clarifying questions
+- If contract already exists → reuse it
+- If milestone exists → reuse it

--- a/template/.maestro/templates/commands/pushup.md
+++ b/template/.maestro/templates/commands/pushup.md
@@ -1,0 +1,203 @@
+---
+command: pushup
+version: 1.0.0
+description: Commit semantically, push, create PR, link issue, and complete tasks.
+placeholders:
+  - INCLUDE
+includes:
+  - core/premises.md
+  - core/dependency-graph.md
+source_provenance:
+  ported_from: .claude/commands/pushup.md
+  ported_at: 2026-05-13
+---
+
+# Push Up
+
+Commit semantically, push, create PR, link issue, and complete tasks.
+
+**Usage:** `/pushup` or `/pushup #123` (where #123 is the issue number)
+
+{{INCLUDE path="core/premises.md"}}
+
+---
+
+## Instructions
+
+This command automates the end-of-feature workflow. Execute ALL steps in order.
+
+### Step 1: Determine the Issue
+
+If `$ARGUMENTS` contains an issue number (e.g., `#123` or `123`), use that.
+
+Otherwise, detect the issue from:
+1. The current branch name (e.g., `feat/issue-123-description` → issue #123)
+2. Recent commit messages mentioning an issue
+3. If not found, ask the user: "Which issue does this PR close? (e.g., #123)"
+
+### Step 2: Semantic Commit
+
+1. Run `git status` to see all changes
+2. Run `git diff --staged` and `git diff` to understand what changed
+3. Run `git log --oneline -5` to match the repo's commit style
+4. Stage all relevant files (avoid secrets, .env, credentials)
+5. Ensure a gate log directory exists for editable drafts:
+
+```bash
+: "${GATE_LOG_DIR:=$(mktemp -d)}"
+export GATE_LOG_DIR
+```
+
+6. Generate the mechanical commit draft:
+
+```bash
+scripts/commit-helper.sh <issue-number>
+```
+
+The helper chooses the Conventional Commits prefix from issue labels, writes
+`$GATE_LOG_DIR/commit-draft.txt`, and includes `Closes #<issue-number>`.
+
+7. Fill in only the first-line subject placeholder. Keep the helper-selected
+   prefix and `Closes #<issue-number>` body unchanged. Use the existing HEREDOC
+   pattern to overwrite the draft, then commit from the draft file:
+
+```bash
+cat > "$GATE_LOG_DIR/commit-draft.txt" <<'EOF'
+<prefix>: <filled subject>
+
+Closes #<issue-number>
+EOF
+git commit -F "$GATE_LOG_DIR/commit-draft.txt"
+```
+
+### Step 3: Push to Remote
+
+1. Check if the current branch tracks a remote branch: `git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null`
+2. If no upstream exists, push with `-u`: `git push -u origin <branch-name>`
+3. If upstream exists, push normally: `git push`
+
+### Step 4: Create Pull Request
+
+1. Check if a PR already exists for this branch: `gh pr view --json number 2>/dev/null`
+2. If NO existing PR, create one:
+   - Title: use the commit subject exactly
+   - Body: generate a skeleton, then fill in only 1-3 summary bullets
+
+```
+commit_subject="$(git log -1 --pretty=%s)"
+: "${GATE_LOG_DIR:=$(mktemp -d)}"
+export GATE_LOG_DIR
+scripts/pr-skeleton.sh <issue-number> "$commit_subject"
+# Edit only $GATE_LOG_DIR/pr-draft.md summary bullets; keep Closes and Test plan.
+gh pr create --title "$commit_subject" --body-file "$GATE_LOG_DIR/pr-draft.md"
+```
+
+3. If PR already exists, update it if needed after regenerating/filling the body:
+   `gh pr edit <pr-number> --body-file "$GATE_LOG_DIR/pr-draft.md"`
+
+4. **Surface the new PR to a running maestro TUI for auto-review.** After a successful `gh pr create`, write a single-line JSON marker to `~/.maestro/last-pr-created`. A running maestro instance polls this file once per `check_completions` tick; on a fresh write it enqueues `TuiCommand::PrCreated` and triggers `/review`.
+
+The write must be atomic (write to `.tmp`, then `mv`) so the consumer never reads a partially-written line. The maestro reader also refuses to follow a symlink at this path and validates `owner` and `repo` against argv-injection.
+
+```bash
+mkdir -p "$HOME/.maestro"
+ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+marker="$HOME/.maestro/last-pr-created"
+printf '{"pr_number":%d,"owner":"%s","repo":"%s","ts":"%s"}\n' \
+  "<pr-number>" "<owner>" "<repo>" "$ts" \
+  > "${marker}.tmp"
+mv "${marker}.tmp" "$marker"
+```
+
+The marker is consumed-once: maestro deletes it after dispatching the review. If the marker is malformed or fails the owner/repo guard, maestro logs a Warn entry and deletes it.
+
+### Step 5: Link Issue to PR
+
+The `Closes #<issue-number>` in the PR body automatically links the issue.
+
+Additionally, add the issue as a linked reference:
+```bash
+gh pr edit <pr-number> --add-label "closes-issue"
+```
+
+If the repo doesn't have that label, skip this step (don't fail).
+
+### Step 6: Update Milestone Dependency Graph (MANDATORY — runs BEFORE issue close)
+
+Update the milestone's dependency graph to mark this issue with ✅. **This step runs before the issue close so that a failure here leaves the issue open and `/pushup` can be safely re-run** — closing the issue first would orphan the milestone graph if this step blew up.
+
+1. Fetch the issue's milestone:
+```bash
+MILESTONE=$(gh issue view <issue-number> --json milestone --jq '.milestone.number')
+```
+
+2. If the issue has no milestone, log that no milestone graph exists and continue to Step 6.5.
+
+3. If the issue has a milestone, run the mechanical updater and treat its exit code as the gate:
+```bash
+python3 scripts/update-milestone-graph.py --milestone "$MILESTONE" --issue "<issue-number>"
+```
+
+The script handles idempotency, anchored bullet replacement, level-header roll-up, `Sequence:` token-boundary rewrites, PATCH, and post-PATCH verification. A re-run where the issue is already stamped exits 0 with an "already marked" log line.
+
+**This step is NON-NEGOTIABLE.** Every closed issue MUST be reflected in the milestone graph. If it fails, **STOP** — do not proceed to Step 6.5 (issue close).
+
+The full canonical rules for milestone graph updates after issue closure:
+
+{{INCLUDE path="core/dependency-graph.md"}}
+
+### Step 6.5: Complete Tasks (issue close + checks)
+
+Runs AFTER the milestone graph is correctly stamped. If this step fails after Step 6 succeeded, the milestone graph is correctly stamped but the issue stays open — re-run `/pushup` or close manually. **This partial state is recoverable** (running `/pushup` again will idempotently re-detect the milestone is already stamped via Step 6.3 and skip straight to closing the issue).
+
+1. **On the Issue:** Add a comment and close it idempotently. A previous `/pushup` run may have already closed the issue (e.g., it failed mid-Step-6 and the user re-ran); the close step must NOT fail in that case.
+
+```bash
+issue_state=$(gh issue view <issue-number> --json state --jq '.state' 2>/dev/null || echo "ERROR")
+if [ "$issue_state" = "CLOSED" ]; then
+  echo "/pushup: issue #<issue-number> is already CLOSED — skipping comment + close (idempotent re-run)"
+elif [ "$issue_state" = "ERROR" ]; then
+  echo "/pushup: failed to read issue state; aborting close (will retry on next /pushup)" >&2
+  exit 1
+else
+  gh issue comment <issue-number> --body "Completed in PR #<pr-number>"
+  gh issue close <issue-number>
+fi
+```
+
+2. **On the PR:** Verify all checks pass (informational only, don't block):
+```bash
+gh pr checks <pr-number> 2>/dev/null || echo "No checks configured or still running"
+```
+
+### Step 7: Summary
+
+Print a final summary:
+
+```
+Push Up Complete
+
+  Commit:  <commit-hash> (<commit-type>: <short-message>)
+  Branch:  <branch-name>
+  PR:      #<pr-number> - <pr-title> (<pr-url>)
+  Issue:   #<issue-number> - Closed
+```
+
+---
+
+## Error Handling
+
+- If `gh` CLI is not installed, tell the user to install it: `brew install gh`
+- If not authenticated, tell user to run: `gh auth login`
+- If there are no changes to commit, skip to Step 3 (push any unpushed commits)
+- If push fails, show the error and stop (don't create PR with stale code)
+- If on `main` or `master` branch, WARN the user and ask for confirmation before proceeding
+
+---
+
+## Safety Checks
+
+- NEVER force push
+- NEVER push to `main` or `master` without explicit user confirmation
+- NEVER commit files matching: `.env*`, `credentials*`, `*.key`, `*.pem`, `*.p12`
+- Always show the user what will be committed before committing

--- a/template/.maestro/templates/commands/simplify.md
+++ b/template/.maestro/templates/commands/simplify.md
@@ -1,0 +1,118 @@
+---
+command: simplify
+version: 1.0.0
+description: Review changed code for reuse, quality, and efficiency; remove duplication, dead code, and over-abstraction without breaking tests.
+placeholders:
+  - INCLUDE
+  - INVOKE_SUBAGENT
+  - SKILL
+includes:
+  - core/premises.md
+  - core/tdd-cycle.md
+source_provenance:
+  ported_from: new
+  ported_at: 2026-05-13
+---
+
+# Simplify
+
+Review the working-tree diff against the project's design philosophy and remove what does not earn its place.
+
+**Usage:** `/simplify` (defaults to `main..HEAD`) or `/simplify <base-ref>`
+
+{{INCLUDE path="core/premises.md"}}
+
+---
+
+## When to Use
+
+- After a feature is GREEN but before `/pushup`.
+- After a large refactor, to confirm no new coupling or duplication slipped in.
+- When the diff "feels long" — the heuristic is wrong more often than right, and a structured pass catches what intuition misses.
+
+## Non-Goals
+
+- This is NOT a security review (that is handled by `security-analyst` in `/implement` step 6i).
+- This is NOT a test-coverage review (that is handled by `qa`).
+- This does NOT introduce new abstractions; it removes premature ones.
+
+## Design Principles (the rubric)
+
+Three lenses, applied in order:
+
+1. **ETC (Easy To Change)** — would this be easy to change if the next requirement shifted? Each binding to a concrete implementation is a coupling point; flag it.
+2. **Law of Demeter** — count the dots. Method chains like `app.pool.sessions[0].status.label()` are a code smell. Push behaviour into the owner, not the caller.
+3. **Object Calisthenics (5-7 of 9)** — aspirational compass, not dogma. Score the diff:
+   - One level of indentation per method
+   - No `else` keyword (early returns / match)
+   - Wrap primitives that carry domain meaning
+   - First-class collections (`SessionPool` wraps `Vec<Session>`)
+   - One dot per line
+   - No abbreviations
+   - Keep entities small (< 100 lines per impl, < 500 lines per file)
+   - Two instance variables or fewer
+   - No getters/setters — expose behaviour
+
+   Flag any score below 5/9 as a design smell worth fixing now.
+
+## Workflow
+
+### Step 1: Scope the diff
+
+`git diff --stat <base>..HEAD` to see what changed. If the diff touches more than ~15 files or ~800 lines, recommend splitting the review by directory.
+
+### Step 2: Mechanical rot checks
+
+Run, in order:
+
+- `cargo fmt --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test --quiet`
+
+If any of these fail, **STOP** — simplify is for clean diffs, not broken ones. Fix the basics first.
+
+### Step 3: Quality skills pass
+
+Apply the {{SKILL name="project-patterns"}} skill to the changed files. Look for:
+
+- Naming inconsistent with the existing module
+- New `unwrap()`/`expect()` introduced (forbidden per Rust guardrails §2)
+- New `println!`/`dbg!` (use `tracing` — Rust guardrails §11)
+- Files crossing 500 LOC
+- Functions crossing one indent level
+
+### Step 4: Architect review
+
+{{INVOKE_SUBAGENT name="architect" prompt="Review the diff <base>..HEAD against ETC, Demeter, and Object Calisthenics 5-7/9. Flag duplications, dead code, over-abstraction, and Demeter violations. Return a blueprint, not code."}}
+
+The architect's response is a list of recommendations, not edits. You (the orchestrator) decide which to apply.
+
+### Step 5: Apply edits, tests green
+
+Each recommendation is a small TDD cycle:
+
+{{INCLUDE path="core/tdd-cycle.md"}}
+
+After each edit, re-run `cargo test --quiet`. If a simplification breaks a test, **the test is the spec** — either the simplification was wrong, or the test was over-fitted to the old shape. Decide explicitly which.
+
+### Step 6: Document the trade-off
+
+For every non-trivial change (renaming a type, collapsing two functions, removing a layer), append a one-line entry to the PR body under `## Simplifications`:
+
+```
+- Collapsed `SessionStatus::label()` + `SessionStatus::short_label()` into one method (Demeter, ETC).
+```
+
+This makes the review's intent visible to PR reviewers.
+
+## Error Handling
+
+- If `cargo test` fails before starting → STOP, fix baseline (same Gate 2 as `/implement`).
+- If the architect flags more than ~5 issues → split into a fresh issue and run `/implement` on it. `/simplify` is for low-risk passes, not full refactors.
+- If a simplification cannot keep tests green → revert it and document the constraint in the PR body.
+
+## Do Not
+
+- Introduce new abstractions during simplify.
+- Touch files outside the diff under review.
+- Skip the mechanical rot checks (Step 2) — they're cheap and catch 80% of issues.

--- a/template/.maestro/templates/core/dependency-graph.md
+++ b/template/.maestro/templates/core/dependency-graph.md
@@ -1,0 +1,59 @@
+# Dependency Graph (Canonical Fragment)
+
+> Canonical fragment. Do not edit per-provider — render via `manifest.toml`.
+> Source of truth ported from `.claude/CLAUDE.md` § 4.
+
+## Dependency Chain and Graph — Non-Negotiable
+
+**Every issue and milestone MUST include dependency information. No exceptions. This applies in ALL modes (Subagents Orchestrator, Vibe Coding, Training).**
+
+**Rules for Issues:**
+- Every `gh issue create` call MUST include a `## Blocked By` section with issue numbers (or "None")
+- This field is REQUIRED, not optional
+- Format:
+  ```markdown
+  ## Blocked By
+
+  - #106 feat: sanitize module scaffolding
+  - #107 feat: Phase 1 scanner
+  ```
+  Or if no dependencies:
+  ```markdown
+  ## Blocked By
+
+  - None
+  ```
+
+**Rules for Milestones:**
+- Every `gh api milestones` create/update MUST include a `## Dependency Graph` in the description
+- The dependency graph MUST use ASCII visualization showing the execution order
+- Required sections in milestone description:
+  1. A one-line summary
+  2. A `## Dependency Graph (Implementation Order)` section with levels (Level 0, Level 1, etc.)
+  3. A `Sequence:` line showing the linear/parallel execution order using `→` (sequential) and `∥` (parallel)
+- Format:
+  ```markdown
+  ## Dependency Graph (Implementation Order)
+
+  Level 0 — no dependencies:
+  • #106 feat: scaffolding and types
+
+  Level 1 — depends on #106 (can run in parallel):
+  • #107 feat: Phase 1 scanner
+  • #108 feat: Phase 2 analyzer
+
+  Level 2 — depends on #107, #108:
+  • #110 feat: Wire pipeline
+
+  Sequence: #106 → #107 ∥ #108 → #110
+  ```
+
+**Violation of this rule means the issue/milestone is malformed and MUST be corrected before proceeding.**
+
+**Rules for Milestone Updates After Issue Closure (MANDATORY):**
+- When an issue is closed, its entry in the milestone dependency graph MUST be updated with ✅
+- Change `• #NNN` to `• ✅ #NNN` in the milestone description
+- If ALL issues in a level are now ✅, mark the level header as `(COMPLETED ✅)`
+- Update the `Sequence:` line to reflect completed levels with `✅(LN)`
+- This is done via `gh api repos/<owner>/<repo>/milestones/<number> -X PATCH -f description="..."`
+- **This is NON-NEGOTIABLE.** Every closed issue MUST be reflected in the milestone graph immediately after closure. Skipping this step is a violation.

--- a/template/.maestro/templates/core/premises.md
+++ b/template/.maestro/templates/core/premises.md
@@ -1,0 +1,88 @@
+# Premises (Canonical Fragment)
+
+> Canonical fragment. Do not edit per-provider — render via `manifest.toml`.
+> Source of truth ported from `.claude/CLAUDE.md` § CRITICAL PREMISES.
+
+## 1. YOU ARE THE ONLY AGENT THAT WRITES CODE
+
+**The orchestrator is the ONLY agent authorized to:**
+- Write, edit, or create code files
+- Execute bash commands
+- Run tests
+- Create any files (except documentation - see docs-analyst)
+
+**ALL subagents are CONSULTIVE ONLY.** They:
+- Analyze, research, and plan
+- Provide detailed recommendations with exact file paths and code examples
+- Return blueprints for YOU to implement
+
+**Exception:** `subagent-docs-analyst` can create/edit .md files.
+
+## 2. Subagent Delegation Depends on MODE
+
+**In 🤖 Subagents Orchestrator Mode - You are FORBIDDEN from doing these tasks directly:**
+- Researching or exploring codebases → delegate to subagents
+- Planning implementations → delegate to subagents
+- Analyzing code or architecture → delegate to subagents
+- Web searches for solutions → delegate to subagents
+- Reading documentation to understand how things work → delegate to subagents
+
+**Orchestrator Mode workflow is ALWAYS (TDD ENFORCED):**
+1. Receive user request
+2. **Pre-check hook (MANDATORY):**
+   - Run `bash .claude/hooks/implement-gates.sh <issue-number>`
+   - Abort on any non-zero exit (see exit-code table in `/implement`)
+3. **Delegate to Gatekeeper (MANDATORY):**
+   - `subagent-gatekeeper` → structured JSON report (DOR, blockers, contracts, task_type)
+   - Parse via `.claude/hooks/parse_gatekeeper_report.py`
+   - On DOR FAIL → by default, orchestrator prints the proposed comment for human review and **STOP**s (does NOT auto-post); pass `--auto-comment` to `/implement` to auto-post the comment and apply `needs-info` label
+   - On blocker/contract FAIL → **STOP** with reasons from the report
+4. **Delegate to Architect for blueprint - MANDATORY:**
+   - `subagent-architect` - For all architecture decisions
+   - **NEVER skip architecture step - the architect MUST be called**
+5. **CONTRACT VALIDATION (if task involves API endpoints) - MANDATORY:**
+   - Run `/validate-contracts` to check existing models against `docs/api-contracts/` schemas
+   - If no contract schema exists for the endpoint → **STOP and ask user to provide the JSON schema**
+   - If contract exists but models mismatch → fix models BEFORE proceeding
+6. **Delegate to QA for test blueprint - MANDATORY (TDD):**
+   - `subagent-qa` - Provides test cases, mocks, and expected behaviors
+   - **Tests are designed BEFORE implementation**
+7. **Write tests FIRST (RED)** — verify they fail (enforced by `/implement` Step 6e bash gate)
+8. **Implement minimum code (GREEN)** — make tests pass (enforced by `/implement` Step 6g bash gate)
+9. **Refactor** — clean up while tests stay green
+10. Delegate to Security for review of implemented code
+11. Call docs-analyst at the end
+
+**In 🎸 Vibe Coding Mode - You work DIRECTLY:**
+- Research, plan, and execute yourself
+- ⚠️ WARN user about context window limitations
+- ONLY `subagent-docs-analyst` is mandatory (at task end)
+
+**In 📚 Training Mode - You ONLY MODIFY `.claude/` DIRECTORY:**
+- You can ONLY edit files inside `.claude/` directory (agents, skills, commands, CLAUDE.md)
+- You help user configure and modify the agent structure
+- You CANNOT modify any project files outside `.claude/` directory
+- This mode is for managing and improving the agent system itself
+
+## 3. DOR — Definition of Ready (Issue Quality Gate)
+
+**Before starting any issue, the orchestrator MUST verify the issue meets the Definition of Ready.**
+
+A conforming issue contains these sections (enforced by GitHub issue templates):
+
+| Section | Feature | Bug | Description |
+|---------|---------|-----|-------------|
+| Overview | Required | Required | What and why |
+| Current Behavior | — | Required | What is broken |
+| Expected Behavior | Required | Required | Desired outcome |
+| Steps to Reproduce | — | Required | How to trigger the bug |
+| Acceptance Criteria | Required | Required | Testable conditions |
+| Files to Modify | Required | Optional | Expected file changes |
+| Test Hints | Required | Optional | Mocking and edge-case guidance |
+| Blocked By | Required | Required | Dependency issues (issue numbers or "None") |
+| Definition of Done | Required | Required | Completion checklist |
+
+**If an issue is missing required DOR fields, the orchestrator MUST:**
+1. Comment on the issue requesting the missing information
+2. Apply the `needs-info` label
+3. NOT start implementation until the DOR is satisfied

--- a/template/.maestro/templates/core/tdd-cycle.md
+++ b/template/.maestro/templates/core/tdd-cycle.md
@@ -1,0 +1,69 @@
+# TDD Cycle (Canonical Fragment)
+
+> Canonical fragment. Do not edit per-provider — render via `manifest.toml`.
+> Source of truth ported from `.claude/CLAUDE.md` § 5.
+
+## TDD Is Mandatory — Non-Negotiable
+
+**Every implementation MUST follow Test-Driven Development. No exceptions.**
+
+**The TDD cycle is ALWAYS:**
+1. **RED — Write the test FIRST**
+   - Write a failing test that defines the expected behavior
+   - The test MUST fail before any implementation exists
+
+2. **GREEN — Write the MINIMUM code to pass**
+   - Implement only what is needed to make the failing test pass
+   - Do NOT over-engineer or add features beyond what the test requires
+   - Mock dependencies as needed (traits/protocols + mock implementations)
+
+3. **REFACTOR — Clean up while tests stay green**
+   - Improve code quality without changing behavior
+   - All tests MUST remain passing after refactoring
+
+**Rules:**
+- 🚫 **NEVER write implementation code without a failing test first**
+- 🚫 **NEVER skip the mocking step** — dependencies MUST be mocked via traits/protocols
+- ✅ Tests are written BEFORE implementation in ALL modes
+- ✅ Mocking pattern: Define a trait/protocol → Create a mock → Inject mock in tests
+
+## Orchestrator Mode TDD Flow
+
+```
+Pre-check hook (implement-gates.sh) → STOP on any gate failure
+    │
+    ▼
+subagent-gatekeeper → STOP if DOR/blockers/contracts FAIL
+                      (DOR FAIL: print proposed comment for human review by default;
+                       pass --auto-comment to /implement to auto-post + needs-info)
+    │
+    ▼
+subagent-architect → Blueprint (includes testable interfaces)
+    │
+    ▼
+CONTRACT VALIDATION (if API endpoints involved)
+  → /validate-contracts checks models vs docs/api-contracts/ schemas
+  → STOP if no schema exists — ask user for JSON schema
+  → Fix mismatches before proceeding
+    │
+    ▼
+subagent-qa → Test blueprint (test cases, mocks)
+    │
+    ▼
+YOU WRITE TESTS FIRST (from QA blueprint)
+    │
+    ▼
+YOU VERIFY TESTS FAIL (RED phase)
+    │
+    ▼
+YOU IMPLEMENT (GREEN phase — minimum code to pass)
+    │
+    ▼
+YOU REFACTOR (if needed, tests stay green)
+    │
+    ▼
+subagent-security-analyst → Security review
+    │
+    ▼
+subagent-docs-analyst → Documentation
+```

--- a/template/.maestro/templates/manifest.toml
+++ b/template/.maestro/templates/manifest.toml
@@ -1,0 +1,86 @@
+# .maestro/templates/manifest.toml
+#
+# Canonical templates manifest. Parsed by the render engine
+# (`src/templates/manifest.rs`, issue #701). The renderer's placeholder
+# vocabulary is hard-coded; this file declares per-placeholder validation
+# hints and per-provider metadata.
+
+[meta]
+version = 1
+description = "maestro canonical templates manifest"
+templates_root = ".maestro/templates"
+
+# ── Placeholder validation hints ────────────────────────────────────────
+# Each entry mirrors the renderer's hard-coded vocabulary. `required_args`
+# is informational metadata; the renderer enforces required args itself.
+
+[placeholders.INVOKE_SUBAGENT]
+description = "render the canonical instruction for invoking a subagent"
+required_args = ["name", "prompt"]
+
+[placeholders.HOOK_GATE]
+description = "render the bash invocation for a pre-/post-step hook gate"
+required_args = ["script", "args"]
+
+[placeholders.INCLUDE]
+description = "inline a shared core fragment from the templates root"
+required_args = ["path"]
+max_depth = 8
+
+[placeholders.SUBAGENT_LIST]
+description = "render the active subagent registry for the target provider"
+required_args = []
+
+[placeholders.SKILL]
+description = "reference a skill knowledge base"
+required_args = ["name"]
+
+# ── Per-provider metadata (parsed; consumed by L2 in #703-#705) ─────────
+
+[providers.claude]
+display_name = "Claude Code"
+target_dir = ".claude/commands"
+inline_skills = false
+
+[providers.codex]
+display_name = "Codex CLI"
+target_dir = ".codex/commands"
+inline_skills = true
+
+[providers.http_generic]
+display_name = "Generic HTTP provider"
+target_dir = ""
+inline_skills = true
+
+# ── Subagent registry (rendered by {{SUBAGENT_LIST}}) ────────────────────
+# Order in this file = order in the rendered Markdown table. Drift between
+# this list and `.claude/agents/subagent-*.md` is caught by
+# `tests/subagent_manifest_drift.rs`.
+
+[[subagents]]
+slug = "subagent-gatekeeper"
+purpose = "DOR, blockers, and API-contract gate for `/implement`"
+
+[[subagents]]
+slug = "subagent-architect"
+purpose = "Architecture design and implementation planning"
+
+[[subagents]]
+slug = "subagent-qa"
+purpose = "QA engineering, test design, quality gates"
+
+[[subagents]]
+slug = "subagent-security-analyst"
+purpose = "Security review (OWASP Top 10)"
+
+[[subagents]]
+slug = "subagent-docs-analyst"
+purpose = "Documentation management (only subagent allowed to write `.md`)"
+
+[[subagents]]
+slug = "subagent-master-planner"
+purpose = "System architecture planning, ADRs"
+
+[[subagents]]
+slug = "subagent-idea-triager"
+purpose = "Idea-inbox triage gate (5-question honesty check)"

--- a/tests/template_mirror_drift.rs
+++ b/tests/template_mirror_drift.rs
@@ -1,0 +1,69 @@
+//! Drift guard: the canonical templates at `.maestro/templates/` and the
+//! embedded scaffolding source at `template/.maestro/templates/` MUST stay
+//! byte-identical. The init scaffolder embeds the latter; the sync-templates
+//! flow renders the former. Any divergence breaks `maestro init` correctness.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn collect_tree(base: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
+    let mut out = BTreeMap::new();
+    let walker = walkdir::WalkDir::new(base).sort_by_file_name();
+    for entry in walker {
+        let entry = entry.unwrap_or_else(|e| panic!("walk error under {}: {e}", base.display()));
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let rel = entry
+            .path()
+            .strip_prefix(base)
+            .expect("strip_prefix")
+            .to_path_buf();
+        let bytes = std::fs::read(entry.path())
+            .unwrap_or_else(|e| panic!("read {}: {e}", entry.path().display()));
+        out.insert(rel, bytes);
+    }
+    out
+}
+
+#[test]
+fn template_mirror_same_paths() {
+    let root = manifest_dir();
+    let canonical = collect_tree(&root.join(".maestro/templates"));
+    let mirror = collect_tree(&root.join("template/.maestro/templates"));
+
+    let canonical_keys: Vec<&PathBuf> = canonical.keys().collect();
+    let mirror_keys: Vec<&PathBuf> = mirror.keys().collect();
+
+    assert_eq!(
+        canonical_keys, mirror_keys,
+        "path mismatch between .maestro/templates and template/.maestro/templates.\n\
+         Fix: cp -a .maestro/templates/. template/.maestro/templates/"
+    );
+}
+
+#[test]
+fn template_mirror_byte_equal() {
+    let root = manifest_dir();
+    let canonical = collect_tree(&root.join(".maestro/templates"));
+    let mirror = collect_tree(&root.join("template/.maestro/templates"));
+
+    for (rel, canonical_bytes) in &canonical {
+        let mirror_bytes = mirror.get(rel).unwrap_or_else(|| {
+            panic!(
+                "file missing from mirror: {rel}\nFix: cp .maestro/templates/{rel} template/.maestro/templates/{rel}",
+                rel = rel.display()
+            )
+        });
+        assert_eq!(
+            canonical_bytes,
+            mirror_bytes,
+            "byte mismatch for {rel}.\nFix: cp .maestro/templates/{rel} template/.maestro/templates/{rel}",
+            rel = rel.display()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- `maestro init` now scaffolds `.maestro/templates/` (10 files) into fresh projects via a new `Scaffolder` trait + `FsScaffolder` with path-traversal hardening and `create_new`-based TOCTOU-safe writes.
- Added CRITICAL PREMISES §6 (canonical-vs-rendered rule) to `.claude/CLAUDE.md`, an abbreviated §4 to `template/.claude/CLAUDE.md`, and a new developer guide at `docs/templates.md`.
- Drift guard `tests/template_mirror_drift.rs` keeps `template/.maestro/templates/` byte-equal to canonical `.maestro/templates/`; four follow-up issues filed (#757–#760).

Closes #708

## Test plan

- [x] `cargo test --quiet` — all tests pass (incl. 4 new scaffold unit tests, 3 new init e2e tests, 2 new drift-guard tests, 3 new security-hardening tests)
- [x] `cargo clippy -- -D warnings -A dead_code` clean
- [x] `cargo fmt --check` clean
- [x] RED gate confirmed (6 tests failing pre-implementation) → GREEN gate confirmed (all pass post-implementation)
- [x] Security review: MEDIUM finding on path-traversal addressed via `validate_relative()` + `create_new(true)`; new tests pin both behaviors
- [ ] Manual: `cargo run -- init` in a fresh tempdir produces `.maestro/templates/` with byte-equal manifest.toml
