### PR TITLE
fix(tui/settings): default provider change now live for next spawn

### DIFF
--- a/src/tui/app/mod.rs
+++ b/src/tui/app/mod.rs
@@ -508,6 +508,19 @@ impl App {
             .push_simple("NOTIFICATIONS".into(), msg, LogLevel::Warn);
     }
 
+    /// Re-apply the `[agents]` section of an already-staged `Config` to
+    /// the runtime: refresh `selected_agent_id` from the new default and
+    /// rebuild the per-agent provider map used by `spawn`. Called from
+    /// the Settings save handler so a "Default provider → X" change
+    /// takes effect on the *next* spawn instead of waiting for a restart
+    /// (the log message has always claimed `Live for new sessions` —
+    /// this finally honors it).
+    pub fn apply_agents_config(&mut self, config: &Config) {
+        self.selected_agent_id = default_enabled_agent_id(config);
+        self.pool
+            .set_agent_providers(build_agent_provider_map(config));
+    }
+
     pub fn configure(&mut self, config: Config) {
         self.session_config.apply_config(&config.sessions);
         if self.bypass_active {
@@ -763,6 +776,56 @@ mod tests {
 
     fn make_app() -> crate::tui::app::App {
         crate::tui::make_test_app("maestro-tui-app-test")
+    }
+
+    fn agents_toml(default: &str) -> Config {
+        let toml = format!(
+            "[project]\nrepo = \"owner/repo\"\n\
+             [sessions]\n\
+             [budget]\n\
+             [github]\n[notifications]\n\
+             [agents]\ndefault = \"{default}\"\n\
+             [agents.claude]\nkind = \"claude\"\nenabled = true\ncommand = \"claude\"\n\
+             [agents.opencode]\nkind = \"opencode\"\nenabled = true\ncommand = \"opencode\"\n\
+             [agents.minimax]\nkind = \"minimax\"\nenabled = true\ncommand = \"minimax\"\n"
+        );
+        toml::from_str(&toml).expect("test config parse")
+    }
+
+    /// Regression for the "Default provider → X. Live for new sessions" bug
+    /// surfaced by the user video on 2026-05-22: changing the default
+    /// provider in the Settings screen updated `config.agents.default`
+    /// but `App.selected_agent_id` retained the prior value, so new
+    /// sessions kept spawning with the old agent until maestro restarted.
+    #[test]
+    fn apply_agents_config_updates_selected_agent_id_to_new_default() {
+        let mut app = make_app();
+        app.selected_agent_id = "claude".to_string();
+
+        let new_config = agents_toml("opencode");
+        app.apply_agents_config(&new_config);
+
+        assert_eq!(
+            app.selected_agent_id, "opencode",
+            "selected_agent_id must reflect the new default after settings apply"
+        );
+    }
+
+    #[test]
+    fn apply_agents_config_falls_back_when_default_is_disabled() {
+        let mut app = make_app();
+        app.selected_agent_id = "claude".to_string();
+
+        let mut new_config = agents_toml("minimax");
+        if let Some(agent) = new_config.agents.entries.get_mut("minimax") {
+            agent.enabled = false;
+        }
+        app.apply_agents_config(&new_config);
+
+        assert_ne!(
+            app.selected_agent_id, "minimax",
+            "selected_agent_id must NOT pick a disabled default; should fall back to an enabled entry"
+        );
     }
 
     fn make_app_with_flags(flags: crate::flags::store::FeatureFlags) -> App {

--- a/src/tui/screen_dispatch.rs
+++ b/src/tui/screen_dispatch.rs
@@ -776,6 +776,13 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
                 );
             }
             if default_provider_changed {
+                // Honor the "Live for new sessions" promise: refresh
+                // `App.selected_agent_id` and the pool's per-agent
+                // provider map so the very next spawn picks the new
+                // default. Previously this only ran at startup via
+                // `App::configure`, which forced a restart to take
+                // effect.
+                app.apply_agents_config(&config);
                 app.activity_log.push_simple(
                     "SETTINGS".into(),
                     format!(


### PR DESCRIPTION
## Summary

Bug surfaced during user QA on 2026-05-22 video. Settings → Providers `default` change emits `Default provider → X. Live for new sessions` in the activity log, but `App.selected_agent_id` retains the previous value because the save handler updated `app.config` without re-running the agent-routing wire-up that `App::configure` does at startup. New sessions keep spawning with the old default until maestro restarts.

Reproduce:
1. `cargo run` with `[agents].default = \"claude\"`.
2. Open Settings → Providers → change default to `opencode`. Save.
3. Activity log says `Default provider → opencode. Live for new sessions; running sessions keep their original provider until they finish.`
4. Start a new session.
5. Session pane header reads `agent:claude` — wrong. Same with subsequent change to `minimax`.

## Fix

- New `App::apply_agents_config(&Config)` runs the two agent-routing pieces that `App::configure` does at startup: refresh `selected_agent_id` from `default_enabled_agent_id(config)` and rebuild the pool's per-agent provider map from `build_agent_provider_map(config)`.
- `ScreenAction::ApplySettings` handler in `screen_dispatch.rs` calls it when `default_provider_changed`. Other settings-save branches stay untouched.

## Regression tests (in `src/tui/app/mod.rs::tests`)

- `apply_agents_config_updates_selected_agent_id_to_new_default` — primary regression.
- `apply_agents_config_falls_back_when_default_is_disabled` — guards the disabled-default fallback path.

## Test plan

- [x] `cargo test --quiet` green (10,436 pass, 0 fail, +2 vs main)
- [x] `cargo clippy -- -D warnings -A dead_code` clean
- [x] `cargo fmt --check` clean
- [x] No new colours, no chord changes, no `unsafe`

## Manual verification

Same as the reproduce steps above — expect the session pane header to switch from `agent:opencode` → `agent:claude` → `agent:minimax` as the default changes, with no maestro restart.

## Note

Surfaced during /auto #850 manual QA. Filed off main, independent of the #776 budget umbrella (#848 / #849 / #850).