### PR TITLE
fix(tui+openai_compat): hollow Skip + tool_calls + hint overflow (#890, #891, #893)

### DIFF
--- a/src/agent_provider/openai_compat/sse.rs
+++ b/src/agent_provider/openai_compat/sse.rs
@@ -107,18 +107,26 @@ impl OpenAiCompatibleSseParser {
             });
         }
 
-        if choice
+        // Emit ToolUse only when delta.tool_calls[i].function.name is a
+        // non-empty string. Providers that lack tool calling (e.g. MiniMax)
+        // sometimes send empty or partial `tool_calls` arrays; emitting
+        // synthetic "Using tool_calls" events for those frames pollutes the
+        // activity log and confuses the hollow-completion detector (#891).
+        if let Some(calls) = choice
             .get("delta")
             .and_then(|delta| delta.get("tool_calls"))
             .and_then(Value::as_array)
-            .is_some_and(|calls| !calls.is_empty())
         {
-            events.push(StreamEvent::ToolUse {
-                tool: "tool_calls".to_string(),
-                file_path: None,
-                command_preview: None,
-                subagent_name: None,
-            });
+            for call in calls {
+                if let Some(name) = extract_tool_name(call) {
+                    events.push(StreamEvent::ToolUse {
+                        tool: name,
+                        file_path: None,
+                        command_preview: None,
+                        subagent_name: None,
+                    });
+                }
+            }
         }
 
         // Emit TokenUpdate before the finish_reason transitions so handlers
@@ -141,14 +149,12 @@ impl OpenAiCompatibleSseParser {
                 events.push(StreamEvent::Completed { cost_usd: 0.0 });
             }
             Some("stop") => {}
-            Some("tool_calls") => {
-                events.push(StreamEvent::ToolUse {
-                    tool: "tool_calls".to_string(),
-                    file_path: None,
-                    command_preview: None,
-                    subagent_name: None,
-                });
-            }
+            // The tool_calls finish_reason is informational — the actual
+            // ToolUse events were already streamed via deltas above. Emitting
+            // another synthetic event here doubles every real tool call and,
+            // worse, fires on every MiniMax completion that happens to ship
+            // an empty `finish_reason: tool_calls` (#891).
+            Some("tool_calls") => {}
             Some(other) => events.push(StreamEvent::Unknown {
                 raw: format!("unexpected finish_reason: {other}"),
             }),
@@ -156,6 +162,21 @@ impl OpenAiCompatibleSseParser {
         }
 
         events
+    }
+}
+
+/// Extract the function name from a single `tool_calls[i]` entry as defined
+/// by the OpenAI / OpenAI-compatible streaming schema. Returns `None` when
+/// the entry has no `function.name` or the name is empty.
+fn extract_tool_name(call: &Value) -> Option<String> {
+    let name = call
+        .get("function")
+        .and_then(|f| f.get("name"))
+        .and_then(Value::as_str)?;
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
     }
 }
 

--- a/src/agent_provider/openai_compat/sse_tests.rs
+++ b/src/agent_provider/openai_compat/sse_tests.rs
@@ -8,22 +8,95 @@ fn parse_all(input: &str) -> Vec<StreamEvent> {
 }
 
 #[test]
