### PR TITLE
fix(session/retry): preserve agent_id across hollow retry

### DIFF
--- a/src/session/retry.rs
+++ b/src/session/retry.rs
@@ -157,6 +157,12 @@ impl RetryPolicy {
         new_session.issue_title = original.issue_title.clone();
         new_session.origin = original.origin;
         new_session.active_command = original.active_command.clone();
+        // Preserve the original agent so the retry runs on the same
+        // provider. Without this, `Session::new` defaults `agent_id` to
+        // `None` and the pool routes the retry through the current
+        // `selected_agent_id`, silently switching providers (e.g. a
+        // minimax session retrying as claude). Surfaced 2026-05-22.
+        new_session.agent_id = original.agent_id.clone();
         new_session
     }
 }
@@ -349,6 +355,29 @@ mod tests {
         let retry = policy.prepare_retry(&original, None, None);
         assert_eq!(retry.model, "opus");
         assert_eq!(retry.mode, "orchestrator");
+    }
+
+    /// Regression for 2026-05-22: retry of a hollow session running on
+    /// `agent:minimax` silently switched to `agent:claude` because
+    /// `Session::new` defaults `agent_id` to `None` and the pool's
+    /// fallback routed through `App.selected_agent_id`. Copy the
+    /// original's `agent_id` onto the retry so the provider stays put.
+    #[test]
+    fn prepare_retry_preserves_agent_id() {
+        let policy = RetryPolicy::new(2, 0, legacy_hollow(1));
+        let mut original = make_session(SessionStatus::Stalled, 0);
+        original.agent_id = Some("minimax".to_string());
+        let retry = policy.prepare_retry(&original, None, None);
+        assert_eq!(retry.agent_id.as_deref(), Some("minimax"));
+    }
+
+    #[test]
+    fn prepare_retry_preserves_none_agent_id() {
+        let policy = RetryPolicy::new(2, 0, legacy_hollow(1));
+        let mut original = make_session(SessionStatus::Stalled, 0);
+        original.agent_id = None;
+        let retry = policy.prepare_retry(&original, None, None);
+        assert!(retry.agent_id.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Hollow retry silently switched providers — confirmed by the user's 2026-05-22 screenshots.

`RetryPolicy::prepare_retry` constructs a new `Session` via `Session::new(...)` (which defaults `agent_id` to `None`), then copies prompt / model / mode / role / issue / origin / active_command, but **not** `agent_id`. When the retry was enqueued, the pool's fallback routed it through `App.selected_agent_id` — silently switching from the original session's agent to the current default.

The mismatch surfaces user-facing: a minimax session with model `MiniMax-M2.7` hollowed out, retry spawned on `agent:claude`, Claude rejected the MiniMax model:
> `There's an issue with the selected model (MiniMax-M2.7). It may not exist or you may not have access to it.`

The model+agent pairing must stay matched across retries.

## Fix

```diff
 new_session.active_command = original.active_command.clone();
+new_session.agent_id = original.agent_id.clone();
```

One-line copy alongside the other preserved fields in `src/session/retry.rs:160`.

## Regression tests (in `src/session/retry.rs::tests`)

- `prepare_retry_preserves_agent_id` — primary: minimax stays minimax through retry.
- `prepare_retry_preserves_none_agent_id` — guards the `agent_id == None` case (legacy sessions, pool fallback path).

## Test plan

- [x] `cargo test --quiet` green (10,463 pass, 0 fail)
- [x] `cargo clippy -- -D warnings -A dead_code` clean
- [x] `cargo fmt --check` clean
- [x] No new colours / chord changes / unsafe / unwrap / expect / panic

## Manual verification

1. `cargo run`. Select default agent = minimax.
2. Start a session with prompt `hi` (deliberately triggers hollow detection).
3. Observe: session hollows, retry spawns automatically.
4. With fix: retry pane shows `agent:minimax` (same as original). Without fix: retry pane shows `agent:claude` and surfaces the MiniMax-M2.7 model-rejection error.

## Note

Independent of #776 / #850 / #858. This is a separate retry-path bug that became visible only because #858 made the default-provider switch work correctly — exposing that the retry path doesn't honour the per-session agent at all.