### PR TITLE
feat(config): comment-preserving toml_edit overlay for dynamic sections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,14 @@ thiserror = "2"
 shlex = "1"
 directories = "5"
 
+[features]
+# Off-by-default for one release. When enabled, `Config::save_into_str` detects
+# array-of-tables reorders by element-wise content hash and rewrites only the
+# moved slots, preserving per-element comments. With the feature off, reorders
+# fall back to a wholesale rewrite of the array (per-element comments on moved
+# rows are lost; neighbors survive). See docs/configuration.md §dynamic-config.
+dynamic-config-reorder = []
+
 [build-dependencies]
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -151,6 +151,7 @@ maestro/
 │   │   ├── modes.rs                       # Permission mode config types
 │   │   ├── notifications.rs               # NotificationsConfig
 │   │   ├── overlay.rs                     # Diff-walker algorithm for comment-preserving TOML overlay merge; walks a toml_edit Document tree and applies only the keys that differ between the original and updated Config, leaving unknown sections, comments, and blank lines intact  [Issue #712]
+│   │   ├── overlay_dynamic.rs             # Comment-preserving round-trip writer for dynamic sections (teams, plugins, agents); uses toml_edit to splice spliced/added/removed entries into the live document without disturbing surrounding comments or ordering; gated behind the `dynamic-config-reorder` Cargo feature (off-by-default for one release); tests load fixtures from tests/fixtures/dynamic_config/  [Issue #790]
 │   │   ├── plugins.rs                     # PluginsConfig
 │   │   ├── project.rs                     # ProjectConfig (language/languages/build_command/test_command/run_command fields written by `maestro init --reset`)
 │   │   ├── review.rs                      # ReviewConfig
@@ -803,6 +804,7 @@ maestro/
 │   ├── teams_cookbook_fixtures.rs         # Integration tests validating all six `tests/fixtures/teams_cookbook/*.toml` files parse and resolve correctly via `Loader::resolve`  [Issue #675]
 │   ├── fixtures/                          # Static test fixtures for integration and unit tests
 │   │   ├── config_roundtrip/              # TOML fixtures used by roundtrip_overlay and roundtrip_overlay_single_key tests to verify comment-preserving saves  [Issue #712]
+│   │   ├── dynamic_config/                # TOML fixtures for overlay_dynamic round-trip tests: add/remove/reorder entries in dynamic sections while preserving comments  [Issue #790]
 │   │   │   ├── full_maestro.toml          # Fully-populated maestro.toml used to verify every section round-trips without data loss or comment stripping
 │   │   │   ├── with_comments.toml         # Sparse maestro.toml with inline and header comments; guards that comments survive a Config::save_into_str call unchanged
 │   │   │   └── with_unknown_section.toml  # maestro.toml with a custom [my_tool] section unknown to Config; guards that unknown sections are preserved verbatim by the overlay merge

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -18,6 +18,7 @@ mod models;
 mod modes;
 mod notifications;
 mod overlay;
+mod overlay_dynamic;
 mod plugins;
 mod project;
 mod review;

--- a/src/config/overlay.rs
+++ b/src/config/overlay.rs
@@ -26,6 +26,8 @@
 
 use toml_edit::{DocumentMut, Item, Table, Value};
 
+use super::overlay_dynamic;
+
 pub(super) fn apply_overlay(existing: &mut DocumentMut, on_disk: &Table, new: &Table) {
     merge_table(existing.as_table_mut(), on_disk, new);
 }
