### PR TITLE
docs(ux): v0.32.0–v0.35.5 TUI redesign — spec + 8 phase plans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ __pycache__/
 .env
 .env.*
 !.env.example
+
+.superpowers/

--- a/docs/superpowers/plans/2026-05-21-insights-hub-v0.33.0.md
+++ b/docs/superpowers/plans/2026-05-21-insights-hub-v0.33.0.md
@@ -1,0 +1,429 @@
+# Insights Hub (v0.33.0) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Merge five read-only dashboards (Cost / Tokens / TurboQuant / Agent Graph / Project Stats) into a single tabbed `InsightsHub` screen behind `behavior.new_ux=true`. Smallest blast radius migration phase.
+
+**Architecture:** A new `InsightsHub` screen exposes 5 tabs through the `TabsModel` trait introduced in v0.32.0. Each existing dashboard's draw body is reused — only the outer chrome moves to the hub. Legacy `TuiMode::CostDashboard`/`TokenDashboard`/`TurboquantDashboard`/`AgentGraph`/`DependencyGraph` are marked `#[deprecated]` after migration (removed in v0.35.5).
+
+**Tech Stack:** ratatui · insta. Depends on v0.32.0 chrome + Screen-trait `tabs()`.
+
+**Spec:** `docs/superpowers/specs/2026-05-21-tui-ux-redesign-sidebar-ia-design.md` — Section 3 (Insights bucket), Section 5 (chrome).
+
+---
+
+### Task 1 (UX-1-01): InsightsHub scaffold + 5 tab routes
+
+**Files:**
+- Create: `src/tui/screens/insights/mod.rs`, `src/tui/screens/insights/draw.rs`, `src/tui/screens/insights/tabs.rs`
+- Modify: `src/tui/screens/mod.rs` (export)
+- Test: `src/tui/snapshot_tests/insights_hub.rs`
+
+- [ ] **Step 1: Failing snapshot test**
+
+```rust
+use insta::assert_snapshot;
+use ratatui::{Terminal, backend::TestBackend};
+use crate::tui::screens::insights::{InsightsHub, InsightsTab};
+use crate::tui::theme::Theme;
+
+fn render(tab: InsightsTab) -> Terminal<TestBackend> {
+    let mut t = Terminal::new(TestBackend::new(120, 30)).unwrap();
+    let theme = Theme::dark();
+    let mut hub = InsightsHub::new();
+    hub.set_active(tab);
+    t.draw(|f| hub.draw_for_test(f, f.area(), &theme)).unwrap();
+    t
+}
+
+#[test] fn cost_tab() { let t = render(InsightsTab::Cost); assert_snapshot!(t.backend()); }
+#[test] fn tokens_tab() { let t = render(InsightsTab::Tokens); assert_snapshot!(t.backend()); }
+#[test] fn turboquant_tab() { let t = render(InsightsTab::Turboquant); assert_snapshot!(t.backend()); }
+#[test] fn agents_tab() { let t = render(InsightsTab::Agents); assert_snapshot!(t.backend()); }
+#[test] fn stats_tab() { let t = render(InsightsTab::Stats); assert_snapshot!(t.backend()); }
+```
+
+Add `pub mod insights_hub;` to `src/tui/snapshot_tests/mod.rs`.
+
+- [ ] **Step 2: Confirm fail**
+
+Run: `cargo test --lib tui::snapshot_tests::insights_hub`
+Expected: compile error.
+
+- [ ] **Step 3: Implement Hub skeleton with empty bodies**
+
+`src/tui/screens/insights/mod.rs`:
+
+```rust
+pub mod draw;
+pub mod tabs;
+
+use crossterm::event::{Event, KeyCode};
+use ratatui::{Frame, layout::Rect};
+use crate::tui::navigation::InputMode;
+use crate::tui::navigation::keymap::KeymapProvider;
+use crate::tui::screens::{Screen, ScreenAction, TabsModel};
+use crate::tui::theme::Theme;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum InsightsTab { Cost, Tokens, Turboquant, Agents, Stats }
+
+const TABS: &[&str] = &["Cost", "Tokens", "TurboQuant", "Agent Graph", "Project Stats"];
+
+pub struct InsightsHub { pub active: InsightsTab }
+
+impl InsightsHub {
+    pub fn new() -> Self { Self { active: InsightsTab::Cost } }
+    pub fn set_active(&mut self, t: InsightsTab) { self.active = t; }
+    pub fn draw_for_test(&mut self, f: &mut Frame, area: Rect, theme: &Theme) {
+        draw::draw_hub(f, area, theme, self);
+    }
+}
+
+impl TabsModel for InsightsHub {
+    fn tabs(&self) -> &[&'static str] { TABS }
+    fn active(&self) -> usize {
+        match self.active {
+            InsightsTab::Cost => 0, InsightsTab::Tokens => 1, InsightsTab::Turboquant => 2,
+            InsightsTab::Agents => 3, InsightsTab::Stats => 4,
+        }
+    }
+    fn select(&mut self, idx: usize) {
+        self.active = match idx { 0 => InsightsTab::Cost, 1 => InsightsTab::Tokens,
+            2 => InsightsTab::Turboquant, 3 => InsightsTab::Agents, _ => InsightsTab::Stats };
+    }
+}
+
+impl KeymapProvider for InsightsHub {
+    fn keymap_bindings(&self) -> Vec<(&'static str, &'static str)> {
+        vec![("Tab", "Next tab"), ("Shift+Tab", "Prev tab"), ("1..5", "Jump tab")]
+    }
+}
+
+impl Screen for InsightsHub {
+    fn handle_input(&mut self, e: &Event, _m: InputMode) -> ScreenAction {
+        if let Event::Key(k) = e {
+            if let KeyCode::Char(c @ '1'..='5') = k.code {
+                self.select((c as u8 - b'1') as usize);
+            }
+        }
+        ScreenAction::None
+    }
+    fn draw(&mut self, f: &mut Frame, area: Rect, theme: &Theme) { draw::draw_hub(f, area, theme, self); }
+    fn tabs(&self) -> Option<&dyn TabsModel> { Some(self) }
+    fn breadcrumb(&self) -> &'static str { "Insights" }
+    fn footer_hints(&self) -> Vec<(&'static str, &'static str)> { self.keymap_bindings() }
+}
+```
+
+`src/tui/screens/insights/draw.rs`:
+
+```rust
+use ratatui::{Frame, layout::{Constraint, Direction, Layout, Rect}, style::{Modifier, Style},
+              text::{Line, Span}, widgets::Paragraph};
+use crate::tui::screens::insights::{InsightsHub, InsightsTab, TABS};
+use crate::tui::screens::TabsModel;
+use crate::tui::theme::Theme;
+
+pub fn draw_hub(f: &mut Frame, area: Rect, theme: &Theme, hub: &InsightsHub) {
+    let rows = Layout::default().direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Min(1)]).split(area);
+    draw_tabs_strip(f, rows[0], hub.active(), theme);
+    let body = rows[1];
+    match hub.active {
+        InsightsTab::Cost => f.render_widget(Paragraph::new("[Cost tab — body filled by UX-1-02]"), body),
+        InsightsTab::Tokens => f.render_widget(Paragraph::new("[Tokens tab — body filled by UX-1-03]"), body),
+        InsightsTab::Turboquant => f.render_widget(Paragraph::new("[TurboQuant tab — body filled by UX-1-04]"), body),
+        InsightsTab::Agents => f.render_widget(Paragraph::new("[Agents tab — body filled by UX-1-05]"), body),
+        InsightsTab::Stats => f.render_widget(Paragraph::new("[Stats tab — body filled by UX-1-06]"), body),
+    }
+}
+
+fn draw_tabs_strip(f: &mut Frame, area: Rect, active_idx: usize, _theme: &Theme) {
+    let spans: Vec<Span> = TABS.iter().enumerate().flat_map(|(i, label)| {
+        let style = if i == active_idx { Style::default().add_modifier(Modifier::REVERSED) } else { Style::default() };
+        vec![Span::styled(format!(" {} ", label), style), Span::raw(" ▎ ")]
+    }).collect();
+    f.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+```
+
+Export from `src/tui/screens/mod.rs`: `pub mod insights;` + `pub use insights::InsightsHub;`.
+
+- [ ] **Step 4: Accept snapshots**
+
+```
+cargo test --lib tui::snapshot_tests::insights_hub
+cargo insta accept
+cargo test --lib tui::snapshot_tests::insights_hub
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/screens/insights/ src/tui/screens/mod.rs \
+        src/tui/snapshot_tests/insights_hub.rs src/tui/snapshot_tests/mod.rs \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "feat(tui): InsightsHub scaffold + 5 tabs (UX-1-01)"
+```
+
+---
+
+### Task 2 (UX-1-02): Migrate CostDashboard body → Cost tab
+
+**Files:**
+- Modify: `src/tui/cost_dashboard.rs` (extract draw body into a reusable `fn draw_cost_body(f, area, theme, &CostState)`)
+- Create: `src/tui/screens/insights/cost.rs` (calls `draw_cost_body`)
+- Modify: `src/tui/screens/insights/draw.rs` (Cost arm calls into new module)
+
+- [ ] **Step 1: Locate current draw body**
+
+Run: `grep -n "fn draw" src/tui/cost_dashboard.rs` to find the existing draw entry point.
+
+- [ ] **Step 2: Extract `draw_cost_body`**
+
+In `src/tui/cost_dashboard.rs`, extract the inner body into a free fn:
+
+```rust
+pub fn draw_cost_body(f: &mut ratatui::Frame, area: ratatui::layout::Rect, theme: &crate::tui::theme::Theme, state: &CostState) {
+    // existing body moved here verbatim
+}
+```
+
+`src/tui/screens/insights/cost.rs`:
+
+```rust
+use ratatui::{Frame, layout::Rect};
+use crate::tui::cost_dashboard::{CostState, draw_cost_body};
+use crate::tui::theme::Theme;
+
+pub fn draw(f: &mut Frame, area: Rect, theme: &Theme, state: &CostState) {
+    draw_cost_body(f, area, theme, state);
+}
+```
+
+In `src/tui/screens/insights/draw.rs` Cost arm:
+
+```rust
+InsightsTab::Cost => crate::tui::screens::insights::cost::draw(f, body, theme, &app_cost_state()),
+```
+
+(For test purposes, accept a `CostState::default()` injected on the hub.)
+
+- [ ] **Step 3: Update hub to carry state**
+
+Add to `InsightsHub`: `pub cost_state: CostState` (uses Default impl on `CostState`).
+
+- [ ] **Step 4: Refresh snapshot**
+
+```
+cargo test --lib tui::snapshot_tests::insights_hub::cost_tab
+cargo insta accept
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/cost_dashboard.rs src/tui/screens/insights/ \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "refactor(tui): CostDashboard body → InsightsHub::Cost (UX-1-02)"
+```
+
+---
+
+### Task 3 (UX-1-03): Migrate TokenDashboard body → Tokens tab
+
+Same shape as Task 2. Apply to `src/tui/token_dashboard.rs`.
+
+- [ ] **Step 1:** Locate draw body in `token_dashboard.rs`.
+- [ ] **Step 2:** Extract `draw_token_body(f, area, theme, &TokenState)`.
+- [ ] **Step 3:** Create `src/tui/screens/insights/tokens.rs` and wire from `draw.rs` Tokens arm.
+- [ ] **Step 4:** Refresh snapshot:
+
+```
+cargo test --lib tui::snapshot_tests::insights_hub::tokens_tab
+cargo insta accept
+```
+
+- [ ] **Step 5:** Commit:
+
+```bash
+git add src/tui/token_dashboard.rs src/tui/screens/insights/ \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "refactor(tui): TokenDashboard body → InsightsHub::Tokens (UX-1-03)"
+```
+
+---
+
+### Task 4 (UX-1-04): Migrate TurboquantDashboard body → TurboQuant tab
+
+Same shape. Apply to `src/tui/turboquant_dashboard.rs`.
+
+- [ ] **Step 1:** Locate draw body.
+- [ ] **Step 2:** Extract `draw_turboquant_body(f, area, theme, &TurboquantState)`.
+- [ ] **Step 3:** Create `src/tui/screens/insights/turboquant.rs` and wire.
+- [ ] **Step 4:** Refresh snapshot:
+
+```
+cargo test --lib tui::snapshot_tests::insights_hub::turboquant_tab
+cargo insta accept
+```
+
+- [ ] **Step 5:** Commit:
+
+```bash
+git add src/tui/turboquant_dashboard.rs src/tui/screens/insights/ \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "refactor(tui): TurboquantDashboard body → InsightsHub::TurboQuant (UX-1-04)"
+```
+
+---
+
+### Task 5 (UX-1-05): Merge AgentGraph + DependencyGraph → Agents tab with sub-toggle
+
+**Files:**
+- Modify: `src/tui/agent_graph/`, `src/tui/dep_graph.rs`
+- Create: `src/tui/screens/insights/agents.rs`
+
+- [ ] **Step 1: Failing test for the sub-toggle**
+
+```rust
+#[test]
+fn agents_tab_subtoggle_switches_view() {
+    use crate::tui::screens::insights::{InsightsHub, InsightsTab};
+    use crate::tui::screens::insights::agents::AgentSubview;
+    let mut hub = InsightsHub::new();
+    hub.set_active(InsightsTab::Agents);
+    hub.agents_subview = AgentSubview::Bipartite;
+    assert_eq!(hub.agents_subview, AgentSubview::Bipartite);
+    hub.agents_subview = AgentSubview::Dependency;
+    assert_eq!(hub.agents_subview, AgentSubview::Dependency);
+}
+```
+
+- [ ] **Step 2: Add sub-toggle state**
+
+`src/tui/screens/insights/agents.rs`:
+
+```rust
+use ratatui::{Frame, layout::Rect};
+use crate::tui::theme::Theme;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum AgentSubview { Bipartite, Dependency }
+
+pub fn draw(f: &mut Frame, area: Rect, theme: &Theme, sub: AgentSubview) {
+    match sub {
+        AgentSubview::Bipartite => crate::tui::agent_graph::draw_bipartite(f, area, theme),
+        AgentSubview::Dependency => crate::tui::dep_graph::draw_dep_graph(f, area, theme),
+    }
+}
+```
+
+Add to `InsightsHub`: `pub agents_subview: AgentSubview` (default Bipartite).
+
+In `draw.rs` Agents arm: `crate::tui::screens::insights::agents::draw(f, body, theme, hub.agents_subview);`
+
+- [ ] **Step 3: Extract `draw_bipartite` and `draw_dep_graph`** as free fns from existing screens.
+
+- [ ] **Step 4: Refresh snapshot**
+
+```
+cargo test --lib tui::snapshot_tests::insights_hub::agents_tab
+cargo insta accept
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/agent_graph/ src/tui/dep_graph.rs src/tui/screens/insights/agents.rs \
+        src/tui/screens/insights/ src/tui/snapshot_tests/snapshots/
+git commit -m "refactor(tui): AgentGraph + DependencyGraph → Agents tab with sub-toggle (UX-1-05)"
+```
+
+---
+
+### Task 6 (UX-1-06): Migrate ProjectStats body → Stats tab
+
+Same shape as Task 2.
+
+- [ ] **Step 1:** Locate draw body in `src/tui/screens/project_stats/`.
+- [ ] **Step 2:** Extract `draw_project_stats_body`.
+- [ ] **Step 3:** Create `src/tui/screens/insights/stats.rs` and wire.
+- [ ] **Step 4:** Refresh snapshot:
+
+```
+cargo test --lib tui::snapshot_tests::insights_hub::stats_tab
+cargo insta accept
+```
+
+- [ ] **Step 5:** Commit:
+
+```bash
+git add src/tui/screens/project_stats/ src/tui/screens/insights/ \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "refactor(tui): ProjectStats → InsightsHub::Stats (UX-1-06)"
+```
+
+---
+
+### Task 7 (UX-1-07): Mark 5 legacy TuiMode variants `#[deprecated]`
+
+**Files:**
+- Modify: `src/tui/app/types.rs`
+
+- [ ] **Step 1: Add deprecation annotations**
+
+```rust
+pub enum TuiMode {
+    // ... other variants ...
+    #[deprecated(note = "Use InsightsHub via behavior.new_ux=true")]
+    CostDashboard,
+    #[deprecated(note = "Use InsightsHub via behavior.new_ux=true")]
+    TokenDashboard,
+    #[deprecated(note = "Use InsightsHub via behavior.new_ux=true")]
+    TurboquantDashboard,
+    #[deprecated(note = "Use InsightsHub via behavior.new_ux=true")]
+    AgentGraph,
+    #[deprecated(note = "Use InsightsHub via behavior.new_ux=true")]
+    DependencyGraph,
+    // ...
+}
+```
+
+- [ ] **Step 2: Add `#[allow(deprecated)]` where legacy dispatcher still uses them**
+
+In `src/tui/ui.rs` (legacy branch) and `src/tui/screen_dispatch.rs`, add `#[allow(deprecated)]` at function-level where these variants are still matched.
+
+- [ ] **Step 3: Build clean (no new warnings under `cargo build`)**
+
+Run: `cargo build 2>&1 | rg "deprecated"`
+Expected: 0 unexpected hits.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/tui/app/types.rs src/tui/ui.rs src/tui/screen_dispatch.rs
+git commit -m "chore(tui): deprecate 5 legacy insights TuiMode variants (UX-1-07)"
+```
+
+---
+
+## Milestone Dependency Graph
+
+```
+Level 0:
+• UX-1-01 scaffold (depends on v0.32.0 UX-0-11)
+
+Level 1 (parallel):
+• UX-1-02 Cost
+• UX-1-03 Tokens
+• UX-1-04 TurboQuant
+• UX-1-05 Agents
+• UX-1-06 Stats
+
+Level 2:
+• UX-1-07 deprecate (depends on Level 1)
+
+Sequence: UX-1-01 → (UX-1-02 ∥ UX-1-03 ∥ UX-1-04 ∥ UX-1-05 ∥ UX-1-06) → UX-1-07
+```

--- a/docs/superpowers/plans/2026-05-21-plan-hub-v0.34.0.md
+++ b/docs/superpowers/plans/2026-05-21-plan-hub-v0.34.0.md
@@ -1,0 +1,286 @@
+# Plan Hub (v0.34.0) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans.
+
+**Goal:** Group planning tools — Issues / Milestones / Roadmap / PRD — into a single `PlanHub` with tabs. Milestones tab nests sub-tabs (List / Health).
+
+**Architecture:** Same hub pattern as InsightsHub and RunHub. Wizards (Issue, Milestone) stay as modals launched from each tab via key bindings; depends on v0.32.5 wizard spine for re-entrance.
+
+**Tech Stack:** ratatui · insta. Depends on v0.32.0 chrome + v0.32.5 wizard spine.
+
+**Spec:** Section 3 (Plan bucket).
+
+---
+
+### Task 1 (UX-3-01): PlanHub scaffold + 4 tabs
+
+**Files:**
+- Create: `src/tui/screens/plan/mod.rs`, `src/tui/screens/plan/draw.rs`
+- Modify: `src/tui/screens/mod.rs`
+- Test: `src/tui/snapshot_tests/plan_hub.rs`
+
+- [ ] **Step 1: Failing snapshot per tab**
+
+```rust
+use insta::assert_snapshot;
+use ratatui::{Terminal, backend::TestBackend};
+use crate::tui::screens::plan::{PlanHub, PlanTab};
+use crate::tui::theme::Theme;
+
+fn render(tab: PlanTab) -> Terminal<TestBackend> {
+    let mut t = Terminal::new(TestBackend::new(120, 30)).unwrap();
+    let theme = Theme::dark();
+    let mut hub = PlanHub::new();
+    hub.set_active(tab);
+    t.draw(|f| hub.draw_for_test(f, f.area(), &theme)).unwrap();
+    t
+}
+
+#[test] fn issues_tab() { let t = render(PlanTab::Issues); assert_snapshot!(t.backend()); }
+#[test] fn milestones_tab() { let t = render(PlanTab::Milestones); assert_snapshot!(t.backend()); }
+#[test] fn roadmap_tab() { let t = render(PlanTab::Roadmap); assert_snapshot!(t.backend()); }
+#[test] fn prd_tab() { let t = render(PlanTab::Prd); assert_snapshot!(t.backend()); }
+```
+
+Add `pub mod plan_hub;` in `src/tui/snapshot_tests/mod.rs`.
+
+- [ ] **Step 2: Confirm fail**
+
+- [ ] **Step 3: Implement skeleton**
+
+`src/tui/screens/plan/mod.rs`:
+
+```rust
+pub mod draw;
+
+use crossterm::event::{Event, KeyCode};
+use ratatui::{Frame, layout::Rect};
+use crate::tui::navigation::InputMode;
+use crate::tui::navigation::keymap::KeymapProvider;
+use crate::tui::screens::{Screen, ScreenAction, TabsModel};
+use crate::tui::theme::Theme;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PlanTab { Issues, Milestones, Roadmap, Prd }
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum MilestonesSubTab { List, Health }
+
+const TABS: &[&str] = &["Issues", "Milestones", "Roadmap", "PRD"];
+
+pub struct PlanHub {
+    pub active: PlanTab,
+    pub milestones_subtab: MilestonesSubTab,
+}
+
+impl PlanHub {
+    pub fn new() -> Self { Self { active: PlanTab::Issues, milestones_subtab: MilestonesSubTab::List } }
+    pub fn set_active(&mut self, t: PlanTab) { self.active = t; }
+    pub fn draw_for_test(&mut self, f: &mut Frame, area: Rect, theme: &Theme) {
+        draw::draw_hub(f, area, theme, self);
+    }
+}
+
+impl TabsModel for PlanHub {
+    fn tabs(&self) -> &[&'static str] { TABS }
+    fn active(&self) -> usize { match self.active {
+        PlanTab::Issues => 0, PlanTab::Milestones => 1, PlanTab::Roadmap => 2, PlanTab::Prd => 3 } }
+    fn select(&mut self, idx: usize) {
+        self.active = match idx { 0 => PlanTab::Issues, 1 => PlanTab::Milestones,
+            2 => PlanTab::Roadmap, _ => PlanTab::Prd };
+    }
+}
+
+impl KeymapProvider for PlanHub {
+    fn keymap_bindings(&self) -> Vec<(&'static str, &'static str)> {
+        vec![("Tab", "Next tab"), ("n", "New issue/milestone"), ("/", "Search")]
+    }
+}
+
+impl Screen for PlanHub {
+    fn handle_input(&mut self, e: &Event, _m: InputMode) -> ScreenAction {
+        if let Event::Key(k) = e {
+            if let KeyCode::Char(c @ '1'..='4') = k.code {
+                self.select((c as u8 - b'1') as usize);
+            }
+        }
+        ScreenAction::None
+    }
+    fn draw(&mut self, f: &mut Frame, area: Rect, theme: &Theme) { draw::draw_hub(f, area, theme, self); }
+    fn tabs(&self) -> Option<&dyn TabsModel> { Some(self) }
+    fn breadcrumb(&self) -> &'static str { "Plan" }
+    fn footer_hints(&self) -> Vec<(&'static str, &'static str)> { self.keymap_bindings() }
+}
+```
+
+`src/tui/screens/plan/draw.rs`:
+
+```rust
+use ratatui::{Frame, layout::{Constraint, Direction, Layout, Rect}, style::{Modifier, Style},
+              text::{Line, Span}, widgets::Paragraph};
+use crate::tui::screens::plan::{PlanHub, PlanTab, TABS};
+use crate::tui::screens::TabsModel;
+use crate::tui::theme::Theme;
+
+pub fn draw_hub(f: &mut Frame, area: Rect, theme: &Theme, hub: &PlanHub) {
+    let rows = Layout::default().direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Min(1)]).split(area);
+    let spans: Vec<Span> = TABS.iter().enumerate().flat_map(|(i, l)| {
+        let s = if i == hub.active() { Style::default().add_modifier(Modifier::REVERSED) } else { Style::default() };
+        vec![Span::styled(format!(" {} ", l), s), Span::raw(" ▎ ")]
+    }).collect();
+    f.render_widget(Paragraph::new(Line::from(spans)), rows[0]);
+
+    let body = rows[1];
+    match hub.active {
+        PlanTab::Issues => f.render_widget(Paragraph::new("[Issues — UX-3-02]"), body),
+        PlanTab::Milestones => f.render_widget(Paragraph::new("[Milestones — UX-3-03]"), body),
+        PlanTab::Roadmap => f.render_widget(Paragraph::new("[Roadmap — UX-3-04]"), body),
+        PlanTab::Prd => f.render_widget(Paragraph::new("[PRD — UX-3-05]"), body),
+    }
+}
+```
+
+Export from `src/tui/screens/mod.rs`.
+
+- [ ] **Step 4: Accept snapshots**
+
+```
+cargo test --lib tui::snapshot_tests::plan_hub
+cargo insta accept
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/screens/plan/ src/tui/screens/mod.rs \
+        src/tui/snapshot_tests/plan_hub.rs src/tui/snapshot_tests/mod.rs \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "feat(tui): PlanHub scaffold + 4 tabs (UX-3-01)"
+```
+
+---
+
+### Task 2 (UX-3-02): IssueBrowser body → Issues tab; IssueWizard remains modal
+
+**Files:**
+- Modify: `src/tui/screens/issue_browser/`
+- Create: `src/tui/screens/plan/issues.rs`
+
+- [ ] **Step 1: Failing snapshot for the Issues tab body with a sample list**
+
+- [ ] **Step 2: Extract `draw_issue_browser_body(f, area, theme, &IssueBrowserState)`** from `src/tui/screens/issue_browser/` and call it from `src/tui/screens/plan/issues.rs`.
+
+- [ ] **Step 3: Wire `PlanTab::Issues` arm in `draw.rs`.**
+
+- [ ] **Step 4: Wire `n` key to push IssueWizard modal** via v0.32.5 wizard frame.
+
+- [ ] **Step 5: Accept snapshot + commit**
+
+```bash
+git add src/tui/screens/issue_browser/ src/tui/screens/plan/ \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "feat(tui): Issues tab + IssueWizard modal (UX-3-02)"
+```
+
+---
+
+### Task 3 (UX-3-03): Milestones tab with List/Health sub-tabs
+
+**Files:**
+- Modify: `src/tui/screens/milestone.rs`, `src/tui/screens/milestone_health/`
+- Create: `src/tui/screens/plan/milestones.rs`
+
+- [ ] **Step 1: Failing snapshot tests for both sub-tabs**
+
+```rust
+#[test]
+fn milestones_subtab_list() { /* set hub.milestones_subtab = MilestonesSubTab::List; snapshot */ }
+#[test]
+fn milestones_subtab_health() { /* set hub.milestones_subtab = MilestonesSubTab::Health; snapshot */ }
+```
+
+- [ ] **Step 2: Extract `draw_milestone_list_body` from `milestone.rs` and `draw_milestone_health_body` from `milestone_health/`.**
+
+- [ ] **Step 3: In `plan/draw.rs` Milestones arm, split body horizontally into sub-tab strip + content**:
+
+```rust
+PlanTab::Milestones => {
+    let inner = ratatui::layout::Layout::default().direction(ratatui::layout::Direction::Vertical)
+        .constraints([ratatui::layout::Constraint::Length(1), ratatui::layout::Constraint::Min(1)]).split(body);
+    // sub-tab strip: "List" "Health"
+    // body content based on hub.milestones_subtab
+}
+```
+
+- [ ] **Step 4: Wire `m` key to push MilestoneWizard modal.**
+
+- [ ] **Step 5: Accept + commit**
+
+```bash
+git add src/tui/screens/milestone.rs src/tui/screens/milestone_health/ \
+        src/tui/screens/plan/milestones.rs src/tui/screens/plan/draw.rs \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "feat(tui): Milestones tab with List/Health sub-tabs (UX-3-03)"
+```
+
+---
+
+### Task 4 (UX-3-04): Roadmap body → Roadmap tab
+
+**Files:**
+- Modify: `src/tui/screens/roadmap/`
+- Create: `src/tui/screens/plan/roadmap.rs`
+
+- [ ] **Step 1: Failing snapshot for the Roadmap tab.**
+
+- [ ] **Step 2: Extract `draw_roadmap_body(f, area, theme, &RoadmapState)` from existing roadmap screen.**
+
+- [ ] **Step 3: Create `src/tui/screens/plan/roadmap.rs` calling it. Wire `PlanTab::Roadmap`.**
+
+- [ ] **Step 4: Accept snapshot + commit**
+
+```bash
+git add src/tui/screens/roadmap/ src/tui/screens/plan/roadmap.rs src/tui/screens/plan/draw.rs \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "feat(tui): Roadmap tab (UX-3-04)"
+```
+
+---
+
+### Task 5 (UX-3-05): PRD body → PRD tab
+
+**Files:**
+- Modify: `src/tui/screens/prd/`
+- Create: `src/tui/screens/plan/prd.rs`
+
+- [ ] **Step 1: Failing snapshot for PRD tab.**
+
+- [ ] **Step 2: Extract `draw_prd_body(f, area, theme, &PrdState)`.**
+
+- [ ] **Step 3: Wire `PlanTab::Prd` arm.**
+
+- [ ] **Step 4: Accept snapshot + commit**
+
+```bash
+git add src/tui/screens/prd/ src/tui/screens/plan/prd.rs src/tui/screens/plan/draw.rs \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "feat(tui): PRD tab (UX-3-05)"
+```
+
+---
+
+## Milestone Dependency Graph
+
+```
+Level 0:
+• UX-3-01 scaffold (depends on v0.32.0 UX-0-11)
+
+Level 1 (parallel):
+• UX-3-02 Issues (also depends on v0.32.5 UX-0a-03)
+• UX-3-03 Milestones (also depends on v0.32.5 UX-0a-04)
+• UX-3-04 Roadmap
+• UX-3-05 PRD
+
+Sequence: UX-3-01 → (UX-3-02 ∥ UX-3-03 ∥ UX-3-04 ∥ UX-3-05)
+```

--- a/docs/superpowers/plans/2026-05-21-review-hub-v0.34.5.md
+++ b/docs/superpowers/plans/2026-05-21-review-hub-v0.34.5.md
@@ -1,0 +1,229 @@
+# Review Hub (v0.34.5) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans.
+
+**Goal:** Group review tools — PRs / CI Errors / Release Notes — into a single `ReviewHub` with tabs. CI tab uses `GateOutputViewer` as drilldown.
+
+**Architecture:** Same hub pattern. PRs tab is default. CI Errors and Release Notes follow.
+
+**Tech Stack:** ratatui · insta. Depends on v0.32.0 chrome.
+
+**Spec:** Section 3 (Review bucket).
+
+---
+
+### Task 1 (UX-4-01): ReviewHub scaffold + 3 tabs
+
+**Files:**
+- Create: `src/tui/screens/review/mod.rs`, `src/tui/screens/review/draw.rs`
+- Modify: `src/tui/screens/mod.rs`
+- Test: `src/tui/snapshot_tests/review_hub.rs`
+
+- [ ] **Step 1: Failing snapshot test per tab**
+
+```rust
+use insta::assert_snapshot;
+use ratatui::{Terminal, backend::TestBackend};
+use crate::tui::screens::review::{ReviewHub, ReviewTab};
+use crate::tui::theme::Theme;
+
+fn render(tab: ReviewTab) -> Terminal<TestBackend> {
+    let mut t = Terminal::new(TestBackend::new(120, 30)).unwrap();
+    let theme = Theme::dark();
+    let mut hub = ReviewHub::new();
+    hub.set_active(tab);
+    t.draw(|f| hub.draw_for_test(f, f.area(), &theme)).unwrap();
+    t
+}
+
+#[test] fn prs_tab() { let t = render(ReviewTab::Prs); assert_snapshot!(t.backend()); }
+#[test] fn ci_tab() { let t = render(ReviewTab::Ci); assert_snapshot!(t.backend()); }
+#[test] fn releases_tab() { let t = render(ReviewTab::Releases); assert_snapshot!(t.backend()); }
+```
+
+Add `pub mod review_hub;` in `src/tui/snapshot_tests/mod.rs`.
+
+- [ ] **Step 2: Confirm fail**
+
+- [ ] **Step 3: Implement skeleton**
+
+`src/tui/screens/review/mod.rs`:
+
+```rust
+pub mod draw;
+
+use crossterm::event::{Event, KeyCode};
+use ratatui::{Frame, layout::Rect};
+use crate::tui::navigation::InputMode;
+use crate::tui::navigation::keymap::KeymapProvider;
+use crate::tui::screens::{Screen, ScreenAction, TabsModel};
+use crate::tui::theme::Theme;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ReviewTab { Prs, Ci, Releases }
+
+const TABS: &[&str] = &["PRs", "CI Errors", "Release Notes"];
+
+pub struct ReviewHub { pub active: ReviewTab }
+
+impl ReviewHub {
+    pub fn new() -> Self { Self { active: ReviewTab::Prs } }
+    pub fn set_active(&mut self, t: ReviewTab) { self.active = t; }
+    pub fn draw_for_test(&mut self, f: &mut Frame, area: Rect, theme: &Theme) {
+        draw::draw_hub(f, area, theme, self);
+    }
+}
+
+impl TabsModel for ReviewHub {
+    fn tabs(&self) -> &[&'static str] { TABS }
+    fn active(&self) -> usize { match self.active {
+        ReviewTab::Prs => 0, ReviewTab::Ci => 1, ReviewTab::Releases => 2 } }
+    fn select(&mut self, idx: usize) {
+        self.active = match idx { 0 => ReviewTab::Prs, 1 => ReviewTab::Ci, _ => ReviewTab::Releases };
+    }
+}
+
+impl KeymapProvider for ReviewHub {
+    fn keymap_bindings(&self) -> Vec<(&'static str, &'static str)> {
+        vec![("Tab", "Next tab"), ("Enter", "Open"), ("r", "Refresh")]
+    }
+}
+
+impl Screen for ReviewHub {
+    fn handle_input(&mut self, e: &Event, _m: InputMode) -> ScreenAction {
+        if let Event::Key(k) = e {
+            if let KeyCode::Char(c @ '1'..='3') = k.code {
+                self.select((c as u8 - b'1') as usize);
+            }
+        }
+        ScreenAction::None
+    }
+    fn draw(&mut self, f: &mut Frame, area: Rect, theme: &Theme) { draw::draw_hub(f, area, theme, self); }
+    fn tabs(&self) -> Option<&dyn TabsModel> { Some(self) }
+    fn breadcrumb(&self) -> &'static str { "Review" }
+    fn footer_hints(&self) -> Vec<(&'static str, &'static str)> { self.keymap_bindings() }
+}
+```
+
+`src/tui/screens/review/draw.rs`:
+
+```rust
+use ratatui::{Frame, layout::{Constraint, Direction, Layout, Rect}, style::{Modifier, Style},
+              text::{Line, Span}, widgets::Paragraph};
+use crate::tui::screens::review::{ReviewHub, ReviewTab, TABS};
+use crate::tui::screens::TabsModel;
+use crate::tui::theme::Theme;
+
+pub fn draw_hub(f: &mut Frame, area: Rect, theme: &Theme, hub: &ReviewHub) {
+    let rows = Layout::default().direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Min(1)]).split(area);
+    let spans: Vec<Span> = TABS.iter().enumerate().flat_map(|(i, l)| {
+        let s = if i == hub.active() { Style::default().add_modifier(Modifier::REVERSED) } else { Style::default() };
+        vec![Span::styled(format!(" {} ", l), s), Span::raw(" ▎ ")]
+    }).collect();
+    f.render_widget(Paragraph::new(Line::from(spans)), rows[0]);
+
+    let body = rows[1];
+    match hub.active {
+        ReviewTab::Prs => f.render_widget(Paragraph::new("[PRs — UX-4-02]"), body),
+        ReviewTab::Ci => f.render_widget(Paragraph::new("[CI — UX-4-03]"), body),
+        ReviewTab::Releases => f.render_widget(Paragraph::new("[Releases — UX-4-04]"), body),
+    }
+}
+```
+
+Export from `src/tui/screens/mod.rs`.
+
+- [ ] **Step 4: Accept snapshots + commit**
+
+```bash
+cargo test --lib tui::snapshot_tests::review_hub
+cargo insta accept
+git add src/tui/screens/review/ src/tui/screens/mod.rs \
+        src/tui/snapshot_tests/review_hub.rs src/tui/snapshot_tests/mod.rs \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "feat(tui): ReviewHub scaffold + 3 tabs (UX-4-01)"
+```
+
+---
+
+### Task 2 (UX-4-02): PrReview body → PRs tab
+
+**Files:**
+- Modify: `src/tui/screens/pr_review/`
+- Create: `src/tui/screens/review/prs.rs`
+
+- [ ] **Step 1: Failing snapshot for the PRs tab body.**
+
+- [ ] **Step 2: Extract `draw_pr_review_body(f, area, theme, &PrReviewState)` from existing PR review screen.**
+
+- [ ] **Step 3: Wire `ReviewTab::Prs` arm.**
+
+- [ ] **Step 4: Accept + commit**
+
+```bash
+git add src/tui/screens/pr_review/ src/tui/screens/review/prs.rs src/tui/screens/review/draw.rs \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "feat(tui): PRs tab (UX-4-02)"
+```
+
+---
+
+### Task 3 (UX-4-03): CiErrorReview body → CI tab; GateOutputViewer drilldown
+
+**Files:**
+- Modify: `src/tui/screens/ci_error_review.rs`, `src/tui/screens/gate_output_viewer.rs`
+- Create: `src/tui/screens/review/ci.rs`
+
+- [ ] **Step 1: Failing snapshot for CI tab.**
+
+- [ ] **Step 2: Extract `draw_ci_body(f, area, theme, &CiState)`.**
+
+- [ ] **Step 3: On Enter in CI tab, push `GateOutputViewer` as a screen via `ScreenAction::Push(TuiMode::GateOutputViewer(...))`.**
+
+- [ ] **Step 4: Accept + commit**
+
+```bash
+git add src/tui/screens/ci_error_review.rs src/tui/screens/gate_output_viewer.rs \
+        src/tui/screens/review/ci.rs src/tui/screens/review/draw.rs \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "feat(tui): CI tab + GateOutputViewer drilldown (UX-4-03)"
+```
+
+---
+
+### Task 4 (UX-4-04): ReleaseNotes body → Releases tab
+
+**Files:**
+- Modify: `src/tui/screens/release_notes/`
+- Create: `src/tui/screens/review/releases.rs`
+
+- [ ] **Step 1: Failing snapshot for Releases tab.**
+
+- [ ] **Step 2: Extract `draw_release_notes_body(f, area, theme, &ReleaseNotesState)`.**
+
+- [ ] **Step 3: Wire `ReviewTab::Releases`.**
+
+- [ ] **Step 4: Accept + commit**
+
+```bash
+git add src/tui/screens/release_notes/ src/tui/screens/review/releases.rs src/tui/screens/review/draw.rs \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "feat(tui): Releases tab (UX-4-04)"
+```
+
+---
+
+## Milestone Dependency Graph
+
+```
+Level 0:
+• UX-4-01 scaffold (depends on v0.32.0 UX-0-11)
+
+Level 1 (parallel):
+• UX-4-02 PRs
+• UX-4-03 CI
+• UX-4-04 Releases
+
+Sequence: UX-4-01 → (UX-4-02 ∥ UX-4-03 ∥ UX-4-04)
+```

--- a/docs/superpowers/plans/2026-05-21-run-hub-v0.33.5.md
+++ b/docs/superpowers/plans/2026-05-21-run-hub-v0.33.5.md
@@ -1,0 +1,413 @@
+# Run Hub (v0.33.5) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans.
+
+**Goal:** Bundle five Run-bucket tools — Sessions / Interactions / Queue / Adapt / Prompt — under a tabbed `RunHub`. Primary path of the redesign.
+
+**Architecture:** Same hub pattern as InsightsHub. `RunHub` implements `Screen` + `TabsModel`. Each tab embeds an existing screen body or its successor. Sessions tab replaces both `Overview` and `SessionSwitcher`; `Detail` is reached as a drilldown launched from the Sessions list. Adapt tab launches `AdaptWizard` as a modal (via v0.32.0 modal stack + v0.32.5 wizard frame).
+
+**Tech Stack:** ratatui · insta. Depends on v0.32.0 chrome + v0.32.5 wizard spine.
+
+**Spec:** Section 3 (Run bucket), Section 8 (phasing — Run depends on Interactions which needs v0.30 #738).
+
+---
+
+### Task 1 (UX-2-01): RunHub scaffold + 5 subviews
+
+**Files:**
+- Create: `src/tui/screens/run/mod.rs`, `src/tui/screens/run/draw.rs`
+- Modify: `src/tui/screens/mod.rs`
+- Test: `src/tui/snapshot_tests/run_hub.rs`
+
+- [ ] **Step 1: Failing snapshot test**
+
+```rust
+use insta::assert_snapshot;
+use ratatui::{Terminal, backend::TestBackend};
+use crate::tui::screens::run::{RunHub, RunTab};
+use crate::tui::theme::Theme;
+
+fn render(tab: RunTab) -> Terminal<TestBackend> {
+    let mut t = Terminal::new(TestBackend::new(120, 30)).unwrap();
+    let theme = Theme::dark();
+    let mut hub = RunHub::new();
+    hub.set_active(tab);
+    t.draw(|f| hub.draw_for_test(f, f.area(), &theme)).unwrap();
+    t
+}
+
+#[test] fn sessions_tab() { let t = render(RunTab::Sessions); assert_snapshot!(t.backend()); }
+#[test] fn interactions_tab() { let t = render(RunTab::Interactions); assert_snapshot!(t.backend()); }
+#[test] fn queue_tab() { let t = render(RunTab::Queue); assert_snapshot!(t.backend()); }
+#[test] fn adapt_tab() { let t = render(RunTab::Adapt); assert_snapshot!(t.backend()); }
+#[test] fn prompt_tab() { let t = render(RunTab::Prompt); assert_snapshot!(t.backend()); }
+```
+
+Add `pub mod run_hub;` in `src/tui/snapshot_tests/mod.rs`.
+
+- [ ] **Step 2: Confirm fail**
+
+`cargo test --lib tui::snapshot_tests::run_hub` → compile error.
+
+- [ ] **Step 3: Implement skeleton**
+
+`src/tui/screens/run/mod.rs`:
+
+```rust
+pub mod draw;
+
+use crossterm::event::{Event, KeyCode};
+use ratatui::{Frame, layout::Rect};
+use crate::tui::navigation::InputMode;
+use crate::tui::navigation::keymap::KeymapProvider;
+use crate::tui::screens::{Screen, ScreenAction, TabsModel};
+use crate::tui::theme::Theme;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum RunTab { Sessions, Interactions, Queue, Adapt, Prompt }
+
+const TABS: &[&str] = &["Sessions", "Interactions", "Queue", "Adapt", "Prompt"];
+
+pub struct RunHub { pub active: RunTab }
+
+impl RunHub {
+    pub fn new() -> Self { Self { active: RunTab::Sessions } }
+    pub fn set_active(&mut self, t: RunTab) { self.active = t; }
+    pub fn draw_for_test(&mut self, f: &mut Frame, area: Rect, theme: &Theme) {
+        draw::draw_hub(f, area, theme, self);
+    }
+}
+
+impl TabsModel for RunHub {
+    fn tabs(&self) -> &[&'static str] { TABS }
+    fn active(&self) -> usize { match self.active {
+        RunTab::Sessions => 0, RunTab::Interactions => 1, RunTab::Queue => 2,
+        RunTab::Adapt => 3, RunTab::Prompt => 4 } }
+    fn select(&mut self, idx: usize) {
+        self.active = match idx { 0 => RunTab::Sessions, 1 => RunTab::Interactions,
+            2 => RunTab::Queue, 3 => RunTab::Adapt, _ => RunTab::Prompt };
+    }
+}
+
+impl KeymapProvider for RunHub {
+    fn keymap_bindings(&self) -> Vec<(&'static str, &'static str)> {
+        vec![("Tab", "Next tab"), ("Enter", "Open"), ("n", "New session")]
+    }
+}
+
+impl Screen for RunHub {
+    fn handle_input(&mut self, e: &Event, _m: InputMode) -> ScreenAction {
+        if let Event::Key(k) = e {
+            if let KeyCode::Char(c @ '1'..='5') = k.code {
+                self.select((c as u8 - b'1') as usize);
+            }
+        }
+        ScreenAction::None
+    }
+    fn draw(&mut self, f: &mut Frame, area: Rect, theme: &Theme) { draw::draw_hub(f, area, theme, self); }
+    fn tabs(&self) -> Option<&dyn TabsModel> { Some(self) }
+    fn breadcrumb(&self) -> &'static str { "Run" }
+    fn footer_hints(&self) -> Vec<(&'static str, &'static str)> { self.keymap_bindings() }
+}
+```
+
+`src/tui/screens/run/draw.rs`:
+
+```rust
+use ratatui::{Frame, layout::{Constraint, Direction, Layout, Rect}, style::{Modifier, Style},
+              text::{Line, Span}, widgets::Paragraph};
+use crate::tui::screens::run::{RunHub, RunTab, TABS};
+use crate::tui::screens::TabsModel;
+use crate::tui::theme::Theme;
+
+pub fn draw_hub(f: &mut Frame, area: Rect, theme: &Theme, hub: &RunHub) {
+    let rows = Layout::default().direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Min(1)]).split(area);
+    let spans: Vec<Span> = TABS.iter().enumerate().flat_map(|(i, l)| {
+        let s = if i == hub.active() { Style::default().add_modifier(Modifier::REVERSED) } else { Style::default() };
+        vec![Span::styled(format!(" {} ", l), s), Span::raw(" ▎ ")]
+    }).collect();
+    f.render_widget(Paragraph::new(Line::from(spans)), rows[0]);
+
+    let body = rows[1];
+    match hub.active {
+        RunTab::Sessions => f.render_widget(Paragraph::new("[Sessions — UX-2-02]"), body),
+        RunTab::Interactions => f.render_widget(Paragraph::new("[Interactions — UX-2-07]"), body),
+        RunTab::Queue => f.render_widget(Paragraph::new("[Queue — UX-2-04]"), body),
+        RunTab::Adapt => f.render_widget(Paragraph::new("[Adapt — UX-2-05]"), body),
+        RunTab::Prompt => f.render_widget(Paragraph::new("[Prompt — UX-2-06]"), body),
+    }
+}
+```
+
+Export from `src/tui/screens/mod.rs`.
+
+- [ ] **Step 4: Accept**
+
+```
+cargo test --lib tui::snapshot_tests::run_hub
+cargo insta accept
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/screens/run/ src/tui/screens/mod.rs \
+        src/tui/snapshot_tests/run_hub.rs src/tui/snapshot_tests/mod.rs \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "feat(tui): RunHub scaffold + 5 tabs (UX-2-01)"
+```
+
+---
+
+### Task 2 (UX-2-02): Sessions list view replaces Overview + SessionSwitcher
+
+**Files:**
+- Modify: `src/tui/session_switcher.rs` (extract `draw_session_list(f, area, theme, &[SessionEntry])`)
+- Create: `src/tui/screens/run/sessions.rs`
+- Modify: `src/tui/screens/run/draw.rs` (Sessions arm)
+
+- [ ] **Step 1: Failing test for the new list view**
+
+```rust
+#[test]
+fn sessions_list_renders_running_and_idle() {
+    use ratatui::{Terminal, backend::TestBackend};
+    use crate::tui::screens::run::sessions::{SessionEntry, SessionStatus, draw_sessions};
+    use crate::tui::theme::Theme;
+    let mut t = Terminal::new(TestBackend::new(100, 12)).unwrap();
+    let theme = Theme::dark();
+    let entries = vec![
+        SessionEntry { issue: 809, title: "fix(settings)".into(), status: SessionStatus::Running },
+        SessionEntry { issue: 803, title: "feat(settings)".into(), status: SessionStatus::Idle },
+    ];
+    t.draw(|f| draw_sessions(f, f.area(), &theme, &entries)).unwrap();
+    insta::assert_snapshot!(t.backend());
+}
+```
+
+- [ ] **Step 2: Implement**
+
+`src/tui/screens/run/sessions.rs`:
+
+```rust
+use ratatui::{Frame, layout::Rect, widgets::{Block, Borders, List, ListItem}};
+use crate::tui::theme::Theme;
+
+#[derive(Debug, Clone)]
+pub enum SessionStatus { Running, Idle }
+#[derive(Debug, Clone)]
+pub struct SessionEntry { pub issue: u64, pub title: String, pub status: SessionStatus }
+
+pub fn draw_sessions(f: &mut Frame, area: Rect, _theme: &Theme, entries: &[SessionEntry]) {
+    let items: Vec<ListItem> = entries.iter().map(|e| {
+        let badge = match e.status { SessionStatus::Running => "RUNNING", SessionStatus::Idle => "IDLE" };
+        ListItem::new(format!(" #{} {}    {}", e.issue, e.title, badge))
+    }).collect();
+    let list = List::new(items).block(Block::default().borders(Borders::ALL).title("Sessions"));
+    f.render_widget(list, area);
+}
+```
+
+In `src/tui/screens/run/draw.rs` Sessions arm:
+
+```rust
+RunTab::Sessions => crate::tui::screens::run::sessions::draw_sessions(f, body, theme, &hub.sessions),
+```
+
+Add to `RunHub`: `pub sessions: Vec<sessions::SessionEntry>` (default empty).
+
+- [ ] **Step 3: Accept snapshot**
+
+```
+cargo test --lib tui::snapshot_tests::run_hub
+cargo insta accept
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/tui/screens/run/sessions.rs src/tui/screens/run/draw.rs \
+        src/tui/screens/run/mod.rs src/tui/snapshot_tests/snapshots/
+git commit -m "feat(tui): Sessions list view replaces Overview+SessionSwitcher (UX-2-02)"
+```
+
+---
+
+### Task 3 (UX-2-03): Detail screen as Sessions drilldown
+
+**Files:**
+- Modify: `src/tui/detail.rs`
+- Modify: `src/tui/screens/run/mod.rs` (handle Enter → push Detail modal/screen)
+
+- [ ] **Step 1: Failing test for drilldown action**
+
+```rust
+#[test]
+fn enter_on_session_row_emits_open_detail() {
+    use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+    use crate::tui::screens::run::{RunHub, RunTab};
+    use crate::tui::screens::Screen;
+    use crate::tui::navigation::InputMode;
+    let mut hub = RunHub::new();
+    hub.set_active(RunTab::Sessions);
+    hub.sessions = vec![/* ... */];
+    let key = Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+    let action = hub.handle_input(&key, InputMode::Normal);
+    // expect a ScreenAction that opens detail for selected session
+    assert!(matches!(action, crate::tui::screens::ScreenAction::Push(_) | crate::tui::screens::ScreenAction::None));
+}
+```
+
+- [ ] **Step 2: Wire up selection state**
+
+Add `pub selected: usize` to `RunHub`. On `KeyCode::Down`/`KeyCode::Up`, move selection. On `Enter`, emit `ScreenAction::Push(TuiMode::Detail(uuid))` with the selected session's UUID.
+
+- [ ] **Step 3: Verify Detail still drawable**
+
+`Detail` screen body unchanged — only entrypoint changes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/tui/screens/run/ src/tui/detail.rs
+git commit -m "feat(tui): Detail as Sessions drilldown via Enter (UX-2-03)"
+```
+
+---
+
+### Task 4 (UX-2-04): Queue tab folds QueueConfirmation + QueueExecution
+
+**Files:**
+- Modify: `src/tui/screens/queue_confirmation.rs`
+- Create: `src/tui/screens/run/queue.rs`
+
+- [ ] **Step 1: Failing snapshot test**
+
+Same pattern as UX-2-02 but for queue.
+
+- [ ] **Step 2: Extract `draw_queue_body(f, area, theme, &QueueState)` from `queue_confirmation.rs`.**
+
+- [ ] **Step 3: Create `src/tui/screens/run/queue.rs` calling `draw_queue_body`. Wire `RunTab::Queue` arm.**
+
+- [ ] **Step 4: Accept snapshot.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/screens/queue_confirmation.rs src/tui/screens/run/queue.rs src/tui/screens/run/draw.rs \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "feat(tui): Queue tab folds QueueConfirmation+QueueExecution (UX-2-04)"
+```
+
+---
+
+### Task 5 (UX-2-05): Adapt tab launches AdaptWizard as modal
+
+**Files:**
+- Modify: `src/tui/screens/run/mod.rs`
+- Modify: `src/tui/screens/adapt/`
+
+- [ ] **Step 1: Failing test — pressing `a` from Adapt tab pushes Adapt modal**
+
+```rust
+#[test]
+fn a_key_on_adapt_tab_pushes_modal() {
+    // pseudo:
+    // create RunHub on Adapt tab
+    // simulate key 'a'
+    // assert ScreenAction is Push wrapping AdaptScreen modal
+}
+```
+
+- [ ] **Step 2: Implement**
+
+Inside `RunHub::handle_input` when active tab is Adapt and key is `a`:
+
+```rust
+return ScreenAction::PushAdaptWizardModal;
+```
+
+(Add this variant to `ScreenAction` if not present; have the dispatcher push into `App.modal_stack`.)
+
+- [ ] **Step 3: Render placeholder body for Adapt tab listing recent adapt sessions.**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/tui/screens/run/ src/tui/screens/adapt/ src/tui/screens/mod.rs
+git commit -m "feat(tui): Adapt tab launches AdaptWizard modal (UX-2-05)"
+```
+
+---
+
+### Task 6 (UX-2-06): Prompt tab embeds PromptInput
+
+**Files:**
+- Modify: `src/tui/screens/prompt_input/`
+- Create: `src/tui/screens/run/prompt.rs`
+
+- [ ] **Step 1: Failing snapshot test** (mirror UX-1-02 shape)
+
+- [ ] **Step 2: Extract `draw_prompt_input_body(f, area, theme, &PromptState)` from existing `PromptInputScreen`.**
+
+- [ ] **Step 3: Create `src/tui/screens/run/prompt.rs`. Wire `RunTab::Prompt` arm.**
+
+- [ ] **Step 4: Accept snapshot.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/screens/prompt_input/ src/tui/screens/run/prompt.rs src/tui/screens/run/draw.rs \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "feat(tui): Prompt tab embeds PromptInput (UX-2-06)"
+```
+
+---
+
+### Task 7 (UX-2-07): Interactions tab (depends on v0.30 #738)
+
+**Files:**
+- Create: `src/tui/screens/run/interactions.rs`
+
+- [ ] **Step 1: Verify dependency landed**
+
+Run: `gh issue view 738 --json state --jq .state`
+Expected: `CLOSED`. If `OPEN`, halt and rebase milestone scheduling.
+
+- [ ] **Step 2: Failing snapshot test for the Interactions tab**
+
+- [ ] **Step 3: Embed Interaction screen body**
+
+Use the work from v0.30 #736 (Interaction screen) — extract its draw body and call it from the Interactions tab.
+
+- [ ] **Step 4: Accept snapshot.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/screens/run/interactions.rs src/tui/screens/run/draw.rs \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "feat(tui): Interactions tab embeds v0.30 interaction screen (UX-2-07)"
+```
+
+---
+
+## Milestone Dependency Graph
+
+```
+Level 0:
+• UX-2-01 (depends on v0.32.0 UX-0-11)
+
+Level 1 (parallel):
+• UX-2-02 Sessions
+• UX-2-04 Queue
+• UX-2-05 Adapt (also depends on v0.32.5 UX-0a-06)
+• UX-2-06 Prompt
+• UX-2-07 Interactions (also depends on v0.30.0 #738)
+
+Level 2:
+• UX-2-03 Detail drilldown (depends on UX-2-02)
+
+Sequence: UX-2-01 → (UX-2-02 → UX-2-03) ∥ UX-2-04 ∥ UX-2-05 ∥ UX-2-06 ∥ UX-2-07
+```

