### PR TITLE
fix(tui/completion): dismiss + log + dashboard chords preserve nav stack

### DIFF
--- a/src/tui/app/completion_summary.rs
+++ b/src/tui/app/completion_summary.rs
@@ -177,7 +177,13 @@ impl App {
             screen.start_loading_suggestions();
         }
         self.pending_commands.push(TuiCommand::FetchSuggestionData);
-        self.navigate_to_root();
+        // Push Dashboard onto the nav stack instead of clearing it — `Esc`
+        // from the dashboard then pops back to the screen the user was on
+        // before the completion modal opened, instead of jumping straight
+        // to ConfirmExit (the previous `navigate_to_root` behavior wiped
+        // navigation history every time the user pressed `[d] Dashboard`
+        // from the Session Complete modal — 2026-05-22 UX fix).
+        self.navigate_to(crate::tui::app::TuiMode::Dashboard);
     }
 }
 

--- a/src/tui/input_handler.rs
+++ b/src/tui/input_handler.rs
@@ -265,11 +265,16 @@ fn handle_completion_summary(app: &mut App, key: &KeyEvent) -> KeyAction {
         return handle_completion_summary_failed_gates(app, key);
     }
     match (key.code, key.modifiers) {
-        (KeyCode::Enter, _) | (KeyCode::Esc, _) => {
-            app.transition_to_dashboard();
-        }
-        (KeyCode::Char('s'), _) => {
-            app.transition_to_dashboard();
+        (KeyCode::Enter, _) | (KeyCode::Esc, _) | (KeyCode::Char('s'), _) => {
+            // Dismiss the modal in place — Esc/Enter/[s] all close the
+            // overlay without resetting the navigation stack. The
+            // previous code routed these through `transition_to_dashboard`
+            // which wiped nav history and forced a full Dashboard rebuild
+            // every time the user just wanted to close the modal
+            // (2026-05-22 UX fix).
+            app.completion_summary = None;
+            app.completion_summary_dismissed = true;
+            app.tui_mode = app::TuiMode::Overview;
         }
         (KeyCode::Char('o'), _) => {
             open_first_completion_pr(app);
@@ -281,15 +286,18 @@ fn handle_completion_summary(app: &mut App, key: &KeyEvent) -> KeyAction {
             screen.loading = true;
             app.screen_state.issue_browser_screen = Some(screen);
             app.pending_commands.push(app::TuiCommand::FetchIssues);
-            app.tui_mode = app::TuiMode::IssueBrowser;
+            app.navigate_to(app::TuiMode::IssueBrowser);
         }
         (KeyCode::Char('r'), _) => {
             app.screen_state.prompt_input_screen = Some(app::helpers::create_prompt_input_screen(
                 &app.prompt_history,
             ));
-            app.tui_mode = app::TuiMode::PromptInput;
+            app.navigate_to(app::TuiMode::PromptInput);
         }
         (KeyCode::Char('d'), _) => {
+            // `transition_to_dashboard` now pushes Dashboard onto the
+            // nav stack (instead of clearing it), so `Esc` from the
+            // dashboard returns the user to the screen they came from.
             app.transition_to_dashboard();
         }
         (KeyCode::Char('q'), _) => {
@@ -297,17 +305,19 @@ fn handle_completion_summary(app: &mut App, key: &KeyEvent) -> KeyAction {
             app.navigate_to(app::TuiMode::ConfirmExit);
         }
         (KeyCode::Char('l'), _) => {
-            if let Some(ref summary) = app.completion_summary {
-                if let Some(first) = summary.sessions.first() {
-                    let sid = first.session_id;
-                    app.log_viewer_scroll = 0;
-                    app.completion_summary = None;
-                    app.tui_mode = app::TuiMode::LogViewer(sid);
-                } else {
-                    app.tui_mode = app::TuiMode::Overview;
-                }
-            } else {
-                app.tui_mode = app::TuiMode::Overview;
+            // [l] Logs: navigate (push onto stack) to the LogViewer for
+            // the first session so `Esc` returns to wherever the user
+            // was. Previous code set `tui_mode` directly which skipped
+            // the nav-stack push AND fell back to Overview when the
+            // summary was empty — losing context. If no session exists,
+            // leave the modal open instead of redirecting.
+            if let Some(ref summary) = app.completion_summary
+                && let Some(first) = summary.sessions.first()
+            {
+                let sid = first.session_id;
+                app.log_viewer_scroll = 0;
+                app.completion_summary_dismissed = true;
+                app.navigate_to(app::TuiMode::LogViewer(sid));
             }
         }
         (KeyCode::Char('f'), _) => {
@@ -2107,10 +2117,83 @@ mod tests {
 
         handle_completion_summary(&mut app, &key('s'));
 
-        assert_eq!(app.tui_mode, TuiMode::Dashboard);
+        // [s] dismisses the modal in place — restores the underlying
+        // Overview screen instead of jumping to Dashboard and wiping
+        // navigation state (2026-05-22 UX fix).
+        assert_eq!(app.tui_mode, TuiMode::Overview);
         assert!(app.completion_summary.is_none());
         assert!(app.completion_summary_dismissed);
         assert!(calls.lock().expect("mutex").is_empty());
+    }
+
+    #[test]
+    fn completion_summary_s_key_preserves_nav_stack() {
+        let mut app = make_app();
+        // Simulate the user navigating Overview → Detail → CompletionSummary.
+        app.navigate_to(TuiMode::Detail(uuid::Uuid::nil()));
+        let nav_depth_before = app.nav_stack.depth();
+        app.tui_mode = TuiMode::CompletionSummary;
+        app.completion_summary = Some(completed_summary());
+
+        handle_completion_summary(&mut app, &key('s'));
+
+        assert_eq!(
+            app.nav_stack.depth(),
+            nav_depth_before,
+            "[s] dismiss must NOT touch nav_stack — modal closes in place"
+        );
+    }
+
+    #[test]
+    fn completion_summary_d_key_pushes_dashboard_onto_nav_stack() {
+        let mut app = make_app();
+        app.navigate_to(TuiMode::Detail(uuid::Uuid::nil()));
+        app.tui_mode = TuiMode::CompletionSummary;
+        app.completion_summary = Some(completed_summary());
+        let depth_before = app.nav_stack.depth();
+
+        handle_completion_summary(&mut app, &key('d'));
+
+        assert_eq!(app.tui_mode, TuiMode::Dashboard);
+        // Esc from Dashboard should return the user to whatever they
+        // were on before — `transition_to_dashboard` must push instead
+        // of wiping the stack (2026-05-22 UX fix).
+        assert!(
+            app.nav_stack.depth() >= depth_before,
+            "[d] Dashboard must push onto nav_stack, not clear it"
+        );
+    }
+
+    #[test]
+    fn completion_summary_l_key_navigates_to_log_viewer() {
+        let mut app = make_app();
+        app.tui_mode = TuiMode::CompletionSummary;
+        let summary = completed_summary();
+        let first_id = summary.sessions.first().expect("test fixture").session_id;
+        app.completion_summary = Some(summary);
+
+        handle_completion_summary(&mut app, &key('l'));
+
+        assert!(matches!(app.tui_mode, TuiMode::LogViewer(id) if id == first_id));
+        assert!(app.completion_summary_dismissed);
+        // Post-match auto-clear nulls the summary on any non-scroll key.
+        assert!(app.completion_summary.is_none());
+    }
+
+    #[test]
+    fn completion_summary_l_key_with_no_sessions_keeps_modal_open() {
+        let mut app = make_app();
+        app.tui_mode = TuiMode::CompletionSummary;
+        let mut empty_summary = completed_summary();
+        empty_summary.sessions.clear();
+        app.completion_summary = Some(empty_summary);
+
+        handle_completion_summary(&mut app, &key('l'));
+
+        // No sessions = no LogViewer to open; user should stay on the
+        // overlay rather than fall through to Overview (the old code
+        // routed them off the modal even when [l] was a no-op).
+        assert!(!matches!(app.tui_mode, TuiMode::LogViewer(_)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

User reported 2026-05-22 / 23 across four passes. Each `Esc`/`Enter` press on or around the Session Complete modal misbehaved.

## Root causes (4 layered bugs, all addressed in this PR)

1. **Modal entry sites bypassed `nav_stack`.** Six production paths set `app.tui_mode = CompletionSummary` directly, never pushing the prior mode. → `Esc` from the modal had no breadcrumb to pop.
2. **`Launch*` actions wiped the nav stack.** Five `ScreenAction::Launch*` arms called `app.nav_stack.clear()` before setting `tui_mode = Overview`. → Every session start lost the Welcome/Dashboard breadcrumbs.
3. **Overview's `Esc` fell back to ConfirmExit.** `handle_overview_keys` used `navigate_back()` which goes to `ConfirmExit` on empty stack. Combined with (2), `Esc` from post-session Overview triggered Quit.
4. **`[Enter] Detail` chord broken for terminal sessions.** The handler branched on `is_terminal()` and routed Completed/Errored sessions to `toggle_session_summary` instead of Detail — contradicting the top-bar chord hint.

## Fix

- **New `App::open_completion_summary()`** funnels every production entry site through `navigate_to(CompletionSummary)`, pushing the prior mode onto `nav_stack`.
- **`transition_to_dashboard`** ends with `navigate_to(Dashboard)` instead of `navigate_to_root`.
- **Dismiss arm** (`Esc`/`Enter`/`[s]`) calls `navigate_back_or_dashboard()` — never ConfirmExit.
- **`[i]` / `[r]` / `[l]`** use `navigate_to(...)`.
- **`Launch*` actions** no longer call `nav_stack.clear()` — Welcome/Dashboard anchors survive session launch.
- **Overview's `Esc`** uses `navigate_back_or_dashboard`.
- **Overview's `Enter`** always navigates to Detail — terminal sessions render their transcript in Detail mode just fine, no more popup mismatch.

## Diff

| File | Change |
|---|---|
| `src/tui/app/completion_summary.rs` | New `open_completion_summary`; `transition_to_dashboard` uses `navigate_to(Dashboard)`. |
| `src/tui/mod.rs` | 3 event-loop entry sites. |
| `src/tui/input_handler.rs` | 2 queue-executor sites; dismiss arm; chord rerouting; Overview Esc + Enter. |
| `src/tui/screen_dispatch.rs` | 5 `Launch*` arms no longer clear nav_stack. |

## Regression tests (11 new + 1 updated)

- `completion_summary_s_key_dismisses_success_modal` (updated)
- `completion_summary_s_key_pops_back_to_previous_mode`
- `completion_summary_esc_falls_back_to_dashboard_when_stack_empty`
- `completion_summary_d_key_pushes_dashboard_onto_nav_stack`
- `completion_summary_l_key_navigates_to_log_viewer`
- `completion_summary_l_key_with_no_sessions_keeps_modal_open`
- `overview_esc_falls_back_to_dashboard_when_stack_empty`
- `overview_esc_pops_back_when_stack_has_history`
- `launch_session_action_preserves_nav_stack_anchors`
- **`overview_enter_navigates_to_detail_for_terminal_session`** — new this pass
- **`overview_enter_navigates_to_detail_for_running_session`** — new this pass

## Test plan

- [x] `cargo test --quiet` green (10,483 pass, 0 fail)
- [x] `cargo clippy -- -D warnings -A dead_code` clean
- [x] `cargo fmt --check` clean

## Manual verification (full flow)

1. `cargo run`. Land on Landing → `Welcome`.
2. Navigate to Dashboard → `Welcome > Dashboard`.
3. Press `r` → `Welcome > Dashboard > Prompt`.
4. Submit prompt → `Welcome > Dashboard > Overview`.
5. Session completes → modal → `Welcome > Dashboard > Overview > Summary`.
6. Press `[s]` (or `Esc`) → modal closes → `Welcome > Dashboard > Overview`.
7. Press `Enter` on the completed session pane → Detail view opens with the recorded transcript. (Pre-fix this was broken — chord hint said `[Enter] Detail` but Enter did a popup.)
8. Press `Esc` → back to Overview.
9. Press `Esc` → Dashboard.
10. Press `Esc` → Landing.
11. Press `q` → Quit dialog (canonical exit).

Independent of #776 / #858 / #859 / #861 / #862.