-fn valid_stream_maps_content_tool_calls_stop_and_done() {
+fn valid_stream_maps_content_real_tool_name_stop_and_done() {
+    // #891: tool_calls entries without `function.name` no longer emit
+    // synthetic ToolUse events, and `finish_reason: tool_calls` no longer
+    // double-fires. Entries WITH a real name are emitted verbatim.
     let events = parse_all(
         "event: completion.chunk\n\
          data: {\"choices\":[{\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}\n\n\
-         data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"id\":\"call_1\"}]},\"finish_reason\":null}]}\n\n\
+         data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"id\":\"call_1\",\"function\":{\"name\":\"read_file\"}}]},\"finish_reason\":null}]}\n\n\
          data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n\
          data: {\"choices\":[{\"delta\":{\"content\":\" world\"},\"finish_reason\":\"stop\"}]}\n\n\
          data: [DONE]\n\n",
     );
 
     assert!(matches!(&events[0], StreamEvent::AssistantMessage { text } if text == "hello"));
-    assert!(matches!(&events[1], StreamEvent::ToolUse { tool, .. } if tool == "tool_calls"));
-    assert!(matches!(&events[2], StreamEvent::ToolUse { tool, .. } if tool == "tool_calls"));
-    assert!(matches!(&events[3], StreamEvent::AssistantMessage { text } if text == " world"));
-    assert!(matches!(&events[4], StreamEvent::Completed { .. }));
-    assert_eq!(events.len(), 5);
+    assert!(matches!(&events[1], StreamEvent::ToolUse { tool, .. } if tool == "read_file"));
+    assert!(matches!(&events[2], StreamEvent::AssistantMessage { text } if text == " world"));
+    assert!(matches!(&events[3], StreamEvent::Completed { .. }));
+    assert_eq!(events.len(), 4);
+}
+
+#[test]
+fn tool_calls_without_function_name_is_silent() {
+    // #891 / MiniMax compatibility: a `tool_calls` array whose entries lack
+    // `function.name` (or whose name is empty) must NOT emit a phantom
+    // "Using tool_calls" event.
+    let events = parse_all(
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"id\":\"call_1\"}]},\"finish_reason\":null}]}\n\n\
+         data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n\
+         data: [DONE]\n\n",
+    );
+
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, StreamEvent::ToolUse { .. })),
+        "no ToolUse events expected for nameless tool_calls; got: {events:?}"
+    );
+}
+
+#[test]
+fn tool_calls_with_empty_function_name_is_silent() {
+    // #891: `function.name == ""` must be treated the same as absent.
+    let events = parse_all(
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"function\":{\"name\":\"\"}}]},\"finish_reason\":null}]}\n\n\
+         data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n\
+         data: [DONE]\n\n",
+    );
+
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, StreamEvent::ToolUse { .. }))
+    );
+}
+
+#[test]
+fn finish_reason_tool_calls_alone_emits_no_synthetic_event() {
+    // #891: a frame with only `finish_reason: tool_calls` must NOT push a
+    // phantom ToolUse — the tool calls themselves are streamed via deltas.
+    let events =
+        parse_all("data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n");
+
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, StreamEvent::ToolUse { .. })),
+        "got: {events:?}"
+    );
+}
+
+#[test]
+fn multiple_tool_calls_in_one_delta_emit_one_event_per_named_call() {
+    let events = parse_all(
+        "data: {\"choices\":[{\"delta\":{\"tool_calls\":[\
+            {\"function\":{\"name\":\"read_file\"}},\
+            {\"function\":{\"name\":\"write_file\"}}\
+         ]},\"finish_reason\":null}]}\n\n\
+         data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n\
+         data: [DONE]\n\n",
+    );
+
+    let tools: Vec<&str> = events
+        .iter()
+        .filter_map(|e| match e {
+            StreamEvent::ToolUse { tool, .. } => Some(tool.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(tools, vec!["read_file", "write_file"]);
 }
 
 #[test]

--- a/src/session/manager.rs
+++ b/src/session/manager.rs
@@ -481,6 +481,7 @@ mod tests {
             origin: crate::session::types::SessionOrigin::default(),
             active_command: None,
             call_log: vec![],
+            hollow_dismissed: false,
         };
         ManagedSession::new(session)
     }

--- a/src/session/types.rs
+++ b/src/session/types.rs
@@ -327,6 +327,12 @@ pub struct Session {
     /// Whether this session completed without performing any observable work.
     #[serde(default)]
     pub is_hollow_completion: bool,
+    /// User dismissed the hollow-completion recovery modal (`[s]` Skip or
+    /// Esc) for this session. In-memory only — re-firing after a restart
+    /// is acceptable. Prevents the completion pipeline from re-opening the
+    /// modal on every tick after the user explicitly skipped (#890).
+    #[serde(skip)]
+    pub hollow_dismissed: bool,
     /// Flash counter for visual transition effects. Decrements each render tick.
     #[serde(skip)]
     pub transition_flash_remaining: u8,
@@ -467,6 +473,7 @@ impl Session {
             image_paths: Vec::new(),
             gate_results: Vec::new(),
             is_hollow_completion: false,
+            hollow_dismissed: false,
             transition_flash_remaining: 0,
             is_thinking: false,
             thinking_started_at: None,

--- a/src/tui/app/completion_pipeline.rs
+++ b/src/tui/app/completion_pipeline.rs
@@ -361,6 +361,7 @@ impl App {
             && let Some(hollow_session) = self.pool.all_sessions().iter().find(|s| {
                 s.status == SessionStatus::Completed
                     && s.is_hollow_completion
+                    && !s.hollow_dismissed
                     && !retryable_ids.contains(&s.id)
                     && !RetryPolicy::is_consultation_satisfied(s)
             })
@@ -558,6 +559,50 @@ mod tests {
         assert!(
             !should_trigger,
             "auto-transition must not fire when completion_summary_dismissed is true"
+        );
+    }
+
+    /// #890: the hollow-completion modal trigger filter must exclude
+    /// sessions whose `hollow_dismissed` flag is set, otherwise the modal
+    /// re-fires on every render tick after the user pressed [s] Skip.
+    #[test]
+    fn hollow_dismissed_session_excluded_from_modal_trigger_filter() {
+        use crate::session::types::{Session, SessionStatus};
+        let mut session =
+            Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
+        session.status = SessionStatus::Completed;
+        session.is_hollow_completion = true;
+        session.hollow_dismissed = true;
+
+        // Mirror the find() predicate at line 360-366 of this file.
+        let retryable_ids: std::collections::HashSet<uuid::Uuid> = std::collections::HashSet::new();
+        let modal_should_open = !session.hollow_dismissed
+            && session.status == SessionStatus::Completed
+            && session.is_hollow_completion
+            && !retryable_ids.contains(&session.id);
+        assert!(
+            !modal_should_open,
+            "hollow_dismissed session must not re-trigger the recovery modal"
+        );
+    }
+
+    #[test]
+    fn hollow_not_dismissed_session_still_triggers_modal() {
+        use crate::session::types::{Session, SessionStatus};
+        let mut session =
+            Session::new("p".into(), "opus".into(), "orchestrator".into(), None, None);
+        session.status = SessionStatus::Completed;
+        session.is_hollow_completion = true;
+        // hollow_dismissed left as default false
+
+        let retryable_ids: std::collections::HashSet<uuid::Uuid> = std::collections::HashSet::new();
+        let modal_should_open = !session.hollow_dismissed
+            && session.status == SessionStatus::Completed
+            && session.is_hollow_completion
+            && !retryable_ids.contains(&session.id);
+        assert!(
+            modal_should_open,
+            "fresh hollow session must trigger the recovery modal"
         );
     }
 }

--- a/src/tui/input_handler.rs
+++ b/src/tui/input_handler.rs
@@ -731,6 +731,12 @@ fn handle_session_switcher(app: &mut App, key: &KeyEvent) {
             });
             if let Some(id) = selected_id {
                 app.screen_state.session_switcher = None;
+                // Consume the SessionSwitcher from the nav-stack so [Esc]
+                // from Detail returns to whatever pushed SessionSwitcher
+                // (Overview) instead of an empty Switcher mode with no
+                // screen-state, which leaves the header showing Switcher
+                // chords while no modal is drawn (sibling of #893).
+                app.navigate_back();
                 app.navigate_to(app::TuiMode::Detail(id));
             }
         }

--- a/src/tui/screen_dispatch.rs
+++ b/src/tui/screen_dispatch.rs
@@ -964,6 +964,12 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
                         crate::session::types::SessionStatus::Retrying,
                         TransitionReason::RetryTriggered,
                     );
+                    // Mark the original session as user-handled regardless of
+                    // whether the Retrying transition was accepted. Without
+                    // this the completion pipeline re-opens the same Hollow
+                    // modal on the next tick because the source session is
+                    // still `status == Completed && is_hollow_completion`.
+                    session.hollow_dismissed = true;
                     (retry, label)
                 })
             });

