### PR TITLE
refactor(budget/test_support): consolidate Session test builders

### DIFF
--- a/src/budget/projector.rs
+++ b/src/budget/projector.rs
@@ -51,45 +51,37 @@ impl BudgetProjector for DefaultBudgetProjector {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::session::types::Session;
+    use crate::budget::test_support::make_session;
 
-    fn make_session_with_cost(cost: f64) -> Session {
-        let mut s = Session::new(
-            "test".to_string(),
-            "claude-opus-4-5".to_string(),
-            "orchestrator".to_string(),
-            None,
-            None,
-        );
-        s.cost_usd = cost;
-        s
-    }
+    /// Model string is irrelevant to projection math; tag with a placeholder
+    /// so call-sites don't read as Claude-specific.
+    const TEST_MODEL: &str = "test-model";
 
     #[test]
     fn default_budget_projector_zero_history_returns_floor() {
         let projector = DefaultBudgetProjector::new(5.0, 0.10);
-        let session = make_session_with_cost(0.0);
+        let session = make_session(None, 0.0, TEST_MODEL);
         assert_eq!(projector.projected_turn_cost(&session), 0.50);
     }
 
     #[test]
     fn default_budget_projector_with_history_returns_max_of_delta_and_floor() {
         let projector = DefaultBudgetProjector::new(5.0, 0.10);
-        let session = make_session_with_cost(0.80);
+        let session = make_session(None, 0.80, TEST_MODEL);
         assert_eq!(projector.projected_turn_cost(&session), 0.80);
     }
 
     #[test]
     fn default_budget_projector_nan_cost_returns_floor() {
         let projector = DefaultBudgetProjector::new(5.0, 0.10);
-        let session = make_session_with_cost(f64::NAN);
+        let session = make_session(None, f64::NAN, TEST_MODEL);
         assert_eq!(projector.projected_turn_cost(&session), 0.50);
     }
 
     #[test]
     fn default_budget_projector_cost_below_floor_returns_floor() {
         let projector = DefaultBudgetProjector::new(5.0, 0.10);
-        let session = make_session_with_cost(0.10);
+        let session = make_session(None, 0.10, TEST_MODEL);
         assert_eq!(projector.projected_turn_cost(&session), 0.50);
     }
 }

--- a/src/budget/test_support.rs
+++ b/src/budget/test_support.rs
@@ -1,7 +1,8 @@
-//! Shared test fakes for the budget module (#776/#848/#854).
+//! Shared test fakes for the budget module (#776/#848/#854/#883).
 //!
 //! Gated `#[cfg(test)]` at the parent module declaration in `src/budget.rs`
 //! so this code is never present in release builds. Used by:
+//!   - `budget::projector` tests
 //!   - `budget::quota_snapshot` tests
 //!   - `tui::token_dashboard::provider_rollup` tests
 //!   - `tui::snapshot_tests::token_dashboard_provider_rollup` tests
@@ -9,6 +10,24 @@
 use std::collections::HashMap;
 
 use crate::budget::quota_snapshot::{ProviderQuotaSnapshots, QuotaRow};
+use crate::session::types::Session;
+
+/// Build a `Session` for budget-adjacent unit tests. Sets `agent_id`, `cost_usd`,
+/// and `model`; leaves every other field at `Session::new` defaults. Snapshot
+/// tests that need pinned `Uuid`/timestamps use the helper in
+/// `tui::snapshot_tests::mod` instead.
+pub fn make_session(agent_id: Option<&str>, cost: f64, model: &str) -> Session {
+    let mut s = Session::new(
+        "test".to_string(),
+        model.to_string(),
+        "orchestrator".to_string(),
+        None,
+        None,
+    );
+    s.agent_id = agent_id.map(str::to_string);
+    s.cost_usd = cost;
+    s
+}
 
 /// Test fake — returns whatever the caller seeded for each provider id.
 pub struct FakeProviderQuotaSnapshots {

--- a/src/tui/token_dashboard/provider_rollup.rs
+++ b/src/tui/token_dashboard/provider_rollup.rs
@@ -105,21 +105,7 @@ fn display_name_for(provider_id: &str) -> String {
 mod tests {
     use super::*;
     use crate::budget::quota_snapshot::{QuotaBucket, QuotaRow};
-    use crate::budget::test_support::FakeProviderQuotaSnapshots;
-    use crate::session::types::Session;
-
-    fn make_session(agent_id: Option<&str>, cost: f64, model: &str) -> Session {
-        let mut s = Session::new(
-            "test".to_string(),
-            model.to_string(),
-            "orchestrator".to_string(),
-            None,
-            None,
-        );
-        s.agent_id = agent_id.map(|x| x.to_string());
-        s.cost_usd = cost;
-        s
-    }
+    use crate::budget::test_support::{FakeProviderQuotaSnapshots, make_session};
 
     // ── Seam 1: build_provider_rows ──────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Dedupe two near-identical Session-test-builder helpers into a single `pub fn make_session(agent_id, cost, model) -> Session` in `src/budget/test_support.rs` (next to `FakeProviderQuotaSnapshots`).
- Drop the local helpers in `src/budget/projector.rs` and `src/tui/token_dashboard/provider_rollup.rs`; hoist projector's now-redundant model literal to a `TEST_MODEL` const.
- Leave the snapshot-specific `make_session_with_agent` in `src/tui/snapshot_tests/mod.rs` alone — it depends on pinned `Uuid`/timestamps that don't belong in a generic builder.

Closes #883

## Simplifications

- Replaced 4 hard-coded `"claude-opus-4-5"` literals in `projector.rs` test call-sites with `TEST_MODEL` const — signals "model irrelevant to projection math" (architect /simplify item 1a).

## Test plan

- [x] cargo test --quiet  (5254 + 5427 + binaries — all pass, 0 `.snap.new`)
- [x] cargo clippy -- -D warnings -A dead_code  (clean)
- [x] cargo fmt --check  (clean)
- [x] manual verification: N/A — refactor moves test code only, no production diff
