### PR TITLE
docs: agents documentation verification pass

### DIFF
--- a/directory-tree.md
+++ b/directory-tree.md
@@ -621,6 +621,14 @@ maestro/
 │   ├── adr/                               # Architecture Decision Records; one file per decision; ADRs that survive a spike are the only artifact merged to main from that spike
 │   │   ├── 001-agent-graph-viz.md         # ADR 001: agent graph visualization — Go/No-Go verdict (concentric/radial bipartite layout, Braille canvas); tracking issue #513
 │   │   └── 002-agent-personalities.md     # ADR 002: agent personality sprites — 5-role taxonomy, 6×6 ghost sprites, hybrid derive_role, ASCII fallback; Go verdict; tracking issue #536
+│   ├── agents/                            # Per-provider docs (subprocess + HTTP); each page closes with a "Using <id> in a team binding" subsection that links into docs/teams/  [Issue #676]
+│   │   ├── claude.md                      # Claude subprocess provider — install, configuration, runtime, troubleshooting, team binding
+│   │   ├── codex.md                       # Codex subprocess provider — install, configuration, field behavior, troubleshooting, team binding
+│   │   ├── minimax.md                     # MiniMax HTTP provider — API key, configuration, model choice, doctor output, troubleshooting, team binding
+│   │   ├── mod.md                         # Provider catalog — comparison table, transport types, role-fit matrix, FAQ, links to per-provider pages and team docs
+│   │   ├── ollama.md                      # Ollama HTTP provider — install/start, configuration, doctor output, troubleshooting, team binding
+│   │   ├── opencode.md                    # OpenCode subprocess provider — install, authenticate, configuration, doctor output, troubleshooting, team binding
+│   │   └── qwen.md                        # Qwen subprocess provider — install/authenticate, configuration, field behavior, troubleshooting, team binding
 │   ├── api-contracts/                     # JSON Schema (Draft 2020-12) for every external payload that crosses a process boundary; one file per payload type; referenced by /validate-contracts and subagent-gatekeeper
 │   │   ├── README.md                      # Convention guide: naming, additionalProperties policy, gatekeeper integration  [Issue #327]
 │   │   └── review-comment.json            # Schema for the maestro-review JSON block in /review PR comments; parsed by review::parse and TUI pr_review screen  [Issue #327]

--- a/docs/agents/claude.md
+++ b/docs/agents/claude.md
@@ -61,3 +61,33 @@ maestro run --issue 42 --agent claude
 - Permission prompts block automation: choose the project-appropriate
   `permission_mode`, such as `bypassPermissions`, or restrict tools with
   `allowed_tools`.
+
+## Using `claude` in a team binding
+
+Claude is the built-in default for every role in every preset. Override it only
+when another provider is genuinely a better fit; otherwise leave the role bound
+to `claude`.
+
+Minimal-form binding (top-level role keys):
+
+```toml
+# ~/.config/maestro/maestro/teams/claude-pipeline.toml
+extends = "default-coder"
+
+implementer = "claude"
+reviewer = "claude"
+docs = "claude"
+```
+
+Rich-form binding with a model override:
+
+```toml
+[role_overrides.implementer]
+agent = "claude"
+model_override = "opus"
+prompt_addendum = "Stay terse; do not explain unchanged code."
+```
+
+`model_override` is set on the team binding; the underlying `[agents.claude]`
+table still owns `command`, `permission_mode`, and `allowed_tools`. See
+[`docs/teams/`](../teams/README.md) for the full preset schema.

--- a/docs/agents/codex.md
+++ b/docs/agents/codex.md
@@ -76,3 +76,23 @@ maestro run --prompt "Add tests for the retry policy" --agent codex
 - Model errors: verify the configured `model` is available to your account.
 - Sandbox errors: try `sandbox = "workspace-write"` first, then tighten the
   sandbox once the command is working.
