### PR TITLE
fix(tui/completion): preserve nav stack across launch + unify [Enter] Detail

### DIFF
--- a/src/tui/app/completion_summary.rs
+++ b/src/tui/app/completion_summary.rs
@@ -106,6 +106,18 @@ impl App {
         self.navigate_to(crate::tui::app::TuiMode::SessionSummary);
     }
 
+    /// Build the completion-summary overlay and navigate to its mode.
+    /// Funnels every production entry site (event-loop `all_done` tick,
+    /// continuous-mode end, queue-executor finish) so the prior
+    /// `tui_mode` lands on `nav_stack`. Pressing `Esc`/`Enter`/`[s]`
+    /// from the modal pops back to where the user was, instead of
+    /// falling through to ConfirmExit. Added 2026-05-23.
+    pub fn open_completion_summary(&mut self) {
+        let summary = self.build_completion_summary();
+        self.completion_summary = Some(summary);
+        self.navigate_to(crate::tui::app::TuiMode::CompletionSummary);
+    }
+
     /// Transition from CompletionSummary to Dashboard mode.
     pub fn transition_to_dashboard(&mut self) {
         let all = self.pool.all_sessions();

--- a/src/tui/input_handler.rs
+++ b/src/tui/input_handler.rs
@@ -232,8 +232,7 @@ fn handle_queue_execution(app: &mut App, key: &KeyEvent) -> KeyAction {
             {
                 exec.apply_decision(FailureAction::Skip);
                 if exec.is_finished() {
-                    app.completion_summary = Some(app.build_completion_summary());
-                    app.tui_mode = app::TuiMode::CompletionSummary;
+                    app.open_completion_summary();
                 } else {
                     app.advance_queue_and_launch();
                 }
@@ -244,8 +243,7 @@ fn handle_queue_execution(app: &mut App, key: &KeyEvent) -> KeyAction {
                 && matches!(exec.phase(), ExecutorPhase::AwaitingDecision { .. })
             {
                 exec.apply_decision(FailureAction::Abort);
-                app.completion_summary = Some(app.build_completion_summary());
-                app.tui_mode = app::TuiMode::CompletionSummary;
+                app.open_completion_summary();
             }
         }
         _ => {}
@@ -266,15 +264,16 @@ fn handle_completion_summary(app: &mut App, key: &KeyEvent) -> KeyAction {
     }
     match (key.code, key.modifiers) {
         (KeyCode::Enter, _) | (KeyCode::Esc, _) | (KeyCode::Char('s'), _) => {
-            // Dismiss the modal in place — Esc/Enter/[s] all close the
-            // overlay without resetting the navigation stack. The
-            // previous code routed these through `transition_to_dashboard`
-            // which wiped nav history and forced a full Dashboard rebuild
-            // every time the user just wanted to close the modal
-            // (2026-05-22 UX fix).
+            // Dismiss the modal and pop back to the screen the user was
+            // on before the modal opened. `open_completion_summary`
+            // pushes the prior mode onto `nav_stack`, so
+            // `navigate_back_or_dashboard` pops to that prior mode
+            // (Overview/Detail/etc.). Falls back to Dashboard — NEVER
+            // ConfirmExit — when the stack is empty. Reported 2026-05-23
+            // (Esc on completion modal was bouncing to the Quit dialog).
             app.completion_summary = None;
             app.completion_summary_dismissed = true;
-            app.tui_mode = app::TuiMode::Overview;
+            app.navigate_back_or_dashboard();
         }
         (KeyCode::Char('o'), _) => {
             open_first_completion_pr(app);
@@ -957,18 +956,24 @@ fn handle_overview_keys(app: &mut App, key: &KeyEvent) {
             };
         }
         (KeyCode::Esc, _) => {
-            app.navigate_back();
+            // Match Dashboard's Esc semantics: pop nav stack, fall back
+            // to Dashboard on empty stack — NEVER ConfirmExit. The user
+            // canonical exit paths are `q`, `Ctrl+X`, and `F4`. Reported
+            // 2026-05-23 (LaunchSession cleared the stack, so after
+            // dismissing the completion modal the next `Esc` from
+            // Overview was triggering the Quit dialog).
+            app.navigate_back_or_dashboard();
         }
         (KeyCode::Enter, _) | (KeyCode::Char(' '), _) => {
+            // Honor the advertised `[Enter] Detail` chord. Pre-2026-05-23
+            // code routed terminal (Completed/Errored/etc.) sessions to
+            // `toggle_session_summary` — a popup that conflicted with the
+            // hint shown in the top-bar. Detail works for terminal
+            // sessions too (renders the recorded transcript), so use one
+            // path for both states.
             let selected = app.panel_view.selected_index();
-            if let Some(id) = app.pool.session_id_at_index(selected)
-                && let Some(session) = app.pool.get_session(id)
-            {
-                if session.status.is_terminal() {
-                    app.toggle_session_summary(id);
-                } else {
-                    app.navigate_to(app::TuiMode::Detail(id));
-                }
+            if let Some(id) = app.pool.session_id_at_index(selected) {
+                app.navigate_to(app::TuiMode::Detail(id));
             }
         }
         (KeyCode::Char(c), _) if c.is_ascii_digit() && c != '0' => {
@@ -2112,36 +2117,193 @@ mod tests {
             should_fail: false,
         };
         let mut app = make_app().with_shell_launcher(Box::new(launcher));
-        app.tui_mode = TuiMode::CompletionSummary;
+        // Simulate the real flow: user navigated to Overview, modal
+        // auto-opened via `open_completion_summary` which pushes
+        // Overview onto `nav_stack`.
+        app.navigate_to(TuiMode::CompletionSummary);
         app.completion_summary = Some(completed_summary());
 
         handle_completion_summary(&mut app, &key('s'));
 
-        // [s] dismisses the modal in place — restores the underlying
-        // Overview screen instead of jumping to Dashboard and wiping
-        // navigation state (2026-05-22 UX fix).
+        // [s] pops the nav stack back to the prior mode (Overview)
+        // instead of falling through to ConfirmExit on an empty stack
+        // (2026-05-23 UX fix).
         assert_eq!(app.tui_mode, TuiMode::Overview);
         assert!(app.completion_summary.is_none());
         assert!(app.completion_summary_dismissed);
         assert!(calls.lock().expect("mutex").is_empty());
     }
 
+    /// Regression for 2026-05-23: empty `nav_stack` (e.g. modal opens on
+    /// a fresh Overview with no prior navigation) must fall back to
+    /// Dashboard on dismiss, NOT ConfirmExit.
     #[test]
-    fn completion_summary_s_key_preserves_nav_stack() {
+    fn completion_summary_s_key_falls_back_to_dashboard_on_empty_stack() {
         let mut app = make_app();
-        // Simulate the user navigating Overview → Detail → CompletionSummary.
-        app.navigate_to(TuiMode::Detail(uuid::Uuid::nil()));
-        let nav_depth_before = app.nav_stack.depth();
         app.tui_mode = TuiMode::CompletionSummary;
+        app.completion_summary = Some(completed_summary());
+        // Note: no navigate_to push — stack is empty.
+
+        handle_completion_summary(&mut app, &key('s'));
+
+        assert_eq!(
+            app.tui_mode,
+            TuiMode::Dashboard,
+            "[s] with empty stack must fall back to Dashboard, NEVER ConfirmExit"
+        );
+        assert!(!matches!(app.tui_mode, TuiMode::ConfirmExit));
+    }
+
+    /// Regression for 2026-05-23: dismissing the completion modal pops
+    /// back to Overview (correct), but the user's next `Esc` from
+    /// Overview triggered ConfirmExit because the launch path cleared
+    /// the nav stack. Overview now matches Dashboard's Esc semantics —
+    /// falls back to Dashboard on empty stack, NEVER ConfirmExit.
+    #[test]
+    fn overview_esc_falls_back_to_dashboard_when_stack_empty() {
+        let mut app = make_app();
+        app.tui_mode = TuiMode::Overview;
+        assert_eq!(app.nav_stack.depth(), 0);
+
+        handle_overview_keys(&mut app, &key_code(KeyCode::Esc));
+
+        assert_eq!(
+            app.tui_mode,
+            TuiMode::Dashboard,
+            "Esc on Overview with empty stack must fall back to Dashboard"
+        );
+        assert!(!matches!(app.tui_mode, TuiMode::ConfirmExit));
+    }
+
+    #[test]
+    fn overview_esc_pops_back_when_stack_has_history() {
+        let mut app = make_app();
+        app.tui_mode = TuiMode::Landing;
+        app.navigate_to(TuiMode::Overview);
+        let depth_before = app.nav_stack.depth();
+        assert!(depth_before >= 1);
+
+        handle_overview_keys(&mut app, &key_code(KeyCode::Esc));
+
+        assert_eq!(
+            app.tui_mode,
+            TuiMode::Landing,
+            "Esc on Overview must pop back to the previous mode"
+        );
+    }
+
+    /// Regression for 2026-05-23: `[Enter] Detail` on Overview routed
+    /// terminal (Completed/Errored) sessions to `toggle_session_summary`
+    /// (a popup), contradicting the top-bar chord hint. Unify both
+    /// states under Detail navigation.
+    #[test]
+    fn overview_enter_navigates_to_detail_for_terminal_session() {
+        use crate::session::types::{Session, SessionStatus};
+
+        let mut app = make_app();
+        app.tui_mode = TuiMode::Overview;
+        let mut session = Session::new(
+            "test".into(),
+            "opus".into(),
+            "orchestrator".into(),
+            Some(1),
+            None,
+        );
+        session.status = SessionStatus::Completed;
+        let id = session.id;
+        app.pool.enqueue(session);
+
+        handle_overview_keys(&mut app, &key_code(KeyCode::Enter));
+
+        assert!(
+            matches!(app.tui_mode, TuiMode::Detail(found) if found == id),
+            "Enter on terminal session must navigate to Detail; got {:?}",
+            app.tui_mode
+        );
+    }
+
+    #[test]
+    fn overview_enter_navigates_to_detail_for_running_session() {
+        use crate::session::types::{Session, SessionStatus};
+
+        let mut app = make_app();
+        app.tui_mode = TuiMode::Overview;
+        let mut session = Session::new(
+            "test".into(),
+            "opus".into(),
+            "orchestrator".into(),
+            Some(2),
+            None,
+        );
+        session.status = SessionStatus::Running;
+        let id = session.id;
+        app.pool.enqueue(session);
+
+        handle_overview_keys(&mut app, &key_code(KeyCode::Enter));
+
+        assert!(
+            matches!(app.tui_mode, TuiMode::Detail(found) if found == id),
+            "Enter on running session must navigate to Detail; got {:?}",
+            app.tui_mode
+        );
+    }
+
+    /// Regression for 2026-05-23: `ScreenAction::LaunchSession` (and its
+    /// 4 siblings) used to call `nav_stack.clear()` before setting
+    /// `tui_mode = Overview`. That wiped the stable anchors (Landing,
+    /// Dashboard) below the launch wizard — every session start lost
+    /// the Welcome breadcrumb. Replace the current wizard without
+    /// touching the stack.
+    #[test]
+    fn launch_session_action_preserves_nav_stack_anchors() {
+        use crate::tui::screen_dispatch::handle_screen_action;
+        use crate::tui::screens::{ScreenAction, SessionConfig as ScreenSessionConfig};
+
+        let mut app = make_app();
+        app.tui_mode = TuiMode::Landing;
+        app.navigate_to(TuiMode::Dashboard);
+        app.navigate_to(TuiMode::PromptInput);
+        let breadcrumbs_before: Vec<TuiMode> = app.nav_stack.breadcrumbs().to_vec();
+        assert_eq!(breadcrumbs_before.len(), 2, "fixture must have Landing + Dashboard");
+
+        let cfg = ScreenSessionConfig {
+            issue_number: Some(1),
+            title: "test".to_string(),
+            custom_prompt: None,
+            agent_id: None,
+        };
+        handle_screen_action(&mut app, ScreenAction::LaunchSession(cfg));
+
+        assert_eq!(app.tui_mode, TuiMode::Overview);
+        assert_eq!(
+            app.nav_stack.breadcrumbs(),
+            breadcrumbs_before.as_slice(),
+            "LaunchSession must preserve nav_stack anchors (Welcome/Dashboard)"
+        );
+    }
+
+    #[test]
+    fn completion_summary_s_key_pops_back_to_previous_mode() {
+        let mut app = make_app();
+        // Simulate Overview → Detail → CompletionSummary via real
+        // navigation. [s] must pop the modal off the stack and land on
+        // Detail (the screen the user was on before the modal opened),
+        // NOT jump to ConfirmExit. Reported 2026-05-23.
+        let detail_id = uuid::Uuid::nil();
+        app.navigate_to(TuiMode::Detail(detail_id));
+        app.navigate_to(TuiMode::CompletionSummary);
         app.completion_summary = Some(completed_summary());
 
         handle_completion_summary(&mut app, &key('s'));
 
         assert_eq!(
-            app.nav_stack.depth(),
-            nav_depth_before,
-            "[s] dismiss must NOT touch nav_stack — modal closes in place"
+            app.tui_mode,
+            TuiMode::Detail(detail_id),
+            "[s] dismiss must restore the prior mode via nav_stack pop"
         );
+        assert!(app.completion_summary.is_none());
+        assert!(app.completion_summary_dismissed);
+        assert!(!matches!(app.tui_mode, TuiMode::ConfirmExit));
     }
 
     #[test]

--- a/src/tui/input_handler.rs
+++ b/src/tui/input_handler.rs
@@ -2264,7 +2264,11 @@ mod tests {
         app.navigate_to(TuiMode::Dashboard);
         app.navigate_to(TuiMode::PromptInput);
         let breadcrumbs_before: Vec<TuiMode> = app.nav_stack.breadcrumbs().to_vec();
-        assert_eq!(breadcrumbs_before.len(), 2, "fixture must have Landing + Dashboard");
+        assert_eq!(
+            breadcrumbs_before.len(),
+            2,
+            "fixture must have Landing + Dashboard"
+        );
 
         let cfg = ScreenSessionConfig {
             issue_number: Some(1),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -728,8 +728,7 @@ async fn event_loop(
                     );
                 }
                 app.continuous_mode = None;
-                app.completion_summary = Some(app.build_completion_summary());
-                app.tui_mode = app::TuiMode::CompletionSummary;
+                app.open_completion_summary();
                 continue;
             }
         }
@@ -754,8 +753,7 @@ async fn event_loop(
                     if let Some(ref mut exec) = app.queue_executor {
                         exec.mark_success();
                         if exec.is_finished() {
-                            app.completion_summary = Some(app.build_completion_summary());
-                            app.tui_mode = app::TuiMode::CompletionSummary;
+                            app.open_completion_summary();
                         } else {
                             app.advance_queue_and_launch();
                         }
@@ -788,8 +786,7 @@ async fn event_loop(
                 return Ok(());
             }
 
-            app.completion_summary = Some(app.build_completion_summary());
-            app.tui_mode = app::TuiMode::CompletionSummary;
+            app.open_completion_summary();
         }
     }
 }

--- a/src/tui/screen_dispatch.rs
+++ b/src/tui/screen_dispatch.rs
@@ -813,14 +813,19 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
             let config = config.with_agent_id(app.selected_agent_id());
             app.pending_commands
                 .push(app::TuiCommand::LaunchUnifiedSession(config));
-            app.nav_stack.clear();
+            // Replace the current wizard (PromptInput/IssueBrowser/etc.) with
+            // Overview WITHOUT clearing the nav stack. The wizard is current,
+            // not on the stack, so the stable anchors below it (Landing,
+            // Dashboard) survive — Esc from the post-session Overview pops
+            // back through them as the user expects. Wiping the stack
+            // (previous behavior) lost the Welcome breadcrumb at every
+            // session start. Reported 2026-05-23.
             app.tui_mode = app::TuiMode::Overview;
         }
         ScreenAction::LaunchSession(config) => {
             let config = config.with_agent_id(app.selected_agent_id());
             app.pending_commands
                 .push(app::TuiCommand::LaunchSession(config));
-            app.nav_stack.clear();
             app.tui_mode = app::TuiMode::Overview;
         }
         ScreenAction::LaunchSessions(configs) => {
@@ -831,7 +836,6 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
                 .collect();
             app.pending_commands
                 .push(app::TuiCommand::LaunchSessions(configs));
-            app.nav_stack.clear();
             app.tui_mode = app::TuiMode::Overview;
         }
         ScreenAction::LaunchPromptSession(config) => {
@@ -840,13 +844,11 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
             app.screen_state.adapt_follow_up_screen = None;
             app.pending_commands
                 .push(app::TuiCommand::LaunchPromptSession(config));
-            app.nav_stack.clear();
             app.tui_mode = app::TuiMode::Overview;
         }
         ScreenAction::LaunchConflictFix(config) => {
             app.spawn_conflict_fix_session(&config);
             app.completion_summary = None;
-            app.nav_stack.clear();
             app.tui_mode = app::TuiMode::Overview;
         }
         ScreenAction::LaunchCiFix(config) => {


### PR DESCRIPTION
## Summary

Follow-up to #860. Three layers of that PR's full fix never landed on main — the merge happened against an earlier amend (commit `18178dd`) before the 3rd and 4th force-push. This PR re-applies them in isolation.

## What's missing on main

| Layer | Symptom | File |
|---|---|---|
| 1 | Modal entry sites bypass `nav_stack` — dismiss arm pops an empty stack | `tui/mod.rs`, `input_handler.rs`, `completion_summary.rs` |
| 2 | `Launch*` actions wipe nav_stack → Welcome breadcrumb lost every session start | `screen_dispatch.rs` |
| 3 | Overview `Esc` falls back to ConfirmExit on empty stack | `input_handler.rs` |
| 4 | Overview `Enter` on terminal sessions routes to popup instead of advertised Detail | `input_handler.rs` |

## Fix

- **New `App::open_completion_summary()`** funnels 6 production entry sites through `navigate_to(CompletionSummary)`.
- **`Launch*` arms** (LaunchUnifiedSession, LaunchSession, LaunchSessions, LaunchPromptSession, LaunchConflictFix) no longer call `nav_stack.clear()`. Welcome/Dashboard anchors survive launch.
- **Dismiss arm** uses `navigate_back_or_dashboard()` — pops back; falls back to Dashboard (NEVER ConfirmExit) on empty stack.
- **Overview `Esc`** uses `navigate_back_or_dashboard()` (was `navigate_back()` which hit ConfirmExit).
- **Overview `Enter`** always navigates to Detail (terminal + running sessions both).

## Regression tests (8 new + 1 updated)

- `completion_summary_s_key_dismisses_success_modal` (updated to real flow)
- `completion_summary_s_key_pops_back_to_previous_mode` (Overview → Detail → modal → `[s]` → Detail)
- `completion_summary_s_key_falls_back_to_dashboard_on_empty_stack`
- `overview_esc_falls_back_to_dashboard_when_stack_empty`
- `overview_esc_pops_back_when_stack_has_history`
- `overview_enter_navigates_to_detail_for_terminal_session`
- `overview_enter_navigates_to_detail_for_running_session`
- `launch_session_action_preserves_nav_stack_anchors` (Landing → Dashboard → PromptInput → `LaunchSession` → assert stack still `[Landing, Dashboard]`)

## Test plan

- [x] `cargo test --quiet` green (10,495 pass, 0 fail)
- [x] `cargo clippy -- -D warnings -A dead_code` clean
- [x] `cargo fmt --check` clean

## Manual verification (full breadcrumb flow)

1. `cargo run`. Land on Landing → `Welcome`.
2. Navigate to Dashboard → `Welcome > Dashboard`.
3. Press `r` for Run Prompt → `Welcome > Dashboard > Prompt`.
4. Submit prompt → session runs → `Welcome > Dashboard > Overview`.
5. Session completes → modal opens → `Welcome > Dashboard > Overview > Summary`.
6. Press `[s]` (or `Esc`) → modal closes → `Welcome > Dashboard > Overview`.
7. Press `Enter` on the completed session pane → Detail view opens (recorded transcript).
8. Press `Esc` → back through breadcrumbs (Overview → Dashboard → Landing).
9. Press `q` from Landing → ConfirmExit (canonical exit).

Independent of #776 / #848-#850 / #858 / #859 / #861 / #862. Pure UX fix.