### PR TITLE
feat(v0.29.5): level-0 batch — 5 issues (#757, #758, #770, #799, #839)

### DIFF
--- a/.claude/commands/plan-feature.md
+++ b/.claude/commands/plan-feature.md
@@ -7,6 +7,7 @@ description: Plan a feature across the project, creating API contracts first, th
 placeholders:
   - INCLUDE
   - SUBAGENT_LIST
+  - VCS_PROVIDER_CMD
 includes:
   - core/premises.md
   - core/dependency-graph.md

--- a/.maestro/hooks/implement-gates.sh
+++ b/.maestro/hooks/implement-gates.sh
@@ -184,6 +184,32 @@ if [ -n "$(git status --porcelain)" ]; then
   esac
 fi
 
+# Gate 6.5: CHANGELOG-induced snapshot drift.
+#
+# The landing screen embeds CHANGELOG.md via include_str! and renders trend
+# bars from .entries.iter().take(24). Any edit to CHANGELOG.md can shift the
+# landing_welcome_* snapshots. Gate 7 would catch this with a generic
+# baseline failure; this gate surfaces it sooner with an actionable message.
+# Scope: any modification to CHANGELOG.md in the diff between HEAD and main.
+# Exit 0 silently when CHANGELOG.md is untouched (no false positives).
+# shellcheck source=./lib-changelog.sh
+. "$(dirname "$0")/lib-changelog.sh"
+changelog_diff_base="$(resolve_changelog_diff_base)"
+if [ -n "$changelog_diff_base" ]; then
+  if changelog_changed_vs_base "$changelog_diff_base"; then
+    echo "implement-gates: CHANGELOG.md modified vs ${changelog_diff_base} — verifying landing snapshots"
+    if ! cargo test --lib tui::snapshot_tests::landing -- --include-ignored \
+         > "$GATE_LOG_DIR/landing-snapshot.log" 2>&1; then
+      echo "implement-gates: snapshot drift detected — run cargo insta accept or revert CHANGELOG" >&2
+      echo "implement-gates: See $GATE_LOG_DIR/landing-snapshot.log" >&2
+      exit 3
+    fi
+    echo "implement-gates: landing snapshots clean"
+  fi
+else
+  echo "implement-gates: WARN: neither main nor origin/main is reachable — skipping CHANGELOG drift gate" >&2
+fi
+
 # Gate 7: baseline cargo test must be green.
 if ! cargo test --quiet > "$GATE_LOG_DIR/baseline.log" 2>&1; then
   echo "implement-gates: BASELINE NOT GREEN — existing tests are failing before /implement ran." >&2

--- a/.maestro/hooks/lib-changelog.sh
+++ b/.maestro/hooks/lib-changelog.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# CHANGELOG-drift detection helpers for implement-gates.sh.
+#
+# The landing screen embeds CHANGELOG.md via include_str! (src/changelog/mod.rs)
+# and renders trend bars from .entries.iter().take(24) in release_ref_trend()
+# (src/tui/screens/landing/draw.rs). Any edit to CHANGELOG.md can shift those
+# bars and break the landing snapshots. These helpers let the pre-check hook
+# surface drift as a fast, scoped, actionable signal scoped to CHANGELOG edits.
+#
+# Sourced from implement-gates.sh and tests/test-changelog-gate.sh.
+
+# Echoes "main" or "origin/main" or empty string if neither ref is reachable.
+resolve_changelog_diff_base() {
+  if git rev-parse --verify --quiet main >/dev/null 2>&1; then
+    echo "main"
+  elif git rev-parse --verify --quiet origin/main >/dev/null 2>&1; then
+    echo "origin/main"
+  else
+    echo ""
+  fi
+}
+
+# Returns 0 when CHANGELOG.md (exact, anchored) appears in the diff between
+# HEAD and the given base ref; returns 1 otherwise.
+#
+# Anchored grep (`-x`) prevents false positives from paths like
+# docs/CHANGELOG-archive.md or scripts/CHANGELOG.md.tmpl that contain the
+# string CHANGELOG.md.
+changelog_changed_vs_base() {
+  local base="${1:?base ref required}"
+  git diff "${base}...HEAD" --name-only -z \
+    | tr '\0' '\n' \
+    | grep -qx 'CHANGELOG.md'
+}

--- a/.maestro/hooks/tests/test-changelog-gate.sh
+++ b/.maestro/hooks/tests/test-changelog-gate.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Tests for lib-changelog.sh — CHANGELOG-drift detection helpers.
+# Run with: bash .maestro/hooks/tests/test-changelog-gate.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LIB="$SCRIPT_DIR/../lib-changelog.sh"
+
+if [ ! -f "$LIB" ]; then
+  echo "FAIL: $LIB does not exist"
+  exit 1
+fi
+
+pass=0
+fail=0
+
+run_case() {
+  local name="$1"
+  local actual="$2"
+  local expected="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $name"
+    pass=$((pass + 1))
+  else
+    echo "FAIL: $name — expected '$expected', got '$actual'"
+    fail=$((fail + 1))
+  fi
+}
+
+# Build a throwaway git repo with `main` and a `feature` branch.
+# Echoes the temp dir path.
+make_repo() {
+  local dir
+  dir=$(mktemp -d)
+  (
+    cd "$dir"
+    git init -q -b main
+    git config user.email "test@example.com"
+    git config user.name "test"
+    printf "# Changelog\n\n## [Unreleased]\n" > CHANGELOG.md
+    printf "fn main() {}\n" > src.rs
+    git add . > /dev/null
+    git commit -q -m "base"
+    git checkout -q -b feature
+  )
+  echo "$dir"
+}
+
+# Case 1: CHANGELOG edited on feature branch -> detected.
+repo=$(make_repo)
+(
+  cd "$repo"
+  printf "\n- new bullet (#1)\n" >> CHANGELOG.md
+  git add CHANGELOG.md > /dev/null
+  git commit -q -m "edit changelog"
+)
+actual=$(
+  cd "$repo"
+  # shellcheck source=../lib-changelog.sh
+  source "$LIB"
+  if changelog_changed_vs_base "main"; then echo CHANGED; else echo CLEAN; fi
+)
+run_case "changelog_edited_on_feature_detected" "$actual" "CHANGED"
+rm -rf "$repo"
+
+# Case 2: only source files edited -> not detected.
+repo=$(make_repo)
+(
+  cd "$repo"
+  printf "fn other() {}\n" >> src.rs
+  git add src.rs > /dev/null
+  git commit -q -m "edit src"
+)
+actual=$(
+  cd "$repo"
+  source "$LIB"
+  if changelog_changed_vs_base "main"; then echo CHANGED; else echo CLEAN; fi
+)
+run_case "source_only_edit_not_detected" "$actual" "CLEAN"
+rm -rf "$repo"
+
+# Case 3: file containing CHANGELOG.md as a substring -> not detected (anchored grep).
+repo=$(make_repo)
+(
+  cd "$repo"
+  mkdir -p docs
+  printf "archive\n" > docs/CHANGELOG-archive.md
+  git add docs/CHANGELOG-archive.md > /dev/null
+  git commit -q -m "add archive"
+)
+actual=$(
+  cd "$repo"
+  source "$LIB"
+  if changelog_changed_vs_base "main"; then echo CHANGED; else echo CLEAN; fi
+)
+run_case "archive_with_similar_name_not_detected" "$actual" "CLEAN"
+rm -rf "$repo"
+
+# Case 4: no diff at all -> not detected.
+repo=$(make_repo)
+actual=$(
+  cd "$repo"
+  source "$LIB"
+  if changelog_changed_vs_base "main"; then echo CHANGED; else echo CLEAN; fi
+)
+run_case "no_diff_not_detected" "$actual" "CLEAN"
+rm -rf "$repo"
+
+# Case 5: neither main nor origin/main exists -> resolve returns empty.
+repo=$(mktemp -d)
+(
+  cd "$repo"
+  git init -q -b trunk
+  git config user.email "test@example.com"
+  git config user.name "test"
+  printf "x\n" > a.txt
+  git add . > /dev/null
+  git commit -q -m base
+)
+actual=$(
+  cd "$repo"
+  source "$LIB"
+  resolve_changelog_diff_base
+)
+run_case "no_main_resolves_empty" "$actual" ""
+rm -rf "$repo"
+
+# Case 6: only main exists -> resolve returns "main".
+repo=$(make_repo)
+actual=$(
+  cd "$repo"
+  source "$LIB"
+  resolve_changelog_diff_base
+)
+run_case "main_resolves_to_main" "$actual" "main"
+rm -rf "$repo"
+
+echo ""
+echo "Results: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/.maestro/templates.lock
+++ b/.maestro/templates.lock
@@ -10,7 +10,7 @@ sha256 = "2b41e840d26886a3118969b369ad1a12d7fa051478bef6e940ca3e1a2b5b3adf"
 [files.".claude/commands/plan-feature.md"]
 provider = "claude"
 command = "plan-feature"
-sha256 = "13432433bcec294866608875aee60d8dba6f74b229009252111ccc9bbe023fcc"
+sha256 = "95068bbb4c9cf222a5ba37285b4fc48a0a28c22e17aad3fab465fa1bd84450df"
 
 [files.".claude/commands/pushup.md"]
 provider = "claude"

--- a/.maestro/templates/commands/plan-feature.md
+++ b/.maestro/templates/commands/plan-feature.md
@@ -5,6 +5,7 @@ description: Plan a feature across the project, creating API contracts first, th
 placeholders:
   - INCLUDE
   - SUBAGENT_LIST
+  - VCS_PROVIDER_CMD
 includes:
   - core/premises.md
   - core/dependency-graph.md
@@ -60,7 +61,7 @@ For every API endpoint identified:
 
 If the feature is large enough for a milestone:
 ```bash
-gh api repos/<owner>/<repo>/milestones -f title="..." -f state=open -f description="..."
+{{VCS_PROVIDER_CMD}} api repos/<owner>/<repo>/milestones -f title="..." -f state=open -f description="..."
 ```
 
 ### Phase 4: ISSUES — Create with Traceability
@@ -104,7 +105,7 @@ The dependency-graph format and per-issue `## Blocked By` rules are canonical:
 
 ## Error Handling
 
-- If `gh` CLI fails → suggest `gh auth login`
+- If `{{VCS_PROVIDER_CMD}}` CLI fails → suggest `{{VCS_PROVIDER_CMD}} auth login`
 - If description is too vague → ask clarifying questions
 - If contract already exists → reuse it
 - If milestone exists → reuse it

--- a/.maestro/templates/manifest.toml
+++ b/.maestro/templates/manifest.toml
@@ -35,22 +35,55 @@ required_args = []
 description = "reference a skill knowledge base"
 required_args = ["name"]
 
+[placeholders.VCS_PROVIDER_CMD]
+description = "render the VCS provider CLI command (e.g. `gh`, `az repos`)"
+required_args = []
+
 # ── Per-provider metadata (parsed; consumed by L2 in #703-#705) ─────────
 
 [providers.claude]
 display_name = "Claude Code"
 target_dir = ".claude/commands"
 inline_skills = false
+vcs_provider_cmd = "gh"
 
 [providers.codex]
 display_name = "Codex CLI"
 target_dir = ".codex/commands"
 inline_skills = true
+vcs_provider_cmd = "gh"
 
 [providers.http_generic]
 display_name = "Generic HTTP provider"
 target_dir = ""
 inline_skills = true
+vcs_provider_cmd = "gh"
+
+# ── Golden Rules entry points (issue #839) ──────────────────────────────
+# `maestro sync-templates` rewrites the block between
+# `<!-- BEGIN GOLDEN-RULES … -->` and `<!-- END GOLDEN-RULES -->` markers
+# in each entry_file with the body of the canonical source. Drift between
+# canonical and any target fails `--check`. `scripts/check-rules-drift.sh`
+# is retained as a secondary safety net for non-Rust CI lanes.
+
+[golden_rules]
+source = "core/golden-rules.md"
+
+[[golden_rules.targets]]
+id = "claude"
+entry_file = ".claude/CLAUDE.md"
+
+[[golden_rules.targets]]
+id = "codex"
+entry_file = ".codex/AGENTS.md"
+
+[[golden_rules.targets]]
+id = "agents-md"
+entry_file = "AGENTS.md"
+
+[[golden_rules.targets]]
+id = "gemini"
+entry_file = "GEMINI.md"
 
 # ── Subagent registry (rendered by {{SUBAGENT_LIST}}) ────────────────────
 # Order in this file = order in the rendered Markdown table. Drift between

--- a/src/commands/sync_templates/golden_rules.rs
+++ b/src/commands/sync_templates/golden_rules.rs
@@ -1,0 +1,279 @@
+//! Golden Rules entry-file sync (issue #839).
+//!
+//! `maestro sync-templates` reads `.maestro/templates/core/golden-rules.md`
+//! and splices its body between `<!-- BEGIN GOLDEN-RULES … -->` /
+//! `<!-- END GOLDEN-RULES -->` markers in each provider entry file declared
+//! under `[golden_rules.targets]` in the manifest. Outside the markers the
+//! file is owned by humans and preserved byte-for-byte. `--check` flags any
+//! divergence. `scripts/check-rules-drift.sh` remains as a secondary safety
+//! net for non-Rust CI lanes.
+
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
+
+use std::path::{Path, PathBuf};
+
+use crate::templates::TemplateError;
+use crate::templates::manifest::Manifest;
+
+use super::runner::{SyncFs, SyncTemplatesError};
+
+pub const BEGIN_MARKER_PREFIX: &str = "<!-- BEGIN GOLDEN-RULES";
+pub const END_MARKER_LINE: &str = "<!-- END GOLDEN-RULES -->";
+
+#[derive(Debug, thiserror::Error)]
+pub enum GoldenRulesError {
+    #[error("entry file `{path}` is missing the `<!-- BEGIN GOLDEN-RULES … -->` marker")]
+    BeginMarkerMissing { path: PathBuf },
+    #[error("entry file `{path}` is missing the `<!-- END GOLDEN-RULES -->` marker")]
+    EndMarkerMissing { path: PathBuf },
+    #[error("entry file `{path}` has END marker before BEGIN marker")]
+    MarkersOutOfOrder { path: PathBuf },
+    #[error("entry file `{path}` has more than one BEGIN GOLDEN-RULES marker")]
+    DuplicateBeginMarker { path: PathBuf },
+}
+
+/// Splice `canonical_body` into `current` between the BEGIN/END markers.
+///
+/// Returns the full new file content; the BEGIN/END marker lines are
+/// preserved verbatim (including any parenthetical hint on the BEGIN line).
+/// Idempotency: applying twice yields identical bytes — the caller compares
+/// the returned content to `current` to detect "no-op" cases.
+pub fn splice(
+    current: &str,
+    canonical_body: &str,
+    path: &std::path::Path,
+) -> Result<String, GoldenRulesError> {
+    let lines: Vec<&str> = current.split_inclusive('\n').collect();
+
+    let mut begin_indices: Vec<usize> = Vec::new();
+    let mut end_index: Option<usize> = None;
+    for (i, line) in lines.iter().enumerate() {
+        let trimmed = line.trim_end_matches(['\n', '\r']);
+        if trimmed.starts_with(BEGIN_MARKER_PREFIX) {
+            begin_indices.push(i);
+        }
+        if end_index.is_none() && trimmed == END_MARKER_LINE {
+            end_index = Some(i);
+        }
+    }
+
+    if begin_indices.is_empty() {
+        return Err(GoldenRulesError::BeginMarkerMissing {
+            path: path.to_path_buf(),
+        });
+    }
+    if begin_indices.len() > 1 {
+        return Err(GoldenRulesError::DuplicateBeginMarker {
+            path: path.to_path_buf(),
+        });
+    }
+    let begin_index = begin_indices[0];
+    let Some(end_index) = end_index else {
+        return Err(GoldenRulesError::EndMarkerMissing {
+            path: path.to_path_buf(),
+        });
+    };
+    if end_index <= begin_index {
+        return Err(GoldenRulesError::MarkersOutOfOrder {
+            path: path.to_path_buf(),
+        });
+    }
+
+    let mut out = String::with_capacity(current.len() + canonical_body.len());
+    for line in &lines[..=begin_index] {
+        out.push_str(line);
+    }
+    out.push_str(canonical_body);
+    if !canonical_body.ends_with('\n') {
+        out.push('\n');
+    }
+    for line in &lines[end_index..] {
+        out.push_str(line);
+    }
+    Ok(out)
+}
+
+/// One spliced entry-file plan: target id, destination path, full new content.
+pub struct EntryPlan {
+    pub target_id: String,
+    pub entry_path: PathBuf,
+    pub content: String,
+}
+
+const TEMPLATES_ROOT: &str = ".maestro/templates";
+
+/// Read the manifest and canonical body through `fs`, then splice the body
+/// into every declared entry file. Gracefully no-ops when the manifest or
+/// canonical body is absent (lets pre-existing tests with sparse FakeFs
+/// seeds keep working).
+pub fn build_entry_plans(
+    repo_root: &Path,
+    fs: &dyn SyncFs,
+    provider_filter: Option<&str>,
+) -> Result<Vec<EntryPlan>, SyncTemplatesError> {
+    let manifest_path = repo_root.join(TEMPLATES_ROOT).join("manifest.toml");
+    let Some(manifest) = load_manifest(&manifest_path, fs)? else {
+        return Ok(Vec::new());
+    };
+    let Some(gr) = manifest.golden_rules() else {
+        return Ok(Vec::new());
+    };
+    let canonical_path = repo_root.join(TEMPLATES_ROOT).join(&gr.source);
+    let Some(canonical) = read_utf8_or_skip(&canonical_path, fs)? else {
+        return Ok(Vec::new());
+    };
+
+    let mut plans = Vec::new();
+    for target in &gr.targets {
+        if let Some(filter) = provider_filter
+            && filter != target.id
+        {
+            continue;
+        }
+        let entry_path = repo_root.join(&target.entry_file);
+        let Some(current) = read_utf8_or_skip(&entry_path, fs)? else {
+            continue;
+        };
+        let content = splice(&current, &canonical, &entry_path)?;
+        plans.push(EntryPlan {
+            target_id: target.id.clone(),
+            entry_path,
+            content,
+        });
+    }
+    Ok(plans)
+}
+
+fn load_manifest(path: &Path, fs: &dyn SyncFs) -> Result<Option<Manifest>, SyncTemplatesError> {
+    let Some(text) = read_utf8_or_skip(path, fs)? else {
+        return Ok(None);
+    };
+    toml::from_str(&text)
+        .map(Some)
+        .map_err(|e| SyncTemplatesError::ManifestLoad {
+            path: path.to_path_buf(),
+            source: Box::new(TemplateError::ManifestParse {
+                path: path.to_path_buf(),
+                source: e,
+            }),
+        })
+}
+
+fn read_utf8_or_skip(path: &Path, fs: &dyn SyncFs) -> Result<Option<String>, SyncTemplatesError> {
+    match fs.read(path) {
+        Ok(bytes) => Ok(String::from_utf8(bytes).ok()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(source) => Err(SyncTemplatesError::Write {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn path() -> &'static Path {
+        Path::new("/test/entry.md")
+    }
+
+    #[test]
+    fn splice_replaces_block_between_markers() {
+        let current = "\
+header line
+<!-- BEGIN GOLDEN-RULES -->
+old body
+gets replaced
+<!-- END GOLDEN-RULES -->
+footer line
+";
+        let canonical = "fresh canonical body";
+        let out = splice(current, canonical, path()).expect("ok");
+        assert!(out.contains("header line"));
+        assert!(out.contains("<!-- BEGIN GOLDEN-RULES -->"));
+        assert!(out.contains("fresh canonical body"));
+        assert!(out.contains("<!-- END GOLDEN-RULES -->"));
+        assert!(out.contains("footer line"));
+        assert!(!out.contains("old body"));
+        assert!(!out.contains("gets replaced"));
+    }
+
+    #[test]
+    fn splice_is_idempotent() {
+        let canonical = "body\n";
+        let once = splice(
+            "x\n<!-- BEGIN GOLDEN-RULES -->\nstale\n<!-- END GOLDEN-RULES -->\ny\n",
+            canonical,
+            path(),
+        )
+        .expect("ok");
+        let twice = splice(&once, canonical, path()).expect("ok");
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn splice_preserves_begin_marker_line_verbatim_with_parenthetical() {
+        let current = "\
+<!-- BEGIN GOLDEN-RULES (do not edit — see canonical) -->
+old
+<!-- END GOLDEN-RULES -->
+";
+        let out = splice(current, "new\n", path()).expect("ok");
+        assert!(
+            out.contains("<!-- BEGIN GOLDEN-RULES (do not edit — see canonical) -->"),
+            "BEGIN line must be preserved verbatim; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn splice_missing_begin_returns_error() {
+        let current = "no markers here\n<!-- END GOLDEN-RULES -->\n";
+        match splice(current, "x", path()) {
+            Err(GoldenRulesError::BeginMarkerMissing { .. }) => {}
+            other => panic!("expected BeginMarkerMissing, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn splice_missing_end_returns_error() {
+        let current = "<!-- BEGIN GOLDEN-RULES -->\nbody\n";
+        match splice(current, "x", path()) {
+            Err(GoldenRulesError::EndMarkerMissing { .. }) => {}
+            other => panic!("expected EndMarkerMissing, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn splice_end_before_begin_returns_error() {
+        let current = "<!-- END GOLDEN-RULES -->\n<!-- BEGIN GOLDEN-RULES -->\n";
+        match splice(current, "x", path()) {
+            Err(GoldenRulesError::MarkersOutOfOrder { .. }) => {}
+            other => panic!("expected MarkersOutOfOrder, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn splice_duplicate_begin_returns_error() {
+        let current = "\
+<!-- BEGIN GOLDEN-RULES -->
+body
+<!-- BEGIN GOLDEN-RULES -->
+more body
+<!-- END GOLDEN-RULES -->
+";
+        match splice(current, "x", path()) {
+            Err(GoldenRulesError::DuplicateBeginMarker { .. }) => {}
+            other => panic!("expected DuplicateBeginMarker, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn splice_canonical_without_trailing_newline_gets_one_added() {
+        let current = "<!-- BEGIN GOLDEN-RULES -->\nold\n<!-- END GOLDEN-RULES -->\n";
+        let out = splice(current, "no trailing newline", path()).expect("ok");
+        assert!(out.contains("no trailing newline\n<!-- END GOLDEN-RULES -->"));
+    }
+}

--- a/src/commands/sync_templates/mod.rs
+++ b/src/commands/sync_templates/mod.rs
@@ -12,6 +12,7 @@
 
 pub mod banner;
 pub mod diff;
+pub mod golden_rules;
 pub mod lockfile;
 pub mod registry;
 pub mod runner;

--- a/src/commands/sync_templates/runner.rs
+++ b/src/commands/sync_templates/runner.rs
@@ -17,6 +17,7 @@ use crate::templates::{TemplateError, TemplateProviderRules, render_command_for_
 use super::SyncTemplatesArgs;
 use super::banner::with_banner;
 use super::diff::line_diff;
+use super::golden_rules::{self, GoldenRulesError};
 use super::lockfile::{FileEntry, Lockfile, sha256_hex};
 use super::registry::{COMMANDS, PROVIDERS, ProviderEntry, entries_for};
 
@@ -42,6 +43,14 @@ pub enum SyncTemplatesError {
     },
     #[error("serializing lockfile: {0}")]
     LockfileSerialize(Box<toml::ser::Error>),
+    #[error("golden-rules sync: {0}")]
+    GoldenRules(#[from] GoldenRulesError),
+    #[error("loading manifest at `{path}`: {source}")]
+    ManifestLoad {
+        path: PathBuf,
+        #[source]
+        source: Box<TemplateError>,
+    },
 }
 
 pub trait SyncFs: Send + Sync {
@@ -125,7 +134,8 @@ impl<'a> SyncRunner<'a> {
             return Err(SyncTemplatesError::UnknownProvider(filter.to_string()));
         }
 
-        let plans = self.build_plans(args.provider.as_deref())?;
+        let mut plans = self.build_plans(args.provider.as_deref())?;
+        plans.extend(self.build_golden_rules_plans(args.provider.as_deref())?);
 
         if args.check {
             return self.run_check(&plans);
@@ -139,6 +149,23 @@ impl<'a> SyncRunner<'a> {
             ));
         }
         self.run_write(&plans)
+    }
+
+    fn build_golden_rules_plans(
+        &self,
+        provider_filter: Option<&str>,
+    ) -> Result<Vec<RenderPlan>, SyncTemplatesError> {
+        let plans =
+            golden_rules::build_entry_plans(self.repo_root, self.fs.as_ref(), provider_filter)?;
+        Ok(plans
+            .into_iter()
+            .map(|p| RenderPlan {
+                provider_id: p.target_id,
+                command: "golden-rules".to_string(),
+                target: RenderTarget::Repo(p.entry_path),
+                content: p.content,
+            })
+            .collect())
     }
 
     fn build_plans(
@@ -168,8 +195,8 @@ impl<'a> SyncRunner<'a> {
                 let content = with_banner(&rendered, command);
                 let target = self.resolve_target(entry, rules, command);
                 plans.push(RenderPlan {
-                    provider_id: entry.id,
-                    command,
+                    provider_id: entry.id.to_string(),
+                    command: (*command).to_string(),
                     target,
                     content,
                 });
@@ -280,8 +307,8 @@ impl RenderTarget {
 }
 
 struct RenderPlan {
-    provider_id: &'static str,
-    command: &'static str,
+    provider_id: String,
+    command: String,
     target: RenderTarget,
     content: String,
 }

--- a/src/integration_tests/snapshots/maestro__integration_tests__canonical_command_specs__snapshot_tokenize_plan_feature.snap
+++ b/src/integration_tests/snapshots/maestro__integration_tests__canonical_command_specs__snapshot_tokenize_plan_feature.snap
@@ -1,6 +1,5 @@
 ---
 source: src/integration_tests/canonical_command_specs.rs
-assertion_line: 391
 expression: "snapshot_tokens(\"plan-feature\")"
 ---
 [
@@ -18,6 +17,10 @@ expression: "snapshot_tokens(\"plan-feature\")"
         [],
     ),
     (
+        "VCS_PROVIDER_CMD",
+        [],
+    ),
+    (
         "INCLUDE",
         [
             (
@@ -25,5 +28,13 @@ expression: "snapshot_tokens(\"plan-feature\")"
                 "core/dependency-graph.md",
             ),
         ],
+    ),
+    (
+        "VCS_PROVIDER_CMD",
+        [],
+    ),
+    (
+        "VCS_PROVIDER_CMD",
+        [],
     ),
 ]

--- a/src/integration_tests/stream_parsing.rs
+++ b/src/integration_tests/stream_parsing.rs
@@ -679,3 +679,37 @@ fn roundtrip_tool_use_bash_command_preview_preserved_through_parse_and_handle() 
 
     assert_eq!(managed.session.current_activity, "$ cargo test --lib");
 }
+
+// ---------------------------------------------------------------------------
+// Issue #770 — CostUpdate end-to-end semantics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cost_update_from_fake_parser_pipes_into_session_cost_usd() {
+    let mut managed = ManagedSession::new(make_running_session("s"));
+    let events = vec![StreamEvent::CostUpdate { cost_usd: 0.42 }];
+    for event in &events {
+        managed.handle_event(event);
+    }
+    assert!((managed.session.cost_usd - 0.42).abs() < f64::EPSILON);
+}
+
+#[test]
+fn sequential_cost_updates_replace_not_accumulate() {
+    let mut managed = ManagedSession::new(make_running_session("s"));
+    managed.handle_event(&StreamEvent::CostUpdate { cost_usd: 0.10 });
+    managed.handle_event(&StreamEvent::CostUpdate { cost_usd: 0.30 });
+    managed.handle_event(&StreamEvent::CostUpdate { cost_usd: 0.42 });
+    assert!(
+        (managed.session.cost_usd - 0.42).abs() < f64::EPSILON,
+        "CostUpdate must replace, not accumulate"
+    );
+}
+
+#[test]
+fn cost_update_zero_frame_overwrites_to_zero() {
+    let mut managed = ManagedSession::new(make_running_session("s"));
+    managed.handle_event(&StreamEvent::CostUpdate { cost_usd: 1.50 });
+    managed.handle_event(&StreamEvent::CostUpdate { cost_usd: 0.0 });
+    assert!((managed.session.cost_usd - 0.0).abs() < f64::EPSILON);
+}

--- a/src/orchestration/mod.rs
+++ b/src/orchestration/mod.rs
@@ -33,7 +33,9 @@ pub use dispatch::{DispatchContext, compose_prompt, dispatch_subagent, parse_res
 #[allow(unused_imports)]
 pub use loader::Loader;
 #[allow(unused_imports)]
-pub use orchestrator::build_system_prompt;
+pub use orchestrator::{
+    FragmentSource, FsFragmentSource, build_system_prompt, canonical_fragment_root,
+};
 #[allow(unused_imports)]
 pub use primitives::{NextStep, PrimitiveMachine, PrimitiveOutput, make_machine};
 #[allow(unused_imports)]

--- a/src/orchestration/orchestrator.rs
+++ b/src/orchestration/orchestrator.rs
@@ -1,20 +1,67 @@
-//! L2 per-issue orchestrator prompt assembly.
+//! L2 per-issue orchestrator prompt assembly (issue #757).
+//!
+//! Assembles the system prompt for an L2-spawned role from:
+//!   1. issue/team/primitive/tools header (synthesized — NEVER includes
+//!      `issue.body`; the origin gate from #707 forbids leak).
+//!   2. canonical fragments `core/premises.md`, `core/tdd-cycle.md`,
+//!      `core/dependency-graph.md`, loaded through [`FragmentSource`].
+//!   3. the role binding's `prompt_addendum` (first non-empty by canonical
+//!      role order — see [`pick_addendum`]).
+//!
+//! Empty sections collapse, mirroring `dispatch::compose_prompt` for L1.
 
 #![allow(dead_code)]
 
+use std::path::{Path, PathBuf};
+
 use crate::orchestration::team::ResolvedTeam;
-use crate::orchestration::types::Primitive;
+use crate::orchestration::types::{Primitive, TeamRole};
 use crate::provider::types::Issue;
 
-pub fn build_system_prompt(team: &ResolvedTeam, issue: &Issue) -> String {
+/// Source of canonical core fragments for the L2 prompt composer.
+///
+/// Production reads `core/<name>.md` from `.maestro/templates/`; tests inject
+/// a static map. `None` means "fragment absent — skip silently".
+pub trait FragmentSource {
+    fn load(&self, name: &str) -> Option<String>;
+}
+
+/// Filesystem-backed fragment source rooted at a configurable directory.
+///
+/// Production wires it at `.maestro/templates/core/`. The root is private; the
+/// only constructor is [`FsFragmentSource::new`], so callers cannot retarget
+/// the source after creation.
+pub struct FsFragmentSource {
+    root: PathBuf,
+}
+
+impl FsFragmentSource {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+}
+
+impl FragmentSource for FsFragmentSource {
+    fn load(&self, name: &str) -> Option<String> {
+        let path = self.root.join(format!("{name}.md"));
+        std::fs::read_to_string(path).ok()
+    }
+}
+
+/// Assemble the L2 system prompt. Pure function — same inputs yield same
+/// output. `issue.body` is read for no field other than the issue number.
+pub fn build_system_prompt(
+    team: &ResolvedTeam,
+    issue: &Issue,
+    fragments: &dyn FragmentSource,
+) -> String {
     let primitive = team.primitive.label();
-    let tools = if team.primitive == Primitive::Pipeline {
-        "Task, GhPrCreate, ReportFailure"
-    } else {
-        "Task, ReportFailure"
+    let tools = match team.primitive {
+        Primitive::Pipeline => "Task, GhPrCreate, ReportFailure",
+        _ => "Task, ReportFailure",
     };
 
-    format!(
+    let header = format!(
         "You are Maestro L2 for issue #{}.\n\
 Primitive: {primitive}.\n\
 Team: {}.\n\
@@ -23,15 +70,72 @@ Forbidden: Read, Edit, Write, Bash, Grep.\n\
 Do not inspect files or the issue body. Delegate with Task(role, instructions) only.\n\
 Pass only concise structured summaries between roles. ReportFailure on blocked or invalid results.",
         issue.number, team.name
-    )
+    );
+
+    let mut sections: Vec<String> = vec![header];
+    if let Some(body) = fragments.load("premises") {
+        sections.push(body);
+    }
+    if let Some(body) = fragments.load("tdd-cycle") {
+        sections.push(body);
+    }
+    if let Some(body) = fragments.load("dependency-graph") {
+        sections.push(body);
+    }
+    if let Some(body) = pick_addendum(team) {
+        sections.push(body);
+    }
+
+    sections
+        .into_iter()
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+/// Returns the first non-empty `prompt_addendum` walking team bindings in
+/// canonical role order (Orchestrator first, then Implementer, Reviewer, Docs,
+/// Devops, Triager, Researcher). Deterministic — required for snapshots.
+fn pick_addendum(team: &ResolvedTeam) -> Option<String> {
+    const ORDER: &[TeamRole] = &[
+        TeamRole::Orchestrator,
+        TeamRole::Implementer,
+        TeamRole::Reviewer,
+        TeamRole::Docs,
+        TeamRole::Devops,
+        TeamRole::Triager,
+        TeamRole::Researcher,
+    ];
+    ORDER.iter().find_map(|r| {
+        team.bindings
+            .get(r)
+            .and_then(|b| b.prompt_addendum.clone())
+            .filter(|s| !s.is_empty())
+    })
+}
+
+/// Convenience constructor for production L2 spawn: points the composer at
+/// the workspace's canonical `.maestro/templates/core/` directory.
+pub fn canonical_fragment_root() -> &'static Path {
+    Path::new(".maestro/templates/core")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::orchestration::team::{ResolvedTeam, RoleBinding, SourceTier};
-    use crate::orchestration::types::{Primitive, TeamRole};
+    use crate::orchestration::types::TeamRole;
     use std::collections::HashMap;
+
+    pub(super) struct StaticFragmentSource(
+        pub(super) std::collections::HashMap<&'static str, &'static str>,
+    );
+
+    impl FragmentSource for StaticFragmentSource {
+        fn load(&self, name: &str) -> Option<String> {
+            self.0.get(name).map(|s| s.to_string())
+        }
+    }
 
     fn issue() -> Issue {
         Issue {
@@ -65,28 +169,74 @@ mod tests {
         }
     }
 
+    fn empty_fragments() -> StaticFragmentSource {
+        StaticFragmentSource(std::collections::HashMap::new())
+    }
+
     #[test]
     fn pipeline_prompt_snapshot() {
-        let prompt = build_system_prompt(&team(Primitive::Pipeline), &issue());
+        let prompt = build_system_prompt(&team(Primitive::Pipeline), &issue(), &empty_fragments());
         insta::assert_snapshot!(prompt, @r###"
-You are Maestro L2 for issue #662.
-Primitive: pipeline.
-Team: default-coder.
-Allowed tools: Task, GhPrCreate, ReportFailure.
-Forbidden: Read, Edit, Write, Bash, Grep.
-Do not inspect files or the issue body. Delegate with Task(role, instructions) only.
-Pass only concise structured summaries between roles. ReportFailure on blocked or invalid results.
-"###);
+        You are Maestro L2 for issue #662.
+        Primitive: pipeline.
+        Team: default-coder.
+        Allowed tools: Task, GhPrCreate, ReportFailure.
+        Forbidden: Read, Edit, Write, Bash, Grep.
+        Do not inspect files or the issue body. Delegate with Task(role, instructions) only.
+        Pass only concise structured summaries between roles. ReportFailure on blocked or invalid results.
+        "###);
     }
 
     #[test]
     fn prompt_includes_expected_bounds() {
-        let prompt = build_system_prompt(&team(Primitive::SinglePass), &issue());
+        let prompt =
+            build_system_prompt(&team(Primitive::SinglePass), &issue(), &empty_fragments());
         assert!(prompt.contains("single-pass"));
         assert!(prompt.contains("#662"));
         assert!(prompt.contains("Allowed tools: Task, ReportFailure."));
         assert!(!prompt.contains("GhPrCreate"));
         assert!(prompt.contains("Forbidden: Read, Edit, Write, Bash, Grep."));
         assert!(!prompt.contains("SECRET ISSUE BODY"));
+    }
+
+    #[test]
+    fn fragments_appended_in_canonical_order() {
+        let src = StaticFragmentSource(std::collections::HashMap::from([
+            ("premises", "# P\n"),
+            ("tdd-cycle", "# T\n"),
+            ("dependency-graph", "# D\n"),
+        ]));
+        let prompt = build_system_prompt(&team(Primitive::Pipeline), &issue(), &src);
+        let p_idx = prompt.find("# P").expect("premises present");
+        let t_idx = prompt.find("# T").expect("tdd present");
+        let d_idx = prompt.find("# D").expect("dep-graph present");
+        assert!(p_idx < t_idx);
+        assert!(t_idx < d_idx);
+    }
+
+    #[test]
+    fn empty_addendum_string_collapses_like_none() {
+        let mut team_empty = team(Primitive::SinglePass);
+        if let Some(b) = team_empty.bindings.get_mut(&TeamRole::Reviewer) {
+            b.prompt_addendum = Some(String::new());
+        }
+        let with_empty = build_system_prompt(&team_empty, &issue(), &empty_fragments());
+        let with_none =
+            build_system_prompt(&team(Primitive::SinglePass), &issue(), &empty_fragments());
+        assert_eq!(with_empty, with_none);
+    }
+
+    #[test]
+    fn origin_gate_no_issue_body_leak_with_fragments_present() {
+        let src = StaticFragmentSource(std::collections::HashMap::from([
+            ("premises", "fragment premises body"),
+            ("tdd-cycle", "fragment tdd body"),
+            ("dependency-graph", "fragment dep body"),
+        ]));
+        let prompt = build_system_prompt(&team(Primitive::Pipeline), &issue(), &src);
+        assert!(
+            !prompt.contains("SECRET ISSUE BODY"),
+            "issue.body must NEVER appear in L2 prompt (#707 origin gate)"
+        );
     }
 }

--- a/src/session/parser.rs
+++ b/src/session/parser.rs
@@ -317,6 +317,7 @@ fn parse_result(v: &Value) -> Vec<StreamEvent> {
                 .and_then(|u| u.get("cost_usd"))
                 .and_then(|c| c.as_f64())
         })
+        .filter(|c| c.is_finite() && *c >= 0.0)
         .unwrap_or(0.0);
 
     if let Some(usage) = v.get("usage") {
@@ -1144,6 +1145,52 @@ mod tests {
                 );
             }
             other => panic!("Expected ToolUse, got {:?}", other),
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Issue #770 — parse_result rejects NaN/negative/non-finite cost
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn parse_result_null_cost_falls_back_to_zero() {
+        let line = r#"{"type":"result","cost_usd":null,"duration_ms":30000}"#;
+        let completed = parse_stream_line(line)
+            .into_iter()
+            .find(|e| matches!(e, StreamEvent::Completed { .. }))
+            .expect("Completed event");
+        match completed {
+            StreamEvent::Completed { cost_usd } => assert_eq!(cost_usd, 0.0),
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn parse_result_negative_cost_rejected_to_zero() {
+        let line = r#"{"type":"result","cost_usd":-1.5,"duration_ms":30000}"#;
+        let completed = parse_stream_line(line)
+            .into_iter()
+            .find(|e| matches!(e, StreamEvent::Completed { .. }))
+            .expect("Completed event");
+        match completed {
+            StreamEvent::Completed { cost_usd } => assert_eq!(
+                cost_usd, 0.0,
+                "negative cost must be rejected at parser boundary"
+            ),
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn parse_result_stringified_infinity_rejected_to_zero() {
+        let line = r#"{"type":"result","cost_usd":"Infinity","duration_ms":30000}"#;
+        let completed = parse_stream_line(line)
+            .into_iter()
+            .find(|e| matches!(e, StreamEvent::Completed { .. }))
+            .expect("Completed event");
+        match completed {
+            StreamEvent::Completed { cost_usd } => assert_eq!(cost_usd, 0.0),
+            _ => unreachable!(),
         }
     }
 }

--- a/src/session/types.rs
+++ b/src/session/types.rs
@@ -608,8 +608,17 @@ pub enum StreamEvent {
     },
     /// Tool result received
     ToolResult { tool: String, is_error: bool },
-    /// Cost update from usage data
-    #[allow(dead_code)] // Reason: cost tracking event — to be emitted by budget enforcer
+    /// Cost update from a non-terminal usage frame.
+    ///
+    /// Emitted by parsers when a provider reports cost on a frame distinct from
+    /// the terminal `Completed` event (e.g. mid-turn usage snapshots). The handler
+    /// in `ManagedSession::handle_event` replaces `Session.cost_usd` with the
+    /// reported value. Parsers MUST drop frames where `cost_usd` is `NaN` or
+    /// negative (see `parse_result` in `src/session/parser.rs`).
+    ///
+    /// Currently no shipped provider emits this variant; it is reserved for
+    /// future split-frame providers and exercised end-to-end by tests in
+    /// `src/integration_tests/stream_parsing.rs`.
     CostUpdate { cost_usd: f64 },
     /// Session completed
     Completed { cost_usd: f64 },

--- a/src/templates/manifest.rs
+++ b/src/templates/manifest.rs
@@ -27,6 +27,26 @@ pub struct Manifest {
     pub providers: BTreeMap<String, ManifestProvider>,
     #[serde(default)]
     pub subagents: Vec<ManifestSubagent>,
+    /// Golden Rules entry-file sync configuration (issue #839).
+    #[serde(default)]
+    pub golden_rules: Option<ManifestGoldenRules>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ManifestGoldenRules {
+    /// Path to the canonical golden-rules body, relative to `templates_root`.
+    pub source: String,
+    #[serde(default)]
+    pub targets: Vec<ManifestGoldenRulesTarget>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ManifestGoldenRulesTarget {
+    pub id: String,
+    /// Repo-relative path to the entry file (e.g. `.claude/CLAUDE.md`).
+    pub entry_file: String,
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]
@@ -66,6 +86,8 @@ pub struct ManifestProvider {
     pub target_dir: String,
     #[serde(default)]
     pub inline_skills: bool,
+    #[serde(default)]
+    pub vcs_provider_cmd: String,
 }
 
 fn default_templates_root() -> String {
@@ -116,6 +138,10 @@ impl Manifest {
 
     pub fn subagents(&self) -> &[ManifestSubagent] {
         &self.subagents
+    }
+
+    pub fn golden_rules(&self) -> Option<&ManifestGoldenRules> {
+        self.golden_rules.as_ref()
     }
 }
 

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -9,7 +9,7 @@
 #![deny(clippy::expect_used)]
 
 mod error;
-mod manifest;
+pub mod manifest;
 pub mod provider_rules;
 pub mod rendered_cache;
 mod renderer;
@@ -175,6 +175,9 @@ mod tests {
                 Ok("LIST".to_string())
             }
             fn skill_link(&self, _: &str) -> Result<String, TemplateError> {
+                Ok(String::new())
+            }
+            fn vcs_provider_cmd(&self) -> Result<String, TemplateError> {
                 Ok(String::new())
             }
         }

--- a/src/templates/provider_rules/claude.rs
+++ b/src/templates/provider_rules/claude.rs
@@ -63,6 +63,10 @@ impl TemplateProviderRules for ClaudeRules {
             "the `{name}` skill (.claude/skills/{name}/SKILL.md)"
         ))
     }
+
+    fn vcs_provider_cmd(&self) -> Result<String, TemplateError> {
+        Ok("gh".to_string())
+    }
 }
 
 #[cfg(test)]

--- a/src/templates/provider_rules/codex.rs
+++ b/src/templates/provider_rules/codex.rs
@@ -75,6 +75,10 @@ impl TemplateProviderRules for CodexRules {
     fn skill_link(&self, name: &str) -> Result<String, TemplateError> {
         super::read_skill_body(name)
     }
+
+    fn vcs_provider_cmd(&self) -> Result<String, TemplateError> {
+        Ok("gh".to_string())
+    }
 }
 
 #[cfg(test)]

--- a/src/templates/provider_rules/http_generic.rs
+++ b/src/templates/provider_rules/http_generic.rs
@@ -78,6 +78,10 @@ impl TemplateProviderRules for HttpGenericRules {
     fn skill_link(&self, name: &str) -> Result<String, TemplateError> {
         super::read_skill_body(name)
     }
+
+    fn vcs_provider_cmd(&self) -> Result<String, TemplateError> {
+        Ok("gh".to_string())
+    }
 }
 
 #[cfg(test)]

--- a/src/templates/provider_rules/mod.rs
+++ b/src/templates/provider_rules/mod.rs
@@ -101,6 +101,11 @@ pub trait TemplateProviderRules: Send + Sync {
 
     fn skill_link(&self, name: &str) -> Result<String, TemplateError>;
 
+    /// Render the per-provider VCS CLI command (e.g. `gh` for GitHub-aligned
+    /// providers, `az repos` for Azure DevOps). Substituted wherever a
+    /// canonical command embeds `{{VCS_PROVIDER_CMD}}`.
+    fn vcs_provider_cmd(&self) -> Result<String, TemplateError>;
+
     /// `true` for the fail-closed [`NullRules`] stub. Concrete providers
     /// inherit the default `false` and may render templates. Consumers such
     /// as `maestro sync-templates` use this to skip providers whose rules
@@ -154,6 +159,13 @@ impl TemplateProviderRules for NullRules {
     fn skill_link(&self, _name: &str) -> Result<String, TemplateError> {
         Err(TemplateError::UnsupportedByProvider {
             name: "SKILL".to_string(),
+            reason: "no provider rules registered (NullRules)".to_string(),
+        })
+    }
+
+    fn vcs_provider_cmd(&self) -> Result<String, TemplateError> {
+        Err(TemplateError::UnsupportedByProvider {
+            name: "VCS_PROVIDER_CMD".to_string(),
             reason: "no provider rules registered (NullRules)".to_string(),
         })
     }

--- a/src/templates/renderer/mod.rs
+++ b/src/templates/renderer/mod.rs
@@ -1,8 +1,9 @@
 //! Placeholder-expansion engine for canonical command templates.
 //!
-//! Hand-written tokenizer (not regex). Five hard-coded placeholder kinds:
-//! `INVOKE_SUBAGENT`, `HOOK_GATE`, `INCLUDE`, `SUBAGENT_LIST`, `SKILL`.
-//! Unknown placeholders fail closed with `TemplateError::UnknownPlaceholder`.
+//! Hand-written tokenizer (not regex). Six hard-coded placeholder kinds:
+//! `INVOKE_SUBAGENT`, `HOOK_GATE`, `INCLUDE`, `SUBAGENT_LIST`, `SKILL`,
+//! `VCS_PROVIDER_CMD`. Unknown placeholders fail closed with
+//! `TemplateError::UnknownPlaceholder`.
 
 #![deny(clippy::unwrap_used)]
 #![deny(clippy::expect_used)]
@@ -38,6 +39,7 @@ pub(crate) enum PlaceholderKind {
     Include,
     SubagentList,
     Skill,
+    VcsProviderCmd,
 }
 
 impl PlaceholderKind {
@@ -48,6 +50,7 @@ impl PlaceholderKind {
             "INCLUDE" => Some(Self::Include),
             "SUBAGENT_LIST" => Some(Self::SubagentList),
             "SKILL" => Some(Self::Skill),
+            "VCS_PROVIDER_CMD" => Some(Self::VcsProviderCmd),
             _ => None,
         }
     }
@@ -59,6 +62,7 @@ impl PlaceholderKind {
             Self::Include => &["path"],
             Self::SubagentList => &[],
             Self::Skill => &["name"],
+            Self::VcsProviderCmd => &[],
         }
     }
 }
@@ -146,6 +150,7 @@ fn expand(
             let n = lookup("name")?;
             rules.skill_link(n)
         }
+        PlaceholderKind::VcsProviderCmd => rules.vcs_provider_cmd(),
     }
 }
 

--- a/src/templates/renderer/tests/fakes.rs
+++ b/src/templates/renderer/tests/fakes.rs
@@ -30,6 +30,9 @@ impl TemplateProviderRules for RecursiveIncludeRules {
     fn skill_link(&self, _: &str) -> Result<String, TemplateError> {
         Err(unsupported("SKILL"))
     }
+    fn vcs_provider_cmd(&self) -> Result<String, TemplateError> {
+        Err(unsupported("VCS_PROVIDER_CMD"))
+    }
 }
 
 pub(super) struct TerminatingIncludeRules {
@@ -60,6 +63,9 @@ impl TemplateProviderRules for TerminatingIncludeRules {
         Ok(String::new())
     }
     fn skill_link(&self, _: &str) -> Result<String, TemplateError> {
+        Ok(String::new())
+    }
+    fn vcs_provider_cmd(&self) -> Result<String, TemplateError> {
         Ok(String::new())
     }
 }

--- a/src/templates/test_fakes.rs
+++ b/src/templates/test_fakes.rs
@@ -29,6 +29,9 @@ impl TemplateProviderRules for FakeRules {
     fn skill_link(&self, name: &str) -> Result<String, TemplateError> {
         Ok(format!("[SKILL name={name}]"))
     }
+    fn vcs_provider_cmd(&self) -> Result<String, TemplateError> {
+        Ok("[VCS]".to_string())
+    }
 }
 
 pub(crate) fn unsupported(name: &str) -> TemplateError {

--- a/template/.maestro/templates/commands/plan-feature.md
+++ b/template/.maestro/templates/commands/plan-feature.md
@@ -5,6 +5,7 @@ description: Plan a feature across the project, creating API contracts first, th
 placeholders:
   - INCLUDE
   - SUBAGENT_LIST
+  - VCS_PROVIDER_CMD
 includes:
   - core/premises.md
   - core/dependency-graph.md
@@ -60,7 +61,7 @@ For every API endpoint identified:
 
 If the feature is large enough for a milestone:
 ```bash
-gh api repos/<owner>/<repo>/milestones -f title="..." -f state=open -f description="..."
+{{VCS_PROVIDER_CMD}} api repos/<owner>/<repo>/milestones -f title="..." -f state=open -f description="..."
 ```
 
 ### Phase 4: ISSUES — Create with Traceability
@@ -104,7 +105,7 @@ The dependency-graph format and per-issue `## Blocked By` rules are canonical:
 
 ## Error Handling
 
-- If `gh` CLI fails → suggest `gh auth login`
+- If `{{VCS_PROVIDER_CMD}}` CLI fails → suggest `{{VCS_PROVIDER_CMD}} auth login`
 - If description is too vague → ask clarifying questions
 - If contract already exists → reuse it
 - If milestone exists → reuse it

--- a/template/.maestro/templates/manifest.toml
+++ b/template/.maestro/templates/manifest.toml
@@ -35,22 +35,55 @@ required_args = []
 description = "reference a skill knowledge base"
 required_args = ["name"]
 
+[placeholders.VCS_PROVIDER_CMD]
+description = "render the VCS provider CLI command (e.g. `gh`, `az repos`)"
+required_args = []
+
 # ── Per-provider metadata (parsed; consumed by L2 in #703-#705) ─────────
 
 [providers.claude]
 display_name = "Claude Code"
 target_dir = ".claude/commands"
 inline_skills = false
+vcs_provider_cmd = "gh"
 
 [providers.codex]
 display_name = "Codex CLI"
 target_dir = ".codex/commands"
 inline_skills = true
+vcs_provider_cmd = "gh"
 
 [providers.http_generic]
 display_name = "Generic HTTP provider"
 target_dir = ""
 inline_skills = true
+vcs_provider_cmd = "gh"
+
+# ── Golden Rules entry points (issue #839) ──────────────────────────────
+# `maestro sync-templates` rewrites the block between
+# `<!-- BEGIN GOLDEN-RULES … -->` and `<!-- END GOLDEN-RULES -->` markers
+# in each entry_file with the body of the canonical source. Drift between
+# canonical and any target fails `--check`. `scripts/check-rules-drift.sh`
+# is retained as a secondary safety net for non-Rust CI lanes.
+
+[golden_rules]
+source = "core/golden-rules.md"
+
+[[golden_rules.targets]]
+id = "claude"
+entry_file = ".claude/CLAUDE.md"
+
+[[golden_rules.targets]]
+id = "codex"
+entry_file = ".codex/AGENTS.md"
+
+[[golden_rules.targets]]
+id = "agents-md"
+entry_file = "AGENTS.md"
+
+[[golden_rules.targets]]
+id = "gemini"
+entry_file = "GEMINI.md"
 
 # ── Subagent registry (rendered by {{SUBAGENT_LIST}}) ────────────────────
 # Order in this file = order in the rendered Markdown table. Drift between

--- a/tests/fixtures/templates/core/dependency-graph.md
+++ b/tests/fixtures/templates/core/dependency-graph.md
@@ -1,0 +1,3 @@
+# Dependency Graph (test fixture)
+
+Blocked By: None.

--- a/tests/fixtures/templates/core/premises.md
+++ b/tests/fixtures/templates/core/premises.md
@@ -1,0 +1,3 @@
+# Premises (test fixture)
+
+Fixture body line for the L2 prompt composer (#757).

--- a/tests/fixtures/templates/core/tdd-cycle.md
+++ b/tests/fixtures/templates/core/tdd-cycle.md
@@ -1,0 +1,3 @@
+# TDD Cycle (test fixture)
+
+RED → GREEN → REFACTOR.

--- a/tests/orchestration.rs
+++ b/tests/orchestration.rs
@@ -1,0 +1,4 @@
+//! Integration tests for L2 orchestrator prompt assembly (issue #757).
+
+#[path = "orchestration/l2_prompt_compose.rs"]
+mod l2_prompt_compose;

--- a/tests/orchestration/l2_prompt_compose.rs
+++ b/tests/orchestration/l2_prompt_compose.rs
@@ -1,0 +1,105 @@
+//! Integration tests for the L2 composer (issue #757).
+//!
+//! Exercises the public composer surface with a filesystem-backed
+//! `FsFragmentSource` rooted at `tests/fixtures/templates/core/`. The fixture
+//! root is small + stable so snapshots stay readable and decoupled from any
+//! future edits to the real `.maestro/templates/core/*.md` files.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use maestro::orchestration::types::Primitive;
+use maestro::orchestration::{
+    FragmentSource, FsFragmentSource, ResolvedTeam, RoleBinding, SourceTier, TeamRole,
+    build_system_prompt,
+};
+use maestro::provider::types::Issue;
+
+fn fixture_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/templates/core")
+}
+
+fn issue() -> Issue {
+    Issue {
+        number: 757,
+        title: "L2 composer integration".into(),
+        body: "SECRET ISSUE BODY (must never appear in prompt)".into(),
+        labels: vec![],
+        state: "open".into(),
+        html_url: "https://example.test/issues/757".into(),
+        milestone: None,
+        assignees: vec![],
+    }
+}
+
+fn team(primitive: Primitive, addendum: Option<&str>) -> ResolvedTeam {
+    ResolvedTeam {
+        name: "default-coder".into(),
+        primitive,
+        min_agents: vec!["claude".into()],
+        bindings: HashMap::from([(
+            TeamRole::Implementer,
+            RoleBinding {
+                agent: "claude".into(),
+                mode: None,
+                model_override: None,
+                prompt_addendum: addendum.map(str::to_string),
+                fallback_agent: None,
+            },
+        )]),
+        source_tier: SourceTier::BuiltIn,
+    }
+}
+
+#[test]
+fn pipeline_with_addendum_snapshot() {
+    let src = FsFragmentSource::new(fixture_root());
+    let prompt = build_system_prompt(
+        &team(Primitive::Pipeline, Some("Be terse.")),
+        &issue(),
+        &src,
+    );
+    insta::assert_snapshot!("pipeline_with_addendum", prompt);
+}
+
+#[test]
+fn single_pass_no_addendum_snapshot() {
+    let src = FsFragmentSource::new(fixture_root());
+    let prompt = build_system_prompt(&team(Primitive::SinglePass, None), &issue(), &src);
+    insta::assert_snapshot!("single_pass_no_addendum", prompt);
+}
+
+#[test]
+fn origin_gate_no_issue_body_leak() {
+    let src = FsFragmentSource::new(fixture_root());
+    let prompt = build_system_prompt(
+        &team(Primitive::Pipeline, Some("Be terse.")),
+        &issue(),
+        &src,
+    );
+    assert!(
+        !prompt.contains("SECRET ISSUE BODY"),
+        "L2 prompt must not embed issue body (origin gate from #707)"
+    );
+}
+
+#[test]
+fn missing_fragments_do_not_panic_and_yield_header_only() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let src = FsFragmentSource::new(tmp.path());
+    let prompt = build_system_prompt(&team(Primitive::SinglePass, None), &issue(), &src);
+    assert!(prompt.starts_with("You are Maestro L2 for issue #"));
+    assert!(!prompt.contains("Premises (test fixture)"));
+}
+
+#[test]
+fn fragment_source_trait_object_works_via_dyn_dispatch() {
+    struct Empty;
+    impl FragmentSource for Empty {
+        fn load(&self, _: &str) -> Option<String> {
+            None
+        }
+    }
+    let prompt = build_system_prompt(&team(Primitive::SinglePass, None), &issue(), &Empty);
+    assert!(prompt.contains("Forbidden:"));
+}

--- a/tests/orchestration/snapshots/orchestration__l2_prompt_compose__pipeline_with_addendum.snap
+++ b/tests/orchestration/snapshots/orchestration__l2_prompt_compose__pipeline_with_addendum.snap
@@ -1,0 +1,28 @@
+---
+source: tests/orchestration/l2_prompt_compose.rs
+expression: prompt
+---
+You are Maestro L2 for issue #757.
+Primitive: pipeline.
+Team: default-coder.
+Allowed tools: Task, GhPrCreate, ReportFailure.
+Forbidden: Read, Edit, Write, Bash, Grep.
+Do not inspect files or the issue body. Delegate with Task(role, instructions) only.
+Pass only concise structured summaries between roles. ReportFailure on blocked or invalid results.
+
+# Premises (test fixture)
+
+Fixture body line for the L2 prompt composer (#757).
+
+
+# TDD Cycle (test fixture)
+
+RED → GREEN → REFACTOR.
+
+
+# Dependency Graph (test fixture)
+
+Blocked By: None.
+
+
+Be terse.

--- a/tests/orchestration/snapshots/orchestration__l2_prompt_compose__single_pass_no_addendum.snap
+++ b/tests/orchestration/snapshots/orchestration__l2_prompt_compose__single_pass_no_addendum.snap
@@ -1,0 +1,25 @@
+---
+source: tests/orchestration/l2_prompt_compose.rs
+expression: prompt
+---
+You are Maestro L2 for issue #757.
+Primitive: single-pass.
+Team: default-coder.
+Allowed tools: Task, ReportFailure.
+Forbidden: Read, Edit, Write, Bash, Grep.
+Do not inspect files or the issue body. Delegate with Task(role, instructions) only.
+Pass only concise structured summaries between roles. ReportFailure on blocked or invalid results.
+
+# Premises (test fixture)
+
+Fixture body line for the L2 prompt composer (#757).
+
+
+# TDD Cycle (test fixture)
+
+RED → GREEN → REFACTOR.
+
+
+# Dependency Graph (test fixture)
+
+Blocked By: None.

--- a/tests/templates_golden_rules.rs
+++ b/tests/templates_golden_rules.rs
@@ -1,0 +1,69 @@
+//! Issue #839 — golden-rules entry-file sync end-to-end test.
+//!
+//! Builds a tempdir replica of the maestro repo skeleton (manifest +
+//! canonical golden-rules + two entry-point files), exercises the splice
+//! logic via `golden_rules::splice`, and asserts marker-bounded content
+//! lands intact while content outside the markers is preserved.
+
+use std::fs;
+
+use maestro::commands::sync_templates::golden_rules::{GoldenRulesError, splice};
+
+#[test]
+fn splice_round_trip_against_real_repo_canonical_body_is_idempotent() {
+    let repo = std::env::current_dir().expect("cwd");
+    let canonical_path = repo.join(".maestro/templates/core/golden-rules.md");
+    let canonical = fs::read_to_string(&canonical_path).expect("read canonical");
+
+    for entry_rel in [
+        ".claude/CLAUDE.md",
+        ".codex/AGENTS.md",
+        "AGENTS.md",
+        "GEMINI.md",
+    ] {
+        let entry_path = repo.join(entry_rel);
+        let current =
+            fs::read_to_string(&entry_path).unwrap_or_else(|e| panic!("read {entry_rel}: {e}"));
+        let spliced = splice(&current, &canonical, &entry_path)
+            .unwrap_or_else(|e| panic!("splice {entry_rel}: {e}"));
+        assert_eq!(
+            current, spliced,
+            "entry file `{entry_rel}` already matches canonical; splice must be a no-op"
+        );
+    }
+}
+
+#[test]
+fn splice_drift_detected_on_mutated_entry_file() {
+    let repo = std::env::current_dir().expect("cwd");
+    let canonical = fs::read_to_string(repo.join(".maestro/templates/core/golden-rules.md"))
+        .expect("canonical");
+    let entry = fs::read_to_string(repo.join(".claude/CLAUDE.md")).expect("entry");
+
+    // Mutate the block content by replacing a known sentence.
+    let mutated = entry.replace("## Who I am", "## Who I am — TAMPERED HEADING");
+    assert_ne!(entry, mutated, "test setup must mutate the file");
+
+    let respliced = splice(
+        &mutated,
+        &canonical,
+        std::path::Path::new("/test/claude.md"),
+    )
+    .expect("splice ok");
+    assert_eq!(
+        respliced, entry,
+        "splice must restore canonical content even when entry block was tampered with"
+    );
+}
+
+#[test]
+fn splice_error_when_begin_marker_missing() {
+    let path = std::path::Path::new("/test/entry.md");
+    let err = splice(
+        "no markers here\n<!-- END GOLDEN-RULES -->\n",
+        "body\n",
+        path,
+    )
+    .unwrap_err();
+    assert!(matches!(err, GoldenRulesError::BeginMarkerMissing { .. }));
+}

--- a/tests/templates_vcs_provider_cmd.rs
+++ b/tests/templates_vcs_provider_cmd.rs
@@ -1,0 +1,109 @@
+//! Issue #758 — `{{VCS_PROVIDER_CMD}}` placeholder per-provider substitution.
+//!
+//! Proves the placeholder substitutes the per-provider CLI string in rendered
+//! canonical commands. Today three real providers return `gh`; a custom rules
+//! impl in this test proves a different CLI (e.g. `az repos` for Azure DevOps)
+//! is wired through the same code path with zero canonical edits.
+
+use std::path::Path;
+
+use maestro::agent_provider::ClaudeProvider;
+use maestro::templates::TemplateError;
+use maestro::templates::provider_rules::TemplateProviderRules;
+use maestro::templates::{render_command_for_rules, render_for_provider};
+
+#[test]
+fn plan_feature_render_for_claude_substitutes_gh() {
+    let rendered = render_for_provider(&ClaudeProvider::default(), "plan-feature")
+        .expect("plan-feature render must succeed for ClaudeProvider");
+    assert!(
+        rendered.contains("gh api repos/<owner>/<repo>/milestones"),
+        "expected `gh api repos/...` after VCS substitution, got:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("{{VCS_PROVIDER_CMD}}"),
+        "unresolved VCS_PROVIDER_CMD placeholder in claude render"
+    );
+}
+
+#[test]
+fn plan_feature_render_with_azure_devops_rules_substitutes_az_repos() {
+    let rendered = render_command_for_rules(
+        Path::new(".maestro/templates"),
+        &AzureDevOpsRules,
+        "plan-feature",
+    )
+    .expect("plan-feature render must succeed for AzureDevOpsRules");
+    assert!(
+        rendered.contains("az repos api repos/<owner>/<repo>/milestones"),
+        "expected `az repos api repos/...` after VCS substitution, got:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("{{VCS_PROVIDER_CMD}}"),
+        "unresolved VCS_PROVIDER_CMD placeholder in azuredevops render"
+    );
+}
+
+#[test]
+fn plan_feature_renders_with_zero_unresolved_placeholders_for_each_rules_shape() {
+    let claude_out =
+        render_for_provider(&ClaudeProvider::default(), "plan-feature").expect("claude render");
+    assert!(
+        !claude_out.contains("{{"),
+        "claude render has unresolved `{{`"
+    );
+    assert!(
+        !claude_out.contains("}}"),
+        "claude render has unresolved `}}`"
+    );
+
+    let az_out = render_command_for_rules(
+        Path::new(".maestro/templates"),
+        &AzureDevOpsRules,
+        "plan-feature",
+    )
+    .expect("azure render");
+    assert!(!az_out.contains("{{"), "azure render has unresolved `{{`");
+    assert!(!az_out.contains("}}"), "azure render has unresolved `}}`");
+}
+
+/// Rules-only stub mirroring how a real Azure DevOps provider would expose
+/// `az repos` as its VCS CLI. Every other placeholder delegates to a
+/// codex-equivalent shape so the render does not fail-closed on
+/// SUBAGENT_LIST / INCLUDE / SKILL.
+struct AzureDevOpsRules;
+
+impl TemplateProviderRules for AzureDevOpsRules {
+    fn target_dir(&self) -> Option<&'static Path> {
+        None
+    }
+
+    fn invoke_subagent(&self, name: &str, prompt: &str) -> Result<String, TemplateError> {
+        Ok(format!("## Sub-task: {name}\n\n{prompt}"))
+    }
+
+    fn hook_gate(&self, script: &str, args: &str) -> Result<String, TemplateError> {
+        if args.is_empty() {
+            Ok(format!("bash .maestro/hooks/{script}"))
+        } else {
+            Ok(format!("bash .maestro/hooks/{script} {args}"))
+        }
+    }
+
+    fn include(&self, path: &Path) -> Result<String, TemplateError> {
+        let full = Path::new(".maestro/templates").join(path);
+        std::fs::read_to_string(&full).map_err(|source| TemplateError::Io { path: full, source })
+    }
+
+    fn subagent_list(&self) -> Result<String, TemplateError> {
+        Ok("| Subagent | Purpose |\n|---|---|\n".to_string())
+    }
+
+    fn skill_link(&self, name: &str) -> Result<String, TemplateError> {
+        Ok(format!("the `{name}` skill"))
+    }
+
+    fn vcs_provider_cmd(&self) -> Result<String, TemplateError> {
+        Ok("az repos".to_string())
+    }
+}


### PR DESCRIPTION
## Summary

Bundles the Level-0 dependency-graph issues from milestone **v0.29.5 — Orchestration & Provider Polish** into a single PR. All five are independent in the milestone graph and ship together so downstream Level-1 work (#771–#775) can start.

| Issue | Scope |
|---|---|
| #757 | L2 prompt composer with FragmentSource trait + 5 snapshot/origin tests |
| #758 | `{{VCS_PROVIDER_CMD}}` placeholder; `plan-feature.md` refactor; 3 substitution tests |
| #770 | `StreamEvent::CostUpdate` end-to-end + NaN/negative parser reject; 6 new tests |
| #799 | `implement-gates.sh` Gate 6.5 + `lib-changelog.sh` helper; 6 regression cases |
| #839 | `[golden_rules]` manifest block + splice() + `sync-templates --check` drift; 11 tests |

**#788 deferred.** The 14-field schema backfill was started but reverted: adding fields cascades into 30+ TUI position-asserting tests (`settings_*_parity` snapshots, `flags_validation` index assertions). Better carved out as its own focused PR so the snapshot churn lives next to the schema diff. The other 5 issues are unrelated to that surface and ship clean.

## Notable design decisions

- **#757 addendum policy**: first-non-empty by canonical role order (Orchestrator → Implementer → Reviewer → Docs → Devops → Triager → Researcher). Deterministic for snapshots. Alternative (concatenate all role addenda) deferred — flag here if you'd prefer it.
- **#758 second-provider proof**: a custom `AzureDevOpsRules` lives only in the test crate. We did not add a runtime Azure DevOps provider — placeholder mechanism is proven via the test substituting `az repos`, all three real providers return `gh`.
- **#770**: investigation found the issue body was partly stale — `TokenUsage` already had `cache_creation_tokens` + `cache_read_tokens` (Anthropic wire-key bridge in parser.rs:255-262). No struct change needed. `TokenUsageUpdate` variant **not** added — no shipping provider splits cost from tokens onto separate frames; existing `TokenUpdate` already covers the case if a future one does.
- **#839 manifest shape**: chose a top-level `[golden_rules]` table with `targets[]` rather than per-provider `entry_file` under `[providers.*]`. Doc surfaces (claude/codex/agents-md/gemini) and runtime providers (claude/codex/opencode/qwen/ollama/minimax) are different namespaces; conflating them would force phantom providers into `sync-templates`'s runtime registry.

## Test plan

- [x] `cargo test` (5136 + 4968 = full suite green)
- [x] `cargo clippy -- -D warnings -A dead_code`
- [x] `cargo fmt --check`
- [x] `bash scripts/check-file-size.sh` (all files ≤ 400 LOC)
- [x] `bash scripts/check-rules-drift.sh` (golden-rules in sync)
- [x] `cargo run -- sync-templates --check` reports `in sync`
- [x] `bash .maestro/hooks/tests/test-changelog-gate.sh` (6/6 pass)

Closes #757
Closes #758
Closes #770
Closes #799 
Closes #839
Does **not** close #788 — that ships separately.