+
+## Using `codex` in a team binding
+
+Codex is a strong implementer when you want an OpenAI-backed alternative to
+Claude. Pair it with a Claude fallback so a transient Codex outage still leaves
+the pipeline runnable:
+
+```toml
+# .maestro/teams/codex-pipeline.toml
+extends = "default-coder"
+
+[role_overrides.implementer]
+agent = "codex"
+fallback_agent = "claude"
+```
+
+Sandbox, profile, and `config_overrides` come from `[agents.codex]`; team
+bindings only carry `agent`, `mode`, `model_override`, `prompt_addendum`, and
+`fallback_agent`. See [`docs/teams/`](../teams/README.md) for the full preset
+schema.

--- a/docs/agents/minimax.md
+++ b/docs/agents/minimax.md
@@ -77,3 +77,31 @@ maestro run --prompt "Implement a focused bug fix" --agent minimax
   in MiniMax's platform docs before changing the config.
 - **Rate limits**: reduce `sessions.max_concurrent`, wait for the quota window,
   or use Ollama/OpenCode for lower-priority work.
+
+## Using `minimax` in a team binding
+
+MiniMax's 204k-token context window makes it useful for the docs and researcher
+roles, where the prompt may carry a large repo slice. Like Ollama, it is an
+HTTP provider — Maestro sends the role prompt as a chat-completions user
+message, so MiniMax is not appropriate for roles that need CLI-only behavior
+(interactive prompts, subprocess sandboxes).
+
+```toml
+# ~/.config/maestro/maestro/teams/longctx-researcher.toml
+extends = "default-researcher"
+
+implementer = "minimax"
+```
+
+To bind MiniMax to the docs role with a stricter prompt:
+
+```toml
+[role_overrides.docs]
+agent = "minimax"
+prompt_addendum = "Quote source paths inline; never invent file names."
+fallback_agent = "claude"
+```
+
+`api_key_env`, `base_url`, and `request_timeout_secs` come from
+`[agents.minimax]`. See [`docs/teams/`](../teams/README.md) for the full preset
+schema.

--- a/docs/agents/mod.md
+++ b/docs/agents/mod.md
@@ -59,6 +59,29 @@ through their own CLI flags.
 - [Ollama](ollama.md)
 - [MiniMax](minimax.md)
 - [Configuration Reference](../configuration.md)
+- [Team Orchestration Presets](../teams/README.md)
+
+## Using providers inside a team
+
+`[agents.<id>]` defines _how_ a provider is launched (command, base URL, model,
+credentials). A **team preset** defines _which_ provider runs each role
+(implementer, reviewer, docs, …) and how the roles compose into a coordination
+primitive (pipeline, fan-out, single-pass, verdict-only).
+
+Each per-provider page closes with a "Using `<id>` in a team binding"
+subsection showing a worked example. The TL;DR for picking providers:
+
+| Role | Subprocess provider best fit | HTTP provider best fit |
+| --- | --- | --- |
+| implementer | `claude`, `codex` | `minimax` (long-context only) |
+| reviewer | `qwen`, `opencode` | `ollama`, `minimax` |
+| docs | `claude`, `opencode` | `minimax` |
+| researcher | `claude` | `minimax` |
+| triager | `claude` | — |
+
+HTTP providers (`ollama`, `minimax`) call OpenAI-compatible chat completions
+and have no CLI/subprocess, so they cannot drive roles that need interactive
+permission prompts, sandboxes, or Claude/Codex-only flags.
 
 ## Migration
 

--- a/docs/agents/ollama.md
+++ b/docs/agents/ollama.md
@@ -81,3 +81,32 @@ maestro run --prompt "Summarize the module boundaries" --agent ollama
   or raise `request_timeout_secs`.
 - **Remote host fails**: confirm the remote Ollama server is reachable from the
   machine running Maestro.
