### PR TITLE
docs(schema): render FieldKind::Map and VecOfStruct dynamic sections

### DIFF
--- a/directory-tree.md
+++ b/directory-tree.md
@@ -175,6 +175,7 @@ maestro/
 │   │   ├── schema/                        # Submodule tree for the config schema registry  [Issue #713]
 │   │   │   ├── docs_render.rs             # Pure renderer module: walks a TableSchema and emits a Markdown table block; used by the autogen system to produce AUTOGEN-marked sections in docs/configuration.md  [Issue #717]
 │   │   │   ├── docs_render_tests.rs       # Sibling test module for docs_render.rs loaded via `#[path]`; unit tests for the renderer covering all FieldKind leaf variants and NestedTable flattening  [Issue #717]
+│   │   │   ├── docs_render_dynamic_tests.rs # Sibling test module loaded via `#[path]`; insta + unit tests for `FieldKind::Map` and `FieldKind::VecOfStruct` dynamic-section rendering (heading, prose, entry-field table)  [Issue #793]
 │   │   │   └── registry/                  # Const &'static [TableSchema] registry covering 17 tables / 52 fields
 │   │   │       ├── mod.rs                 # Registry module facade; re-exports the combined table slice
 │   │   │       ├── core.rs                # Core registry entries: adapt, agents, budget, gates, github, models, modes, notifications, plugins, project, review, runtime, sessions, tui, turboquant, views