--- a/docs/superpowers/plans/2026-05-21-system-hub-ga-v0.35.0.md
+++ b/docs/superpowers/plans/2026-05-21-system-hub-ga-v0.35.0.md
@@ -1,0 +1,386 @@
+# System Hub + GA Flip (v0.35.0) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans.
+
+**Goal:** Land the final hub (Settings + Teams), promote Teams from wizard-only to a first-class list screen with launch modal, then flip `behavior.new_ux` default to `true`. Publish user-facing docs.
+
+**Architecture:** `SystemHub` wraps the already-tabbed `SettingsScreen` body inside one tab and adds a Teams tab built on top of the v0.32.5 wizard spine. Once all five hubs ship, the flag default flips and CHANGELOG/user-guide get published in the same release window.
+
+**Tech Stack:** ratatui · insta · `gh` for milestone update. Depends on v0.32.0..v0.34.5, plus v0.31.0 #821 (ranking surface for Teams) and v0.32.5 UX-0a-05 (TeamWizard).
+
+**Spec:** Section 3 (System bucket), Section 8 (Phase 5).
+
+---
+
+### Task 1 (UX-5-01): SystemHub scaffold + Settings/Teams tabs
+
+**Files:**
+- Create: `src/tui/screens/system/mod.rs`, `src/tui/screens/system/draw.rs`
+- Modify: `src/tui/screens/mod.rs`
+- Test: `src/tui/snapshot_tests/system_hub.rs`
+
+- [ ] **Step 1: Failing snapshot per tab**
+
+```rust
+use insta::assert_snapshot;
+use ratatui::{Terminal, backend::TestBackend};
+use crate::tui::screens::system::{SystemHub, SystemTab};
+use crate::tui::theme::Theme;
+
+fn render(tab: SystemTab) -> Terminal<TestBackend> {
+    let mut t = Terminal::new(TestBackend::new(120, 30)).unwrap();
+    let theme = Theme::dark();
+    let mut hub = SystemHub::new();
+    hub.set_active(tab);
+    t.draw(|f| hub.draw_for_test(f, f.area(), &theme)).unwrap();
+    t
+}
+
+#[test] fn settings_tab() { let t = render(SystemTab::Settings); assert_snapshot!(t.backend()); }
+#[test] fn teams_tab() { let t = render(SystemTab::Teams); assert_snapshot!(t.backend()); }
+```
+
+Add `pub mod system_hub;` in `src/tui/snapshot_tests/mod.rs`.
+
+- [ ] **Step 2: Confirm fail**
+
+- [ ] **Step 3: Implement skeleton**
+
+`src/tui/screens/system/mod.rs`:
+
+```rust
+pub mod draw;
+
+use crossterm::event::{Event, KeyCode};
+use ratatui::{Frame, layout::Rect};
+use crate::tui::navigation::InputMode;
+use crate::tui::navigation::keymap::KeymapProvider;
+use crate::tui::screens::{Screen, ScreenAction, TabsModel};
+use crate::tui::theme::Theme;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SystemTab { Settings, Teams }
+
+const TABS: &[&str] = &["Settings", "Teams"];
+
+pub struct SystemHub { pub active: SystemTab }
+
+impl SystemHub {
+    pub fn new() -> Self { Self { active: SystemTab::Settings } }
+    pub fn set_active(&mut self, t: SystemTab) { self.active = t; }
+    pub fn draw_for_test(&mut self, f: &mut Frame, area: Rect, theme: &Theme) {
+        draw::draw_hub(f, area, theme, self);
+    }
+}
+
+impl TabsModel for SystemHub {
+    fn tabs(&self) -> &[&'static str] { TABS }
+    fn active(&self) -> usize { match self.active { SystemTab::Settings => 0, SystemTab::Teams => 1 } }
+    fn select(&mut self, idx: usize) {
+        self.active = match idx { 0 => SystemTab::Settings, _ => SystemTab::Teams };
+    }
+}
+
+impl KeymapProvider for SystemHub {
+    fn keymap_bindings(&self) -> Vec<(&'static str, &'static str)> {
+        vec![("Tab", "Next tab"), ("Enter", "Open"), ("n", "New team")]
+    }
+}
+
+impl Screen for SystemHub {
+    fn handle_input(&mut self, e: &Event, _m: InputMode) -> ScreenAction {
+        if let Event::Key(k) = e {
+            if let KeyCode::Char(c @ '1'..='2') = k.code {
+                self.select((c as u8 - b'1') as usize);
+            }
+        }
+        ScreenAction::None
+    }
+    fn draw(&mut self, f: &mut Frame, area: Rect, theme: &Theme) { draw::draw_hub(f, area, theme, self); }
+    fn tabs(&self) -> Option<&dyn TabsModel> { Some(self) }
+    fn breadcrumb(&self) -> &'static str { "System" }
+    fn footer_hints(&self) -> Vec<(&'static str, &'static str)> { self.keymap_bindings() }
+}
+```
+
+`src/tui/screens/system/draw.rs`:
+
+```rust
+use ratatui::{Frame, layout::{Constraint, Direction, Layout, Rect}, style::{Modifier, Style},
+              text::{Line, Span}, widgets::Paragraph};
+use crate::tui::screens::system::{SystemHub, SystemTab, TABS};
+use crate::tui::screens::TabsModel;
+use crate::tui::theme::Theme;
+
+pub fn draw_hub(f: &mut Frame, area: Rect, theme: &Theme, hub: &SystemHub) {
+    let rows = Layout::default().direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Min(1)]).split(area);
+    let spans: Vec<Span> = TABS.iter().enumerate().flat_map(|(i, l)| {
+        let s = if i == hub.active() { Style::default().add_modifier(Modifier::REVERSED) } else { Style::default() };
+        vec![Span::styled(format!(" {} ", l), s), Span::raw(" ▎ ")]
+    }).collect();
+    f.render_widget(Paragraph::new(Line::from(spans)), rows[0]);
+
+    let body = rows[1];
+    match hub.active {
+        SystemTab::Settings => f.render_widget(Paragraph::new("[Settings — UX-5-02]"), body),
+        SystemTab::Teams => f.render_widget(Paragraph::new("[Teams — UX-5-03]"), body),
+    }
+}
+```
+
+Export from `src/tui/screens/mod.rs`.
+
+- [ ] **Step 4: Accept snapshots + commit**
+
+```bash
+cargo test --lib tui::snapshot_tests::system_hub
+cargo insta accept
+git add src/tui/screens/system/ src/tui/screens/mod.rs \
+        src/tui/snapshot_tests/system_hub.rs src/tui/snapshot_tests/mod.rs \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "feat(tui): SystemHub scaffold + 2 tabs (UX-5-01)"
+```
+
+---
+
+### Task 2 (UX-5-02): Settings → SystemHub::Settings (inner tabs preserved)
+
+**Files:**
+- Modify: `src/tui/screens/settings/` (extract `draw_settings_body(f, area, theme, &SettingsState)`)
+- Create: `src/tui/screens/system/settings.rs`
+
+- [ ] **Step 1: Failing snapshot for Settings tab.**
+
+- [ ] **Step 2: Extract draw body from existing `SettingsScreen::draw`** keeping its internal tab strip — that strip becomes a sub-tab inside the System Settings tab.
+
+- [ ] **Step 3: Wire `SystemTab::Settings` arm.**
+
+- [ ] **Step 4: Verify ALL existing Settings snapshot tests still pass (memory `settings_layout_parity` etc.).**
+
+```
+cargo test --lib tui::snapshot_tests::settings
+```
+Expected: PASS.
+
+- [ ] **Step 5: Accept new snapshot + commit**
+
+```bash
+git add src/tui/screens/settings/ src/tui/screens/system/settings.rs src/tui/screens/system/draw.rs \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "feat(tui): Settings tab inside SystemHub (UX-5-02)"
+```
+
+---
+
+### Task 3 (UX-5-03): Teams promoted from wizard-only to list screen + launch modal
+
+**Files:**
+- Modify: `src/tui/screens/team_wizard/` (split into `TeamsListScreen` + `TeamWizard` modal)
+- Create: `src/tui/screens/system/teams.rs`
+
+- [ ] **Step 1: Verify dependency**
+
+Run: `gh issue view 821 --json state --jq .state`
+Expected: `CLOSED`. If `OPEN`, halt — Teams tab depends on ranking surface from v0.31.0 #821.
+
+- [ ] **Step 2: Failing snapshot for the Teams list view**
+
+```rust
+#[test]
+fn teams_list_shows_existing_teams_with_ranking() {
+    use ratatui::{Terminal, backend::TestBackend};
+    use crate::tui::screens::system::teams::{TeamRow, draw_teams_list};
+    use crate::tui::theme::Theme;
+    let mut t = Terminal::new(TestBackend::new(120, 12)).unwrap();
+    let theme = Theme::dark();
+    let rows = vec![
+        TeamRow { name: "default".into(), agents: 4, ranking_score: 0.92 },
+        TeamRow { name: "experimental".into(), agents: 2, ranking_score: 0.55 },
+    ];
+    t.draw(|f| draw_teams_list(f, f.area(), &theme, &rows)).unwrap();
+    insta::assert_snapshot!(t.backend());
+}
+```
+
+- [ ] **Step 3: Implement list view**
+
+`src/tui/screens/system/teams.rs`:
+
+```rust
+use ratatui::{Frame, layout::Rect, widgets::{Block, Borders, List, ListItem}};
+use crate::tui::theme::Theme;
+
+#[derive(Debug, Clone)]
+pub struct TeamRow { pub name: String, pub agents: u32, pub ranking_score: f64 }
+
+pub fn draw_teams_list(f: &mut Frame, area: Rect, _t: &Theme, rows: &[TeamRow]) {
+    let items: Vec<ListItem> = rows.iter().map(|r| {
+        ListItem::new(format!(" {:20}  agents:{:>3}  rank:{:.2}", r.name, r.agents, r.ranking_score))
+    }).collect();
+    let list = List::new(items).block(Block::default().borders(Borders::ALL).title("Teams"));
+    f.render_widget(list, area);
+}
+```
+
+Wire `SystemTab::Teams` arm in `draw.rs` to call `draw_teams_list(..., &hub.teams)`.
+
+Add to `SystemHub`: `pub teams: Vec<teams::TeamRow>` (default empty).
+
+- [ ] **Step 4: `n` key pushes TeamWizard modal**
+
+```rust
+if let Event::Key(k) = e {
+    if matches!(k.code, KeyCode::Char('n')) && self.active == SystemTab::Teams {
+        return ScreenAction::PushTeamWizardModal;
+    }
+}
+```
+
+- [ ] **Step 5: Accept + commit**
+
+```bash
+git add src/tui/screens/team_wizard/ src/tui/screens/system/teams.rs src/tui/screens/system/draw.rs \
+        src/tui/screens/system/mod.rs src/tui/snapshot_tests/snapshots/
+git commit -m "feat(tui): Teams list screen + ranking column + launch modal (UX-5-03)"
+```
+
+---
+
+### Task 4 (UX-5-04): Flip behavior.new_ux default to true; CHANGELOG
+
+**Files:**
+- Modify: `src/config.rs` (default flips)
+- Modify: `CHANGELOG.md`
+- Modify: `src/tui/landing.rs` snapshot fixtures may need to refresh (per memory `project_changelog_snapshot_coupling`)
+
+- [ ] **Step 1: Failing test for new default**
+
+In `src/config.rs`:
+
+```rust
+#[test]
+fn behavior_new_ux_now_defaults_true() {
+    let cfg: Config = toml::from_str(r#"
+[project]
+name = "demo"
+"#).unwrap();
+    assert!(cfg.behavior.new_ux);
+}
+```
+
+- [ ] **Step 2: Confirm fail**
+
+Run: `cargo test --lib config::new_ux_flag_tests::behavior_new_ux_now_defaults_true`
+Expected: fail — flag still defaults `false`.
+
+- [ ] **Step 3: Flip default**
+
+In `BehaviorConfig::default()`:
+
+```rust
+impl Default for BehaviorConfig {
+    fn default() -> Self { Self { caveman_mode: false, new_ux: true } }
+}
+```
+
+- [ ] **Step 4: CHANGELOG entry**
+
+Add to `CHANGELOG.md` under `## [v0.35.0]`:
+
+```markdown
+### Changed
+- TUI: new sidebar-driven UX is now the default. Set `[behavior] new_ux = false` to opt back into the legacy chrome (will be removed in v0.35.5).
+```
+
+- [ ] **Step 5: Refresh landing snapshots**
+
+Per memory `project_changelog_snapshot_coupling`: `CHANGELOG.md` is `include_str!`'d into the TUI landing widget. Run:
+
+```
+cargo test --lib tui::snapshot_tests::landing
+cargo insta accept
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/config.rs CHANGELOG.md src/tui/snapshot_tests/snapshots/
+git commit -m "feat(config): flip behavior.new_ux default to true + CHANGELOG (UX-5-04)"
+```
+
+---
+
+### Task 5 (UX-5-05): User guide + screenshots for new spine
+
+**Files:**
+- Create: `docs/user-guide/ux-spine.md`
+- Create: `docs/screenshots/ux-spine/*.png` (captured from a running TUI)
+
+- [ ] **Step 1: Write the user guide page**
+
+`docs/user-guide/ux-spine.md`:
+
+```markdown
+# UX Spine (since v0.35.0)
+
+Maestro reorganized around five buckets:
+
+| Bucket | Hotkey | Tools |
+|---|---|---|
+| Run | Ctrl+R | Sessions · Interactions · Queue · Adapt · Prompt |
+| Plan | Ctrl+N | Issues · Milestones · Roadmap · PRD |
+| Review | Ctrl+V | PRs · CI Errors · Release Notes |
+| Insights | Ctrl+I | Cost · Tokens · TurboQuant · Agent Graph · Project Stats |
+| System | Ctrl+S | Settings · Teams |
+
+Also:
+- `Ctrl+H` → Home dashboard
+- `Ctrl+P` → fuzzy command palette
+- `Ctrl+B` → toggle sidebar between full and narrow rail
+- `Ctrl+L` → toggle activity log strip
+- `Tab` / `Shift+Tab` → cycle focus between Sidebar, Tabs strip, Content
+- `?` → contextual help
+- `q` → quit (with confirmation)
+
+Wizards (Issue / Milestone / Team / Adapt) now share a single frame with consistent step counter, validation banner, and footer hints.
+
+To opt back into the legacy chrome temporarily:
+
+```toml
+[behavior]
+new_ux = false
+```
+
+This flag will be removed in v0.35.5.
+```
+
+- [ ] **Step 2: Capture screenshots** at three terminal sizes (80×24, 120×40, 200×60) for each bucket landing page. Save under `docs/screenshots/ux-spine/`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/user-guide/ux-spine.md docs/screenshots/ux-spine/
+git commit -m "docs(ux): user guide + screenshots for new sidebar UX (UX-5-05)"
+```
+
+---
+
+## Milestone Dependency Graph
+
+```
+Level 0:
+• UX-5-01 scaffold (depends on v0.32.0 UX-0-11)
+
+Level 1 (parallel):
+• UX-5-02 Settings
+• UX-5-03 Teams (also depends on v0.31.0 #821 and v0.32.5 UX-0a-05)
+
+Level 2:
+• UX-5-04 flag flip (depends on UX-5-01..03 + v0.33.0..v0.34.5 closed)
+
+Level 3:
+• UX-5-05 docs (depends on UX-5-04)
+
+Sequence: UX-5-01 → (UX-5-02 ∥ UX-5-03) → UX-5-04 → UX-5-05
+```

--- a/docs/superpowers/plans/2026-05-21-ux-cleanup-v0.35.5.md
+++ b/docs/superpowers/plans/2026-05-21-ux-cleanup-v0.35.5.md
@@ -1,0 +1,210 @@
+# UX Cleanup (v0.35.5) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans.
+
+**Goal:** Remove the legacy TUI chrome that survived behind `behavior.new_ux=false`, drop the flag itself, and delete unused snapshots and test fixtures.
+
+**Architecture:** Three subtraction commits. Order matters: legacy TuiMode variants go first (so callers can't reference them), then the flag (so no branch depends on it), then snapshot housekeeping.
+
+**Tech Stack:** Rust 2024 · `cargo build --workspace` for compile gate.
+
+**Spec:** Section 8 (Phase 6).
+
+---
+
+### Task 1 (UX-6-01): Remove legacy Landing / Dashboard / Overview / SessionSwitcher TuiMode variants
+
+**Files:**
+- Modify: `src/tui/app/types.rs` (delete variants)
+- Delete: `src/tui/landing.rs`, `src/tui/session_switcher.rs` (after callers migrated)
+- Modify: `src/tui/ui.rs` (delete `draw_legacy` branch — see Task 2)
+- Modify: `src/tui/screen_dispatch.rs` (drop matches)
+- Modify: every `#[allow(deprecated)]` attribute added in v0.33.0 UX-1-07 — remove the attribute now that the variants are gone
+
+- [ ] **Step 1: Inventory legacy uses**
+
+Run: `rg "TuiMode::(Overview|Landing|Dashboard|SessionSwitcher|CostDashboard|TokenDashboard|TurboquantDashboard|AgentGraph|DependencyGraph)" src/`
+
+Confirm every hit is inside the legacy-only `draw_legacy` path or an outdated test fixture.
+
+- [ ] **Step 2: Delete variants from `TuiMode` enum**
+
+In `src/tui/app/types.rs`, remove these arms:
+
+```rust
+Overview,
+Landing,
+Dashboard,
+SessionSwitcher,
+CostDashboard,
+TokenDashboard,
+TurboquantDashboard,
+AgentGraph,
+DependencyGraph,
+```
+
+- [ ] **Step 3: Delete obsolete screen modules**
+
+Remove files:
+- `src/tui/landing.rs` (if not referenced; the `LandingScreen` struct from `src/tui/screens/landing/` may still be referenced by tests — verify before delete)
+- `src/tui/session_switcher.rs`
+- `src/tui/cost_dashboard.rs` (after extraction in UX-1-02 left only the body fn; the rest is now dead)
+- `src/tui/token_dashboard.rs`
+- `src/tui/turboquant_dashboard.rs`
+- `src/tui/dep_graph.rs`
+- `src/tui/agent_graph/` (only the now-unused parent; keep the bipartite renderer if InsightsHub::Agents tab calls it)
+
+For each, confirm with `rg "<symbol>" src/` before deleting.
+
+- [ ] **Step 4: Build clean**
+
+Run: `cargo build`
+Expected: PASS with no warnings about unused or dead code.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/app/types.rs src/tui/ui.rs src/tui/screen_dispatch.rs src/tui/landing.rs \
+        src/tui/session_switcher.rs src/tui/cost_dashboard.rs src/tui/token_dashboard.rs \
+        src/tui/turboquant_dashboard.rs src/tui/dep_graph.rs src/tui/agent_graph/
+git commit -m "chore(tui): remove legacy TuiMode variants + screens (UX-6-01)"
+```
+
+---
+
+### Task 2 (UX-6-02): Remove behavior.new_ux flag + legacy dispatcher branch
+
+**Files:**
+- Modify: `src/config.rs` (drop `new_ux` field from `BehaviorConfig`)
+- Modify: `src/tui/ui.rs` (delete `draw_legacy` and the dispatcher branch)
+- Modify: `CHANGELOG.md` (announce removal)
+- Modify: `docs/user-guide/ux-spine.md` (drop the opt-out paragraph)
+
+- [ ] **Step 1: Failing test for absence of the flag**
+
+In `src/config.rs`:
+
+```rust
+#[test]
+fn new_ux_flag_is_gone() {
+    // Compiles iff BehaviorConfig has no new_ux field.
+    let s: &str = "[behavior]\ncaveman_mode = false";
+    let cfg: BehaviorConfig = toml::from_str(s).unwrap();
+    // No new_ux access anywhere — if this comments out, the test still must compile.
+    assert!(!cfg.caveman_mode);
+}
+```
+
+- [ ] **Step 2: Drop the field**
+
+In `BehaviorConfig`:
+
+```rust
+#[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
+pub struct BehaviorConfig {
+    pub caveman_mode: bool,
+}
+```
+
+- [ ] **Step 3: Delete the dispatcher branch**
+
+In `src/tui/ui.rs`:
+
+```rust
+pub fn draw(f: &mut Frame, app: &mut App, theme: &Theme) {
+    draw_new_ux(f, app, theme);
+}
+// remove fn draw_legacy entirely
+```
+
+- [ ] **Step 4: Update docs**
+
+In `CHANGELOG.md` under `## [v0.35.5]`:
+
+```markdown
+### Removed
+- `behavior.new_ux` config flag (the new sidebar UX is now the only path). Legacy chrome code paths fully removed.
+```
+
+In `docs/user-guide/ux-spine.md`, remove the opt-out paragraph.
+
+- [ ] **Step 5: Build + test + refresh landing snapshots (CHANGELOG coupling)**
+
+```
+cargo build
+cargo test
+cargo insta accept   # for any landing snapshot drift from CHANGELOG change
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/config.rs src/tui/ui.rs CHANGELOG.md docs/user-guide/ux-spine.md \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "chore(config): remove behavior.new_ux flag + legacy draw branch (UX-6-02)"
+```
+
+---
+
+### Task 3 (UX-6-03): Delete unused snapshot tests for retired screens
+
+**Files:**
+- Delete: `src/tui/snapshot_tests/landing.rs` (after gathering any still-useful tests into a different module)
+- Delete: outdated snapshots under `src/tui/snapshot_tests/snapshots/` (those whose source files were removed in UX-6-01)
+- Modify: `src/tui/snapshot_tests/mod.rs` to drop module declarations
+
+- [ ] **Step 1: List orphan snapshots**
+
+Run:
+
+```bash
+cd /Users/carlos/projects/maestro
+ls src/tui/snapshot_tests/snapshots/ | sort
+rg "fn " src/tui/snapshot_tests/ | awk -F: '{print $1}' | sort -u
+```
+
+Cross-reference. Snapshots without a backing test become orphans.
+
+- [ ] **Step 2: Delete orphan snapshot files**
+
+For each orphan:
+
+```bash
+git rm src/tui/snapshot_tests/snapshots/<orphan>.snap
+```
+
+- [ ] **Step 3: Delete now-empty test modules**
+
+If `src/tui/snapshot_tests/landing.rs` has no surviving tests, delete it and drop `pub mod landing;` from `src/tui/snapshot_tests/mod.rs`. Same for `agent_graph_dispatcher`, `agent_graph_keybinding_hint`, any other module whose source was removed.
+
+- [ ] **Step 4: Build + test (full suite)**
+
+```
+cargo test
+```
+Expected: PASS with no orphan snapshot warnings (`insta` reports them otherwise).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A src/tui/snapshot_tests/
+git commit -m "chore(tui): delete orphan snapshot tests for retired screens (UX-6-03)"
+```
+
+---
+
+## Milestone Dependency Graph
+
+```
+Level 0:
+• UX-6-01 (depends on v0.35.0 UX-5-04 GA flip)
+
+Level 1:
+• UX-6-02 (depends on UX-6-01)
+
+Level 2:
+• UX-6-03 (depends on UX-6-01)
+
+Sequence: UX-6-01 → UX-6-02 ∥ UX-6-03
+```

--- a/docs/superpowers/plans/2026-05-21-ux-spine-v0.32.0.md
+++ b/docs/superpowers/plans/2026-05-21-ux-spine-v0.32.0.md
@@ -1,0 +1,1328 @@
+# UX Spine (v0.32.0) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lay down the chrome foundation — sidebar accordion, header/footer composer, modal stack, fuzzy command palette, global hotkeys, focus rings, `behavior.new_ux` flag, Home dashboard — without migrating any existing screens yet.
+
+**Architecture:** A new `tui::chrome` composer wraps every screen with a shared bypass-banner → header → split(sidebar, body=tabs+content) → footer → optional activity-log strip layout. New `SidebarState` lives on `App` and is mutated by `ScreenAction::SelectTool(ToolId)`. The `Screen` trait gains default-implemented `tabs()`, `breadcrumb()`, `footer_hints()` so existing screens compile unchanged. A new `App.modal_stack: Vec<Box<dyn Modal>>` renders centered dim-overlay modals above the frame. `behavior.new_ux=false` keeps the legacy `tui::ui::draw` path; `=true` switches to the chrome path.
+
+**Tech Stack:** Rust 2024 edition · ratatui · crossterm · tokio · `insta` for snapshot tests · `nucleo` for fuzzy matching (new dep).
+
+**Spec:** `docs/superpowers/specs/2026-05-21-tui-ux-redesign-sidebar-ia-design.md` — Sections 4, 5, 6, 8.
+
+---
+
+### Task 1 (UX-0-01): Bucket + ToolId enums + SidebarState struct
+
+**Files:**
+- Create: `src/tui/navigation/sidebar_state.rs`
+- Modify: `src/tui/navigation/mod.rs` (add `pub mod sidebar_state;`)
+- Test: same file, `#[cfg(test)] mod tests`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/tui/navigation/sidebar_state.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sidebar_state_default_lands_home() {
+        let s = SidebarState::default();
+        assert_eq!(s.active_bucket, Bucket::Home);
+        assert_eq!(s.active_tool, ToolId::Home);
+        assert!(!s.collapsed);
+    }
+
+    #[test]
+    fn tool_id_bucket_is_consistent() {
+        assert_eq!(ToolId::RunSessions.bucket(), Bucket::Run);
+        assert_eq!(ToolId::PlanIssues.bucket(), Bucket::Plan);
+        assert_eq!(ToolId::ReviewPrs.bucket(), Bucket::Review);
+        assert_eq!(ToolId::InsightsCost.bucket(), Bucket::Insights);
+        assert_eq!(ToolId::SystemSettings.bucket(), Bucket::System);
+        assert_eq!(ToolId::Home.bucket(), Bucket::Home);
+    }
+
+    #[test]
+    fn select_tool_updates_bucket() {
+        let mut s = SidebarState::default();
+        s.select(ToolId::InsightsCost);
+        assert_eq!(s.active_bucket, Bucket::Insights);
+        assert_eq!(s.active_tool, ToolId::InsightsCost);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+Run: `cargo test --lib tui::navigation::sidebar_state`
+Expected: compile error — `SidebarState`/`Bucket`/`ToolId` undefined.
+
+- [ ] **Step 3: Implement enums + struct**
+
+Replace the `src/tui/navigation/sidebar_state.rs` content with:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Bucket {
+    Home,
+    Run,
+    Plan,
+    Review,
+    Insights,
+    System,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ToolId {
+    Home,
+    RunSessions, RunInteractions, RunQueue, RunAdapt, RunPrompt,
+    PlanIssues, PlanMilestones, PlanRoadmap, PlanPrd,
+    ReviewPrs, ReviewCi, ReviewReleases,
+    InsightsCost, InsightsTokens, InsightsTurboquant, InsightsAgents, InsightsStats,
+    SystemSettings, SystemTeams,
+}
+
+impl ToolId {
+    pub fn bucket(self) -> Bucket {
+        use ToolId::*;
+        match self {
+            Home => Bucket::Home,
+            RunSessions | RunInteractions | RunQueue | RunAdapt | RunPrompt => Bucket::Run,
+            PlanIssues | PlanMilestones | PlanRoadmap | PlanPrd => Bucket::Plan,
+            ReviewPrs | ReviewCi | ReviewReleases => Bucket::Review,
+            InsightsCost | InsightsTokens | InsightsTurboquant | InsightsAgents | InsightsStats => Bucket::Insights,
+            SystemSettings | SystemTeams => Bucket::System,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SidebarState {
+    pub active_bucket: Bucket,
+    pub active_tool: ToolId,
+    pub collapsed: bool,
+}
+
+impl Default for SidebarState {
+    fn default() -> Self {
+        Self { active_bucket: Bucket::Home, active_tool: ToolId::Home, collapsed: false }
+    }
+}
+
+impl SidebarState {
+    pub fn select(&mut self, tool: ToolId) {
+        self.active_tool = tool;
+        self.active_bucket = tool.bucket();
+    }
+}
+```
+
+Then in `src/tui/navigation/mod.rs` add `pub mod sidebar_state;`.
+
+- [ ] **Step 4: Run test to confirm it passes**
+
+Run: `cargo test --lib tui::navigation::sidebar_state`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/navigation/sidebar_state.rs src/tui/navigation/mod.rs
+git commit -m "feat(tui): add Bucket/ToolId enums + SidebarState (UX-0-01)"
+```
+
+---
+
+### Task 2 (UX-0-02): Sidebar accordion widget + snapshot tests
+
+**Files:**
+- Create: `src/tui/widgets/sidebar.rs`
+- Modify: `src/tui/widgets/mod.rs` (add `pub mod sidebar;`)
+- Test: `src/tui/snapshot_tests/sidebar.rs` + `mod.rs`
+
+- [ ] **Step 1: Write the failing snapshot test**
+
+Create `src/tui/snapshot_tests/sidebar.rs`:
+
+```rust
+use insta::assert_snapshot;
+use ratatui::{Terminal, backend::TestBackend};
+use crate::tui::navigation::sidebar_state::{Bucket, SidebarState, ToolId};
+use crate::tui::theme::Theme;
+use crate::tui::widgets::sidebar::Sidebar;
+
+fn render(width: u16, height: u16, state: &SidebarState) -> Terminal<TestBackend> {
+    let mut t = Terminal::new(TestBackend::new(width, height)).unwrap();
+    let theme = Theme::dark();
+    t.draw(|f| Sidebar::new(state, &theme, "MAESTRO v0.32.0").render(f, f.area())).unwrap();
+    t
+}
+
+#[test]
+fn sidebar_default_expanded_home() {
+    let s = SidebarState::default();
+    let t = render(22, 24, &s);
+    assert_snapshot!(t.backend());
+}
+
+#[test]
+fn sidebar_run_bucket_open() {
+    let mut s = SidebarState::default();
+    s.select(ToolId::RunSessions);
+    let t = render(22, 24, &s);
+    assert_snapshot!(t.backend());
+}
+
+#[test]
+fn sidebar_collapsed_rail() {
+    let mut s = SidebarState::default();
+    s.collapsed = true;
+    s.select(ToolId::InsightsCost);
+    let t = render(3, 24, &s);
+    assert_snapshot!(t.backend());
+}
+```
+
+Add `pub mod sidebar;` to `src/tui/snapshot_tests/mod.rs`.
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+Run: `cargo test --lib tui::snapshot_tests::sidebar`
+Expected: compile error — `Sidebar` undefined.
+
+- [ ] **Step 3: Implement the widget**
+
+Create `src/tui/widgets/sidebar.rs`:
+
+```rust
+use ratatui::{Frame, layout::Rect, style::{Modifier, Style}, text::{Line, Span}, widgets::{Block, Borders, Paragraph}};
+use crate::tui::navigation::sidebar_state::{Bucket, SidebarState, ToolId};
+use crate::tui::theme::Theme;
+
+pub struct Sidebar<'a> {
+    state: &'a SidebarState,
+    theme: &'a Theme,
+    brand: &'a str,
+}
+
+const BUCKETS: &[Bucket] = &[Bucket::Run, Bucket::Plan, Bucket::Review, Bucket::Insights, Bucket::System];
+
+fn bucket_label(b: Bucket) -> &'static str {
+    match b { Bucket::Home => "Home", Bucket::Run => "Run", Bucket::Plan => "Plan",
+              Bucket::Review => "Review", Bucket::Insights => "Insights", Bucket::System => "System" }
+}
+
+fn bucket_initial(b: Bucket) -> char {
+    match b { Bucket::Home => 'H', Bucket::Run => 'R', Bucket::Plan => 'N',
+              Bucket::Review => 'V', Bucket::Insights => 'I', Bucket::System => 'S' }
+}
+
+fn tools_in(b: Bucket) -> &'static [(ToolId, &'static str)] {
+    use ToolId::*;
+    match b {
+        Bucket::Home => &[(Home, "Home")],
+        Bucket::Run => &[(RunSessions, "Sessions"), (RunInteractions, "Interactions"),
+                         (RunQueue, "Queue"), (RunAdapt, "Adapt"), (RunPrompt, "Prompt")],
+        Bucket::Plan => &[(PlanIssues, "Issues"), (PlanMilestones, "Milestones"),
+                          (PlanRoadmap, "Roadmap"), (PlanPrd, "PRD")],
+        Bucket::Review => &[(ReviewPrs, "PRs"), (ReviewCi, "CI Errors"), (ReviewReleases, "Release Notes")],
+        Bucket::Insights => &[(InsightsCost, "Cost"), (InsightsTokens, "Tokens"),
+                              (InsightsTurboquant, "TurboQuant"), (InsightsAgents, "Agent Graph"),
+                              (InsightsStats, "Project Stats")],
+        Bucket::System => &[(SystemSettings, "Settings"), (SystemTeams, "Teams")],
+    }
+}
+
+impl<'a> Sidebar<'a> {
+    pub fn new(state: &'a SidebarState, theme: &'a Theme, brand: &'a str) -> Self {
+        Self { state, theme, brand }
+    }
+
+    pub fn render(&self, f: &mut Frame, area: Rect) {
+        if self.state.collapsed { self.render_rail(f, area); } else { self.render_expanded(f, area); }
+    }
+
+    fn render_expanded(&self, f: &mut Frame, area: Rect) {
+        let mut lines: Vec<Line> = Vec::new();
+        lines.push(Line::from(Span::styled(self.brand.to_string(),
+            Style::default().add_modifier(Modifier::BOLD).fg(self.theme.accent_success))));
+        lines.push(Line::from("─".repeat(area.width.saturating_sub(2) as usize)));
+
+        // Home above buckets
+        let home_marker = if self.state.active_tool == ToolId::Home { "•" } else { "◌" };
+        lines.push(Line::from(format!("{} Home", home_marker)));
+
+        for &b in BUCKETS {
+            let marker = if self.state.active_bucket == b && !self.state.collapsed { "▼" } else { "▶" };
+            lines.push(Line::from(Span::styled(format!("{} {}", marker, bucket_label(b)),
+                Style::default().add_modifier(Modifier::BOLD))));
+            if self.state.active_bucket == b {
+                for (t, label) in tools_in(b) {
+                    let m = if self.state.active_tool == *t { "•" } else { " " };
+                    lines.push(Line::from(format!("  {} {}", m, label)));
+                }
+            }
+        }
+        f.render_widget(Paragraph::new(lines).block(Block::default().borders(Borders::RIGHT)), area);
+    }
+
+    fn render_rail(&self, f: &mut Frame, area: Rect) {
+        let mut lines: Vec<Line> = Vec::new();
+        let home = if self.state.active_bucket == Bucket::Home { Style::default().add_modifier(Modifier::REVERSED) } else { Style::default() };
+        lines.push(Line::from(Span::styled("H", home)));
+        for &b in BUCKETS {
+            let s = if self.state.active_bucket == b { Style::default().add_modifier(Modifier::REVERSED) } else { Style::default() };
+            lines.push(Line::from(Span::styled(bucket_initial(b).to_string(), s)));
+        }
+        f.render_widget(Paragraph::new(lines).block(Block::default().borders(Borders::RIGHT)), area);
+    }
+}
+```
+
+Add `pub mod sidebar;` to `src/tui/widgets/mod.rs`.
+
+- [ ] **Step 4: Run test, accept snapshots**
+
+Run: `cargo test --lib tui::snapshot_tests::sidebar`
+Expected: 3 snapshots created, tests fail-then-pass after `cargo insta accept`.
+
+Run: `cargo insta accept`
+Re-run tests — should PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/widgets/sidebar.rs src/tui/widgets/mod.rs \
+        src/tui/snapshot_tests/sidebar.rs src/tui/snapshot_tests/mod.rs \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "feat(tui): sidebar accordion widget + snapshots (UX-0-02)"
+```
+
+---
+
+### Task 3 (UX-0-03): Chrome composer
+
+**Files:**
+- Create: `src/tui/chrome.rs`
+- Modify: `src/tui/mod.rs` (add `pub mod chrome;`)
+- Test: `src/tui/snapshot_tests/chrome.rs`
+
+- [ ] **Step 1: Write the failing snapshot test**
+
+```rust
+use insta::assert_snapshot;
+use ratatui::{Terminal, backend::TestBackend};
+use crate::tui::chrome::{Chrome, ChromeInputs};
+use crate::tui::navigation::sidebar_state::{SidebarState, ToolId};
+use crate::tui::theme::Theme;
+
+#[test]
+fn chrome_renders_default_home_120x40() {
+    let mut t = Terminal::new(TestBackend::new(120, 40)).unwrap();
+    let theme = Theme::dark();
+    let sidebar = SidebarState::default();
+    let inputs = ChromeInputs {
+        sidebar: &sidebar, theme: &theme,
+        brand: "MAESTRO v0.32.0", breadcrumb: "Home",
+        live_stats: "0 agents · $0.00/$50.00 · TQ:ON",
+        footer_hints: vec![("Ctrl+R", "Run"), ("Ctrl+P", "Palette"), ("?", "Help"), ("q", "Quit")],
+        bypass_active: false, log_visible: false,
+    };
+    t.draw(|f| {
+        Chrome::draw(f, f.area(), &inputs, |_f, _content_area| {});
+    }).unwrap();
+    assert_snapshot!(t.backend());
+}
+```
+
+- [ ] **Step 2: Run, confirm fail**
+
+Run: `cargo test --lib tui::snapshot_tests::chrome::chrome_renders_default_home_120x40`
+Expected: compile error.
+
+- [ ] **Step 3: Implement chrome composer**
+
+Create `src/tui/chrome.rs`:
+
+```rust
+use ratatui::{Frame, layout::{Constraint, Direction, Layout, Rect}, style::{Modifier, Style},
+              text::{Line, Span}, widgets::{Block, Borders, Paragraph}};
+use crate::tui::navigation::sidebar_state::SidebarState;
+use crate::tui::theme::Theme;
+use crate::tui::widgets::sidebar::Sidebar;
+
+pub struct ChromeInputs<'a> {
+    pub sidebar: &'a SidebarState,
+    pub theme: &'a Theme,
+    pub brand: &'a str,
+    pub breadcrumb: &'a str,
+    pub live_stats: &'a str,
+    pub footer_hints: Vec<(&'a str, &'a str)>,
+    pub bypass_active: bool,
+    pub log_visible: bool,
+}
+
+pub struct Chrome;
+
+impl Chrome {
+    pub fn draw<F: FnOnce(&mut Frame, Rect)>(f: &mut Frame, area: Rect, c: &ChromeInputs, body: F) {
+        let banner_h: u16 = if c.bypass_active { 1 } else { 0 };
+        let log_h: u16 = if c.log_visible { 6 } else { 0 };
+
+        let chunks = Layout::default().direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(banner_h),
+                Constraint::Length(1),                      // header
+                Constraint::Min(1),                          // body
+                Constraint::Length(log_h),
+                Constraint::Length(1),                      // footer
+            ]).split(area);
+
+        if c.bypass_active { draw_bypass(f, chunks[0]); }
+        draw_header(f, chunks[1], c);
+
+        let sidebar_w: u16 = if c.sidebar.collapsed { 3 } else { 22 };
+        let inner = Layout::default().direction(Direction::Horizontal)
+            .constraints([Constraint::Length(sidebar_w), Constraint::Min(1)]).split(chunks[2]);
+        Sidebar::new(c.sidebar, c.theme, c.brand).render(f, inner[0]);
+
+        body(f, inner[1]);
+
+        if c.log_visible { draw_log(f, chunks[3]); }
+        draw_footer(f, chunks[4], c);
+    }
+}
+
+fn draw_bypass(f: &mut Frame, area: Rect) {
+    let p = Paragraph::new("⚠ BYPASS MODE — auto-accepting review corrections")
+        .style(Style::default().add_modifier(Modifier::REVERSED));
+    f.render_widget(p, area);
+}
+
+fn draw_header(f: &mut Frame, area: Rect, c: &ChromeInputs) {
+    let crumb = format!("{} » {}", c.brand, c.breadcrumb);
+    let line = Line::from(vec![
+        Span::styled(crumb, Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw("    "),
+        Span::raw(format!("✦ {}", c.live_stats)),
+    ]);
+    f.render_widget(Paragraph::new(line), area);
+}
+
+fn draw_footer(f: &mut Frame, area: Rect, c: &ChromeInputs) {
+    let mut spans: Vec<Span> = Vec::new();
+    for (i, (k, v)) in c.footer_hints.iter().enumerate() {
+        if i > 0 { spans.push(Span::raw(" · ")); }
+        spans.push(Span::styled(format!("[{}]", k), Style::default().add_modifier(Modifier::BOLD)));
+        spans.push(Span::raw(format!(" {}", v)));
+    }
+    f.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+fn draw_log(f: &mut Frame, area: Rect) {
+    f.render_widget(Block::default().borders(Borders::TOP).title("Activity Log"), area);
+}
+```
+
+Add `pub mod chrome;` to `src/tui/mod.rs`.
+
+- [ ] **Step 4: Run + accept snapshot**
+
+```
+cargo test --lib tui::snapshot_tests::chrome
+cargo insta accept
+cargo test --lib tui::snapshot_tests::chrome
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/chrome.rs src/tui/mod.rs \
+        src/tui/snapshot_tests/chrome.rs src/tui/snapshot_tests/snapshots/
+git commit -m "feat(tui): chrome composer (banner/header/sidebar/footer/log) (UX-0-03)"
+```
+
+---
+
+### Task 4 (UX-0-04): Extend Screen trait with tabs/breadcrumb/footer_hints
+
+**Files:**
+- Modify: `src/tui/screens/mod.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/tui/screens/mod.rs`:
+
+```rust
+#[cfg(test)]
+mod trait_tests {
+    use super::*;
+    struct DummyScreen;
+    impl crate::tui::navigation::keymap::KeymapProvider for DummyScreen {
+        fn keymap_bindings(&self) -> Vec<(&'static str, &'static str)> { Vec::new() }
+    }
+    impl Screen for DummyScreen {
+        fn handle_input(&mut self, _e: &crossterm::event::Event, _m: crate::tui::navigation::InputMode) -> ScreenAction { ScreenAction::None }
+        fn draw(&mut self, _f: &mut ratatui::Frame, _r: ratatui::layout::Rect, _t: &crate::tui::theme::Theme) {}
+    }
+
+    #[test]
+    fn defaults_compile_for_existing_screens() {
+        let s = DummyScreen;
+        assert!(s.tabs().is_none());
+        assert_eq!(s.breadcrumb(), "");
+        assert!(s.footer_hints().is_empty());
+    }
+}
+```
+
+- [ ] **Step 2: Run, confirm fail**
+
+Run: `cargo test --lib tui::screens::trait_tests`
+Expected: compile error — `tabs()` / `breadcrumb()` / `footer_hints()` not in trait.
+
+- [ ] **Step 3: Add default methods**
+
+In `src/tui/screens/mod.rs` extend the `Screen` trait:
+
+```rust
+pub trait Screen: KeymapProvider {
+    fn handle_input(&mut self, event: &Event, mode: InputMode) -> ScreenAction;
+    fn draw(&mut self, f: &mut Frame, area: Rect, theme: &Theme);
+
+    fn tabs(&self) -> Option<&dyn TabsModel> { None }
+    fn breadcrumb(&self) -> &'static str { "" }
+    fn footer_hints(&self) -> Vec<(&'static str, &'static str)> { Vec::new() }
+
+    fn desired_input_mode(&self) -> Option<InputMode> { None }
+}
+
+pub trait TabsModel {
+    fn tabs(&self) -> &[&'static str];
+    fn active(&self) -> usize;
+    fn select(&mut self, idx: usize);
+}
+```
+
+- [ ] **Step 4: Run test, full build**
+
+Run: `cargo build && cargo test --lib tui::screens::trait_tests`
+Expected: PASS. All existing screens still compile (defaults make this additive).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/screens/mod.rs
+git commit -m "feat(tui): extend Screen trait with tabs/breadcrumb/footer_hints (UX-0-04)"
+```
+
+---
+
+### Task 5 (UX-0-05): Modal stack + dim overlay
+
+**Files:**
+- Create: `src/tui/modal.rs`
+- Modify: `src/tui/app/mod.rs` (add `pub modal_stack: Vec<Box<dyn Modal>>`)
+- Modify: `src/tui/mod.rs` (export `modal`)
+- Test: `src/tui/snapshot_tests/modal.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+use insta::assert_snapshot;
+use ratatui::{Terminal, backend::TestBackend, Frame, layout::Rect};
+use crate::tui::modal::{Modal, ModalAction, draw_dimmed};
+use crate::tui::theme::Theme;
+use crossterm::event::Event;
+
+struct Hello;
+impl Modal for Hello {
+    fn draw(&mut self, f: &mut Frame, area: Rect, _t: &Theme) {
+        f.render_widget(ratatui::widgets::Paragraph::new("HELLO"), area);
+    }
+    fn handle_input(&mut self, _e: &Event) -> ModalAction { ModalAction::None }
+}
+
+#[test]
+fn dim_overlay_with_centered_modal() {
+    let mut t = Terminal::new(TestBackend::new(60, 20)).unwrap();
+    let theme = Theme::dark();
+    t.draw(|f| {
+        // base
+        f.render_widget(ratatui::widgets::Paragraph::new("base content"), f.area());
+        // dim + modal
+        let mut m = Hello;
+        draw_dimmed(f, &theme);
+        m.draw(f, ratatui::layout::Rect { x: 20, y: 8, width: 20, height: 4 }, &theme);
+    }).unwrap();
+    assert_snapshot!(t.backend());
+}
+```
+
+- [ ] **Step 2: Confirm fail**
+
+Run: `cargo test --lib tui::snapshot_tests::modal`
+Expected: compile error — `Modal`, `ModalAction`, `draw_dimmed` not defined.
+
+- [ ] **Step 3: Implement modal trait + helpers**
+
+Create `src/tui/modal.rs`:
+
+```rust
+use crossterm::event::Event;
+use ratatui::{Frame, layout::Rect, style::{Color, Style}, widgets::{Block, Widget}};
+use crate::tui::theme::Theme;
+
+pub enum ModalAction {
+    None,
+    Pop,
+    Submit(ModalResult),
+    Cancel,
+}
+
+#[derive(Debug, Clone)]
+pub enum ModalResult {
+    String(String),
+    Number(i64),
+    Bool(bool),
+    None,
+}
+
+pub trait Modal {
+    fn draw(&mut self, f: &mut Frame, area: Rect, theme: &Theme);
+    fn handle_input(&mut self, event: &Event) -> ModalAction;
+}
+
+pub fn draw_dimmed(f: &mut Frame, _theme: &Theme) {
+    let area = f.area();
+    let dim = Block::default().style(Style::default().bg(Color::Black).fg(Color::DarkGray));
+    f.render_widget(dim, area);
+}
+
+pub fn center_rect(parent: Rect, width: u16, height: u16) -> Rect {
+    let x = parent.x + (parent.width.saturating_sub(width)) / 2;
+    let y = parent.y + (parent.height.saturating_sub(height)) / 2;
+    Rect { x, y, width: width.min(parent.width), height: height.min(parent.height) }
+}
+```
+
+Add to `src/tui/app/mod.rs` `App` struct:
+
+```rust
+pub modal_stack: Vec<Box<dyn crate::tui::modal::Modal>>,
+```
+
+Initialize in `App::new()` as `Vec::new()`.
+
+Add `pub mod modal;` to `src/tui/mod.rs`.
+
+- [ ] **Step 4: Run + accept snapshot**
+
+```
+cargo test --lib tui::snapshot_tests::modal
+cargo insta accept
+cargo test --lib tui::snapshot_tests::modal
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/modal.rs src/tui/mod.rs src/tui/app/mod.rs \
+        src/tui/snapshot_tests/modal.rs src/tui/snapshot_tests/snapshots/
+git commit -m "feat(tui): modal stack + dim overlay (UX-0-05)"
+```
+
+---
+
+### Task 6 (UX-0-06): Command palette widget + fuzzy matcher
+
+**Files:**
+- Modify: `Cargo.toml` (add `nucleo-matcher = "0.3"`)
+- Create: `src/tui/widgets/palette.rs`
+- Modify: `src/tui/widgets/mod.rs`
+- Test: same file
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/tui/widgets/palette.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn fuzzy_ranks_exact_first() {
+        let entries = vec![
+            PaletteEntry::tool("Cost", "Insights → Cost"),
+            PaletteEntry::tool("Cost Forecast", "Insights → Cost Forecast"),
+            PaletteEntry::tool("Tokens", "Insights → Tokens"),
+        ];
+        let p = Palette::new(entries);
+        let results = p.search("cost");
+        assert_eq!(results[0].label, "Cost");
+        assert_eq!(results[1].label, "Cost Forecast");
+    }
+    #[test]
+    fn fuzzy_substring_matches() {
+        let entries = vec![
+            PaletteEntry::tool("Project Stats", "Insights → Project Stats"),
+            PaletteEntry::tool("Settings", "System → Settings"),
+        ];
+        let p = Palette::new(entries);
+        let results = p.search("stat");
+        assert_eq!(results[0].label, "Project Stats");
+    }
+}
+```
+
+- [ ] **Step 2: Confirm fail**
+
+Run: `cargo test --lib tui::widgets::palette`
+Expected: compile error.
+
+- [ ] **Step 3: Add dep + implement**
+
+`Cargo.toml`:
+
+```toml
+[dependencies]
+nucleo-matcher = "0.3"
+```
+
+Create `src/tui/widgets/palette.rs`:
+
+```rust
+use nucleo_matcher::{Matcher, Config, pattern::{Pattern, CaseMatching, Normalization}};
+
+#[derive(Debug, Clone)]
+pub struct PaletteEntry {
+    pub label: String,
+    pub breadcrumb: String,
+}
+
+impl PaletteEntry {
+    pub fn tool(label: &str, breadcrumb: &str) -> Self {
+        Self { label: label.to_string(), breadcrumb: breadcrumb.to_string() }
+    }
+}
+
+pub struct Palette {
+    entries: Vec<PaletteEntry>,
+    matcher: Matcher,
+}
+
+impl Palette {
+    pub fn new(entries: Vec<PaletteEntry>) -> Self {
+        Self { entries, matcher: Matcher::new(Config::DEFAULT) }
+    }
+
+    pub fn search(&self, query: &str) -> Vec<&PaletteEntry> {
+        if query.is_empty() { return self.entries.iter().collect(); }
+        let p = Pattern::parse(query, CaseMatching::Ignore, Normalization::Smart);
+        let mut scored: Vec<(&PaletteEntry, u32)> = self.entries.iter()
+            .filter_map(|e| {
+                let mut buf = Vec::new();
+                let cs = nucleo_matcher::Utf32Str::new(&e.label, &mut buf);
+                let mut self_matcher = Matcher::new(Config::DEFAULT);
+                p.score(cs, &mut self_matcher).map(|s| (e, s))
+            }).collect();
+        scored.sort_by_key(|(_, s)| std::cmp::Reverse(*s));
+        scored.into_iter().map(|(e, _)| e).collect()
+    }
+}
+```
+
+Add `pub mod palette;` to `src/tui/widgets/mod.rs`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test --lib tui::widgets::palette`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock src/tui/widgets/palette.rs src/tui/widgets/mod.rs
+git commit -m "feat(tui): command palette widget + nucleo fuzzy matcher (UX-0-06)"
+```
+
+---
+
+### Task 7 (UX-0-07): Global hotkeys Ctrl+H/R/N/V/I/S/P/B/L
+
+**Files:**
+- Modify: `src/tui/input_handler.rs`
+- Modify: `src/tui/navigation/keymap.rs` (constants)
+- Test: `src/tui/input_handler.rs` `#[cfg(test)]`
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/tui/input_handler.rs`:
+
+```rust
+#[cfg(test)]
+mod global_hotkey_tests {
+    use super::*;
+    use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+    use crate::tui::navigation::sidebar_state::{Bucket, SidebarState};
+
+    fn ctrl(c: char) -> Event {
+        Event::Key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL))
+    }
+
+    #[test]
+    fn ctrl_r_jumps_to_run() {
+        let mut s = SidebarState::default();
+        let acted = apply_global_hotkey(&ctrl('r'), &mut s);
+        assert!(acted);
+        assert_eq!(s.active_bucket, Bucket::Run);
+    }
+
+    #[test]
+    fn ctrl_n_jumps_to_plan() {
+        let mut s = SidebarState::default();
+        let acted = apply_global_hotkey(&ctrl('n'), &mut s);
+        assert!(acted);
+        assert_eq!(s.active_bucket, Bucket::Plan);
+    }
+
+    #[test]
+    fn unrelated_key_does_nothing() {
+        let mut s = SidebarState::default();
+        let acted = apply_global_hotkey(&Event::Key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE)), &mut s);
+        assert!(!acted);
+        assert_eq!(s.active_bucket, Bucket::Home);
+    }
+}
+```
+
+- [ ] **Step 2: Confirm fail**
+
+Run: `cargo test --lib tui::input_handler::global_hotkey_tests`
+Expected: compile error — `apply_global_hotkey` missing.
+
+- [ ] **Step 3: Implement handler**
+
+Append to `src/tui/input_handler.rs`:
+
+```rust
+use crossterm::event::{Event, KeyCode, KeyModifiers};
+use crate::tui::navigation::sidebar_state::{Bucket, SidebarState, ToolId};
+
+pub fn apply_global_hotkey(event: &Event, sidebar: &mut SidebarState) -> bool {
+    let Event::Key(k) = event else { return false };
+    if !k.modifiers.contains(KeyModifiers::CONTROL) { return false; }
+    let target = match k.code {
+        KeyCode::Char('h') => Some((Bucket::Home, ToolId::Home)),
+        KeyCode::Char('r') => Some((Bucket::Run, ToolId::RunSessions)),
+        KeyCode::Char('n') => Some((Bucket::Plan, ToolId::PlanIssues)),
+        KeyCode::Char('v') => Some((Bucket::Review, ToolId::ReviewPrs)),
+        KeyCode::Char('i') => Some((Bucket::Insights, ToolId::InsightsCost)),
+        KeyCode::Char('s') => Some((Bucket::System, ToolId::SystemSettings)),
+        _ => None,
+    };
+    if let Some((_, tool)) = target { sidebar.select(tool); return true; }
+    false
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test --lib tui::input_handler::global_hotkey_tests`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/input_handler.rs
+git commit -m "feat(tui): global Ctrl+letter hotkeys for bucket jumps (UX-0-07)"
+```
+
+---
+
+### Task 8 (UX-0-08): Focus rings — Tab cycles Sidebar↔Tabs↔Content
+
+**Files:**
+- Create: `src/tui/navigation/focus.rs`
+- Modify: `src/tui/navigation/mod.rs`
+- Test: same file
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn cycles_default() {
+        let mut f = FocusRing::new(true, true);
+        assert_eq!(f.current(), FocusRegion::Sidebar);
+        f.next(); assert_eq!(f.current(), FocusRegion::Tabs);
+        f.next(); assert_eq!(f.current(), FocusRegion::Content);
+        f.next(); assert_eq!(f.current(), FocusRegion::Sidebar);
+    }
+    #[test]
+    fn skips_collapsed_sidebar() {
+        let mut f = FocusRing::new(false, true);
+        assert_eq!(f.current(), FocusRegion::Tabs);
+        f.next(); assert_eq!(f.current(), FocusRegion::Content);
+        f.next(); assert_eq!(f.current(), FocusRegion::Tabs);
+    }
+    #[test]
+    fn skips_no_tabs() {
+        let mut f = FocusRing::new(true, false);
+        assert_eq!(f.current(), FocusRegion::Sidebar);
+        f.next(); assert_eq!(f.current(), FocusRegion::Content);
+        f.next(); assert_eq!(f.current(), FocusRegion::Sidebar);
+    }
+}
+```
+
+- [ ] **Step 2: Confirm fail**
+
+Run: `cargo test --lib tui::navigation::focus`
+Expected: compile error.
+
+- [ ] **Step 3: Implement**
+
+Create `src/tui/navigation/focus.rs`:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FocusRegion { Sidebar, Tabs, Content }
+
+pub struct FocusRing {
+    sidebar_expanded: bool,
+    has_tabs: bool,
+    current: FocusRegion,
+}
+
+impl FocusRing {
+    pub fn new(sidebar_expanded: bool, has_tabs: bool) -> Self {
+        let current = if sidebar_expanded { FocusRegion::Sidebar }
+                      else if has_tabs { FocusRegion::Tabs }
+                      else { FocusRegion::Content };
+        Self { sidebar_expanded, has_tabs, current }
+    }
+
+    pub fn current(&self) -> FocusRegion { self.current }
+
+    pub fn next(&mut self) {
+        let order: Vec<FocusRegion> = {
+            let mut o = Vec::new();
+            if self.sidebar_expanded { o.push(FocusRegion::Sidebar); }
+            if self.has_tabs { o.push(FocusRegion::Tabs); }
+            o.push(FocusRegion::Content);
+            o
+        };
+        if order.len() < 2 { return; }
+        let idx = order.iter().position(|r| *r == self.current).unwrap_or(0);
+        self.current = order[(idx + 1) % order.len()];
+    }
+    pub fn prev(&mut self) {
+        let order: Vec<FocusRegion> = {
+            let mut o = Vec::new();
+            if self.sidebar_expanded { o.push(FocusRegion::Sidebar); }
+            if self.has_tabs { o.push(FocusRegion::Tabs); }
+            o.push(FocusRegion::Content);
+            o
+        };
+        if order.len() < 2 { return; }
+        let idx = order.iter().position(|r| *r == self.current).unwrap_or(0);
+        self.current = order[(idx + order.len() - 1) % order.len()];
+    }
+}
+```
+
+Add `pub mod focus;` to `src/tui/navigation/mod.rs`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test --lib tui::navigation::focus`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/navigation/focus.rs src/tui/navigation/mod.rs
+git commit -m "feat(tui): focus ring (Sidebar↔Tabs↔Content) with skip rules (UX-0-08)"
+```
+
+---
+
+### Task 9 (UX-0-09): behavior.new_ux flag + dispatcher branch
+
+**Files:**
+- Modify: `src/config.rs` (add `[behavior] new_ux: bool`)
+- Modify: `src/tui/ui.rs` (top-of-`draw` dispatcher branch)
+- Test: `src/config.rs` `#[cfg(test)]`
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/config.rs`:
+
+```rust
+#[cfg(test)]
+mod new_ux_flag_tests {
+    use super::*;
+    #[test]
+    fn behavior_new_ux_defaults_false() {
+        let cfg: Config = toml::from_str(r#"
+[project]
+name = "demo"
+"#).unwrap();
+        assert!(!cfg.behavior.new_ux);
+    }
+    #[test]
+    fn behavior_new_ux_reads_true() {
+        let cfg: Config = toml::from_str(r#"
+[project]
+name = "demo"
+[behavior]
+new_ux = true
+"#).unwrap();
+        assert!(cfg.behavior.new_ux);
+    }
+}
+```
+
+- [ ] **Step 2: Confirm fail**
+
+Run: `cargo test --lib config::new_ux_flag_tests`
+Expected: fail — `behavior.new_ux` not in `Config`.
+
+- [ ] **Step 3: Add flag**
+
+In `src/config.rs`:
+
+```rust
+#[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize)]
+#[serde(default)]
+pub struct BehaviorConfig {
+    pub caveman_mode: bool,
+    pub new_ux: bool,
+}
+
+// Inside Config struct (add field if not present):
+// pub behavior: BehaviorConfig,
+```
+
+In `src/tui/ui.rs`, top of `pub fn draw(...)`:
+
+```rust
+pub fn draw(f: &mut Frame, app: &mut App, theme: &Theme) {
+    if app.config.behavior.new_ux {
+        draw_new_ux(f, app, theme);
+        return;
+    }
+    draw_legacy(f, app, theme);
+}
+
+fn draw_new_ux(f: &mut Frame, app: &mut App, theme: &Theme) {
+    // For Task 10 (Home) and onward. For now: empty chrome.
+    use crate::tui::chrome::{Chrome, ChromeInputs};
+    let inputs = ChromeInputs {
+        sidebar: &app.sidebar_state, theme,
+        brand: "MAESTRO v0.32.0",
+        breadcrumb: "Home",
+        live_stats: "0 agents · $0.00/$50.00 · TQ:OFF",
+        footer_hints: vec![("Ctrl+R", "Run"), ("Ctrl+P", "Palette"), ("?", "Help"), ("q", "Quit")],
+        bypass_active: app.bypass_mode_active,
+        log_visible: app.log_strip_visible,
+    };
+    Chrome::draw(f, f.area(), &inputs, |_f, _content| { /* Home in Task 10 */ });
+}
+
+// Rename current draw body to draw_legacy:
+fn draw_legacy(f: &mut Frame, app: &mut App, theme: &Theme) {
+    // ... existing draw body unchanged ...
+}
+```
+
+Add to `App`: `pub sidebar_state: SidebarState` and `pub log_strip_visible: bool`. Init defaults in `App::new`.
+
+- [ ] **Step 4: Run tests + build**
+
+Run: `cargo build && cargo test --lib config::new_ux_flag_tests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/config.rs src/tui/ui.rs src/tui/app/mod.rs
+git commit -m "feat(config): behavior.new_ux flag + chrome dispatcher branch (UX-0-09)"
+```
+
+---
+
+### Task 10 (UX-0-10): Home screen — Sessions / Cost / Suggestions cards
+
+**Files:**
+- Create: `src/tui/screens/home/mod.rs`, `src/tui/screens/home/draw.rs`, `src/tui/screens/home/cards.rs`
+- Modify: `src/tui/screens/mod.rs` (export HomeScreen)
+- Modify: `src/tui/ui.rs` (`draw_new_ux` renders HomeScreen)
+- Test: `src/tui/snapshot_tests/home.rs`
+
+- [ ] **Step 1: Write the failing snapshot**
+
+```rust
+use insta::assert_snapshot;
+use ratatui::{Terminal, backend::TestBackend};
+use crate::tui::screens::home::HomeScreen;
+use crate::tui::theme::Theme;
+
+#[test]
+fn home_renders_120x30_empty_state() {
+    let mut t = Terminal::new(TestBackend::new(120, 30)).unwrap();
+    let theme = Theme::dark();
+    let mut s = HomeScreen::new();
+    t.draw(|f| s.draw_for_test(f, f.area(), &theme, 0, 0.0, vec![])).unwrap();
+    assert_snapshot!(t.backend());
+}
+
+#[test]
+fn home_renders_with_data() {
+    let mut t = Terminal::new(TestBackend::new(120, 30)).unwrap();
+    let theme = Theme::dark();
+    let mut s = HomeScreen::new();
+    t.draw(|f| s.draw_for_test(f, f.area(), &theme, 2, 12.40, vec![
+        "v0.29.0 95% — close #809".to_string(),
+        "v0.30 0% — start interactive session".to_string(),
+    ])).unwrap();
+    assert_snapshot!(t.backend());
+}
+```
+
+Add `pub mod home;` to `src/tui/snapshot_tests/mod.rs`.
+
+- [ ] **Step 2: Confirm fail**
+
+Run: `cargo test --lib tui::snapshot_tests::home`
+Expected: compile error.
+
+- [ ] **Step 3: Implement HomeScreen**
+
+`src/tui/screens/home/mod.rs`:
+
+```rust
+pub mod draw;
+pub mod cards;
+
+use crossterm::event::Event;
+use ratatui::{Frame, layout::Rect};
+use crate::tui::navigation::InputMode;
+use crate::tui::navigation::keymap::KeymapProvider;
+use crate::tui::screens::{Screen, ScreenAction};
+use crate::tui::theme::Theme;
+
+pub struct HomeScreen {
+    pub active_sessions: u32,
+    pub cost_used: f64,
+    pub cost_quota: f64,
+    pub suggestions: Vec<String>,
+}
+
+impl HomeScreen {
+    pub fn new() -> Self {
+        Self { active_sessions: 0, cost_used: 0.0, cost_quota: 50.0, suggestions: Vec::new() }
+    }
+    pub fn draw_for_test(&mut self, f: &mut Frame, area: Rect, theme: &Theme,
+                         sessions: u32, cost: f64, sugg: Vec<String>) {
+        self.active_sessions = sessions; self.cost_used = cost; self.suggestions = sugg;
+        draw::draw_home(f, area, theme, self);
+    }
+}
+
+impl KeymapProvider for HomeScreen {
+    fn keymap_bindings(&self) -> Vec<(&'static str, &'static str)> {
+        vec![("Enter", "Open suggestion"), ("Ctrl+R", "Run"), ("Ctrl+P", "Palette")]
+    }
+}
+
+impl Screen for HomeScreen {
+    fn handle_input(&mut self, _e: &Event, _m: InputMode) -> ScreenAction { ScreenAction::None }
+    fn draw(&mut self, f: &mut Frame, area: Rect, theme: &Theme) {
+        draw::draw_home(f, area, theme, self);
+    }
+    fn breadcrumb(&self) -> &'static str { "Home" }
+    fn footer_hints(&self) -> Vec<(&'static str, &'static str)> { self.keymap_bindings() }
+}
+```
+
+`src/tui/screens/home/cards.rs`:
+
+```rust
+use ratatui::{Frame, layout::Rect, widgets::{Block, Borders, Paragraph, Gauge}};
+use ratatui::style::{Color, Style};
+
+pub fn sessions_card(f: &mut Frame, area: Rect, active: u32) {
+    let body = format!(" {} active\n {} idle", active, 0);
+    let p = Paragraph::new(body).block(Block::default().borders(Borders::ALL).title("Active Sessions"));
+    f.render_widget(p, area);
+}
+
+pub fn cost_card(f: &mut Frame, area: Rect, used: f64, quota: f64) {
+    let pct = ((used / quota).clamp(0.0, 1.0) * 100.0) as u16;
+    let g = Gauge::default()
+        .block(Block::default().borders(Borders::ALL).title("Cost (this run)"))
+        .gauge_style(Style::default().fg(Color::Green))
+        .percent(pct)
+        .label(format!("${:.2} / ${:.2}", used, quota));
+    f.render_widget(g, area);
+}
+
+pub fn suggestions_card(f: &mut Frame, area: Rect, items: &[String]) {
+    let body = if items.is_empty() { " (none)".to_string() } else {
+        items.iter().map(|s| format!(" • {}", s)).collect::<Vec<_>>().join("\n")
+    };
+    let p = Paragraph::new(body).block(Block::default().borders(Borders::ALL).title("Suggestions"));
+    f.render_widget(p, area);
+}
+```
+
+`src/tui/screens/home/draw.rs`:
+
+```rust
+use ratatui::{Frame, layout::{Constraint, Direction, Layout, Rect}};
+use crate::tui::screens::home::{HomeScreen, cards};
+use crate::tui::theme::Theme;
+
+pub fn draw_home(f: &mut Frame, area: Rect, _theme: &Theme, s: &HomeScreen) {
+    let rows = Layout::default().direction(Direction::Vertical)
+        .constraints([Constraint::Length(5), Constraint::Min(1)]).split(area);
+    let top = Layout::default().direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)]).split(rows[0]);
+    cards::sessions_card(f, top[0], s.active_sessions);
+    cards::cost_card(f, top[1], s.cost_used, s.cost_quota);
+    cards::suggestions_card(f, rows[1], &s.suggestions);
+}
+```
+
+Export from `src/tui/screens/mod.rs`:
+
+```rust
+pub mod home;
+pub use home::HomeScreen;
+```
+
+In `src/tui/ui.rs::draw_new_ux`, body closure renders home:
+
+```rust
+Chrome::draw(f, f.area(), &inputs, |f, content| {
+    app.home_screen.draw(f, content, theme);
+});
+```
+
+Add `pub home_screen: HomeScreen` to `App` and init in `App::new`.
+
+- [ ] **Step 4: Snapshot accept**
+
+```
+cargo test --lib tui::snapshot_tests::home
+cargo insta accept
+cargo test --lib tui::snapshot_tests::home
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/screens/home/ src/tui/screens/mod.rs src/tui/ui.rs src/tui/app/mod.rs \
+        src/tui/snapshot_tests/home.rs src/tui/snapshot_tests/mod.rs \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "feat(tui): Home screen with Sessions/Cost/Suggestions cards (UX-0-10)"
+```
+
+---
+
+### Task 11 (UX-0-11): Chrome + sidebar snapshot suite at 3 terminal sizes
+
+**Files:**
+- Create snapshots at `src/tui/snapshot_tests/chrome_sizes.rs`
+
+- [ ] **Step 1: Add three-size snapshot test**
+
+```rust
+use insta::assert_snapshot;
+use ratatui::{Terminal, backend::TestBackend};
+use crate::tui::chrome::{Chrome, ChromeInputs};
+use crate::tui::navigation::sidebar_state::SidebarState;
+use crate::tui::theme::Theme;
+
+fn render(width: u16, height: u16) -> Terminal<TestBackend> {
+    let mut t = Terminal::new(TestBackend::new(width, height)).unwrap();
+    let theme = Theme::dark();
+    let s = SidebarState::default();
+    let inputs = ChromeInputs {
+        sidebar: &s, theme: &theme,
+        brand: "MAESTRO v0.32.0", breadcrumb: "Home",
+        live_stats: "0 agents · $0/$50 · TQ:OFF",
+        footer_hints: vec![("Ctrl+R", "Run"), ("Ctrl+P", "Palette"), ("?", "Help"), ("q", "Quit")],
+        bypass_active: false, log_visible: false,
+    };
+    t.draw(|f| Chrome::draw(f, f.area(), &inputs, |_f, _c| {})).unwrap();
+    t
+}
+
+#[test] fn chrome_80x24()  { let t = render(80, 24);  assert_snapshot!(t.backend()); }
+#[test] fn chrome_120x40() { let t = render(120, 40); assert_snapshot!(t.backend()); }
+#[test] fn chrome_200x60() { let t = render(200, 60); assert_snapshot!(t.backend()); }
+```
+
+Add `pub mod chrome_sizes;` to `src/tui/snapshot_tests/mod.rs`.
+
+- [ ] **Step 2: Accept snapshots**
+
+```
+cargo test --lib tui::snapshot_tests::chrome_sizes
+cargo insta accept
+cargo test --lib tui::snapshot_tests::chrome_sizes
+```
+Expected: PASS (3 tests).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/tui/snapshot_tests/chrome_sizes.rs src/tui/snapshot_tests/mod.rs \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "test(tui): chrome + sidebar snapshots at 80x24/120x40/200x60 (UX-0-11)"
+```
+
+---
+
+## Milestone Dependency Graph (for `gh api milestones` PATCH body)
+
+```
+Level 0:
+• UX-0-01 (none)
+
+Level 1 (parallel, depend on UX-0-01):
+• UX-0-02 sidebar
+• UX-0-03 chrome
+• UX-0-04 Screen trait
+• UX-0-06 palette
+
+Level 2:
+• UX-0-05 modal stack (depends on UX-0-04)
+• UX-0-07 global hotkeys (depends on UX-0-01, UX-0-05)
+
+Level 3:
+• UX-0-08 focus rings (depends on UX-0-07)
+
+Level 4:
+• UX-0-09 flag (depends on UX-0-03, UX-0-07, UX-0-08)
+
+Level 5:
+• UX-0-10 Home (depends on UX-0-03, UX-0-09)
+
+Level 6:
+• UX-0-11 snapshot suite (depends on UX-0-02, UX-0-03, UX-0-10)
+
+Sequence: UX-0-01 → (UX-0-02 ∥ UX-0-03 ∥ UX-0-04 ∥ UX-0-06) → UX-0-05 → UX-0-07 → UX-0-08 → UX-0-09 → UX-0-10 → UX-0-11
+```