@@ -72,6 +74,15 @@ fn merge_key(target: &mut Table, key: &str, old: Option<&Item>, new: &Item) {
         }
         (Some(Item::Value(_)), Item::Value(new_val)) => {
             replace_value_preserving_decor(target, key, new_val.clone());
+        }
+        (Some(Item::ArrayOfTables(old_arr)), Item::ArrayOfTables(new_arr)) => {
+            if let Some(target_item) = target.get_mut(key)
+                && let Some(target_arr) = target_item.as_array_of_tables_mut()
+            {
+                overlay_dynamic::merge_array_of_tables(target_arr, old_arr, new_arr);
+                return;
+            }
+            target.insert(key, new.clone());
         }
         _ => {
             target.insert(key, new.clone());

--- a/src/config/overlay_dynamic.rs
+++ b/src/config/overlay_dynamic.rs
@@ -1,0 +1,148 @@
+//! Dynamic-section helpers for the overlay merge: comment-preserving
+//! `add` / `remove` / `reorder` on `[[array-of-tables]]` blocks introduced
+//! by issue #790.
+//!
+//! Sub-table handling for dynamic-keyed maps (`[agents.<id>]`, `[modes.<id>]`,
+//! `[teams.<id>]`) already works through the existing `merge_table` recursion
+//! and the wildcard `target.insert` arm in `merge_key`. The pain point this
+//! module fixes is `Item::ArrayOfTables`: the old wildcard arm rewrote the
+//! whole array on any change, destroying per-element prefix comments.
+//!
+//! Reorder is feature-gated behind `dynamic-config-reorder` (off-by-default
+//! for one release). Append, remove, and per-slot edits ship unconditionally;
+//! they preserve neighbor comments by mutating only the affected slots.
+
+use std::collections::{BTreeMap, VecDeque};
+
+use toml_edit::{ArrayOfTables, Item, Table, Value};
+
+const REORDER_ENABLED: bool = cfg!(feature = "dynamic-config-reorder");
+
+/// Merge `new_arr` into `target_arr` using `old_arr` as the on-disk view.
+/// Detects per-element identity by canonical content hash, so a swap of two
+/// neighbours is recognised as a reorder rather than two unrelated edits.
+pub(super) fn merge_array_of_tables(
+    target_arr: &mut ArrayOfTables,
+    old_arr: &ArrayOfTables,
+    new_arr: &ArrayOfTables,
+) {
+    let perm = build_permutation(old_arr, new_arr);
+    let reorder_needed = perm
+        .iter()
+        .enumerate()
+        .any(|(new_idx, src)| matches!(src, Source::Existing(old_idx) if *old_idx != new_idx));
+
+    if reorder_needed && !REORDER_ENABLED {
+        tracing::debug!(
+            target: "config.overlay",
+            "array-of-tables reorder: dynamic-config-reorder feature is off — \
+             falling back to wholesale rewrite (moved-row comments lost)",
+        );
+        let fresh: Vec<Source> = (0..new_arr.len()).map(Source::Fresh).collect();
+        apply_permutation(target_arr, new_arr, &fresh);
+        return;
+    }
+
+    apply_permutation(target_arr, new_arr, &perm);
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Source {
+    /// Pull from `target_arr` at this old-slot index (preserves decor).
+    Existing(usize),
+    /// Pull from `new_arr` at this new-slot index (fresh element, no decor
+    /// to preserve).
+    Fresh(usize),
+}
+
+/// FIFO-bucket match: each new element claims the first unmatched old
+/// element with an equal canonical hash. Unmatched new elements are `Fresh`;
+/// unmatched old elements are dropped (i.e. removed).
+fn build_permutation(old_arr: &ArrayOfTables, new_arr: &ArrayOfTables) -> Vec<Source> {
+    let mut buckets: BTreeMap<String, VecDeque<usize>> = BTreeMap::new();
+    for i in 0..old_arr.len() {
+        buckets
+            .entry(canon_table(old_arr.get(i)))
+            .or_default()
+            .push_back(i);
+    }
+    let mut out = Vec::with_capacity(new_arr.len());
+    for j in 0..new_arr.len() {
+        let claimed = buckets
+            .get_mut(&canon_table(new_arr.get(j)))
+            .and_then(VecDeque::pop_front);
+        out.push(match claimed {
+            Some(i) => Source::Existing(i),
+            None => Source::Fresh(j),
+        });
+    }
+    out
+}
+
+fn apply_permutation(target_arr: &mut ArrayOfTables, new_arr: &ArrayOfTables, perm: &[Source]) {
+    let snapshot: Vec<Table> = (0..target_arr.len())
+        .map(|i| target_arr.get(i).cloned().expect("len-checked snapshot"))
+        .collect();
+    let base_position = snapshot
+        .iter()
+        .filter_map(Table::position)
+        .min()
+        .unwrap_or(0);
+    target_arr.clear();
+    for (offset, src) in perm.iter().enumerate() {
+        let mut table = match src {
+            Source::Existing(i) => snapshot[*i].clone(),
+            Source::Fresh(j) => match new_arr.get(*j) {
+                Some(t) => t.clone(),
+                None => continue,
+            },
+        };
+        table.set_position(base_position.saturating_add(offset));
+        target_arr.push(table);
+    }
+}
+
+/// Canonical, decor-blind, key-sorted serialization used as a content hash.
+/// Two tables with identical primitive payloads canonicalize to the same
+/// string regardless of insertion order or surrounding comments.
+fn canon_table(table: Option<&Table>) -> String {
+    let Some(t) = table else { return String::new() };
+    let mut entries: Vec<(String, String)> = Vec::new();
+    for (key, item) in t.iter() {
+        entries.push((key.to_string(), canon_item(item)));
+    }
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut out = String::with_capacity(64);
+    out.push('{');
+    for (k, v) in &entries {
+        out.push_str(k);
+        out.push('=');
+        out.push_str(v);
+        out.push(';');
+    }
+    out.push('}');
+    out
+}
+
+fn canon_item(item: &Item) -> String {
+    match item {
+        Item::None => String::new(),
+        Item::Value(v) => canon_value(v),
+        Item::Table(t) => canon_table(Some(t)),
+        Item::ArrayOfTables(arr) => {
+            let mut s = String::from("[");
+            for i in 0..arr.len() {
+                s.push_str(&canon_table(arr.get(i)));
+                s.push(',');
+            }
+            s.push(']');
+            s
+        }
+    }
+}
+
+fn canon_value(value: &Value) -> String {
+    let mut clone = value.clone();
+    clone.decor_mut().clear();
+    clone.to_string().trim().to_string()
+}

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -14,6 +14,7 @@ mod notifications_views;
 mod orchestration;
 mod roundtrip;
 mod roundtrip_overlay;
+mod roundtrip_overlay_dynamic;
 mod roundtrip_overlay_single_key;
 mod sessions_layout;
 mod turbo_adapt_paths;

--- a/src/config/tests/roundtrip_overlay.rs
+++ b/src/config/tests/roundtrip_overlay.rs
@@ -7,10 +7,26 @@ use super::*;
 use std::io::Write;
 
 pub(super) fn fixture(name: &str) -> String {
+    fixture_in("tests/fixtures/config_roundtrip", name)
+}
+
+pub(super) fn fixture_in(dir: &str, name: &str) -> String {
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("tests/fixtures/config_roundtrip")
+        .join(dir)
         .join(name);
     std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("failed to read fixture {name}: {e}"))
+}
+
+/// Convenience for the very common "read fixture file → temp-file → load
+/// `Config`" preamble in round-trip tests. Returns the original text and the
+/// loaded `Config` (the temp file is dropped immediately — `Config::load`
+/// reads it eagerly).
+pub(super) fn load_fixture(dir: &str, name: &str) -> (String, Config) {
+    let text = fixture_in(dir, name);
+    let tmp = temp_file_with(&text);
+    let cfg = Config::load(tmp.path())
+        .unwrap_or_else(|e| panic!("fixture {name} failed to parse as Config: {e}"));
+    (text, cfg)
 }
 
 pub(super) fn assert_byte_identical(label_a: &str, a: &str, label_b: &str, b: &str) {

--- a/src/config/tests/roundtrip_overlay_dynamic.rs
+++ b/src/config/tests/roundtrip_overlay_dynamic.rs
@@ -1,0 +1,260 @@
+//! Round-trip tests for `Config::save_into_str` covering dynamic-section
+//! edits — add, remove, and (feature-gated) reorder — introduced by issue
+//! #790. See `tests/fixtures/dynamic_config/` for the golden fixtures.
+
+use super::roundtrip_overlay::{load_fixture, temp_file_with};
+use super::*;
+use crate::config::agents::{AgentConfig, AgentKind};
+use crate::config::sessions::CompletionGateEntry;
+use std::collections::BTreeMap;
+
+const FIXTURE_DIR: &str = "tests/fixtures/dynamic_config";
+
+fn qwen_fast_agent() -> AgentConfig {
+    AgentConfig {
+        kind: AgentKind::Qwen,
+        enabled: true,
+        command: Some("qwen".to_string()),
+        base_url: None,
+        model: Some("qwen-fast".to_string()),
+        env: BTreeMap::new(),
+        extra_args: Vec::new(),
+        permission_mode: None,
+        allowed_tools: Vec::new(),
+        sandbox: None,
+        json: None,
+        ephemeral: None,
+        profile: None,
+        config_overrides: BTreeMap::new(),
+        cli_flags: BTreeMap::new(),
+        request_timeout_secs: None,
+        api_key_env: None,
+    }
+}
+
+#[test]
+fn add_agents_entry_appends_block_and_preserves_neighbor_comments() {
+    let (before, mut cfg) = load_fixture(FIXTURE_DIR, "agents_add.toml.before");
+    cfg.agents
+        .entries
+        .insert("qwen-fast".to_string(), qwen_fast_agent());
+
+    let after = cfg
+        .save_into_str(&before)
+        .expect("save_into_str must succeed");
+
+    assert!(
+        after.contains("[agents.qwen-fast]"),
+        "new agent block must be emitted as a header:\n{after}"
+    );
+    assert!(
+        after.contains("# === Agents ===")
+            && after.contains("# Primary Claude agent — do not remove")
+            && after.contains("# Marker comment that must survive an add operation"),
+        "all neighbor comments must survive the add:\n{after}"
+    );
+    let claude_idx = after
+        .find("[agents.claude]")
+        .expect("claude header present");
+    let qwen_idx = after
+        .find("[agents.qwen-fast]")
+        .expect("qwen header present");
+    assert!(
+        claude_idx < qwen_idx,
+        "added agent must follow the existing one, not replace it"
+    );
+}
+
+#[test]
+fn remove_agents_entry_drops_block_and_collapses_blank_lines() {
+    let (before, mut cfg) = load_fixture(FIXTURE_DIR, "agents_remove.toml.before");
+    cfg.agents.entries.remove("qwen-fast");
+
+    let after = cfg
+        .save_into_str(&before)
+        .expect("save_into_str must succeed");
+
+    assert!(
+        !after.contains("[agents.qwen-fast]"),
+        "removed agent header must be gone:\n{after}"
+    );
+    assert!(
+        !after.contains("kind = \"qwen\""),
+        "removed agent body must be gone:\n{after}"
+    );
+    assert!(
+        after.contains("# Primary Claude agent")
+            && after.contains("# Sentinel section that must remain comment-anchored after removal"),
+        "neighbor comments must survive removal:\n{after}"
+    );
+    assert!(
+        !after.contains("\n\n\n\n"),
+        "blank lines must not pile up after removal:\n{after}"
+    );
+}
+
+#[test]
+fn remove_then_add_idempotent_does_not_accumulate_blank_lines() {
+    let (before, mut cfg) = load_fixture(FIXTURE_DIR, "agents_remove.toml.before");
+    cfg.agents.entries.remove("qwen-fast");
+    let pass1 = cfg.save_into_str(&before).expect("first save");
+
+    let tmp2 = temp_file_with(&pass1);
+    let cfg2 = Config::load(tmp2.path()).expect("pass1 must parse");
+    let pass2 = cfg2.save_into_str(&pass1).expect("second save");
+
+    assert_eq!(
+        pass1.matches("\n\n\n").count(),
+        pass2.matches("\n\n\n").count(),
+        "blank-line density must not drift on resave:\nfirst:\n{pass1}\nsecond:\n{pass2}"
+    );
+}
+
+#[test]
+fn array_of_tables_pure_append_preserves_existing_comments() {
+    let (before, mut cfg) = load_fixture(FIXTURE_DIR, "completion_gates_reorder.toml.before");
+    cfg.sessions
+        .completion_gates
+        .commands
+        .push(CompletionGateEntry {
+            name: "doc".to_string(),
+            run: "cargo doc".to_string(),
+            required: false,
+        });
+
+    let after = cfg
+        .save_into_str(&before)
+        .expect("save_into_str must succeed");
+
+    assert!(
+        after.contains("name = \"doc\""),
+        "appended gate must be present"
+    );
+    for marker in [
+        "# Gate 1 — runs first",
+        "# Gate 2 — runs second",
+        "# Gate 3 — runs last",
+    ] {
+        assert!(
+            after.contains(marker),
+            "existing comment {marker:?} must survive append:\n{after}"
+        );
+    }
+}
+
+#[test]
+fn array_of_tables_pure_remove_keeps_remaining_comments_anchored() {
+    let (before, mut cfg) = load_fixture(FIXTURE_DIR, "completion_gates_reorder.toml.before");
+    cfg.sessions.completion_gates.commands.pop();
+
+    let after = cfg
+        .save_into_str(&before)
+        .expect("save_into_str must succeed");
+
+    assert!(
+        !after.contains("name = \"test\""),
+        "popped gate's body must be gone:\n{after}"
+    );
+    for marker in ["# Gate 1 — runs first", "# Gate 2 — runs second"] {
+        assert!(
+            after.contains(marker),
+            "kept gate comment must survive:\n{after}"
+        );
+    }
+}
+
+#[cfg(feature = "dynamic-config-reorder")]
+#[test]
+fn array_of_tables_reorder_swaps_elements_carrying_comments() {
+    let (before, mut cfg) = load_fixture(FIXTURE_DIR, "completion_gates_reorder.toml.before");
+    cfg.sessions.completion_gates.commands.swap(0, 1);
+
+    let after = cfg
+        .save_into_str(&before)
+        .expect("save_into_str must succeed");
+
+    let clippy_idx = after
+        .find("name = \"clippy\"")
+        .expect("clippy element present");
+    let fmt_idx = after.find("name = \"fmt\"").expect("fmt element present");
+    assert!(
+        clippy_idx < fmt_idx,
+        "clippy must now precede fmt:\n{after}"
+    );
+
+    let gate1_idx = after.find("# Gate 1 — runs first").expect("gate 1 comment");
+    let gate2_idx = after
+        .find("# Gate 2 — runs second")
+        .expect("gate 2 comment");
+    assert!(
+        gate2_idx < gate1_idx,
+        "comments must follow their elements through the swap:\n{after}"
+    );
+    let gate3_idx = after.find("# Gate 3 — runs last").expect("gate 3 comment");
+    assert!(
+        gate3_idx > fmt_idx,
+        "third element comment must remain anchored:\n{after}"
+    );
+}
+
+#[cfg(not(feature = "dynamic-config-reorder"))]
+#[test]
+fn array_of_tables_reorder_without_feature_falls_back_to_wholesale_rewrite() {
+    let (before, mut cfg) = load_fixture(FIXTURE_DIR, "completion_gates_reorder.toml.before");
+    cfg.sessions.completion_gates.commands.swap(0, 1);
+
+    let after = cfg
+        .save_into_str(&before)
+        .expect("save_into_str must succeed");
+
+    let clippy_idx = after
+        .find("name = \"clippy\"")
+        .expect("clippy element present");
+    let fmt_idx = after.find("name = \"fmt\"").expect("fmt element present");
+    assert!(
+        clippy_idx < fmt_idx,
+        "fallback rewrite must still reflect the new order:\n{after}"
+    );
+    assert!(
+        !after.contains("# Gate 1 — runs first") && !after.contains("# Gate 2 — runs second"),
+        "wholesale-rewrite path is documented to drop per-element comments on \
+         moved rows; the feature-on path keeps them. Without this distinction \
+         the test would not exercise the fallback:\n{after}"
+    );
+}
+
+#[test]
+fn comments_preserved_mixed_scenario_keeps_every_input_comment() {
+    let (before, mut cfg) = load_fixture(FIXTURE_DIR, "comments_preserved.toml");
+    cfg.agents
+        .entries
+        .insert("qwen-fast".to_string(), qwen_fast_agent());
+    cfg.budget.alert_threshold_pct = 90;
+    cfg.sessions
+        .completion_gates
+        .commands
+        .push(CompletionGateEntry {
+            name: "doc".to_string(),
+            run: "cargo doc".to_string(),
+            required: false,
+        });
+
+    let after = cfg
+        .save_into_str(&before)
+        .expect("save_into_str must succeed");
+
+    for comment in before.lines().filter(|l| l.trim_start().starts_with('#')) {
+        assert!(
+            after.contains(comment),
+            "comment {comment:?} from input must appear in output:\n{after}"
+        );
+    }
+
+    let tmp2 = temp_file_with(&after);
+    let cfg2 = Config::load(tmp2.path()).expect("after must parse");
+    let after2 = cfg2.save_into_str(&after).expect("re-save");
+    assert_eq!(
+        after, after2,
+        "second save with no mutations must be byte-identical (idempotent)"
+    );
+}

--- a/tests/fixtures/dynamic_config/agents_add.toml.after
+++ b/tests/fixtures/dynamic_config/agents_add.toml.after
@@ -1,0 +1,71 @@
+# maestro config for issue #790 add test
+[project]
+repo = "owner/repo"
+base_branch = "main"
+
+[sessions]
+max_concurrent = 3
+stall_timeout_secs = 300
+default_model = "opus"
+default_mode = "orchestrator"
+permission_mode = "default"
+allowed_tools = []
+max_retries = 2
+retry_cooldown_secs = 60
+max_prompt_history = 100
+
+[sessions.hollow_retry]
+policy = "intent-aware"
+work_max_retries = 2
+consultation_max_retries = 0
+
+[sessions.context_overflow]
+overflow_threshold_pct = 70
+auto_fork = true
+commit_prompt_pct = 50
+max_fork_depth = 5
+
+[sessions.conflict]
+enabled = true
+policy = "warn"
+
+[sessions.completion_gates]
+enabled = true
+commands = []
+
+[budget]
+per_session_usd = 5.0
+total_usd = 50.0
+alert_threshold_pct = 80
+
+[github]
+issue_filter_labels = []
+auto_pr = true
+cache_ttl_secs = 300
+auto_merge = false
+merge_method = "merge"
+
+[notifications]
+desktop = true
+slack = false
+slack_rate_limit_per_min = 10
+
+# === Agents ===
+[agents]
+default = "claude"
+
+# Primary Claude agent — do not remove
+[agents.claude]
+kind = "claude"
+enabled = true
+command = "claude"
+model = "opus"
+
+[agents.qwen-fast]
+kind = "qwen"
+enabled = true
+command = "qwen"
+model = "qwen-fast"
+
+# Marker comment that must survive an add operation
+[budget.alerts]

--- a/tests/fixtures/dynamic_config/agents_add.toml.before
+++ b/tests/fixtures/dynamic_config/agents_add.toml.before
@@ -1,0 +1,65 @@
+# maestro config for issue #790 add test
+[project]
+repo = "owner/repo"
+base_branch = "main"
+
+[sessions]
+max_concurrent = 3
+stall_timeout_secs = 300
+default_model = "opus"
+default_mode = "orchestrator"
+permission_mode = "default"
+allowed_tools = []
+max_retries = 2
+retry_cooldown_secs = 60
+max_prompt_history = 100
+
+[sessions.hollow_retry]
+policy = "intent-aware"
+work_max_retries = 2
+consultation_max_retries = 0
+
+[sessions.context_overflow]
+overflow_threshold_pct = 70
+auto_fork = true
+commit_prompt_pct = 50
+max_fork_depth = 5
+
+[sessions.conflict]
+enabled = true
+policy = "warn"
+
+[sessions.completion_gates]
+enabled = true
+commands = []
+
+[budget]
+per_session_usd = 5.0
+total_usd = 50.0
+alert_threshold_pct = 80
+
+[github]
+issue_filter_labels = []
+auto_pr = true
+cache_ttl_secs = 300
+auto_merge = false
+merge_method = "merge"
+
+[notifications]
+desktop = true
+slack = false
+slack_rate_limit_per_min = 10
+
+# === Agents ===
+[agents]
+default = "claude"
+
+# Primary Claude agent — do not remove
+[agents.claude]
+kind = "claude"
+enabled = true
+command = "claude"
+model = "opus"
+
+# Marker comment that must survive an add operation
+[budget.alerts]

--- a/tests/fixtures/dynamic_config/agents_remove.toml.after
+++ b/tests/fixtures/dynamic_config/agents_remove.toml.after
@@ -1,0 +1,64 @@
+# maestro config for issue #790 remove test
+[project]
+repo = "owner/repo"
+base_branch = "main"
+
+[sessions]
+max_concurrent = 3
+stall_timeout_secs = 300
+default_model = "opus"
+default_mode = "orchestrator"
+permission_mode = "default"
+allowed_tools = []
+max_retries = 2
+retry_cooldown_secs = 60
+max_prompt_history = 100
+
+[sessions.hollow_retry]
+policy = "intent-aware"
+work_max_retries = 2
+consultation_max_retries = 0
+
+[sessions.context_overflow]
+overflow_threshold_pct = 70
+auto_fork = true
+commit_prompt_pct = 50
+max_fork_depth = 5
+
+[sessions.conflict]
+enabled = true
+policy = "warn"
+
+[sessions.completion_gates]
+enabled = true
+commands = []
+
+[budget]
+per_session_usd = 5.0
+total_usd = 50.0
+alert_threshold_pct = 80
+
+[github]
+issue_filter_labels = []
+auto_pr = true
+cache_ttl_secs = 300
+auto_merge = false
+merge_method = "merge"
+
+[notifications]
+desktop = true
+slack = false
+slack_rate_limit_per_min = 10
+
+[agents]
+default = "claude"
+
+# Primary Claude agent
+[agents.claude]
+kind = "claude"
+enabled = true
+command = "claude"
+model = "opus"
+
+# Sentinel section that must remain comment-anchored after removal
+[budget.alerts]

--- a/tests/fixtures/dynamic_config/agents_remove.toml.before
+++ b/tests/fixtures/dynamic_config/agents_remove.toml.before
@@ -1,0 +1,71 @@
+# maestro config for issue #790 remove test
+[project]
+repo = "owner/repo"
+base_branch = "main"
+
+[sessions]
+max_concurrent = 3
+stall_timeout_secs = 300
+default_model = "opus"
+default_mode = "orchestrator"
+permission_mode = "default"
+allowed_tools = []
+max_retries = 2
+retry_cooldown_secs = 60
+max_prompt_history = 100
+
+[sessions.hollow_retry]
+policy = "intent-aware"
+work_max_retries = 2
+consultation_max_retries = 0
+
+[sessions.context_overflow]
+overflow_threshold_pct = 70
+auto_fork = true
+commit_prompt_pct = 50
+max_fork_depth = 5
+
+[sessions.conflict]
+enabled = true
+policy = "warn"
+
+[sessions.completion_gates]
+enabled = true
+commands = []
+
+[budget]
+per_session_usd = 5.0
+total_usd = 50.0
+alert_threshold_pct = 80
+
+[github]
+issue_filter_labels = []
+auto_pr = true
+cache_ttl_secs = 300
+auto_merge = false
+merge_method = "merge"
+
+[notifications]
+desktop = true
+slack = false
+slack_rate_limit_per_min = 10
+
+[agents]
+default = "claude"
+
+# Primary Claude agent
+[agents.claude]
+kind = "claude"
+enabled = true
+command = "claude"
+model = "opus"
+
+# Secondary Qwen agent — slated for removal
+[agents.qwen-fast]
+kind = "qwen"
+enabled = true
+command = "qwen"
+model = "qwen-fast"
+
+# Sentinel section that must remain comment-anchored after removal
+[budget.alerts]

--- a/tests/fixtures/dynamic_config/comments_preserved.toml
+++ b/tests/fixtures/dynamic_config/comments_preserved.toml
@@ -1,0 +1,75 @@
+# mixed-scenario regression for issue #790
+# this file is loaded, mutated (add + remove + reorder), and re-saved
+# every comment line that appears here must appear in the saved output
+[project]
+repo = "owner/repo"
+base_branch = "main"
+
+[sessions]
+max_concurrent = 3
+stall_timeout_secs = 300
+default_model = "opus"
+default_mode = "orchestrator"
+permission_mode = "default"
+allowed_tools = []
+max_retries = 2
+retry_cooldown_secs = 60
+max_prompt_history = 100
+
+[sessions.hollow_retry]
+policy = "intent-aware"
+work_max_retries = 2
+consultation_max_retries = 0
+
+[sessions.context_overflow]
+overflow_threshold_pct = 70
+auto_fork = true
+commit_prompt_pct = 50
+max_fork_depth = 5
+
+[sessions.conflict]
+enabled = true
+policy = "warn"
+
+[sessions.completion_gates]
+enabled = true
+
+# Gate alpha
+[[sessions.completion_gates.commands]]
+name = "fmt"
+run = "cargo fmt --check"
+required = true
+
+# Gate beta
+[[sessions.completion_gates.commands]]
+name = "clippy"
+run = "cargo clippy -- -D warnings"
+required = true
+
+# Financial guardrails
+[budget]
+per_session_usd = 5.0
+total_usd = 50.0
+alert_threshold_pct = 80
+
+[github]
+issue_filter_labels = []
+auto_pr = true
+cache_ttl_secs = 300
+auto_merge = false
+merge_method = "merge"
+
+[notifications]
+desktop = true
+slack = false
+slack_rate_limit_per_min = 10
+
+[agents]
+default = "claude"
+
+# Existing claude agent
+[agents.claude]
+kind = "claude"
+enabled = true
+command = "claude"
+model = "opus"

--- a/tests/fixtures/dynamic_config/completion_gates_reorder.toml.after
+++ b/tests/fixtures/dynamic_config/completion_gates_reorder.toml.after
@@ -1,0 +1,68 @@
+# maestro config for issue #790 array-of-tables reorder test
+[project]
+repo = "owner/repo"
+base_branch = "main"
+
+[sessions]
+max_concurrent = 3
+stall_timeout_secs = 300
+default_model = "opus"
+default_mode = "orchestrator"
+permission_mode = "default"
+allowed_tools = []
+max_retries = 2
+retry_cooldown_secs = 60
+max_prompt_history = 100
+
+[sessions.hollow_retry]
+policy = "intent-aware"
+work_max_retries = 2
+consultation_max_retries = 0
+
+[sessions.context_overflow]
+overflow_threshold_pct = 70
+auto_fork = true
+commit_prompt_pct = 50
+max_fork_depth = 5
+
+[sessions.conflict]
+enabled = true
+policy = "warn"
+
+[sessions.completion_gates]
+enabled = true
+
+# Gate 2 — runs second
+[[sessions.completion_gates.commands]]
+name = "clippy"
+run = "cargo clippy -- -D warnings"
+required = true
+
+# Gate 1 — runs first
+[[sessions.completion_gates.commands]]
+name = "fmt"
+run = "cargo fmt --check"
+required = true
+
+# Gate 3 — runs last
+[[sessions.completion_gates.commands]]
+name = "test"
+run = "cargo test"
+required = true
+
+[budget]
+per_session_usd = 5.0
+total_usd = 50.0
+alert_threshold_pct = 80
+
+[github]
+issue_filter_labels = []
+auto_pr = true
+cache_ttl_secs = 300
+auto_merge = false
+merge_method = "merge"
+
+[notifications]
+desktop = true
+slack = false
+slack_rate_limit_per_min = 10

--- a/tests/fixtures/dynamic_config/completion_gates_reorder.toml.before
+++ b/tests/fixtures/dynamic_config/completion_gates_reorder.toml.before
@@ -1,0 +1,68 @@
+# maestro config for issue #790 array-of-tables reorder test
+[project]
+repo = "owner/repo"
+base_branch = "main"
+
+[sessions]
+max_concurrent = 3
+stall_timeout_secs = 300
+default_model = "opus"
+default_mode = "orchestrator"
+permission_mode = "default"
+allowed_tools = []
+max_retries = 2
+retry_cooldown_secs = 60
+max_prompt_history = 100
+
+[sessions.hollow_retry]
+policy = "intent-aware"
+work_max_retries = 2
+consultation_max_retries = 0
+
+[sessions.context_overflow]
+overflow_threshold_pct = 70
+auto_fork = true
+commit_prompt_pct = 50
+max_fork_depth = 5
+
+[sessions.conflict]
+enabled = true
+policy = "warn"
+
+[sessions.completion_gates]
+enabled = true
+
+# Gate 1 — runs first
+[[sessions.completion_gates.commands]]
+name = "fmt"
+run = "cargo fmt --check"
+required = true
+
+# Gate 2 — runs second
+[[sessions.completion_gates.commands]]
+name = "clippy"
+run = "cargo clippy -- -D warnings"
+required = true
+
+# Gate 3 — runs last
+[[sessions.completion_gates.commands]]
+name = "test"
+run = "cargo test"
+required = true
+
+[budget]
+per_session_usd = 5.0
+total_usd = 50.0
+alert_threshold_pct = 80
+
+[github]
+issue_filter_labels = []
+auto_pr = true
+cache_ttl_secs = 300
+auto_merge = false
+merge_method = "merge"
+
+[notifications]
+desktop = true
+slack = false
+slack_rate_limit_per_min = 10


### PR DESCRIPTION
## Summary

- Adds `src/config/overlay_dynamic.rs` to handle `[[array-of-tables]]` add / remove / reorder in `Config::save_into_str` without destroying neighbor comments.
- Reorder uses element-wise content hashing (decor-blind canonical serialization) and is gated behind the off-by-default cargo feature `dynamic-config-reorder` (fallback path is wholesale rewrite).
- Six golden fixtures + seven tests under `tests/fixtures/dynamic_config/` and `src/config/tests/roundtrip_overlay_dynamic.rs`. Existing static-shape round-trip tests stay green.

Closes #790

## Test plan

- [x] `cargo test --quiet` (default features) — all green
- [x] `cargo test --quiet --features dynamic-config-reorder` — all green incl. reorder swap test
- [x] `cargo clippy -- -D warnings -A dead_code`
- [x] `cargo fmt --check`
- [x] Security review: only one Low (saturating_add) — applied
