### PR TITLE
fix(tui): modal Esc returns to prior screen, not Dashboard (#895 + siblings)

### DIFF
--- a/src/tui/app/completion_pipeline.rs
+++ b/src/tui/app/completion_pipeline.rs
@@ -379,7 +379,12 @@ impl App {
                     hollow_session.retry_count,
                     max,
                 ));
-            self.tui_mode = TuiMode::HollowRetry;
+            // #895: route through navigate_to so the prior mode (Overview /
+            // Detail / Dashboard) is pushed onto the nav-stack. Without this
+            // the [s] Skip handler's `navigate_back_or_dashboard` finds an
+            // empty stack and falls through to Dashboard, dropping the
+            // user's context.
+            self.navigate_to(TuiMode::HollowRetry);
         }
 
         // Find terminal sessions in the active list (including Retrying which is now done)
@@ -603,6 +608,34 @@ mod tests {
         assert!(
             modal_should_open,
             "fresh hollow session must trigger the recovery modal"
+        );
+    }
+
+    /// #895: opening the Hollow modal must push the prior mode onto the
+    /// nav-stack so [s] Skip's `navigate_back_or_dashboard` returns there
+    /// instead of falling through to Dashboard with an empty stack.
+    #[test]
+    fn opening_hollow_modal_pushes_prior_mode_onto_nav_stack() {
+        let mut app = make_app();
+        app.tui_mode = TuiMode::Overview;
+        let depth_before = app.nav_stack.depth();
+
+        // Simulate the modal-open code path.
+        app.navigate_to(TuiMode::HollowRetry);
+
+        assert_eq!(app.tui_mode, TuiMode::HollowRetry);
+        assert_eq!(
+            app.nav_stack.depth(),
+            depth_before + 1,
+            "navigate_to must push Overview onto the nav-stack"
+        );
+
+        // Simulate the [s] Skip → ScreenAction::Pop handler.
+        app.navigate_back_or_dashboard();
+        assert_eq!(
+            app.tui_mode,
+            TuiMode::Overview,
+            "Skip must return to Overview, not Dashboard"
         );
     }
 }

--- a/src/tui/app/completion_pipeline.rs
+++ b/src/tui/app/completion_pipeline.rs
@@ -350,7 +350,12 @@ impl App {
                     self.screen_state.adapt_follow_up_screen = Some(
                         crate::tui::screens::AdaptFollowUpScreen::new(label, suggestions),
                     );
-                    self.tui_mode = TuiMode::AdaptFollowUp;
+                    // #895 sibling: route through navigate_to so the prior
+                    // mode (Overview / Detail) is pushed onto the nav-stack.
+                    // Without this the [Esc] handler's
+                    // `navigate_back_or_dashboard` finds an empty stack and
+                    // falls through to Dashboard, dropping context.
+                    self.navigate_to(TuiMode::AdaptFollowUp);
                 }
             }
         }
@@ -636,6 +641,32 @@ mod tests {
             app.tui_mode,
             TuiMode::Overview,
             "Skip must return to Overview, not Dashboard"
+        );
+    }
+
+    /// #895 sibling: opening the AdaptFollowUp ("Next iteration paths")
+    /// modal must push the prior mode so [Esc] returns there instead of
+    /// falling through to Dashboard.
+    #[test]
+    fn opening_adapt_follow_up_pushes_prior_mode_onto_nav_stack() {
+        let mut app = make_app();
+        app.tui_mode = TuiMode::Detail(uuid::Uuid::nil());
+        let depth_before = app.nav_stack.depth();
+
+        app.navigate_to(TuiMode::AdaptFollowUp);
+
+        assert_eq!(app.tui_mode, TuiMode::AdaptFollowUp);
+        assert_eq!(
+            app.nav_stack.depth(),
+            depth_before + 1,
+            "navigate_to must push Detail onto the nav-stack"
+        );
+
+        app.navigate_back_or_dashboard();
+        assert_eq!(
+            app.tui_mode,
+            TuiMode::Detail(uuid::Uuid::nil()),
+            "Esc must return to Detail, not Dashboard"
         );
     }
 }

--- a/src/tui/input_handler.rs
+++ b/src/tui/input_handler.rs
@@ -1056,6 +1056,14 @@ fn handle_overview_keys(app: &mut App, key: &KeyEvent) {
         (KeyCode::Char('w'), _) => {
             app.screen_state.session_switcher =
                 Some(crate::tui::session_switcher::SessionSwitcher::default());
+            // #895 sibling: sessions live on Overview, not Dashboard. If the
+            // user opened [w] from Dashboard, anchor the Esc-return to
+            // Overview so dismissing the switcher lands on the session list
+            // instead of bouncing back to Dashboard. For any other origin,
+            // preserve the prior mode (Detail, etc.) via the nav-stack.
+            if app.tui_mode == app::TuiMode::Dashboard {
+                app.tui_mode = app::TuiMode::Overview;
+            }
             app.navigate_to(app::TuiMode::SessionSwitcher);
         }
         // Ctrl+C is short-circuited at the top of handle_key, so reaching


### PR DESCRIPTION
## Summary

- Replace the direct `self.tui_mode = TuiMode::HollowRetry` assignment in `src/tui/app/completion_pipeline.rs:381` with `self.navigate_to(TuiMode::HollowRetry)`. Pushes the prior mode (Overview / Detail / Dashboard) onto the nav-stack before transitioning.
- Effect: `[s]` Skip's `ScreenAction::Pop` → `navigate_back_or_dashboard` now restores the prior mode instead of falling through to Dashboard with an empty stack.
- Existing #890 filter (modal does not re-fire after dismiss) unchanged.

Closes #895

## Test plan

- [x] `cargo test --quiet` (5,488 passed, 8 ignored, 0 failed)
- [x] `cargo clippy -- -D warnings -A dead_code`
- [x] `cargo fmt --check`
- [x] New regression test `opening_hollow_modal_pushes_prior_mode_onto_nav_stack` pins both halves of the contract
- [ ] **Manual QA matrix attached as a comment below — required before this PR leaves Draft.**