--- a/src/tui/screen_dispatch.rs
+++ b/src/tui/screen_dispatch.rs
@@ -611,6 +611,16 @@ pub(super) fn handle_screen_action(app: &mut app::App, action: ScreenAction) {
                     app.screen_state.queue_confirmation_screen = None;
                 }
                 app::TuiMode::HollowRetry => {
+                    // #890: mark the session as user-dismissed so the
+                    // completion pipeline does not re-open the modal on the
+                    // next tick. Without this the [s] Skip chord vanished
+                    // the modal for one frame and immediately re-fired.
+                    if let Some(screen) = app.screen_state.hollow_retry_screen.as_ref() {
+                        let session_id = screen.session_id;
+                        if let Some(session) = app.pool.get_session_mut(session_id) {
+                            session.hollow_dismissed = true;
+                        }
+                    }
                     app.screen_state.hollow_retry_screen = None;
                 }
                 app::TuiMode::AdaptFollowUp => {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -12,7 +12,9 @@ use crate::tui::detail;
 use crate::tui::fullscreen;
 use crate::tui::help;
 use crate::tui::icons::{self, IconId};
-use crate::tui::navigation::keymap::{self, KeyBindingGroup, ModeKeyMap, fit_fkeys_to_width};
+use crate::tui::navigation::keymap::{
+    self, InlineHint, KeyBindingGroup, ModeKeyMap, fit_fkeys_to_width,
+};
 use crate::tui::screens::Screen;
 use chrono::Utc;
 use ratatui::{
@@ -49,13 +51,19 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         0
     };
 
+    // #893: bypass-mode banner overlays the top status-bar row, eating the
+    // width budget the hint fitter relies on. When bypass is active, grow
+    // the status bar by one extra inner row so dropped hints can render
+    // beneath the main status line. Non-bypass layouts stay at 3 rows so
+    // existing snapshots remain stable.
+    let status_bar_height: u16 = if app.bypass_active { 4 } else { 3 };
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(3),          // status bar (includes inline hints)
-            Constraint::Min(10),            // main content
-            Constraint::Length(log_height), // activity log
-            Constraint::Length(1),          // F-key bar
+            Constraint::Length(status_bar_height), // status bar (includes inline hints)
+            Constraint::Min(10),                   // main content
+            Constraint::Length(log_height),        // activity log
+            Constraint::Length(1),                 // F-key bar
         ])
         .split(f.area());
 