+
+## Using `ollama` in a team binding
+
+Ollama is best for offline iteration or free-tier review/docs roles. Because
+it is an HTTP provider, Maestro sends the role prompt as a single user message
+to Ollama's `/v1/chat/completions` endpoint — there is no CLI subprocess, no
+stdin, and no tool-use plumbing. That makes Ollama a poor fit for roles that need to call CLI-only
+features (interactive permission prompts, Claude/Codex sandboxes) and a good
+fit for roles that only read and write text.
+
+```toml
+# .maestro/teams/offline-coder.toml
+extends = "default-coder"
+
+implementer = "ollama"
+reviewer = "ollama"
+```
+
+To pair a fast local reviewer with a Claude fallback for failure cases:
+
+```toml
+[role_overrides.reviewer]
+agent = "ollama"
+model_override = "qwen3"
+fallback_agent = "claude"
+```
+
+`base_url` and `request_timeout_secs` come from `[agents.ollama]`. See
+[`docs/teams/`](../teams/README.md) for the full preset schema.

--- a/docs/agents/opencode.md
+++ b/docs/agents/opencode.md
@@ -114,3 +114,29 @@ maestro run --prompt "Implement the issue parser" --agent opencode
   Check pricing with the backend provider before using it as the default.
 - **No JSON events**: update OpenCode and confirm `opencode run --format json`
   works outside Maestro.
+
+## Using `opencode` in a team binding
+
+OpenCode shines in cheap-iteration roles: docs refresh, scoped reviews, or a
+budget implementer that escalates to Claude on fallback. Use it for fan-out
+patterns where you want multiple low-cost opinions.
+
+```toml
+# ~/.config/maestro/maestro/teams/cheap-coder.toml
+extends = "default-coder"
+
+implementer = "opencode"
+docs = "opencode"
+```
+
+`model_override` for OpenCode must use the `provider/model` form:
+
+```toml
+[role_overrides.implementer]
+agent = "opencode"
+model_override = "openrouter/deepseek/deepseek-chat"
+fallback_agent = "claude"
+```
+
+CLI flags, auth, and `command` come from `[agents.opencode]`. See
+[`docs/teams/`](../teams/README.md) for the full preset schema.

--- a/docs/agents/qwen.md
+++ b/docs/agents/qwen.md
@@ -70,3 +70,27 @@ maestro run --prompt "Review the config loader" --agent qwen
   environment.
 - Empty or malformed output: confirm your Qwen version supports
   `--output-format stream-json`.
+
+## Using `qwen` in a team binding
+
+Qwen is well-suited to the reviewer or docs role, where you want a second
+opinion without spending Claude tokens. The implementer typically stays on
+Claude or Codex.
+
+```toml
+# ~/.config/maestro/maestro/teams/qwen-reviewer.toml
+extends = "default-coder"
+
+reviewer = "qwen"
+```
+
+To pair Qwen with a stricter review prompt:
+
+```toml
+[role_overrides.reviewer]
+agent = "qwen"
+prompt_addendum = "List risks only — skip praise and restating diffs."
+```
+
+Auth keys, base URLs, and `extra_args` live in `[agents.qwen]`. See
+[`docs/teams/`](../teams/README.md) for the full preset schema.


### PR DESCRIPTION
## Summary

- Add a "Using `<id>` in a team binding" subsection to each provider doc (claude, codex, qwen, opencode, ollama, minimax) with a tailored worked example and a link to `docs/teams/`.
- Refresh `docs/agents/mod.md` with a role-fit matrix, a `docs/teams/` cross-link, and an explicit note that HTTP providers can't drive CLI-only roles.
- Backfill the missing `docs/agents/` subtree in `directory-tree.md` (was absent entirely).

Closes #676

## Test plan

- [x] cargo test --quiet (9411 tests passing)
- [x] cargo clippy -- -D warnings -A dead_code (preflight clean)
- [x] cargo fmt --check (preflight clean)
- [x] manual verification: cross-links from `docs/configuration.md` → `docs/agents/*.md` resolve; team-usage examples mirror the actual `RoleOverride` schema (`agent`, `mode`, `model_override`, `prompt_addendum`, `fallback_agent`).