--- a/src/config/schema/docs_render.rs
+++ b/src/config/schema/docs_render.rs
@@ -111,7 +111,10 @@ fn escape_pipes(s: &str) -> String {
 }
 
 pub(crate) fn render_field_row(field: &FieldSchema) -> Option<String> {
-    if matches!(field.kind, FieldKind::NestedTable(_)) {
+    if matches!(
+        field.kind,
+        FieldKind::NestedTable(_) | FieldKind::Map { .. } | FieldKind::VecOfStruct { .. }
+    ) {
         return None;
     }
     Some(format!(
@@ -123,13 +126,71 @@ pub(crate) fn render_field_row(field: &FieldSchema) -> Option<String> {
     ))
 }
 
-pub(crate) fn render_table_body(fields: &[FieldSchema]) -> String {
+fn render_entry_table(entry_fields: &[FieldSchema]) -> String {
     let mut out = String::new();
     out.push_str("| Field | Type | Default | Description |\n");
     out.push_str("|---|---|---|---|\n");
-    for field in fields {
+    for field in entry_fields {
         if let Some(row) = render_field_row(field) {
             out.push_str(&row);
+        }
+    }
+    out
+}
+
+/// Render a dynamic-key `Map` section: `### [name.<id>] — dynamic-key map`,
+/// prose explaining the dynamic shape, then a fields table for entries.
+fn render_dynamic_map_section(parent_name: &str, entry_fields: &[FieldSchema]) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "\n### `[{parent_name}.<id>]` — dynamic-key map\n\n"
+    ));
+    out.push_str(&format!(
+        "Each `<id>` is a user-chosen identifier matching `[a-z0-9_-]+`. \
+         Add or remove entries via the Settings UI or by hand-editing \
+         `maestro.toml`. Each `[{parent_name}.<id>]` table has the following \
+         fields:\n\n"
+    ));
+    out.push_str(&render_entry_table(entry_fields));
+    out
+}
+
+/// Render a `VecOfStruct` section: `### [[name]] — array-of-tables
+/// (order-sensitive)`, prose noting that order matters, then a fields table.
+fn render_dynamic_vec_section(parent_name: &str, entry_fields: &[FieldSchema]) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "\n### `[[{parent_name}]]` — array-of-tables (order-sensitive)\n\n"
+    ));
+    out.push_str(&format!(
+        "Each `[[{parent_name}]]` block defines one entry. The list is \
+         **order-sensitive — declaration order is execution order.** Add, \
+         remove, or reorder entries via the Settings UI or by hand-editing \
+         `maestro.toml`. Each entry has the following fields:\n\n"
+    ));
+    out.push_str(&render_entry_table(entry_fields));
+    out
+}
+
+pub(crate) fn render_table_body(name: &str, fields: &[FieldSchema]) -> String {
+    let static_rows: Vec<String> = fields.iter().filter_map(render_field_row).collect();
+    let mut out = String::new();
+    if !static_rows.is_empty() {
+        out.push_str("| Field | Type | Default | Description |\n");
+        out.push_str("|---|---|---|---|\n");
+        for row in static_rows {
+            out.push_str(&row);
+        }
+    }
+    for field in fields {
+        match field.kind {
+            FieldKind::Map { entry_fields } => {
+                out.push_str(&render_dynamic_map_section(name, entry_fields));
+            }
+            FieldKind::VecOfStruct { entry_fields } => {
+                out.push_str(&render_dynamic_vec_section(name, entry_fields));
+            }
+            _ => {}
         }
     }
     out
@@ -163,7 +224,7 @@ pub(crate) fn regenerate(existing: &str, schema: &[TableSchema]) -> Result<Strin
 
             out.push_str(line);
             out.push('\n');
-            out.push_str(&render_table_body(fields));
+            out.push_str(&render_table_body(name, fields));
 
             let expected_end = end_marker(name);
             let mut found_end = false;
@@ -215,3 +276,7 @@ fn parse_end_marker(line: &str) -> Option<&str> {
 #[cfg(test)]
 #[path = "docs_render_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "docs_render_dynamic_tests.rs"]
+mod dynamic_tests;

--- a/src/config/schema/docs_render_dynamic_tests.rs
+++ b/src/config/schema/docs_render_dynamic_tests.rs
@@ -1,0 +1,210 @@
+//! Dynamic-section rendering tests for `docs_render` — `FieldKind::Map` and
+//! `FieldKind::VecOfStruct`. Split from `docs_render_tests.rs` to keep both
+//! files under the 400-line file-size cap. Static-shape regressions stay in
+//! `docs_render_tests.rs`; this file only owns the new variants.
+
+use super::*;
+
+const AGENTS_ENTRY: &[FieldSchema] = &[
+    FieldSchema {
+        key: "kind",
+        label: "Kind",
+        help: "Agent kind (claude, codex, qwen, ...).",
+        default: DefaultValue::Str(""),
+        kind: FieldKind::Enum(&["claude", "codex", "qwen"]),
+        validator: None,
+        presentation: None,
+    },
+    FieldSchema {
+        key: "enabled",
+        label: "Enabled",
+        help: "Whether this agent participates in sessions.",
+        default: DefaultValue::Bool(true),
+        kind: FieldKind::Bool,
+        validator: None,
+        presentation: None,
+    },
+];
+
+const COMMANDS_ENTRY: &[FieldSchema] = &[
+    FieldSchema {
+        key: "name",
+        label: "Name",
+        help: "Display name for the gate command.",
+        default: DefaultValue::Str(""),
+        kind: FieldKind::String,
+        validator: None,
+        presentation: None,
+    },
+    FieldSchema {
+        key: "command",
+        label: "Command",
+        help: "Shell command executed by the gate.",
+        default: DefaultValue::Str(""),
+        kind: FieldKind::String,
+        validator: None,
+        presentation: None,
+    },
+];
+
+fn map_field(key: &'static str, help: &'static str, entry: &'static [FieldSchema]) -> FieldSchema {
+    FieldSchema {
+        key,
+        label: key,
+        help,
+        default: DefaultValue::Empty,
+        kind: FieldKind::Map {
+            entry_fields: entry,
+        },
+        validator: None,
+        presentation: None,
+    }
+}
+
+fn vec_field(key: &'static str, help: &'static str, entry: &'static [FieldSchema]) -> FieldSchema {
+    FieldSchema {
+        key,
+        label: key,
+        help,
+        default: DefaultValue::Empty,
+        kind: FieldKind::VecOfStruct {
+            entry_fields: entry,
+        },
+        validator: None,
+        presentation: None,
+    }
+}
+
+#[test]
+fn render_type_map_returns_dynamic_map() {
+    let s = render_type_string(&FieldKind::Map {
+        entry_fields: AGENTS_ENTRY,
+    });
+    assert_eq!(s, "dynamic map");
+}
+
+#[test]
+fn render_type_vec_of_struct_returns_array_of_table() {
+    let s = render_type_string(&FieldKind::VecOfStruct {
+        entry_fields: COMMANDS_ENTRY,
+    });
+    assert_eq!(s, "array of table");
+}
+
+#[test]
+fn render_field_row_skips_map_field() {
+    let f = map_field("entries", "Dynamic entries", AGENTS_ENTRY);
+    assert!(
+        render_field_row(&f).is_none(),
+        "Map fields render as sections, not rows"
+    );
+}
+
+#[test]
+fn render_field_row_skips_vec_of_struct_field() {
+    let f = vec_field("commands", "Dynamic rows", COMMANDS_ENTRY);
+    assert!(
+        render_field_row(&f).is_none(),
+        "VecOfStruct fields render as sections, not rows"
+    );
+}
+
+#[test]
+fn render_table_body_emits_map_section_after_static_rows() {
+    let fields: &[FieldSchema] = &[
+        FieldSchema {
+            key: "default",
+            label: "Default",
+            help: "Default agent id.",
+            default: DefaultValue::Str("claude"),
+            kind: FieldKind::String,
+            validator: None,
+            presentation: None,
+        },
+        map_field("entries", "Dynamic entries", AGENTS_ENTRY),
+    ];
+    let body = render_table_body("agents", fields);
+    assert!(
+        body.contains("### `[agents.<id>]` — dynamic-key map"),
+        "Map heading missing, body was:\n{body}"
+    );
+    assert!(
+        body.contains("user-chosen identifier matching `[a-z0-9_-]+`"),
+        "Map prose missing regex constraint"
+    );
+    assert!(
+        body.contains("Settings UI") && body.contains("hand-edit"),
+        "Map prose missing add/remove guidance"
+    );
+    assert!(
+        body.contains("| `default` | string | `claude` |"),
+        "Static row missing"
+    );
+    assert!(body.contains("| `kind` | enum"), "Entry-field row missing");
+    assert!(
+        body.contains("| `enabled` | bool | `true` |"),
+        "Entry-field row missing"
+    );
+}
+
+#[test]
+fn render_table_body_emits_vec_of_struct_section_with_order_note() {
+    let fields: &[FieldSchema] = &[vec_field("commands", "Dynamic rows", COMMANDS_ENTRY)];
+    let body = render_table_body("sessions.completion_gates.commands", fields);
+    assert!(
+        body.contains(
+            "### `[[sessions.completion_gates.commands]]` — array-of-tables (order-sensitive)"
+        ),
+        "VecOfStruct heading missing, body was:\n{body}"
+    );
+    assert!(
+        body.contains("order-sensitive — declaration order is execution order"),
+        "VecOfStruct prose missing order-sensitivity note"
+    );
+    assert!(body.contains("| `name` | string"));
+    assert!(body.contains("| `command` | string"));
+}
+
+const AGENTS_TABLE_FIELDS: &[FieldSchema] = &[FieldSchema {
+    key: "entries",
+    label: "entries",
+    help: "Dynamic entries",
+    default: DefaultValue::Empty,
+    kind: FieldKind::Map {
+        entry_fields: AGENTS_ENTRY,
+    },
+    validator: None,
+    presentation: None,
+}];
+
+#[test]
+fn regenerate_emits_dynamic_section_inside_markers() {
+    let table = TableSchema {
+        name: "agents",
+        label: "Agents",
+        fields: AGENTS_TABLE_FIELDS,
+    };
+    let doc = "# Header\n\
+               <!-- BEGIN AUTOGEN:agents -->\n\
+               stale body\n\
+               <!-- END AUTOGEN:agents -->\n";
+    let got = regenerate(doc, &[table]).expect("regenerate ok");
+    assert!(got.contains("### `[agents.<id>]` — dynamic-key map"));
+    assert!(got.contains("user-chosen identifier"));
+    assert!(got.contains("| `kind` | enum"));
+    assert!(!got.contains("stale body"));
+}
+
+#[test]
+fn dynamic_section_snapshot_map() {
+    let fields: &[FieldSchema] = &[map_field("entries", "Dynamic entries", AGENTS_ENTRY)];
+    let body = render_table_body("agents", fields);
+    insta::assert_snapshot!("dynamic_section_map", body);
+}
+
+#[test]
+fn dynamic_section_snapshot_vec_of_struct() {
+    let fields: &[FieldSchema] = &[vec_field("commands", "Dynamic rows", COMMANDS_ENTRY)];
+    let body = render_table_body("sessions.completion_gates.commands", fields);
+    insta::assert_snapshot!("dynamic_section_vec_of_struct", body);
+}

--- a/src/config/schema/docs_render_tests.rs
+++ b/src/config/schema/docs_render_tests.rs
@@ -218,7 +218,7 @@ fn render_table_body_has_header_and_one_row_per_leaf() {
             "Sub",
         ),
     ];
-    let body = render_table_body(fields);
+    let body = render_table_body("demo", fields);
     assert!(body.starts_with("| Field | Type | Default | Description |\n|---|---|---|---|\n"));
     let data_rows = body.lines().filter(|l| l.starts_with("| `")).count();
     assert_eq!(data_rows, 2, "two non-nested leaf rows");
@@ -337,3 +337,5 @@ fn flatten_schema_includes_nested_dotted_tables() {
     assert!(map.contains_key("sessions.conflict"));
     assert!(map.contains_key("gates.ci_auto_fix"));
 }
+
+// Dynamic-section tests live in `docs_render_dynamic_tests.rs`.

--- a/src/config/schema/snapshots/maestro__config__schema__docs_render__dynamic_tests__dynamic_section_map.snap
+++ b/src/config/schema/snapshots/maestro__config__schema__docs_render__dynamic_tests__dynamic_section_map.snap
@@ -1,0 +1,14 @@
+---
+source: src/config/schema/docs_render_dynamic_tests.rs
+assertion_line: 202
+expression: body
+---
+
+### `[agents.<id>]` — dynamic-key map
+
+Each `<id>` is a user-chosen identifier matching `[a-z0-9_-]+`. Add or remove entries via the Settings UI or by hand-editing `maestro.toml`. Each `[agents.<id>]` table has the following fields:
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `kind` | enum (`claude`, `codex`, `qwen`) | unset | Agent kind (claude, codex, qwen, ...). |
+| `enabled` | bool | `true` | Whether this agent participates in sessions. |

--- a/src/config/schema/snapshots/maestro__config__schema__docs_render__dynamic_tests__dynamic_section_vec_of_struct.snap
+++ b/src/config/schema/snapshots/maestro__config__schema__docs_render__dynamic_tests__dynamic_section_vec_of_struct.snap
@@ -1,0 +1,14 @@
+---
+source: src/config/schema/docs_render_dynamic_tests.rs
+assertion_line: 209
+expression: body
+---
+
+### `[[sessions.completion_gates.commands]]` — array-of-tables (order-sensitive)
+
+Each `[[sessions.completion_gates.commands]]` block defines one entry. The list is **order-sensitive — declaration order is execution order.** Add, remove, or reorder entries via the Settings UI or by hand-editing `maestro.toml`. Each entry has the following fields:
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `name` | string | unset | Display name for the gate command. |
+| `command` | string | unset | Shell command executed by the gate. |


### PR DESCRIPTION
## Summary

- Extends `src/config/schema/docs_render.rs` (#717) to emit dynamic-section blocks for `FieldKind::Map` and `FieldKind::VecOfStruct`: `### \`[name.<id>]\` — dynamic-key map` and `### \`[[name]]\` — array-of-tables (order-sensitive)` headings, prose paragraph (regex constraint + add/remove guidance, order-sensitivity note), then a fields table for `entry_fields`.
- Static-table rendering preserved (existing snapshots stay green). When a table has only dynamic fields the empty header row is suppressed.
- Two insta snapshots committed in `src/config/schema/snapshots/`; dynamic tests live in `docs_render_dynamic_tests.rs` to keep both test files under the 400-LOC cap.

Closes #793

## Test plan

- [x] `cargo test --quiet` (lib + integration suites pass)
- [x] `cargo clippy -- -D warnings -A dead_code`
- [x] `cargo fmt --check`
- [x] `bash scripts/check-file-size.sh`
- [x] No Map/VecOfStruct schemas registered yet, so `docs_gen_no_drift` stays green; renderer is ready for the A.2/A.3 follow-ups that wire `[agents]`, `[modes]`, `[teams]`, `[[sessions.completion_gates.commands]]`.