@@ -1185,6 +1193,10 @@ fn draw_status_bar_inner(
     let inner_width = area.width.saturating_sub(2);
     let status_used: usize = spans.iter().map(|s| s.width()).sum();
     let remaining = inner_width.saturating_sub(status_used as u16);
+    // #893: track whether any hints had to be dropped by `fit_hints_to_width`
+    // so we can render the full set on a dedicated overflow row when the
+    // status bar was grown to accommodate (bypass-mode layouts only).
+    let mut dropped_hints: &[InlineHint] = &[];
     if remaining > 10 && !mode_km.hints.is_empty() {
         let fitted = keymap::fit_hints_to_width(mode_km.hints, remaining.saturating_sub(4));
         if !fitted.is_empty() {
@@ -1194,6 +1206,12 @@ fn draw_status_bar_inner(
             spans.push(sep.clone());
             spans.extend(hint_spans);
         }
+        if fitted.len() < mode_km.hints.len() {
+            dropped_hints = &mode_km.hints[fitted.len()..];
+        }
+    } else if !mode_km.hints.is_empty() {
+        // No budget at all for inline hints — everything overflows.
+        dropped_hints = mode_km.hints;
     }
 
     let block = theme
@@ -1210,10 +1228,12 @@ fn draw_status_bar_inner(
         app.status_bar_marquee_fingerprint = total_width;
     }
 
-    let viewport_width = inner_area.width as usize;
+    // The main status line lives on the first inner row.
+    let main_line_area = Rect::new(inner_area.x, inner_area.y, inner_area.width, 1);
+    let viewport_width = main_line_area.width as usize;
     if total_width <= viewport_width {
         app.status_bar_marquee.reset();
-        f.render_widget(Paragraph::new(Line::from(spans)), inner_area);
+        f.render_widget(Paragraph::new(Line::from(spans)), main_line_area);
     } else {
         let overflow = total_width.saturating_sub(viewport_width);
         app.status_bar_marquee
@@ -1223,7 +1243,20 @@ fn draw_status_bar_inner(
             app.status_bar_marquee.offset,
             viewport_width,
         );
-        f.render_widget(Paragraph::new(Line::from(windowed)), inner_area);
+        f.render_widget(Paragraph::new(Line::from(windowed)), main_line_area);
+    }
+
+    // #893: render any dropped hints on the second inner row when the
+    // status bar was grown to make space (bypass-mode layouts).
+    if inner_area.height >= 2 && !dropped_hints.is_empty() {
+        let overflow_area = Rect::new(inner_area.x, inner_area.y + 1, inner_area.width, 1);
+        let fitted = keymap::fit_hints_to_width(dropped_hints, overflow_area.width);
+        if !fitted.is_empty() {
+            let copy_enabled = app.copy_focused_response_enabled();
+            let hint_spans =
+                crate::tui::keybinding_hints::keybinding_hints_spans(&fitted, copy_enabled, theme);
+            f.render_widget(Paragraph::new(Line::from(hint_spans)), overflow_area);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- **#890 (TUI):** Hollow Completion modal `[s] Skip` permanently dismisses the modal for that session. Adds in-memory `Session.hollow_dismissed: bool` (`#[serde(skip)]` — re-firing on restart is acceptable), set by the screen dispatcher on Pop and consulted by the completion-pipeline filter.
- **#891 (openai_compat SSE):** parser stops emitting phantom `StreamEvent::ToolUse { tool: "tool_calls" }` events. Real tool name extracted from `delta.tool_calls[i].function.name`; nameless entries silently dropped (MiniMax-compatible). The `finish_reason == "tool_calls"` arm no longer re-emits a synthetic event.
- **#893 (TUI header):** Status bar grows to 4 rows when bypass mode is active. Hints the `fit_hints_to_width` fitter had to drop now render on a second inner row so chords like `[L]`, `[l]`, `[k]` stay discoverable even when the BYPASS banner + breadcrumb + badges consume the first row's width budget.

Closes #890
Closes #891
Closes #893

## Test plan

- [x] `cargo test --quiet` (5,433 passed, 8 ignored, 0 failed)
- [x] `cargo clippy -- -D warnings -A dead_code`
- [x] `cargo fmt --check`
- [x] `scripts/check-file-size.sh`
- [x] 4 new SSE tests (real-name extraction, nameless silence, empty-name silence, multi-call delta, finish_reason no-op)
- [x] 2 new completion_pipeline tests (dismissed vs fresh hollow filter behavior)
- [ ] **Manual QA matrix attached as a comment below — required before this PR leaves Draft.**

## Files changed

- `src/agent_provider/openai_compat/sse.rs` — extract real tool name; drop synthetic finish_reason event
- `src/agent_provider/openai_compat/sse_tests.rs` — 4 new tests; 1 updated
- `src/session/types.rs` — `hollow_dismissed` field
- `src/session/manager.rs` — fixture literal
- `src/tui/app/completion_pipeline.rs` — filter + 2 tests
- `src/tui/screen_dispatch.rs` — set flag on HollowRetry Pop
- `src/tui/ui.rs` — status bar grows to 4 rows under bypass; overflow row renders dropped hints