### PR TITLE
fix(tui/completion): dismiss + log + dashboard chords preserve nav stack

### DIFF
--- a/src/tui/app/completion_summary.rs
+++ b/src/tui/app/completion_summary.rs
@@ -106,6 +106,18 @@ impl App {
         self.navigate_to(crate::tui::app::TuiMode::SessionSummary);
     }
 
+    /// Build the completion-summary overlay and navigate to its mode.
+    /// Funnels every production entry site (event-loop tick when
+    /// `all_done`, continuous-mode end, queue-executor finish) so the
+    /// prior `tui_mode` lands on `nav_stack`. Pressing `Esc`/`Enter`/`[s]`
+    /// from the modal pops back to where the user was, instead of
+    /// falling through to ConfirmExit. Added 2026-05-23.
+    pub fn open_completion_summary(&mut self) {
+        let summary = self.build_completion_summary();
+        self.completion_summary = Some(summary);
+        self.navigate_to(crate::tui::app::TuiMode::CompletionSummary);
+    }
+
     /// Transition from CompletionSummary to Dashboard mode.
     pub fn transition_to_dashboard(&mut self) {
         let all = self.pool.all_sessions();
@@ -177,7 +189,13 @@ impl App {
             screen.start_loading_suggestions();
         }
         self.pending_commands.push(TuiCommand::FetchSuggestionData);
-        self.navigate_to_root();
+        // Push Dashboard onto the nav stack instead of clearing it — `Esc`
+        // from the dashboard then pops back to the screen the user was on
+        // before the completion modal opened, instead of jumping straight
+        // to ConfirmExit (the previous `navigate_to_root` behavior wiped
+        // navigation history every time the user pressed `[d] Dashboard`
+        // from the Session Complete modal — 2026-05-22 UX fix).
+        self.navigate_to(crate::tui::app::TuiMode::Dashboard);
     }
 }
 

