### PR TITLE
feat(tui): add Bucket/ToolId enums + SidebarState (UX-0-01)

### DIFF
--- a/src/tui/navigation/mod.rs
+++ b/src/tui/navigation/mod.rs
@@ -1,6 +1,7 @@
 pub mod focus;
 pub mod keymap;
 mod mode_hints;
+pub mod sidebar_state;
 
 /// Vim-style input mode for the entire application.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]

--- a/src/tui/navigation/sidebar_state.rs
+++ b/src/tui/navigation/sidebar_state.rs
@@ -1,3 +1,4 @@
+/// Top-level sidebar bucket — `Home` is a singleton; the other five (`Run`/`Plan`/`Review`/`Insights`/`System`) group tools
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Bucket {
     Home,
@@ -8,6 +9,7 @@ pub enum Bucket {
     System,
 }
 
+/// Every addressable sidebar tool — `Home` singleton plus 19 bucketed tools across Run/Plan/Review/Insights/System
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ToolId {
     Home,
@@ -33,6 +35,7 @@ pub enum ToolId {
 }
 
 impl ToolId {
+    /// Returns the `Bucket` that owns this tool
     pub fn bucket(self) -> Bucket {
         use ToolId::*;
         match self {
@@ -48,6 +51,7 @@ impl ToolId {
     }
 }
 
+/// Runtime state for the sidebar — tracks the active bucket and tool and whether the panel is collapsed
 #[derive(Debug, Clone)]
 pub struct SidebarState {
     pub active_bucket: Bucket,
@@ -66,6 +70,7 @@ impl Default for SidebarState {
 }
 
 impl SidebarState {
+    /// Activates `tool` and syncs `active_bucket` to its owning bucket
     pub fn select(&mut self, tool: ToolId) {
         self.active_tool = tool;
         self.active_bucket = tool.bucket();
@@ -86,12 +91,33 @@ mod tests {
 
     #[test]
     fn tool_id_bucket_is_consistent() {
-        assert_eq!(ToolId::RunSessions.bucket(), Bucket::Run);
-        assert_eq!(ToolId::PlanIssues.bucket(), Bucket::Plan);
-        assert_eq!(ToolId::ReviewPrs.bucket(), Bucket::Review);
-        assert_eq!(ToolId::InsightsCost.bucket(), Bucket::Insights);
-        assert_eq!(ToolId::SystemSettings.bucket(), Bucket::System);
-        assert_eq!(ToolId::Home.bucket(), Bucket::Home);
+        use ToolId::*;
+        let cases: &[(ToolId, Bucket)] = &[
+            (Home, Bucket::Home),
+            (RunSessions, Bucket::Run),
+            (RunInteractions, Bucket::Run),
+            (RunQueue, Bucket::Run),
+            (RunAdapt, Bucket::Run),
+            (RunPrompt, Bucket::Run),
+            (PlanIssues, Bucket::Plan),
+            (PlanMilestones, Bucket::Plan),
+            (PlanRoadmap, Bucket::Plan),
+            (PlanPrd, Bucket::Plan),
+            (ReviewPrs, Bucket::Review),
+            (ReviewCi, Bucket::Review),
+            (ReviewReleases, Bucket::Review),
+            (InsightsCost, Bucket::Insights),
+            (InsightsTokens, Bucket::Insights),
+            (InsightsTurboquant, Bucket::Insights),
+            (InsightsAgents, Bucket::Insights),
+            (InsightsStats, Bucket::Insights),
+            (SystemSettings, Bucket::System),
+            (SystemTeams, Bucket::System),
+        ];
+        assert_eq!(cases.len(), 20);
+        for (tool, expected) in cases {
+            assert_eq!(tool.bucket(), *expected, "bucket mismatch for {:?}", tool);
+        }
     }
 
     #[test]

--- a/src/tui/navigation/sidebar_state.rs
+++ b/src/tui/navigation/sidebar_state.rs
@@ -1,0 +1,104 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Bucket {
+    Home,
+    Run,
+    Plan,
+    Review,
+    Insights,
+    System,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ToolId {
+    Home,
+    RunSessions,
+    RunInteractions,
+    RunQueue,
+    RunAdapt,
+    RunPrompt,
+    PlanIssues,
+    PlanMilestones,
+    PlanRoadmap,
+    PlanPrd,
+    ReviewPrs,
+    ReviewCi,
+    ReviewReleases,
+    InsightsCost,
+    InsightsTokens,
+    InsightsTurboquant,
+    InsightsAgents,
+    InsightsStats,
+    SystemSettings,
+    SystemTeams,
+}
+
+impl ToolId {
+    pub fn bucket(self) -> Bucket {
+        use ToolId::*;
+        match self {
+            Home => Bucket::Home,
+            RunSessions | RunInteractions | RunQueue | RunAdapt | RunPrompt => Bucket::Run,
+            PlanIssues | PlanMilestones | PlanRoadmap | PlanPrd => Bucket::Plan,
+            ReviewPrs | ReviewCi | ReviewReleases => Bucket::Review,
+            InsightsCost | InsightsTokens | InsightsTurboquant | InsightsAgents | InsightsStats => {
+                Bucket::Insights
+            }
+            SystemSettings | SystemTeams => Bucket::System,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SidebarState {
+    pub active_bucket: Bucket,
+    pub active_tool: ToolId,
+    pub collapsed: bool,
+}
+
+impl Default for SidebarState {
+    fn default() -> Self {
+        Self {
+            active_bucket: Bucket::Home,
+            active_tool: ToolId::Home,
+            collapsed: false,
+        }
+    }
+}
+
+impl SidebarState {
+    pub fn select(&mut self, tool: ToolId) {
+        self.active_tool = tool;
+        self.active_bucket = tool.bucket();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sidebar_state_default_lands_home() {
+        let s = SidebarState::default();
+        assert_eq!(s.active_bucket, Bucket::Home);
+        assert_eq!(s.active_tool, ToolId::Home);
+        assert!(!s.collapsed);
+    }
+
+    #[test]
+    fn tool_id_bucket_is_consistent() {
+        assert_eq!(ToolId::RunSessions.bucket(), Bucket::Run);
+        assert_eq!(ToolId::PlanIssues.bucket(), Bucket::Plan);
+        assert_eq!(ToolId::ReviewPrs.bucket(), Bucket::Review);
+        assert_eq!(ToolId::InsightsCost.bucket(), Bucket::Insights);
+        assert_eq!(ToolId::SystemSettings.bucket(), Bucket::System);
+        assert_eq!(ToolId::Home.bucket(), Bucket::Home);
+    }
+
+    #[test]
+    fn select_tool_updates_bucket() {
+        let mut s = SidebarState::default();
+        s.select(ToolId::InsightsCost);
+        assert_eq!(s.active_bucket, Bucket::Insights);
+        assert_eq!(s.active_tool, ToolId::InsightsCost);
+    }
+}


### PR DESCRIPTION
## Summary

- Foundational types for the v0.32.0 UX Spine. `Bucket` names the 5 main sidebar buckets (Run/Plan/Review/Insights/System) plus the `Home` singleton; `ToolId` names every sidebar item with a `bucket()` lookup so `SidebarState::select()` derives `active_bucket` from `active_tool`.
- Default `SidebarState` lands on `Home`/`Home`/!collapsed.
- 20-entry exhaustive variant table in `tool_id_bucket_is_consistent` so a renamed match arm is caught.
- Doc comments on all 5 public items.

Closes #825. Part of milestone v0.32.0 — UX Spine.

## Files

- `src/tui/navigation/sidebar_state.rs` (new, ~150 LOC including tests + doc comments)
- `src/tui/navigation/mod.rs` (+1 line — `pub mod sidebar_state;`)

## Test plan

- [x] `cargo test --lib tui::navigation::sidebar_state` — 3/3 PASS
- [x] `cargo build` — clean (5 expected dead-code warnings for scaffolding not yet wired up)
- [x] `cargo clippy --lib -- -D warnings` — clean
- [x] Manual smoke not applicable — no UI surface in this PR

## Notes for reviewers

- `pub active_bucket` / `pub active_tool` are intentionally `pub` per the v0.32.0 spec. Invariant `active_bucket == active_tool.bucket()` is preserved by `select()`; direct field assignment is permitted as an explicit escape hatch. Future hub work that wants invariant enforcement can wrap calls in a `select_*` helper without breaking this API.
- `SidebarState` is `Clone` (not `Copy`) per spec — future callers that need cheap copies can revisit.