--- a/docs/superpowers/plans/2026-05-21-wizard-spine-v0.32.5.md
+++ b/docs/superpowers/plans/2026-05-21-wizard-spine-v0.32.5.md
@@ -1,0 +1,591 @@
+# Wizard Spine (v0.32.5) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace four bespoke wizards (Issue / Milestone / Team / Adapt) with a single `Wizard` + `WizardStep` trait pair plus a shared `WizardFrame` widget that renders step counter, title, body slot, validation banner, and nav footer.
+
+**Architecture:** A single `wizard::WizardFrame` widget draws every wizard in a modal overlay (via Phase-0 modal stack). The `Wizard` trait holds step list + cursor + advance/rewind/cancel/submit. Each `WizardStep` impl owns its body rendering, input handling, validation, and footer hints. The Settings schema-tab field renderer is extracted into a reusable `wizard::fields` module so wizards get the same typed inputs.
+
+**Tech Stack:** Rust 2024 · ratatui · `insta` snapshots. Depends on v0.32.0 modal stack (UX-0-05) and Settings schema renderer.
+
+**Spec:** `docs/superpowers/specs/2026-05-21-tui-ux-redesign-sidebar-ia-design.md` — Section 7.
+
+---
+
+### Task 1 (UX-0a-01): Wizard + WizardStep traits + WizardFrame
+
+**Files:**
+- Create: `src/tui/widgets/wizard/mod.rs`, `src/tui/widgets/wizard/frame.rs`
+- Modify: `src/tui/widgets/mod.rs`
+- Test: `src/tui/widgets/wizard/mod.rs` `#[cfg(test)]`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::Event;
+
+    struct StepA { input: String }
+    impl WizardStep for StepA {
+        fn header(&self) -> String { "Step 1/2: Name".into() }
+        fn render_body(&self, _f: &mut ratatui::Frame, _r: ratatui::layout::Rect, _t: &crate::tui::theme::Theme) {}
+        fn handle_input(&mut self, _e: &Event) -> WizardStepAction { WizardStepAction::None }
+        fn validate(&self) -> Vec<ValidationError> {
+            if self.input.is_empty() { vec![ValidationError::new("name required")] } else { Vec::new() }
+        }
+        fn footer_hints(&self) -> Vec<(&'static str, &'static str)> { vec![("→", "Next")] }
+    }
+    struct StepB;
+    impl WizardStep for StepB {
+        fn header(&self) -> String { "Step 2/2: Confirm".into() }
+        fn render_body(&self, _f: &mut ratatui::Frame, _r: ratatui::layout::Rect, _t: &crate::tui::theme::Theme) {}
+        fn handle_input(&mut self, _e: &Event) -> WizardStepAction { WizardStepAction::None }
+        fn validate(&self) -> Vec<ValidationError> { Vec::new() }
+        fn footer_hints(&self) -> Vec<(&'static str, &'static str)> { vec![("Ctrl+Enter", "Submit")] }
+    }
+
+    struct Demo { steps: Vec<Box<dyn WizardStep>>, cursor: usize }
+    impl Wizard for Demo {
+        fn title(&self) -> &'static str { "Demo Wizard" }
+        fn steps(&self) -> &[Box<dyn WizardStep>] { &self.steps }
+        fn steps_mut(&mut self) -> &mut [Box<dyn WizardStep>] { &mut self.steps }
+        fn current_step(&self) -> usize { self.cursor }
+        fn set_cursor(&mut self, idx: usize) { self.cursor = idx; }
+    }
+
+    #[test]
+    fn advance_blocked_by_validation_errors() {
+        let steps: Vec<Box<dyn WizardStep>> = vec![
+            Box::new(StepA { input: String::new() }),
+            Box::new(StepB),
+        ];
+        let mut w = Demo { steps, cursor: 0 };
+        let r = w.advance();
+        assert!(matches!(r, WizardResult::BlockedByValidation));
+        assert_eq!(w.current_step(), 0);
+    }
+
+    #[test]
+    fn advance_passes_when_valid() {
+        let steps: Vec<Box<dyn WizardStep>> = vec![
+            Box::new(StepA { input: "ok".into() }),
+            Box::new(StepB),
+        ];
+        let mut w = Demo { steps, cursor: 0 };
+        let r = w.advance();
+        assert!(matches!(r, WizardResult::Continue));
+        assert_eq!(w.current_step(), 1);
+    }
+
+    #[test]
+    fn submit_on_final_step() {
+        let steps: Vec<Box<dyn WizardStep>> = vec![Box::new(StepB)];
+        let mut w = Demo { steps, cursor: 0 };
+        let r = w.advance();
+        assert!(matches!(r, WizardResult::Done(_)));
+    }
+}
+```
+
+- [ ] **Step 2: Confirm fail**
+
+Run: `cargo test --lib tui::widgets::wizard`
+Expected: compile error — `Wizard`, `WizardStep`, `WizardResult`, `ValidationError` undefined.
+
+- [ ] **Step 3: Implement traits**
+
+`src/tui/widgets/wizard/mod.rs`:
+
+```rust
+pub mod frame;
+
+use crossterm::event::Event;
+use ratatui::{Frame, layout::Rect};
+use crate::tui::theme::Theme;
+use crate::tui::modal::ModalResult;
+
+#[derive(Debug, Clone)]
+pub struct ValidationError { pub message: String }
+impl ValidationError { pub fn new(m: &str) -> Self { Self { message: m.into() } } }
+
+pub enum WizardStepAction { None, Submit, Back, Cancel }
+pub enum WizardResult { Continue, BlockedByValidation, Done(ModalResult), Cancelled }
+
+pub trait WizardStep {
+    fn header(&self) -> String;
+    fn render_body(&self, f: &mut Frame, area: Rect, theme: &Theme);
+    fn handle_input(&mut self, event: &Event) -> WizardStepAction;
+    fn validate(&self) -> Vec<ValidationError>;
+    fn footer_hints(&self) -> Vec<(&'static str, &'static str)>;
+}
+
+pub trait Wizard {
+    fn title(&self) -> &'static str;
+    fn steps(&self) -> &[Box<dyn WizardStep>];
+    fn steps_mut(&mut self) -> &mut [Box<dyn WizardStep>];
+    fn current_step(&self) -> usize;
+    fn set_cursor(&mut self, idx: usize);
+
+    fn advance(&mut self) -> WizardResult {
+        let idx = self.current_step();
+        let errors = self.steps()[idx].validate();
+        if !errors.is_empty() { return WizardResult::BlockedByValidation; }
+        if idx + 1 < self.steps().len() {
+            self.set_cursor(idx + 1);
+            WizardResult::Continue
+        } else {
+            WizardResult::Done(ModalResult::None)
+        }
+    }
+    fn rewind(&mut self) -> WizardResult {
+        let idx = self.current_step();
+        if idx > 0 { self.set_cursor(idx - 1); WizardResult::Continue } else { WizardResult::Cancelled }
+    }
+    fn cancel(&mut self) -> WizardResult { WizardResult::Cancelled }
+}
+```
+
+- [ ] **Step 4: Implement WizardFrame draw**
+
+`src/tui/widgets/wizard/frame.rs`:
+
+```rust
+use ratatui::{Frame, layout::{Constraint, Direction, Layout, Rect}, style::{Color, Modifier, Style},
+              text::Line, widgets::{Block, Borders, Paragraph}};
+use crate::tui::theme::Theme;
+use crate::tui::widgets::wizard::{Wizard, ValidationError};
+
+pub fn draw_wizard(f: &mut Frame, area: Rect, theme: &Theme, w: &dyn Wizard) {
+    let block = Block::default().borders(Borders::ALL).title(w.title());
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let idx = w.current_step();
+    let step = &w.steps()[idx];
+
+    let rows = Layout::default().direction(Direction::Vertical).constraints([
+        Constraint::Length(1),  // header
+        Constraint::Length(1),  // separator
+        Constraint::Min(3),     // body
+        Constraint::Length(1),  // separator
+        Constraint::Length(2),  // validation banner (up to 1 line + sep)
+        Constraint::Length(1),  // footer
+    ]).split(inner);
+
+    f.render_widget(Paragraph::new(step.header()).style(Style::default().add_modifier(Modifier::BOLD)), rows[0]);
+    f.render_widget(Paragraph::new("─".repeat(inner.width as usize)), rows[1]);
+    step.render_body(f, rows[2], theme);
+    f.render_widget(Paragraph::new("─".repeat(inner.width as usize)), rows[3]);
+
+    let errors = step.validate();
+    if !errors.is_empty() {
+        let line = format!("⚠ {}", errors[0].message);
+        f.render_widget(Paragraph::new(line).style(Style::default().fg(Color::Yellow)), rows[4]);
+    }
+
+    let hints = step.footer_hints();
+    let footer_line: Vec<ratatui::text::Span> = hints.iter().flat_map(|(k, v)| vec![
+        ratatui::text::Span::styled(format!("[{}]", k), Style::default().add_modifier(Modifier::BOLD)),
+        ratatui::text::Span::raw(format!(" {} · ", v)),
+    ]).collect();
+    f.render_widget(Paragraph::new(Line::from(footer_line)), rows[5]);
+}
+```
+
+Export `pub mod wizard;` from `src/tui/widgets/mod.rs`.
+
+- [ ] **Step 5: Run + commit**
+
+```
+cargo test --lib tui::widgets::wizard
+git add src/tui/widgets/wizard/ src/tui/widgets/mod.rs
+git commit -m "feat(tui): Wizard + WizardStep traits + WizardFrame (UX-0a-01)"
+```
+
+---
+
+### Task 2 (UX-0a-02): Reuse Settings schema field renderer in wizard body
+
+**Files:**
+- Create: `src/tui/widgets/wizard/fields.rs`
+- Modify: `src/tui/widgets/wizard/mod.rs` (`pub mod fields;`)
+- Test: `src/tui/widgets/wizard/fields.rs` `#[cfg(test)]`
+
+- [ ] **Step 1: Identify reusable field types**
+
+Read `src/tui/screens/settings/schema_tab/` to find `TextInputField`, `DropdownField`, `ToggleField`, `NumberStepperField`. List them in the file header comment.
+
+- [ ] **Step 2: Write the failing test for SchemaField wrapper**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::{Terminal, backend::TestBackend};
+    use crate::tui::theme::Theme;
+
+    #[test]
+    fn schema_text_field_renders() {
+        let mut t = Terminal::new(TestBackend::new(40, 3)).unwrap();
+        let theme = Theme::dark();
+        let mut field = SchemaField::text("Issue title", "fix(thing)");
+        t.draw(|f| field.render(f, f.area(), &theme)).unwrap();
+        let buf = format!("{:?}", t.backend().buffer());
+        assert!(buf.contains("Issue title"));
+        assert!(buf.contains("fix(thing)"));
+    }
+}
+```
+
+- [ ] **Step 3: Wrap existing schema field types behind `SchemaField`**
+
+`src/tui/widgets/wizard/fields.rs`:
+
+```rust
+use ratatui::{Frame, layout::Rect, widgets::{Block, Borders, Paragraph}};
+use crate::tui::theme::Theme;
+
+pub enum SchemaField {
+    Text { label: String, value: String },
+    Number { label: String, value: i64 },
+    Toggle { label: String, value: bool },
+    Dropdown { label: String, value: String, options: Vec<String> },
+}
+
+impl SchemaField {
+    pub fn text(label: &str, initial: &str) -> Self { Self::Text { label: label.into(), value: initial.into() } }
+    pub fn number(label: &str, initial: i64) -> Self { Self::Number { label: label.into(), value: initial } }
+    pub fn toggle(label: &str, initial: bool) -> Self { Self::Toggle { label: label.into(), value: initial } }
+    pub fn dropdown(label: &str, initial: &str, options: Vec<String>) -> Self {
+        Self::Dropdown { label: label.into(), value: initial.into(), options }
+    }
+
+    pub fn render(&self, f: &mut Frame, area: Rect, _theme: &Theme) {
+        match self {
+            Self::Text { label, value } => {
+                let body = format!(" {}", value);
+                let p = Paragraph::new(body).block(Block::default().borders(Borders::ALL).title(label.as_str()));
+                f.render_widget(p, area);
+            }
+            Self::Number { label, value } => {
+                let body = format!(" {}", value);
+                let p = Paragraph::new(body).block(Block::default().borders(Borders::ALL).title(label.as_str()));
+                f.render_widget(p, area);
+            }
+            Self::Toggle { label, value } => {
+                let body = format!(" [{}]", if *value { "x" } else { " " });
+                let p = Paragraph::new(body).block(Block::default().borders(Borders::ALL).title(label.as_str()));
+                f.render_widget(p, area);
+            }
+            Self::Dropdown { label, value, options } => {
+                let body = format!(" {} (one of {})", value, options.len());
+                let p = Paragraph::new(body).block(Block::default().borders(Borders::ALL).title(label.as_str()));
+                f.render_widget(p, area);
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run + commit**
+
+```
+cargo test --lib tui::widgets::wizard::fields
+git add src/tui/widgets/wizard/fields.rs src/tui/widgets/wizard/mod.rs
+git commit -m "feat(tui): SchemaField renderer reused in wizards (UX-0a-02)"
+```
+
+---
+
+### Task 3 (UX-0a-03): Migrate IssueWizard onto Wizard trait
+
+**Files:**
+- Modify: `src/tui/screens/issue_wizard/` (multiple files)
+- Test: `src/tui/snapshot_tests/issue_wizard.rs` (replace or add `wizard_frame_*` snapshots)
+
+- [ ] **Step 1: Add failing snapshot test for new wizard frame**
+
+```rust
+use insta::assert_snapshot;
+use ratatui::{Terminal, backend::TestBackend};
+use crate::tui::theme::Theme;
+use crate::tui::screens::issue_wizard::IssueWizardScreen;
+use crate::tui::widgets::wizard::frame::draw_wizard;
+
+#[test]
+fn issue_wizard_step1_in_new_frame() {
+    let mut t = Terminal::new(TestBackend::new(80, 24)).unwrap();
+    let theme = Theme::dark();
+    let w = IssueWizardScreen::new();
+    t.draw(|f| draw_wizard(f, f.area(), &theme, &w)).unwrap();
+    assert_snapshot!(t.backend());
+}
+```
+
+- [ ] **Step 2: Confirm fail**
+
+Run: `cargo test --lib tui::snapshot_tests::issue_wizard::issue_wizard_step1_in_new_frame`
+Expected: compile error — `IssueWizardScreen` doesn't implement `Wizard`.
+
+- [ ] **Step 3: Implement Wizard for IssueWizardScreen**
+
+In `src/tui/screens/issue_wizard/mod.rs`:
+
+```rust
+use crate::tui::widgets::wizard::{Wizard, WizardStep};
+
+impl Wizard for IssueWizardScreen {
+    fn title(&self) -> &'static str { "Issue Wizard" }
+    fn steps(&self) -> &[Box<dyn WizardStep>] { &self.steps }
+    fn steps_mut(&mut self) -> &mut [Box<dyn WizardStep>] { &mut self.steps }
+    fn current_step(&self) -> usize { self.current_step_idx }
+    fn set_cursor(&mut self, idx: usize) { self.current_step_idx = idx; }
+}
+```
+
+Wrap each existing step page into a struct implementing `WizardStep`. For each existing step in `issue_wizard/steps/`, write an adapter:
+
+```rust
+pub struct ClassifyStep { pub kind: String }
+impl WizardStep for ClassifyStep {
+    fn header(&self) -> String { format!("Step 1/10: Classification") }
+    fn render_body(&self, f: &mut ratatui::Frame, area: ratatui::layout::Rect, _t: &crate::tui::theme::Theme) {
+        // existing render
+    }
+    fn handle_input(&mut self, _e: &crossterm::event::Event) -> crate::tui::widgets::wizard::WizardStepAction {
+        crate::tui::widgets::wizard::WizardStepAction::None
+    }
+    fn validate(&self) -> Vec<crate::tui::widgets::wizard::ValidationError> {
+        if self.kind.is_empty() { vec![crate::tui::widgets::wizard::ValidationError::new("pick a classification")] }
+        else { Vec::new() }
+    }
+    fn footer_hints(&self) -> Vec<(&'static str, &'static str)> { vec![("→", "Next"), ("Esc", "Cancel")] }
+}
+```
+
+Replace `IssueWizardScreen::draw` with delegation to `draw_wizard(f, area, theme, self)`.
+
+- [ ] **Step 4: Accept new snapshot + verify legacy snapshots**
+
+```
+cargo test --lib tui::snapshot_tests::issue_wizard
+cargo insta accept
+cargo test --lib tui::snapshot_tests::issue_wizard
+```
+Expected: new `issue_wizard_step1_in_new_frame` PASS. Old `milestone_wizard`/`team_wizard` snapshots unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/screens/issue_wizard/ src/tui/snapshot_tests/issue_wizard.rs \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "refactor(tui): migrate IssueWizard onto Wizard trait + WizardFrame (UX-0a-03)"
+```
+
+---
+
+### Task 4 (UX-0a-04): Migrate MilestoneWizard onto Wizard trait
+
+**Files:**
+- Modify: `src/tui/screens/milestone_wizard/`
+- Test: `src/tui/snapshot_tests/milestone_wizard.rs`
+
+Repeat the Task 3 pattern. Specifically:
+
+- [ ] **Step 1: Snapshot test for first step in new frame**
+
+```rust
+#[test]
+fn milestone_wizard_step1_in_new_frame() {
+    let mut t = ratatui::Terminal::new(ratatui::backend::TestBackend::new(80, 24)).unwrap();
+    let theme = crate::tui::theme::Theme::dark();
+    let w = crate::tui::screens::milestone_wizard::MilestoneWizardScreen::new();
+    t.draw(|f| crate::tui::widgets::wizard::frame::draw_wizard(f, f.area(), &theme, &w)).unwrap();
+    insta::assert_snapshot!(t.backend());
+}
+```
+
+- [ ] **Step 2: Confirm fail, then implement `Wizard` for `MilestoneWizardScreen`**
+
+Same shape as Task 3 Step 3.
+
+- [ ] **Step 3: Wrap each existing milestone step as `WizardStep`**
+
+For each of the wizard's existing steps, write the adapter struct (header, render_body, handle_input, validate, footer_hints). Use exact existing fields.
+
+- [ ] **Step 4: Accept snapshot**
+
+```
+cargo test --lib tui::snapshot_tests::milestone_wizard
+cargo insta accept
+cargo test --lib tui::snapshot_tests::milestone_wizard
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/screens/milestone_wizard/ src/tui/snapshot_tests/milestone_wizard.rs \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "refactor(tui): migrate MilestoneWizard onto Wizard trait (UX-0a-04)"
+```
+
+---
+
+### Task 5 (UX-0a-05): Migrate TeamWizard onto Wizard trait
+
+**Files:**
+- Modify: `src/tui/screens/team_wizard/`
+- Test: `src/tui/snapshot_tests/team_wizard.rs`
+
+Same shape as Task 4. Watch for the in-flight #805/#806 issue picker bug — keep current logic, just wrap into a `WizardStep`.
+
+- [ ] **Step 1: Snapshot test in new frame** (same pattern)
+- [ ] **Step 2: Implement `Wizard` for `TeamWizardScreen`**
+- [ ] **Step 3: Wrap each existing step**
+- [ ] **Step 4: Accept**
+
+```
+cargo test --lib tui::snapshot_tests::team_wizard
+cargo insta accept
+cargo test --lib tui::snapshot_tests::team_wizard
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/screens/team_wizard/ src/tui/snapshot_tests/team_wizard.rs \
+        src/tui/snapshot_tests/snapshots/
+git commit -m "refactor(tui): migrate TeamWizard onto Wizard trait (UX-0a-05)"
+```
+
+---
+
+### Task 6 (UX-0a-06): Migrate AdaptWizard onto Wizard trait
+
+**Files:**
+- Modify: `src/tui/screens/adapt/`
+- Test: new snapshot
+
+- [ ] **Step 1: Snapshot test for first adapt step**
+
+```rust
+#[test]
+fn adapt_wizard_step1_in_new_frame() {
+    let mut t = ratatui::Terminal::new(ratatui::backend::TestBackend::new(80, 24)).unwrap();
+    let theme = crate::tui::theme::Theme::dark();
+    let w = crate::tui::screens::adapt::AdaptScreen::new();
+    t.draw(|f| crate::tui::widgets::wizard::frame::draw_wizard(f, f.area(), &theme, &w)).unwrap();
+    insta::assert_snapshot!(t.backend());
+}
+```
+
+Add to `src/tui/snapshot_tests/adapt_wizard.rs` (create file) and `pub mod adapt_wizard;` in `src/tui/snapshot_tests/mod.rs`.
+
+- [ ] **Step 2: Implement Wizard for AdaptScreen** (same shape as previous)
+- [ ] **Step 3: Wrap each adapt step** (Source URL, Adapter type, Confirm)
+- [ ] **Step 4: Accept**
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tui/screens/adapt/ src/tui/snapshot_tests/adapt_wizard.rs \
+        src/tui/snapshot_tests/mod.rs src/tui/snapshot_tests/snapshots/
+git commit -m "refactor(tui): migrate AdaptWizard onto Wizard trait (UX-0a-06)"
+```
+
+---
+
+### Task 7 (UX-0a-07): Retire bespoke wizard scaffolding
+
+**Files:**
+- Modify: `src/tui/screens/wizard_fields.rs` — keep only schema-reusable parts (text input, dropdown). Move them under `widgets/wizard/fields.rs`.
+- Delete: `src/tui/screens/wizard_fields_tests.rs` once the suites have been re-pointed.
+
+- [ ] **Step 1: Verify no caller references retained**
+
+Run: `rg "use crate::tui::screens::wizard_fields" src/`
+Expected: empty (after Tasks 3-6 stopped using the legacy adapters).
+
+- [ ] **Step 2: Delete legacy file**
+
+Remove `src/tui/screens/wizard_fields.rs` and `src/tui/screens/wizard_fields_tests.rs` if all symbols are unused.
+
+- [ ] **Step 3: Remove module declarations**
+
+In `src/tui/screens/mod.rs` drop `pub mod wizard_fields;` and `pub mod wizard_fields_tests;`.
+
+- [ ] **Step 4: Build + test**
+
+Run: `cargo build && cargo test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -u src/tui/screens/
+git commit -m "chore(tui): retire wizard_fields legacy scaffolding (UX-0a-07)"
+```
+
+---
+
+### Task 8 (UX-0a-08): Snapshot tests for one representative step per wizard
+
+**Files:**
+- Modify: existing wizard snapshot files to include one extra "middle step" snapshot per wizard.
+
+- [ ] **Step 1: Add snapshots**
+
+For each wizard, write a test that pre-fills 2-3 steps' state then asserts the rendering of a non-first step. Example:
+
+```rust
+#[test]
+fn issue_wizard_step5_files_to_modify_in_new_frame() {
+    let mut t = ratatui::Terminal::new(ratatui::backend::TestBackend::new(80, 24)).unwrap();
+    let theme = crate::tui::theme::Theme::dark();
+    let mut w = crate::tui::screens::issue_wizard::IssueWizardScreen::new();
+    w.set_cursor(4); // Step 5/10 — Files to Modify
+    t.draw(|f| crate::tui::widgets::wizard::frame::draw_wizard(f, f.area(), &theme, &w)).unwrap();
+    insta::assert_snapshot!(t.backend());
+}
+```
+
+Repeat for milestone wizard, team wizard, adapt wizard.
+
+- [ ] **Step 2: Accept snapshots**
+
+```
+cargo test --lib tui::snapshot_tests::issue_wizard tui::snapshot_tests::milestone_wizard tui::snapshot_tests::team_wizard tui::snapshot_tests::adapt_wizard
+cargo insta accept
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/tui/snapshot_tests/ 
+git commit -m "test(tui): mid-step snapshots for each wizard (UX-0a-08)"
+```
+
+---
+
+## Milestone Dependency Graph
+
+```
+Level 0:
+• UX-0a-01 (depends on v0.32.0 UX-0-05 modal stack)
+
+Level 1:
+• UX-0a-02 (depends on UX-0a-01)
+
+Level 2 (parallel):
+• UX-0a-03 IssueWizard
+• UX-0a-04 MilestoneWizard
+• UX-0a-05 TeamWizard
+• UX-0a-06 AdaptWizard
+
+Level 3:
+• UX-0a-07 retire scaffold (depends on Level 2)
+• UX-0a-08 snapshots (depends on Level 2)
+
+Sequence: UX-0a-01 → UX-0a-02 → (UX-0a-03 ∥ UX-0a-04 ∥ UX-0a-05 ∥ UX-0a-06) → (UX-0a-07 ∥ UX-0a-08)
+```

--- a/docs/superpowers/specs/2026-05-21-tui-ux-redesign-sidebar-ia-design.md
+++ b/docs/superpowers/specs/2026-05-21-tui-ux-redesign-sidebar-ia-design.md
@@ -1,0 +1,664 @@
+# Maestro TUI UX Redesign — Sidebar IA + Wizard Spine
+
+**Status:** Draft
+**Date:** 2026-05-21
+**Owner:** Carlos Daniel
+**Brainstorm transcript:** brainstorming skill, 6 clarifying questions + 6 design sections
+
+---
+
+## 1. Problem Statement
+
+Maestro v0.28.x ships ~30 `TuiMode` variants reachable from a flat letter-hotkey landing menu. Tools (Cost / Token / TurboQuant dashboards, Issues / Milestones / Roadmap / PRD, Sessions / SessionSwitcher / Detail / Fullscreen, Adapt, Settings, multiple wizards) sit at the same level with no semantic grouping. Users cannot tell at a glance what Maestro is fundamentally _for_ (running sessions and interactions); the long menu hides the primary path. There is no consistent chrome across screens — each screen draws its own header, borders, footer, and activity log. Wizards are bespoke implementations sharing no base trait.
+
+### Goals
+
+1. Surface Maestro's primary path (Sessions, Interactions) on launch.
+2. Give every screen the same outer chrome (banner, header, sidebar, footer, activity log strip).
+3. Group ~30 screens into 5 semantic buckets reachable from a persistent sidebar.
+4. Standardize wizards behind one trait so step UX is consistent across IssueWizard, MilestoneWizard, TeamWizard, AdaptWizard.
+5. Ship incrementally behind a runtime flag, without freezing the 42 in-flight issues.
+
+### Non-goals
+
+- Theming overhaul (themes already work).
+- Replacing ratatui or moving away from a TUI.
+- Removing keyboard-driven UX in favor of mouse — mouse remains optional.
+- Changing the data model (sessions, issues, milestones, settings).
+
+---
+
+## 2. Brainstorm Decisions (locked)
+
+| Question | Decision |
+|---|---|
+| Blast radius | B — Spine + IA reshuffle (group screens into buckets; chrome consistent; some merges) |
+| Categories | A — 5 buckets: **Run · Plan · Review · Insights · System** |
+| Sidebar grammar | C — Hybrid accordion (single bucket expanded at a time) |
+| Keyboard contract | C — Ctrl+letter global hotkeys + Tab focus rings + Ctrl+P palette |
+| Default landing | B — Home dashboard with summary cards (Sessions / Cost / Suggestions) |
+| Cutover strategy | A — Spine first + one hub per phase, behind `behavior.new_ux` flag |
+| Wizard standardization | Added as Phase 0.5 — own milestone v0.32.5 |
+| Milestone shape | Phase 0 = single milestone v0.32.0; cleanup = own milestone v0.35.5 |
+| Adapt | Sidebar row inside Run |
+| Prompt | Inside Run (not System) |
+| Project Stats | Inside Insights (not Plan) |
+| Sidebar width | Fixed 22 cols (3-col rail when collapsed) |
+| Bypass banner | Above sidebar, full width |
+| Activity Log default | Hidden, toggle with `Ctrl+L` |
+| Breadcrumb format | `MAESTRO v0.X » Bucket » Tool` |
+| Tab visual | Background highlight box for active tab |
+| Footer hints | Global + screen-local |
+| Plan global key | `Ctrl+N` |
+| Tab cycling | Skip collapsed sidebar |
+| Esc in narrow rail | Expands sidebar back |
+
+---
+
+## 3. Tool Inventory and Bucket Assignment
+
+Mapping current `TuiMode` variants to new buckets. Wizards and confirms are modals, not sidebar items.
+
+### Home (always above buckets)
+
+| Sidebar item | New screen | Replaces |
+|---|---|---|
+| Home | `HomeScreen` | `Landing`, `Dashboard` |
+
+### Run
+
+| Sidebar item | New screen / tab | Current `TuiMode`(s) |
+|---|---|---|
+| Sessions | `RunHub::Sessions` (list + drilldown) | `Overview`, `SessionSwitcher`, `Detail`, `Fullscreen`, `LogViewer`, `SessionSummary`, `CompletionSummary`, `HollowRetry`, `ConfirmKill` |
+| Interactions | `RunHub::Interactions` | new (v0.30 work, #732..#743) |
+| Queue | `RunHub::Queue` | `QueueConfirmation`, `QueueExecution`, `ContinuousPause` |
+| Adapt | `RunHub::Adapt` (launches modal) | `AdaptWizard`, `AdaptFollowUp` |
+| Prompt | `RunHub::Prompt` | `PromptInput` |
+
+### Plan
+
+| Sidebar item | New screen | Current `TuiMode`(s) |
+|---|---|---|
+| Issues | `PlanHub::Issues` | `IssueBrowser` (+ `IssueWizard` as modal) |
+| Milestones | `PlanHub::Milestones` (sub-tabs List/Health) | `MilestoneView`, `MilestoneHealth` (+ `MilestoneWizard` as modal) |
+| Roadmap | `PlanHub::Roadmap` | `Roadmap` |
+| PRD | `PlanHub::PRD` | `Prd` |
+
+### Review
+
+| Sidebar item | New screen | Current `TuiMode`(s) |
+|---|---|---|
+| PRs | `ReviewHub::PRs` | `PrReview` |
+| CI Errors | `ReviewHub::CiErrors` (+ `GateOutputViewer` drilldown) | `CiErrorReview`, `GateOutputViewer` |
+| Release Notes | `ReviewHub::Releases` | `ReleaseNotes` |
+
+### Insights (hub with tabs)
+
+| Tab | Current `TuiMode` |
+|---|---|
+| Cost | `CostDashboard` |
+| Tokens | `TokenDashboard` |
+| TurboQuant | `TurboquantDashboard` |
+| Agent Graph | `AgentGraph`, `DependencyGraph` (sub-toggle) |
+| Project Stats | `ProjectStats` |
+
+### System
+
+| Sidebar item | New screen | Current `TuiMode`(s) |
+|---|---|---|
+| Settings | `SystemHub::Settings` (inner tabs preserved) | `Settings` |
+| Teams | `SystemHub::Teams` (list + launch modal) | `TeamWizard` |
+
+### Modals (not in sidebar)
+
+`ConfirmKill`, `ConfirmExit`, `BypassWarning`, `Sanitize`, `IssueWizard`, `MilestoneWizard`, `TeamWizard`, `AdaptWizard`, `AdaptFollowUp`.
+
+### Retired entirely
+
+`Overview`, `Landing`, `Dashboard`, `SessionSwitcher`, `Sanitize` (as TuiMode), bespoke `*Dashboard` TuiModes once Insights tabs ship.
+
+---
+
+## 4. Sidebar Contract
+
+### Visual
+
+```
+┌─ Bypass banner (when active, full width) ─────────────────────────────┐
+├─ Header bar ──────────────────────────────────────────────────────────┤
+│ MAESTRO v0.32  »  Run  »  Sessions   ✦ 0 agents · $12.40/$50 · TQ:ON  │
+├──────────────┬────────────────────────────────────────────────────────┤
+│              │ ┌─ Tabs strip (tabbed hubs only) ───────────────────┐  │
+│   Sidebar    │ │  Cost  ▎ Tokens ▎ TurboQuant ▎ Agents ▎ Stats     │  │
+│   (22 cols)  │ └────────────────────────────────────────────────────┘ │
+│              │                                                        │
+│              │   Content pane (screen body)                           │
+│              │                                                        │
+├──────────────┴────────────────────────────────────────────────────────┤
+│ Footer hints: [Ctrl+R] Run · [Ctrl+P] Palette · [?] Help · [q] Quit   │
+└───────────────────────────────────────────────────────────────────────┘
+[ Activity Log strip — toggleable Ctrl+L ]
+```
+
+### Sidebar (expanded)
+
+```
+┌──────────────────────┐
+│ MAESTRO v0.32.0      │  ← brand row
+├──────────────────────┤
+│ ◌ Home               │
+│ ▼ Run                │  ← active bucket
+│   • Sessions         │  ← selected item (bullet)
+│     Interactions     │
+│     Queue            │
+│     Adapt            │
+│     Prompt           │
+│ ▶ Plan               │
+│ ▶ Review             │
+│ ▶ Insights           │
+│ ▶ System             │
+├──────────────────────┤
+│ 0 agents · $12.40/$50│  ← live stats
+└──────────────────────┘
+```
+
+### Sidebar (collapsed rail, `Ctrl+B`)
+
+```
+┌───┐
+│ H │
+│ R │  ← active highlighted
+│ N │
+│ V │
+│ I │
+│ S │
+└───┘
+```
+
+### Rules
+
+| Rule | Behavior |
+|---|---|
+| Single bucket open | Exactly one bucket expanded at a time. Opening another collapses prior. |
+| Selected item bullet | `•` precedes the active item. |
+| Collapsed bucket | `▶ Bucket`. Expanded: `▼ Bucket` + nested rows. |
+| Width | Fixed 22 cols expanded, 3 cols collapsed. |
+| Activity Log | Moved off bottom-of-every-screen. Toggleable via `Ctrl+L`, opens 6-line strip at bottom of content pane. |
+| Bypass banner | Full-width strip above sidebar. |
+| Footer stats | Live: agents count · cost · TQ on/off · update badge. |
+
+### Rust state
+
+```rust
+// src/tui/navigation/sidebar_state.rs (new)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Bucket { Home, Run, Plan, Review, Insights, System }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ToolId {
+    Home,
+    RunSessions, RunInteractions, RunQueue, RunAdapt, RunPrompt,
+    PlanIssues, PlanMilestones, PlanRoadmap, PlanPrd,
+    ReviewPrs, ReviewCi, ReviewReleases,
+    InsightsCost, InsightsTokens, InsightsTurboquant, InsightsAgents, InsightsStats,
+    SystemSettings, SystemTeams,
+}
+
+pub struct SidebarState {
+    pub active_bucket: Bucket,
+    pub active_tool: ToolId,
+    pub collapsed: bool,
+}
+```
+
+Lives in `App`. Screen impls read it; they emit `ScreenAction::SelectTool(ToolId)` to change selection — they do not mutate the state directly.
+
+---
+
+## 5. Screen Contract (Chrome)
+
+### Trait changes
+
+```rust
+pub trait Screen: KeymapProvider {
+    fn handle_input(&mut self, event: &Event, mode: InputMode) -> ScreenAction;
+    fn draw(&mut self, f: &mut Frame, area: Rect, theme: &Theme);
+
+    // NEW — defaults so existing screens compile:
+    fn tabs(&self) -> Option<&dyn TabsModel> { None }
+    fn breadcrumb(&self) -> &'static str { "" }
+    fn footer_hints(&self) -> Vec<(&'static str, &'static str)> { Vec::new() }
+
+    fn desired_input_mode(&self) -> Option<InputMode> { None }
+}
+
+pub trait TabsModel {
+    fn tabs(&self) -> &[&'static str];
+    fn active(&self) -> usize;
+    fn select(&mut self, idx: usize);
+}
+```
+
+### Chrome composer
+
+`src/tui/chrome.rs` (new) composes per-frame:
+
+1. Optional `bypass_banner` strip (1 line).
+2. `header` strip (1 line: breadcrumb + live stats).
+3. Split horizontally: `sidebar` (22 cols or 3 cols) + `body`.
+4. Body splits vertically: optional `tabs` strip (1 line) + `content`.
+5. `footer` strip (1 line: global + screen-local hints).
+6. Optional `activity_log` strip (6 lines) above footer when toggled.
+
+Screen body owns only the content pane area. Screens stop drawing their own headers, borders, footers, activity logs.
+
+### Modal stack
+
+```rust
+// src/tui/app/mod.rs
+pub struct App {
+    pub modal_stack: Vec<Box<dyn Modal>>,
+    // ... existing fields
+}
+
+pub trait Modal {
+    fn draw(&mut self, f: &mut Frame, area: Rect, theme: &Theme);
+    fn handle_input(&mut self, event: &Event) -> ModalAction;
+}
+
+pub enum ModalAction { None, Pop, Submit(ModalResult), Cancel }
+```
+
+Modal renders centered over the dimmed frame. `Esc` pops top of stack. All wizards become `Modal` impls.
+
+### Standard content sub-grammar
+
+When a screen has list + detail, use `widgets::split_pane::SplitPane`:
+
+```
+┌─ list (≥40% width) ──┬─ detail (≥40% width) ─┐
+│ row 1                │ rendered detail        │
+│ row 2 (selected)     │                        │
+│ row 3                │                        │
+└──────────────────────┴────────────────────────┘
+```
+
+Most screens collapse to a single content pane.
+
+---
+
+## 6. Keyboard Contract
+
+### Global hotkeys
+
+| Key | Action |
+|---|---|
+| `Ctrl+H` | Home |
+| `Ctrl+R` | Run bucket |
+| `Ctrl+N` | Plan bucket (P reserved for palette) |
+| `Ctrl+V` | Review bucket |
+| `Ctrl+I` | Insights bucket |
+| `Ctrl+S` | System bucket |
+| `Ctrl+P` | Command palette |
+| `Ctrl+B` | Toggle sidebar (full ↔ rail) |
+| `Ctrl+L` | Toggle Activity Log strip |
+| `?` | Help overlay |
+| `q` | Quit (with confirm) |
+| `Esc` | Pop modal · collapse bucket · expand rail · leave region |
+
+### Focus rings
+
+| Key | Action |
+|---|---|
+| `Tab` | Next region: Sidebar → Tabs → Content (skip empty + skip collapsed sidebar) |
+| `Shift+Tab` | Previous region |
+| `j/k` or `↓/↑` | Move within focused region |
+| `h/l` or `←/→` | Sidebar: collapse / expand bucket. Tabs: prev / next tab. |
+| `Enter` | Activate focused item |
+| `g/G` | Top / bottom (content region only) |
+
+### Command palette
+
+`Ctrl+P` opens fuzzy palette across:
+1. All tools (e.g. "cost dashboard", "issues").
+2. Verbs (e.g. "launch session", "create milestone").
+3. Active sessions by issue # / title.
+4. Open issues by number.
+
+Result rows: `[icon] Title · breadcrumb · hotkey-hint`. `Enter` runs; `Tab` reveals subverbs.
+
+### Text-input mode (wizards)
+
+When `InputMode::Text` active:
+- Letter keys → input field.
+- `Ctrl+*` global hotkeys still work.
+- `Esc` cancels wizard.
+- `Ctrl+Enter` submits.
+
+### Screen-local conventions (preserved)
+
+`Enter` open · `n` new · `/` filter · `r` refresh · `1..9` jump to tab N.
+
+### Collision policy
+
+1. Rarely-used local hotkey colliding with new global → drop.
+2. Core local (e.g. Settings `s` Save) → keep local; global rebinds (Settings still reached via `Ctrl+S` bucket key).
+3. New globals are always `Ctrl+`-prefixed.
+
+---
+
+## 7. Wizard Spine (Phase 0.5)
+
+### Problem
+
+Today's wizards (IssueWizard, MilestoneWizard, TeamWizard, AdaptWizard) share patterns but no code:
+- Each step page implements its own header/footer/keymap.
+- Step counters (`1/10`, `1/7`) drawn inconsistently.
+- Validation reporting differs per wizard.
+- Navigation keys (Next/Back/Cancel) differ.
+- Field rendering reimplemented per wizard (some use Settings schema renderer, others bespoke).
+
+### Solution
+
+Introduce a `Wizard` trait + `WizardFrame` widget. Every wizard becomes a list of `WizardStep` impls. Frame draws step counter, title, body slot, validation banner, nav footer. Validation lifecycle standardized.
+
+```rust
+// src/tui/widgets/wizard/mod.rs (new)
+pub trait Wizard {
+    fn title(&self) -> &'static str;
+    fn steps(&self) -> &[Box<dyn WizardStep>];
+    fn current_step(&self) -> usize;
+    fn advance(&mut self) -> WizardResult;
+    fn rewind(&mut self) -> WizardResult;
+    fn cancel(&mut self);
+    fn submit(&mut self) -> WizardResult;
+}
+
+pub trait WizardStep {
+    fn header(&self) -> &'static str;            // "Step 3/7: Issue Type"
+    fn render_body(&self, f: &mut Frame, area: Rect, theme: &Theme);
+    fn handle_input(&mut self, event: &Event) -> WizardStepAction;
+    fn validate(&self) -> Vec<ValidationError>;  // empty = ready to advance
+    fn footer_hints(&self) -> Vec<(&'static str, &'static str)>;
+}
+
+pub enum WizardResult { Continue, Done(ModalResult), Cancelled }
+pub enum WizardStepAction { None, Submit, Back, Cancel }
+```
+
+### Frame
+
+```
+┌─ Modal (centered over dimmed frame) ─────────────────────┐
+│ Issue Wizard                                  Step 3/10  │
+│ ──────────────────────────────────────────────────────── │
+│ Classification                                           │
+│                                                          │
+│   (•) feat — new functionality                           │
+│   ( ) fix — defect repair                                │
+│   ( ) chore — maintenance                                │
+│                                                          │
+│ ──────────────────────────────────────────────────────── │
+│ ⚠ Validation: pick a classification before continuing.   │
+│ ──────────────────────────────────────────────────────── │
+│ [←] Back  [→] Next  [Ctrl+Enter] Submit  [Esc] Cancel    │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Migration
+
+Phase 0.5 issues:
+
+1. Define `Wizard` + `WizardStep` traits + `WizardFrame` widget.
+2. Reuse Settings `schema_tab` field renderer for typed fields (text, number, dropdown, toggle).
+3. Migrate IssueWizard step-by-step.
+4. Migrate MilestoneWizard.
+5. Migrate TeamWizard.
+6. Migrate AdaptWizard.
+7. Retire bespoke wizard scaffolding (`screens::wizard_fields.rs` and friends — keep schema reusable parts).
+8. Snapshot tests for one representative step of each wizard.
+
+---
+
+## 8. Phasing and Flag Rollout
+
+### Feature flag
+
+```toml
+# maestro.toml
+[behavior]
+new_ux = false   # default false until Phase 5; flipped in v0.35.0
+```
+
+Read at startup, NOT live-toggleable. Per CLAUDE.md `behavior.*` namespace policy: style toggle only, no security control gated on it.
+
+`tui::ui::draw` branches once at top: `new_ux ? chrome::draw_new(app, f) : legacy::draw_old(app, f)`. No compile-time `cfg`; both code paths coexist until Phase 6.
+
+### Phases
+
+| Phase | Milestone | Theme |
+|---|---|---|
+| 0 | v0.32.0 — UX Spine | Sidebar, chrome, palette, modal stack, Home cards |
+| 0.5 | v0.32.5 — Wizard Spine | Wizard trait + 4 wizards migrated |
+| 1 | v0.33.0 — Insights Hub | Cost/Tokens/TurboQuant/Agents/Stats merged |
+| 2 | v0.33.5 — Run Hub | Sessions/Interactions/Queue/Adapt/Prompt |
+| 3 | v0.34.0 — Plan Hub | Issues/Milestones/Roadmap/PRD |
+| 4 | v0.34.5 — Review Hub | PRs/CI/Releases |
+| 5 | v0.35.0 — System Hub + GA | Settings/Teams + flag default flip + docs |
+| 6 | v0.35.5 — UX Cleanup | Remove legacy code paths + flag |
+
+### Coexistence with in-flight 42 issues
+
+- **v0.29.0 #809** — landed before this redesign starts. No conflict.
+- **v0.29.5 (15 open)** — Cost/Token/Quota plumbing (#769..#776). Backend work. Feeds Insights tab content (Phase 1). SHOULD land before v0.33.0.
+- **v0.30.0 (12 open)** — Interactive Iteration Sessions. UX-2-07 (Interactions tab) blocks on this milestone's #738.
+- **v0.30.5 (6 open)** — Subscription Transport. Pure backend.
+- **v0.31.0 (8 open)** — Role-Routed Orchestration. #821 (Teams tab ranking surface) MUST land before v0.35.0 UX-5-03.
+
+### Risk register
+
+| Risk | Mitigation |
+|---|---|
+| 42 in-flight issues touch old screens | Flag default `false`. In-flight PRs target legacy chrome until Phase 5 flip. |
+| CHANGELOG↔snapshot coupling (memory `project_changelog_snapshot_coupling`) | Each phase ships landing-snapshot update if it touches the CHANGELOG release section. Pre-check hook surfaces drift. |
+| Snapshot churn explosion | New snapshots gated by `new_ux=true` test fixture. Old snapshots pristine until Phase 6. |
+| User accidentally enables half-finished `new_ux` | Flag undocumented in user-facing UI until Phase 5. Documented internally in CHANGELOG and CLAUDE.md. |
+| Wizard standardization fragility | Phase 0.5 migrates one wizard per PR; existing wizard stays in tree until its migration lands. |
+
+---
+
+## 9. Issue Manifest
+
+Stable spec IDs: `UX-P-NN` where P = phase digit (0, 0a for 0.5, 1..6), NN = serial within phase. Real GH issue numbers assigned at `gh issue create` time and recorded alongside.
+
+### Milestone v0.32.0 — UX Spine (Phase 0)
+
+| Spec ID | Title | Blocked By | Key files |
+|---|---|---|---|
+| UX-0-01 | feat(tui): Bucket + ToolId enums + SidebarState struct | none | `src/tui/app/types.rs`, `src/tui/navigation/sidebar_state.rs` (new) |
+| UX-0-02 | feat(tui): widgets::sidebar accordion renderer + snapshot tests | UX-0-01 | `src/tui/widgets/sidebar.rs` (new) |
+| UX-0-03 | feat(tui): chrome composer (banner + header + footer + split) | UX-0-01 | `src/tui/chrome.rs` (new), `src/tui/ui.rs` |
+| UX-0-04 | feat(tui): Screen trait — add `tabs()`/`breadcrumb()`/`footer_hints()` defaults | UX-0-01 | `src/tui/screens/mod.rs` |
+| UX-0-05 | feat(tui): modal stack (App.modal_stack + dim overlay rendering) | UX-0-04 | `src/tui/app/mod.rs`, `src/tui/screens/mod.rs` |
+| UX-0-06 | feat(tui): command palette widget + fuzzy matcher (ADR for `nucleo` vs `fuzzy-matcher`) | UX-0-01 | `src/tui/widgets/palette.rs` (new), `Cargo.toml` |
+| UX-0-07 | feat(tui): global hotkeys `Ctrl+H/R/N/V/I/S/P/B/L` | UX-0-01, UX-0-05 | `src/tui/input_handler.rs`, `src/tui/navigation/keymap.rs` |
+| UX-0-08 | feat(tui): focus rings — Tab cycles Sidebar↔Tabs↔Content; skip collapsed sidebar | UX-0-07 | `src/tui/navigation/focus.rs` |
+| UX-0-09 | feat(config): `behavior.new_ux` flag + dispatcher branch in `ui.rs` | UX-0-03, UX-0-07, UX-0-08 | `src/config.rs`, `src/tui/ui.rs` |
+| UX-0-10 | feat(tui): Home screen — Sessions / Cost / Suggestions cards | UX-0-03, UX-0-09 | `src/tui/screens/home/` (new) |
+| UX-0-11 | test(tui): chrome + sidebar snapshot suite at 80×24 / 120×40 / 200×60 | UX-0-02, UX-0-03, UX-0-10 | `src/tui/snapshot_tests/chrome.rs` (new) |
+
+**Dependency graph for milestone description:**
+
+```
+Level 0 — no deps:
+• UX-0-01 enums + state
+
+Level 1 — depends on UX-0-01:
+• UX-0-02 sidebar renderer
+• UX-0-03 chrome composer
+• UX-0-04 Screen trait extension
+• UX-0-06 palette widget
+
+Level 2:
+• UX-0-05 modal stack (depends on UX-0-04)
+• UX-0-07 global hotkeys (depends on UX-0-01, UX-0-05)
+
+Level 3:
+• UX-0-08 focus rings (depends on UX-0-07)
+
+Level 4:
+• UX-0-09 flag + dispatcher (depends on UX-0-03, UX-0-07, UX-0-08)
+
+Level 5:
+• UX-0-10 Home screen (depends on UX-0-03, UX-0-09)
+
+Level 6:
+• UX-0-11 snapshot suite (depends on UX-0-02, UX-0-03, UX-0-10)
+
+Sequence: UX-0-01 → (UX-0-02 ∥ UX-0-03 ∥ UX-0-04 ∥ UX-0-06) → UX-0-05 → UX-0-07 → UX-0-08 → UX-0-09 → UX-0-10 → UX-0-11
+```
+
+### Milestone v0.32.5 — Wizard Spine (Phase 0.5)
+
+| Spec ID | Title | Blocked By | Key files |
+|---|---|---|---|
+| UX-0a-01 | feat(tui): Wizard + WizardStep traits + WizardFrame widget | UX-0-05 | `src/tui/widgets/wizard/mod.rs` (new) |
+| UX-0a-02 | feat(tui): reuse Settings schema field renderer in WizardFrame body slot | UX-0a-01 | `src/tui/screens/settings/schema_tab/`, `src/tui/widgets/wizard/fields.rs` |
+| UX-0a-03 | refactor(tui): migrate IssueWizard onto Wizard trait | UX-0a-02 | `src/tui/screens/issue_wizard/` |
+| UX-0a-04 | refactor(tui): migrate MilestoneWizard onto Wizard trait | UX-0a-02 | `src/tui/screens/milestone_wizard/` |
+| UX-0a-05 | refactor(tui): migrate TeamWizard onto Wizard trait | UX-0a-02 | `src/tui/screens/team_wizard/` |
+| UX-0a-06 | refactor(tui): migrate AdaptWizard onto Wizard trait | UX-0a-02 | `src/tui/screens/adapt/` |
+| UX-0a-07 | chore(tui): retire bespoke wizard scaffolding in `screens::wizard_fields.rs` (keep schema-reusable parts) | UX-0a-03..06 | `src/tui/screens/wizard_fields.rs` |
+| UX-0a-08 | test(tui): one snapshot per wizard at a representative step | UX-0a-03..06 | `src/tui/snapshot_tests/wizards.rs` (new) |
+
+**Dependency graph:**
+
+```
+Level 0:
+• UX-0a-01 (depends on v0.32.0 UX-0-05 modal stack)
+
+Level 1:
+• UX-0a-02 (depends on UX-0a-01)
+
+Level 2 (parallel):
+• UX-0a-03 IssueWizard
+• UX-0a-04 MilestoneWizard
+• UX-0a-05 TeamWizard
+• UX-0a-06 AdaptWizard
+
+Level 3:
+• UX-0a-07 retire scaffold (depends on Level 2)
+• UX-0a-08 snapshots (depends on Level 2)
+
+Sequence: UX-0a-01 → UX-0a-02 → (UX-0a-03 ∥ UX-0a-04 ∥ UX-0a-05 ∥ UX-0a-06) → (UX-0a-07 ∥ UX-0a-08)
+```
+
+### Milestone v0.33.0 — Insights Hub (Phase 1)
+
+| Spec ID | Title | Blocked By | Key files |
+|---|---|---|---|
+| UX-1-01 | feat(tui): InsightsHub scaffold + 5 tab routes (Cost / Tokens / TurboQuant / Agents / Stats) | v0.32.0 UX-0-11 | `src/tui/screens/insights/` (new) |
+| UX-1-02 | refactor(tui): migrate CostDashboard body → InsightsHub::Cost | UX-1-01 | `src/tui/cost_dashboard.rs`, `src/tui/screens/insights/cost.rs` |
+| UX-1-03 | refactor(tui): migrate TokenDashboard body → InsightsHub::Tokens | UX-1-01 | `src/tui/token_dashboard.rs`, `src/tui/screens/insights/tokens.rs` |
+| UX-1-04 | refactor(tui): migrate TurboquantDashboard body → InsightsHub::TurboQuant | UX-1-01 | `src/tui/turboquant_dashboard.rs`, `src/tui/screens/insights/turboquant.rs` |
+| UX-1-05 | refactor(tui): merge AgentGraph + DependencyGraph → InsightsHub::Agents (sub-toggle) | UX-1-01 | `src/tui/agent_graph/`, `src/tui/dep_graph.rs`, `src/tui/screens/insights/agents.rs` |
+| UX-1-06 | refactor(tui): migrate ProjectStats body → InsightsHub::Stats | UX-1-01 | `src/tui/screens/project_stats/`, `src/tui/screens/insights/stats.rs` |
+| UX-1-07 | chore(tui): mark 5 legacy TuiMode variants `#[deprecated]` | UX-1-02..06 | `src/tui/app/types.rs` |
+
+**Sequence:** `UX-1-01 → (UX-1-02 ∥ UX-1-03 ∥ UX-1-04 ∥ UX-1-05 ∥ UX-1-06) → UX-1-07`
+
+### Milestone v0.33.5 — Run Hub (Phase 2)
+
+| Spec ID | Title | Blocked By | Key files |
+|---|---|---|---|
+| UX-2-01 | feat(tui): RunHub scaffold + 5 subviews | v0.32.0 UX-0-11 | `src/tui/screens/run/` |
+| UX-2-02 | refactor(tui): Sessions list view replaces Overview + SessionSwitcher | UX-2-01 | `src/tui/session_switcher.rs`, `src/tui/screens/run/sessions.rs` |
+| UX-2-03 | refactor(tui): Detail screen reachable as Sessions drilldown | UX-2-02 | `src/tui/detail.rs` |
+| UX-2-04 | feat(tui): Queue tab folds QueueConfirmation + QueueExecution | UX-2-01 | `src/tui/screens/queue_confirmation.rs`, `src/tui/screens/run/queue.rs` |
+| UX-2-05 | refactor(tui): Adapt tab launches AdaptWizard as modal | UX-2-01, v0.32.5 UX-0a-06 | `src/tui/screens/adapt/`, `src/tui/screens/run/adapt.rs` |
+| UX-2-06 | refactor(tui): Prompt tab embeds PromptInput | UX-2-01 | `src/tui/screens/prompt_input/`, `src/tui/screens/run/prompt.rs` |
+| UX-2-07 | feat(tui): Interactions tab (depends on v0.30 #738) | UX-2-01, v0.30.0 #738 | `src/tui/screens/run/interactions.rs` |
+
+**Sequence:** `UX-2-01 → (UX-2-02 → UX-2-03) ∥ UX-2-04 ∥ UX-2-05 ∥ UX-2-06 ∥ UX-2-07`
+
+### Milestone v0.34.0 — Plan Hub (Phase 3)
+
+| Spec ID | Title | Blocked By | Key files |
+|---|---|---|---|
+| UX-3-01 | feat(tui): PlanHub scaffold + Issues / Milestones / Roadmap / PRD tabs | v0.32.0 UX-0-11 | `src/tui/screens/plan/` |
+| UX-3-02 | refactor(tui): IssueBrowser body → PlanHub::Issues (wizard remains modal) | UX-3-01, v0.32.5 UX-0a-03 | `src/tui/screens/issue_browser/`, `src/tui/screens/plan/issues.rs` |
+| UX-3-03 | refactor(tui): MilestoneView + MilestoneHealth → PlanHub::Milestones (sub-tabs List/Health) | UX-3-01, v0.32.5 UX-0a-04 | `src/tui/screens/milestone.rs`, `src/tui/screens/milestone_health/`, `src/tui/screens/plan/milestones.rs` |
+| UX-3-04 | refactor(tui): Roadmap body → PlanHub::Roadmap | UX-3-01 | `src/tui/screens/roadmap/` |
+| UX-3-05 | refactor(tui): Prd body → PlanHub::PRD | UX-3-01 | `src/tui/screens/prd/` |
+
+**Sequence:** `UX-3-01 → (UX-3-02 ∥ UX-3-03 ∥ UX-3-04 ∥ UX-3-05)`
+
+### Milestone v0.34.5 — Review Hub (Phase 4)
+
+| Spec ID | Title | Blocked By | Key files |
+|---|---|---|---|
+| UX-4-01 | feat(tui): ReviewHub scaffold + PRs / CI Errors / Releases tabs | v0.32.0 UX-0-11 | `src/tui/screens/review/` |
+| UX-4-02 | refactor(tui): PrReview body → ReviewHub::PRs | UX-4-01 | `src/tui/screens/pr_review/` |
+| UX-4-03 | refactor(tui): CiErrorReview body → ReviewHub::CI; GateOutputViewer = drilldown | UX-4-01 | `src/tui/screens/ci_error_review.rs`, `src/tui/screens/gate_output_viewer.rs` |
+| UX-4-04 | refactor(tui): ReleaseNotes body → ReviewHub::Releases | UX-4-01 | `src/tui/screens/release_notes/` |
+
+**Sequence:** `UX-4-01 → (UX-4-02 ∥ UX-4-03 ∥ UX-4-04)`
+
+### Milestone v0.35.0 — System Hub + GA flip (Phase 5)
+
+| Spec ID | Title | Blocked By | Key files |
+|---|---|---|---|
+| UX-5-01 | feat(tui): SystemHub scaffold + Settings / Teams tabs | v0.32.0 UX-0-11 | `src/tui/screens/system/` |
+| UX-5-02 | refactor(tui): Settings → SystemHub::Settings (inner tabs preserved) | UX-5-01 | `src/tui/screens/settings/` |
+| UX-5-03 | feat(tui): Teams promoted from wizard-only → list screen + launch modal | UX-5-01, v0.31.0 #821, v0.32.5 UX-0a-05 | `src/tui/screens/team_wizard/`, `src/tui/screens/system/teams.rs` |
+| UX-5-04 | feat(config): flip `behavior.new_ux` default → true; CHANGELOG entry | UX-5-01, UX-5-02, UX-5-03, v0.34.5, v0.34.0, v0.33.5, v0.33.0 | `src/config.rs`, `CHANGELOG.md` |
+| UX-5-05 | docs(ux): user guide + screenshots for new spine | UX-5-04 | `docs/user-guide/ux-spine.md`, `docs/screenshots/` |
+
+**Sequence:** `UX-5-01 → (UX-5-02 ∥ UX-5-03) → UX-5-04 → UX-5-05`
+
+### Milestone v0.35.5 — UX Cleanup (Phase 6)
+
+| Spec ID | Title | Blocked By | Key files |
+|---|---|---|---|
+| UX-6-01 | chore(tui): remove legacy Landing / Dashboard / Overview / SessionSwitcher TuiMode variants | v0.35.0 UX-5-04 | `src/tui/app/types.rs`, `src/tui/landing.rs`, ... |
+| UX-6-02 | chore(config): remove `behavior.new_ux` flag + legacy dispatcher branch | UX-6-01 | `src/config.rs`, `src/tui/ui.rs` |
+| UX-6-03 | chore(tui): delete unused snapshot tests for retired screens | UX-6-01 | `src/tui/snapshot_tests/` |
+
+**Sequence:** `UX-6-01 → UX-6-02 ∥ UX-6-03`
+
+---
+
+## 10. Testing Strategy
+
+| Layer | Approach |
+|---|---|
+| Unit | `Bucket`/`ToolId` transitions; `SidebarState::next/prev`; fuzzy palette ranking. |
+| Snapshot | `insta` snapshots of chrome at 80×24 / 120×40 / 200×60. Sidebar collapsed + expanded. Each hub tab. |
+| Integration | `src/integration_tests/` — global hotkey jumps fire correct `ScreenAction::SelectTool`. Modal stack push/pop. |
+| Behavior | Toggle `behavior.new_ux=true` test fixture launches new chrome; `false` launches legacy. Both pass existing snapshots. |
+| Manual | Manual smoke per phase against terminal sizes; `?` help renders correctly; `Ctrl+P` palette indexes all tools. |
+
+Snapshots that depend on `new_ux=true` live in a separate fixture file to prevent legacy snapshot drift.
+
+---
+
+## 11. Open Questions (deferred)
+
+1. Fuzzy-match crate choice (`nucleo` vs `fuzzy-matcher`) — ADR in UX-0-06.
+2. Activity Log strip height — fixed 6 lines, or configurable? Defaults to 6, configurable in v0.35.0.
+3. Sidebar mouse support — out of scope until post-GA.
+4. Dark/light theme behavior on new chrome — assumed unchanged; verify in v0.32.0 snapshots.
+5. Whether sidebar `Ctrl+B`-collapsed rail shows live stats — out of scope; rail shows bucket letters only.
+
+---
+
+## 12. Acceptance — overall (Definition of Done for v0.35.0 GA)
+
+- All 7 milestones closed.
+- `behavior.new_ux` default `true`.
+- Every previous `TuiMode` reachable through new chrome.
+- Every wizard runs through `WizardFrame`.
+- `Ctrl+P` palette indexes every tool + active session + verb.
+- Snapshot suite green at three terminal sizes.
+- `docs/user-guide/ux-spine.md` published with screenshots.
+- CHANGELOG `v0.35.0` entry approved; landing-snapshot updated alongside per `project_changelog_snapshot_coupling`.


### PR DESCRIPTION
## Summary

- Captures the full brainstorm-locked design for the sidebar-driven IA shuffle: 5 buckets (Run / Plan / Review / Insights / System) over a hybrid accordion sidebar, hub-with-tabs grammar, Ctrl+letter globals + Tab focus rings + Ctrl+P palette, behind a `behavior.new_ux` flag.
- 8 phased milestones (v0.32.0 UX Spine, v0.32.5 Wizard Spine, v0.33.0 Insights, v0.33.5 Run, v0.34.0 Plan, v0.34.5 Review, v0.35.0 System + GA flip, v0.35.5 Cleanup) with stable `UX-P-NN` issue IDs, per-milestone dependency graphs, and coexistence notes for the 42 in-flight issues across v0.29.5–v0.31.0.
- 50 TDD-shaped tasks total (failing test → minimum impl → green → commit), with file paths, code snippets, and run commands.

## Files

- `docs/superpowers/specs/2026-05-21-tui-ux-redesign-sidebar-ia-design.md` (666 LOC)
- `docs/superpowers/plans/2026-05-21-{ux-spine,wizard-spine,insights-hub,run-hub,plan-hub,review-hub,system-hub-ga,ux-cleanup}-vX.Y.Z.md` (8 files, 3206 LOC combined)
- `.gitignore` (+`.superpowers/`)

## Companion work

- Milestone v0.32.0 + issues #825–#835 already filed with this spec/plan as authoritative reference.
- First implementation PR #836 (UX-0-01) already open under the same plan.

## Test plan

- [x] No code touched — doc-only PR
- [x] Reviewer sanity-checks the dep graph in the v0.32.0 plan against milestone #61 description on GitHub
- [x] Reviewer skims spec Section 6 (Keyboard contract) for any collisions with existing screen-local hotkeys

## Notes

- 8 milestones, not 7 — Phase 0.5 (Wizard Spine, v0.32.5) was added during brainstorm to standardize the four bespoke wizards.
- `Bucket::Home` is a singleton sidebar slot above the 5 main buckets — renderer handles separately.
- Open questions (Section 11 of the spec) are explicitly deferred and named so they don't leak into later phases.