--- a/src/tui/input_handler.rs
+++ b/src/tui/input_handler.rs
@@ -232,8 +232,7 @@ fn handle_queue_execution(app: &mut App, key: &KeyEvent) -> KeyAction {
             {
                 exec.apply_decision(FailureAction::Skip);
                 if exec.is_finished() {
-                    app.completion_summary = Some(app.build_completion_summary());
-                    app.tui_mode = app::TuiMode::CompletionSummary;
+                    app.open_completion_summary();
                 } else {
                     app.advance_queue_and_launch();
                 }
@@ -244,8 +243,7 @@ fn handle_queue_execution(app: &mut App, key: &KeyEvent) -> KeyAction {
                 && matches!(exec.phase(), ExecutorPhase::AwaitingDecision { .. })
             {
                 exec.apply_decision(FailureAction::Abort);
-                app.completion_summary = Some(app.build_completion_summary());
-                app.tui_mode = app::TuiMode::CompletionSummary;
+                app.open_completion_summary();
             }
         }
         _ => {}
@@ -265,11 +263,17 @@ fn handle_completion_summary(app: &mut App, key: &KeyEvent) -> KeyAction {
         return handle_completion_summary_failed_gates(app, key);
     }
     match (key.code, key.modifiers) {
-        (KeyCode::Enter, _) | (KeyCode::Esc, _) => {
-            app.transition_to_dashboard();
-        }
-        (KeyCode::Char('s'), _) => {
-            app.transition_to_dashboard();
+        (KeyCode::Enter, _) | (KeyCode::Esc, _) | (KeyCode::Char('s'), _) => {
+            // Dismiss the modal and pop back to the screen the user was
+            // on before the modal opened. The CompletionSummary entry
+            // sites push onto `nav_stack` via `App::open_completion_summary`,
+            // so `navigate_back_or_dashboard` pops to that prior mode
+            // (Overview/Detail/etc.). Falls back to Dashboard — NEVER
+            // ConfirmExit — when the stack is empty. Reported 2026-05-23
+            // (Esc on completion modal was bouncing to the Quit dialog).
+            app.completion_summary = None;
+            app.completion_summary_dismissed = true;
+            app.navigate_back_or_dashboard();
         }
         (KeyCode::Char('o'), _) => {
             open_first_completion_pr(app);
@@ -281,15 +285,18 @@ fn handle_completion_summary(app: &mut App, key: &KeyEvent) -> KeyAction {
             screen.loading = true;
             app.screen_state.issue_browser_screen = Some(screen);
             app.pending_commands.push(app::TuiCommand::FetchIssues);
-            app.tui_mode = app::TuiMode::IssueBrowser;
+            app.navigate_to(app::TuiMode::IssueBrowser);
         }
         (KeyCode::Char('r'), _) => {
             app.screen_state.prompt_input_screen = Some(app::helpers::create_prompt_input_screen(
                 &app.prompt_history,
             ));
-            app.tui_mode = app::TuiMode::PromptInput;
+            app.navigate_to(app::TuiMode::PromptInput);
         }
         (KeyCode::Char('d'), _) => {
+            // `transition_to_dashboard` now pushes Dashboard onto the
+            // nav stack (instead of clearing it), so `Esc` from the
+            // dashboard returns the user to the screen they came from.
             app.transition_to_dashboard();
         }
         (KeyCode::Char('q'), _) => {
@@ -297,17 +304,19 @@ fn handle_completion_summary(app: &mut App, key: &KeyEvent) -> KeyAction {
             app.navigate_to(app::TuiMode::ConfirmExit);
         }
         (KeyCode::Char('l'), _) => {
-            if let Some(ref summary) = app.completion_summary {
-                if let Some(first) = summary.sessions.first() {
-                    let sid = first.session_id;
-                    app.log_viewer_scroll = 0;
-                    app.completion_summary = None;
-                    app.tui_mode = app::TuiMode::LogViewer(sid);
-                } else {
-                    app.tui_mode = app::TuiMode::Overview;
-                }
-            } else {
-                app.tui_mode = app::TuiMode::Overview;
+            // [l] Logs: navigate (push onto stack) to the LogViewer for
+            // the first session so `Esc` returns to wherever the user
+            // was. Previous code set `tui_mode` directly which skipped
+            // the nav-stack push AND fell back to Overview when the
+            // summary was empty — losing context. If no session exists,
+            // leave the modal open instead of redirecting.
+            if let Some(ref summary) = app.completion_summary
+                && let Some(first) = summary.sessions.first()
+            {
+                let sid = first.session_id;
+                app.log_viewer_scroll = 0;
+                app.completion_summary_dismissed = true;
+                app.navigate_to(app::TuiMode::LogViewer(sid));
             }
         }
         (KeyCode::Char('f'), _) => {
@@ -947,18 +956,24 @@ fn handle_overview_keys(app: &mut App, key: &KeyEvent) {
             };
         }
         (KeyCode::Esc, _) => {
-            app.navigate_back();
+            // Match Dashboard's Esc semantics: pop nav stack, fall back
+            // to Dashboard on empty stack — NEVER ConfirmExit. The user
+            // canonical exit paths are `q`, `Ctrl+X`, and `F4`. Reported
+            // 2026-05-23 (LaunchSession cleared the stack, so after
+            // dismissing the completion modal the next `Esc` from
+            // Overview was triggering the Quit dialog).
+            app.navigate_back_or_dashboard();
         }
         (KeyCode::Enter, _) | (KeyCode::Char(' '), _) => {
+            // Honor the advertised `[Enter] Detail` chord. Pre-2026-05-23
+            // code routed terminal (Completed/Errored/etc.) sessions to
+            // `toggle_session_summary` — a popup that conflicted with the
+            // hint shown in the top-bar. Detail works for terminal
+            // sessions too (renders the recorded transcript), so use one
+            // path for both states.
             let selected = app.panel_view.selected_index();
-            if let Some(id) = app.pool.session_id_at_index(selected)
-                && let Some(session) = app.pool.get_session(id)
-            {
-                if session.status.is_terminal() {
-                    app.toggle_session_summary(id);
-                } else {
-                    app.navigate_to(app::TuiMode::Detail(id));
-                }
+            if let Some(id) = app.pool.session_id_at_index(selected) {
+                app.navigate_to(app::TuiMode::Detail(id));
             }
         }
         (KeyCode::Char(c), _) if c.is_ascii_digit() && c != '0' => {
@@ -2102,15 +2117,256 @@ mod tests {
             should_fail: false,
         };
         let mut app = make_app().with_shell_launcher(Box::new(launcher));
-        app.tui_mode = TuiMode::CompletionSummary;
+        // Simulate the real flow: user navigated Overview, then the
+        // completion modal auto-opened via `open_completion_summary`
+        // which pushes Overview onto `nav_stack`.
+        app.navigate_to(TuiMode::CompletionSummary);
         app.completion_summary = Some(completed_summary());
 
         handle_completion_summary(&mut app, &key('s'));
 
-        assert_eq!(app.tui_mode, TuiMode::Dashboard);
+        // [s] pops the nav stack back to the screen the user was on
+        // before the modal opened (2026-05-23 UX fix — Esc was bouncing
+        // to ConfirmExit on an empty stack).
+        assert_eq!(app.tui_mode, TuiMode::Overview);
         assert!(app.completion_summary.is_none());
         assert!(app.completion_summary_dismissed);
         assert!(calls.lock().expect("mutex").is_empty());
+    }
+
+    #[test]
+    fn completion_summary_s_key_pops_back_to_previous_mode() {
+        let mut app = make_app();
+        // Simulate Overview → Detail → CompletionSummary via real
+        // navigation. [s] must pop the modal off the stack and land on
+        // Detail (the screen the user was on before the modal opened),
+        // NOT jump to ConfirmExit. Reported 2026-05-23.
+        let detail_id = uuid::Uuid::nil();
+        app.navigate_to(TuiMode::Detail(detail_id));
+        app.navigate_to(TuiMode::CompletionSummary);
+        app.completion_summary = Some(completed_summary());
+
+        handle_completion_summary(&mut app, &key('s'));
+
+        assert_eq!(
+            app.tui_mode,
+            TuiMode::Detail(detail_id),
+            "[s] dismiss must restore the prior mode via nav_stack pop"
+        );
+        assert!(app.completion_summary.is_none());
+        assert!(app.completion_summary_dismissed);
+        // Must NEVER fall through to ConfirmExit on an empty stack.
+        assert!(!matches!(app.tui_mode, TuiMode::ConfirmExit));
+    }
+
+    /// Regression for 2026-05-23: dismissing the completion modal popped
+    /// back to Overview (correct), but the user's next `Esc` from
+    /// Overview triggered ConfirmExit because the launch path cleared
+    /// the nav stack. Match Dashboard's Esc semantics — fall back to
+    /// Dashboard on empty stack, NEVER ConfirmExit. Canonical exits
+    /// stay on `q` / `Ctrl+X` / `F4`.
+    /// Regression for 2026-05-23: `[Enter] Detail` chord on Overview
+    /// stopped working for terminal sessions (Completed/Errored). The
+    /// handler branched on `is_terminal()` and routed those sessions to
+    /// `toggle_session_summary` — a popup that conflicted with the chord
+    /// hint shown at the top of the screen. Detail mode renders the
+    /// recorded transcript fine for terminal sessions, so unify both
+    /// states under one Detail navigation.
+    #[test]
+    fn overview_enter_navigates_to_detail_for_terminal_session() {
+        use crate::session::types::{Session, SessionStatus};
+
+        let mut app = make_app();
+        app.tui_mode = TuiMode::Overview;
+        let mut session = Session::new(
+            "test".into(),
+            "opus".into(),
+            "orchestrator".into(),
+            Some(1),
+            None,
+        );
+        session.status = SessionStatus::Completed;
+        let id = session.id;
+        app.pool.enqueue(session);
+
+        handle_overview_keys(&mut app, &key_code(KeyCode::Enter));
+
+        assert!(
+            matches!(app.tui_mode, TuiMode::Detail(found) if found == id),
+            "Enter on terminal session must navigate to Detail; got {:?}",
+            app.tui_mode
+        );
+    }
+
+    #[test]
+    fn overview_enter_navigates_to_detail_for_running_session() {
+        use crate::session::types::{Session, SessionStatus};
+
+        let mut app = make_app();
+        app.tui_mode = TuiMode::Overview;
+        let mut session = Session::new(
+            "test".into(),
+            "opus".into(),
+            "orchestrator".into(),
+            Some(2),
+            None,
+        );
+        session.status = SessionStatus::Running;
+        let id = session.id;
+        app.pool.enqueue(session);
+
+        handle_overview_keys(&mut app, &key_code(KeyCode::Enter));
+
+        assert!(
+            matches!(app.tui_mode, TuiMode::Detail(found) if found == id),
+            "Enter on running session must navigate to Detail; got {:?}",
+            app.tui_mode
+        );
+    }
+
+    /// Regression for 2026-05-23: `ScreenAction::LaunchSession` (and its
+    /// siblings: LaunchSessions / LaunchPromptSession / LaunchUnifiedSession
+    /// / LaunchConflictFix) used to call `nav_stack.clear()` before
+    /// setting `tui_mode = Overview`. That wiped the stable anchors
+    /// below the current wizard (Landing, Dashboard) — every session
+    /// start lost the "Welcome" breadcrumb. Fix: replace the current
+    /// mode without touching the stack. The wizard was current (not on
+    /// the stack), so this just drops the wizard without disturbing
+    /// history.
+    #[test]
+    fn launch_session_action_preserves_nav_stack_anchors() {
+        use crate::tui::screen_dispatch::handle_screen_action;
+        use crate::tui::screens::{ScreenAction, SessionConfig as ScreenSessionConfig};
+
+        let mut app = make_app();
+        // Simulate Landing → Dashboard → PromptInput via real navigation
+        // (the path a user takes to start a session from Welcome).
+        app.tui_mode = TuiMode::Landing;
+        app.navigate_to(TuiMode::Dashboard);
+        app.navigate_to(TuiMode::PromptInput);
+        let depth_before = app.nav_stack.depth();
+        assert_eq!(depth_before, 2, "test fixture must have Landing + Dashboard");
+        let breadcrumbs_before: Vec<TuiMode> = app.nav_stack.breadcrumbs().to_vec();
+
+        let cfg = ScreenSessionConfig {
+            issue_number: Some(1),
+            title: "test".to_string(),
+            custom_prompt: None,
+            agent_id: None,
+        };
+        handle_screen_action(&mut app, ScreenAction::LaunchSession(cfg));
+
+        assert_eq!(app.tui_mode, TuiMode::Overview);
+        assert_eq!(
+            app.nav_stack.breadcrumbs(),
+            breadcrumbs_before.as_slice(),
+            "LaunchSession must preserve nav_stack anchors (Welcome/Dashboard)"
+        );
+    }
+
+    #[test]
+    fn overview_esc_falls_back_to_dashboard_when_stack_empty() {
+        let mut app = make_app();
+        app.tui_mode = TuiMode::Overview;
+        // No nav history.
+        assert_eq!(app.nav_stack.depth(), 0);
+
+        handle_overview_keys(&mut app, &key_code(KeyCode::Esc));
+
+        assert_eq!(
+            app.tui_mode,
+            TuiMode::Dashboard,
+            "Esc on Overview with empty stack must fall back to Dashboard, not ConfirmExit"
+        );
+        assert!(!matches!(app.tui_mode, TuiMode::ConfirmExit));
+    }
+
+    #[test]
+    fn overview_esc_pops_back_when_stack_has_history() {
+        let mut app = make_app();
+        // Build a nav history: Landing → Overview.
+        app.tui_mode = TuiMode::Landing;
+        app.navigate_to(TuiMode::Overview);
+        let depth_before = app.nav_stack.depth();
+        assert!(depth_before >= 1, "test fixture must have history");
+
+        handle_overview_keys(&mut app, &key_code(KeyCode::Esc));
+
+        assert_eq!(
+            app.tui_mode,
+            TuiMode::Landing,
+            "Esc on Overview must pop back to the previous mode"
+        );
+    }
+
+    #[test]
+    fn completion_summary_esc_falls_back_to_dashboard_when_stack_empty() {
+        let mut app = make_app();
+        // No prior navigation — stack is empty when the modal opens.
+        // Esc must fall back to Dashboard, NEVER to ConfirmExit.
+        app.tui_mode = TuiMode::CompletionSummary;
+        app.completion_summary = Some(completed_summary());
+
+        handle_completion_summary(&mut app, &key_code(KeyCode::Esc));
+
+        assert_eq!(
+            app.tui_mode,
+            TuiMode::Dashboard,
+            "Esc with empty nav_stack must fall back to Dashboard, not ConfirmExit"
+        );
+        assert!(!matches!(app.tui_mode, TuiMode::ConfirmExit));
+    }
+
+    #[test]
+    fn completion_summary_d_key_pushes_dashboard_onto_nav_stack() {
+        let mut app = make_app();
+        app.navigate_to(TuiMode::Detail(uuid::Uuid::nil()));
+        app.tui_mode = TuiMode::CompletionSummary;
+        app.completion_summary = Some(completed_summary());
+        let depth_before = app.nav_stack.depth();
+
+        handle_completion_summary(&mut app, &key('d'));
+
+        assert_eq!(app.tui_mode, TuiMode::Dashboard);
+        // Esc from Dashboard should return the user to whatever they
+        // were on before — `transition_to_dashboard` must push instead
+        // of wiping the stack (2026-05-22 UX fix).
+        assert!(
+            app.nav_stack.depth() >= depth_before,
+            "[d] Dashboard must push onto nav_stack, not clear it"
+        );
+    }
+
+    #[test]
+    fn completion_summary_l_key_navigates_to_log_viewer() {
+        let mut app = make_app();
+        app.tui_mode = TuiMode::CompletionSummary;
+        let summary = completed_summary();
+        let first_id = summary.sessions.first().expect("test fixture").session_id;
+        app.completion_summary = Some(summary);
+
+        handle_completion_summary(&mut app, &key('l'));
+
+        assert!(matches!(app.tui_mode, TuiMode::LogViewer(id) if id == first_id));
+        assert!(app.completion_summary_dismissed);
+        // Post-match auto-clear nulls the summary on any non-scroll key.
+        assert!(app.completion_summary.is_none());
+    }
+
+    #[test]
+    fn completion_summary_l_key_with_no_sessions_keeps_modal_open() {
+        let mut app = make_app();
+        app.tui_mode = TuiMode::CompletionSummary;
+        let mut empty_summary = completed_summary();
+        empty_summary.sessions.clear();
+        app.completion_summary = Some(empty_summary);
+
+        handle_completion_summary(&mut app, &key('l'));
+
+        // No sessions = no LogViewer to open; user should stay on the
+        // overlay rather than fall through to Overview (the old code
+        // routed them off the modal even when [l] was a no-op).
+        assert!(!matches!(app.tui_mode, TuiMode::LogViewer(_)));
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -728,8 +728,7 @@ async fn event_loop(
                     );
                 }
                 app.continuous_mode = None;
-                app.completion_summary = Some(app.build_completion_summary());
-                app.tui_mode = app::TuiMode::CompletionSummary;
+                app.open_completion_summary();
                 continue;
             }
         }
@@ -754,8 +753,7 @@ async fn event_loop(
                     if let Some(ref mut exec) = app.queue_executor {
                         exec.mark_success();
                         if exec.is_finished() {
-                            app.completion_summary = Some(app.build_completion_summary());
-                            app.tui_mode = app::TuiMode::CompletionSummary;
+                            app.open_completion_summary();
                         } else {
                             app.advance_queue_and_launch();
                         }
@@ -788,8 +786,7 @@ async fn event_loop(
                 return Ok(());
             }
 
-            app.completion_summary = Some(app.build_completion_summary());
-            app.tui_mode = app::TuiMode::CompletionSummary;
+            app.open_completion_summary();
         }
     }
 }

--- a/src/tui/screen_dispatch.rs
+++ b/src/tui/screen_dispatch.rs
@@ -813,14 +813,19 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
             let config = config.with_agent_id(app.selected_agent_id());
             app.pending_commands
                 .push(app::TuiCommand::LaunchUnifiedSession(config));
-            app.nav_stack.clear();
+            // Replace the current wizard (PromptInput/IssueBrowser/etc.) with
+            // Overview WITHOUT clearing the nav stack. The wizard is current,
+            // not on the stack, so the stable anchors below it (Landing,
+            // Dashboard) survive — Esc from the post-session Overview pops
+            // back through them as the user expects. Wiping the stack
+            // (previous behavior) lost the Welcome breadcrumb at every
+            // session start. Reported 2026-05-23.
             app.tui_mode = app::TuiMode::Overview;
         }
         ScreenAction::LaunchSession(config) => {
             let config = config.with_agent_id(app.selected_agent_id());
             app.pending_commands
                 .push(app::TuiCommand::LaunchSession(config));
-            app.nav_stack.clear();
             app.tui_mode = app::TuiMode::Overview;
         }
         ScreenAction::LaunchSessions(configs) => {
@@ -831,7 +836,6 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
                 .collect();
             app.pending_commands
                 .push(app::TuiCommand::LaunchSessions(configs));
-            app.nav_stack.clear();
             app.tui_mode = app::TuiMode::Overview;
         }
         ScreenAction::LaunchPromptSession(config) => {
@@ -840,13 +844,11 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
             app.screen_state.adapt_follow_up_screen = None;
             app.pending_commands
                 .push(app::TuiCommand::LaunchPromptSession(config));
-            app.nav_stack.clear();
             app.tui_mode = app::TuiMode::Overview;
         }
         ScreenAction::LaunchConflictFix(config) => {
             app.spawn_conflict_fix_session(&config);
             app.completion_summary = None;
-            app.nav_stack.clear();
             app.tui_mode = app::TuiMode::Overview;
         }
         ScreenAction::LaunchCiFix(config) => {


### PR DESCRIPTION
The Session Complete modal's chord set was misrouted:

- `[s] Dismiss` called `App::transition_to_dashboard()` — wiping the whole nav stack and rebuilding the home screen just to close the overlay.
- `Enter` / `Esc` did the same.
- `[d] Dashboard` worked but the nav stack reset meant the next `Esc` triggered ConfirmExit instead of returning to the previous screen.
- `[l] Logs` set `tui_mode = LogViewer(sid)` directly (skipping `navigate_to`) so `Esc` had no breadcrumb to pop, AND fell back to Overview when the summary was empty — losing context for a no-op chord.

Fix:

- `transition_to_dashboard` now ends with `navigate_to(Dashboard)` so the stack pushes the prior mode (Esc returns to it) instead of `navigate_to_root` clearing the stack. The state-save + home-build
  + suggestion-refresh work stays unchanged.
- `Esc`/`Enter`/`[s]` collapse into one arm: clear `completion_summary`, set `completion_summary_dismissed = true`, restore Overview. No nav-stack mutation — the overlay closes in place.
- `[i]` / `[r]` use `navigate_to` (push) instead of raw `tui_mode = X`.
- `[l]` uses `navigate_to(LogViewer(sid))` when a session exists; no-op when sessions are empty (modal stays open instead of redirecting to Overview).
- `[d]` / `[q]` / `[o]` unchanged in intent — `[d]` benefits automatically from the `transition_to_dashboard` fix.

Regression tests (4 new, all in `src/tui/input_handler.rs::tests`):
- `completion_summary_s_key_preserves_nav_stack`
- `completion_summary_d_key_pushes_dashboard_onto_nav_stack`
- `completion_summary_l_key_navigates_to_log_viewer`
- `completion_summary_l_key_with_no_sessions_keeps_modal_open`

Plus updated `completion_summary_s_key_dismisses_success_modal` to assert `tui_mode == Overview` (the new dismiss target) instead of `Dashboard` (the old, wrong target).

Reported on 2026-05-22; surfaced during /auto #850 manual QA.