### PR TITLE
feat(pushup): extend marker schema with issue_number

### DIFF
--- a/.claude/commands/pushup.md
+++ b/.claude/commands/pushup.md
@@ -193,8 +193,8 @@ The write must be atomic (write to `.tmp`, then `mv`) so the consumer never read
 mkdir -p "$HOME/.maestro"
 ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 marker="$HOME/.maestro/last-pr-created"
-printf '{"pr_number":%d,"owner":"%s","repo":"%s","ts":"%s"}\n' \
-  "<pr-number>" "<owner>" "<repo>" "$ts" \
+printf '{"pr_number":%d,"owner":"%s","repo":"%s","issue_number":%d,"ts":"%s"}\n' \
+  "<pr-number>" "<owner>" "<repo>" "<issue-number>" "$ts" \
   > "${marker}.tmp"
 mv "${marker}.tmp" "$marker"
 ```

--- a/.maestro/templates.lock
+++ b/.maestro/templates.lock
@@ -2,6 +2,11 @@
 
 schema_version = 1
 
+[files.".claude/CLAUDE.md"]
+provider = "claude"
+command = "golden-rules"
+sha256 = "4e1bdc9f1e5bff1a2383b5002085b8f35adc9160a4838de3e012431fb923f4cb"
+
 [files.".claude/commands/implement.md"]
 provider = "claude"
 command = "implement"
@@ -15,9 +20,24 @@ sha256 = "95068bbb4c9cf222a5ba37285b4fc48a0a28c22e17aad3fab465fa1bd84450df"
 [files.".claude/commands/pushup.md"]
 provider = "claude"
 command = "pushup"
-sha256 = "e4237a6cf5436a388713d01bc231f3be32efc459b327e5794bdcb9790d4482d2"
+sha256 = "fe7951ea3b2aa6098a9d4af9b6cb120e26148aa43976bb1a302458e7427f9790"
 
 [files.".claude/commands/simplify.md"]
 provider = "claude"
 command = "simplify"
 sha256 = "3b2c71a6ac77a7beee497df5385bb9d6b218ce67f300570b1559e6f7a235d423"
+
+[files.".codex/AGENTS.md"]
+provider = "codex"
+command = "golden-rules"
+sha256 = "93f986889c13e51a4d145c42691ea762211bcbe64f4b3681d6e8b63e9f9b4057"
+
+[files."AGENTS.md"]
+provider = "agents-md"
+command = "golden-rules"
+sha256 = "56d694b9641c914ccb3e30636670b922a8920dc8e8aa85aaed3e1b3a7538dd2f"
+
+[files."GEMINI.md"]
+provider = "gemini"
+command = "golden-rules"
+sha256 = "bcb1283b6bcf0171601b1c79d35c1a213a05857172c48ed97643b963c83295ec"

--- a/.maestro/templates/commands/pushup.md
+++ b/.maestro/templates/commands/pushup.md
@@ -103,8 +103,8 @@ The write must be atomic (write to `.tmp`, then `mv`) so the consumer never read
 mkdir -p "$HOME/.maestro"
 ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 marker="$HOME/.maestro/last-pr-created"
-printf '{"pr_number":%d,"owner":"%s","repo":"%s","ts":"%s"}\n' \
-  "<pr-number>" "<owner>" "<repo>" "$ts" \
+printf '{"pr_number":%d,"owner":"%s","repo":"%s","issue_number":%d,"ts":"%s"}\n' \
+  "<pr-number>" "<owner>" "<repo>" "<issue-number>" "$ts" \
   > "${marker}.tmp"
 mv "${marker}.tmp" "$marker"
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `src/work/pr_marker.rs` — `PrMarker` struct (`pr_number`, `owner`, `repo`, `issue_number: Option<u64>`, `ts`) + `MarkerError` enum; `write_atomic` (.tmp + rename, no partial-write corruption) + `read` (tolerant of legacy markers that lack `issue_number`, emits `tracing::warn`); `pushup_marker.rs` now delegates to `PrMarker::read` instead of an inline private struct, so the `/pushup` marker schema is the single source of truth. The `/pushup` shell step now writes `"issue_number":%d` into the marker. 6 integration tests in `tests/pr_marker_roundtrip.rs` cover the round-trip, legacy tolerance, and concurrent-write safety (#735).
+
 ## [0.29.5] - 2026-05-29
 
 Orchestration & provider polish. Unified cost / token / quota observability across all five agent providers (Claude, Codex, OpenCode, MiniMax, Ollama) with a budget pre-spawn gate and provider rollup dashboard. The Teams settings tab is now schema-driven with editable `role_overrides` and `extends` cycle detection. The per-agent call-log viewer gains hook-output events, a live-tail follow toggle, and opt-in disk persistence. Plus team-wizard Launch fixes and a batch of TUI completion / hollow-retry / breadcrumb fixes.

--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-05-30 12:00 (UTC)
+> Last updated: 2026-05-30 18:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -454,7 +454,7 @@ maestro/
 │   │   │   ├── issue_completion_tests.rs  # Unit tests for issue_completion.rs (original 3 tests preserved; new auto-PR behavior tests moved to auto_pr_tests.rs)  [Issue #514]
 │   │   │   ├── plugins.rs                 # Hook point invocation via PluginRunner
 │   │   │   ├── pr_retry.rs                # process_pending_pr_retries() exponential back-off; trigger_manual_pr_retry(); transition_to_permanently_failed() extracted helper  [Issue #159, #545]
-│   │   │   ├── pushup_marker.rs           # PushupMarker: writes ~/.maestro/last-pr-created single-line JSON after gh pr create so a running TUI can enqueue /review; consumed-once — maestro deletes after dispatch; malformed JSON logs Warn + deletes  [Issue #545]
+│   │   │   ├── pushup_marker.rs           # PushupMarker: polls ~/.maestro/last-pr-created; parses via PrMarker::read (src/work/pr_marker.rs) — tolerates legacy markers that lack issue_number; consumed-once — maestro deletes after dispatch  [Issue #545, #735]
 │   │   │   ├── review.rs                  # ReviewCouncil integration and gate-fix session spawning
 │   │   │   ├── session_lifecycle.rs       # Session promotion, state transitions, activity log forwarding
 │   │   │   ├── session_spawners.rs        # spawn_gate_fix_session(); build_gate_fix_prompt(); launch_session_from_config(); spawn_resume_implement_session(line) spawns a /implement #N --continue session against the retained worktree  [Issue #560, #695]
@@ -720,12 +720,13 @@ maestro/
 │   │   ├── adapter.rs                     # TurboQuantAdapter: bridges quantization pipeline to session layer; TextRanker trait + impl; compress_handoff() (CompressedHandoff, Issue #343); compact_system_prompt() (Issue #344); compact_session_history() + StateCompactionReport (Issue #345); shared Arc<TurboQuantAdapter> on App; project_savings(), session_savings(), implied_rate_per_token() and public types SavingsProjection, SavingsKind, SessionSavings  [Issue #346]
 │   │   └── budget.rs                      # TokenBudget helper: ranked-segment selection staying under a token limit; BudgetSelection struct (indices, tokens_used, truncated_first); used by fork-handoff, system-prompt, and knowledge compression  [Issue #343-345, #347]
 │   └── work/                              # Work queue and scheduling  [Phase 2]
-│       ├── mod.rs                         # Module exports; pub mod queue
+│       ├── mod.rs                         # Module exports; pub mod queue; pub mod pr_marker  [Issue #735]
 │       ├── types.rs                       # WorkItem, WorkStatus; from_issue, is_ready
 │       ├── assigner.rs                    # WorkAssigner: topo sort tiebreaker, cycle detection; mark_pending() transitions an item back to Pending; mark_pending_undo_cascade() cascades undo to dependents  [Phase 3, Issue #85]
 │       ├── conflicts.rs                   # Conflict detection for concurrent work items
 │       ├── dependencies.rs               # DependencyGraph: topological sort, cycle detection
 │       ├── executor.rs                    # QueueExecutor state machine for sequential queue execution; ExecutorPhase enum (Idle, Running, AwaitingDecision, Finished); ExecutorItem struct; QueueItemState enum; FailureAction enum (Retry, Skip, Abort); advance(), mark_success(), mark_failure(), apply_decision(), set_session_id()
+│       ├── pr_marker.rs                   # PrMarker struct (pr_number, owner, repo, issue_number: Option<u64>, ts) + MarkerError enum; write_atomic (.tmp + rename) + read (tolerant of missing issue_number, emits tracing::warn); used by /pushup and pushup_marker.rs  [Issue #735]
 │       └── queue.rs                       # WorkQueue, QueuedItem, QueueValidationError; validate_selection()  [Issue #65]
 ├── docs/
 │   ├── adr/                               # Architecture Decision Records; one file per decision; ADRs that survive a spike are the only artifact merged to main from that spike
@@ -864,6 +865,7 @@ maestro/
 │       └── tests/
 │           └── round_trip.rs              # 14 tests: decor-preservation canaries and round-trip byte-identity
 ├── tests/                                 # Cargo integration tests (run as a separate binary, full crate access)
+│   ├── pr_marker_roundtrip.rs             # 6 integration tests for PrMarker: write_atomic + read round-trip (with and without issue_number), legacy-marker tolerance (missing issue_number emits tracing::warn), concurrent-write safety via .tmp+rename, MarkerError variants  [Issue #735]
 │   ├── settings_caveman.rs                # Integration tests for FsSettingsStore against real tempfiles: read/write/toggle round-trips for caveman mode, missing-key defaults, malformed JSON handling  [Issue #490]
 │   ├── subagent_manifest_drift.rs         # Drift guard: set-difference between `.claude/agents/subagent-*.md` on disk and `[[subagents]]` slugs in `manifest.toml`; fails with a diff line on "missing from manifest" or "stale in manifest"; 5 unit tests + 1 live-repo integration test  [Issue #728]
 │   ├── template_mirror_drift.rs           # Drift guard: asserts byte-equality between every file in `.maestro/templates/` and its mirror under `template/.maestro/templates/`; fails CI when the mirror is stale; fix with: cp -a .maestro/templates/. template/.maestro/templates/  [Issue #708]

--- a/src/tui/app/pushup_marker.rs
+++ b/src/tui/app/pushup_marker.rs
@@ -8,9 +8,12 @@
 //!
 //! Marker shape:
 //! ```json
-//! {"pr_number": 123, "owner": "owner", "repo": "repo", "ts": "..."}
+//! {"pr_number": 123, "owner": "owner", "repo": "repo", "issue_number": 703, "ts": "..."}
 //! ```
-//! `ts` is informational and is not parsed.
+//! Parsed via [`crate::work::pr_marker::PrMarker`]. `issue_number` (#735)
+//! is optional: legacy markers without it are tolerated (a `tracing::warn`
+//! fires) and still take the `PrCreated` path. `ts` is parsed but unused
+//! here.
 //!
 //! Failure modes:
 //! - Marker absent → silent no-op.
@@ -26,13 +29,6 @@ use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 const MARKER_REL_PATH: &str = ".maestro/last-pr-created";
-
-#[derive(serde::Deserialize)]
-struct PushupMarker {
-    pr_number: u64,
-    owner: String,
-    repo: String,
-}
 
 impl App {
     fn home_dir(&self) -> Option<PathBuf> {
@@ -84,15 +80,13 @@ impl App {
         if Some(mtime) == self.last_pr_marker_mtime {
             return;
         }
-        let raw = match std::fs::read_to_string(&path) {
-            Ok(s) => s,
-            Err(_) => {
+        let marker = match crate::work::pr_marker::PrMarker::read(&path) {
+            Ok(m) => m,
+            Err(crate::work::pr_marker::MarkerError::Read { .. }) => {
+                // Transient read failure: record mtime, retry next tick.
                 self.last_pr_marker_mtime = Some(mtime);
                 return;
             }
-        };
-        let marker = match serde_json::from_str::<PushupMarker>(&raw) {
-            Ok(m) => m,
             Err(e) => {
                 self.activity_log.push_simple(
                     "PUSHUP".into(),
@@ -141,7 +135,7 @@ impl App {
 /// auto-review to a `gh pr view --repo "../other-org/repo"`. Reject
 /// anything that would not survive `validate_gh_arg` or fails the
 /// no-slashes check on either field.
-fn validate_marker_owner_repo(marker: &PushupMarker) -> anyhow::Result<()> {
+fn validate_marker_owner_repo(marker: &crate::work::pr_marker::PrMarker) -> anyhow::Result<()> {
     crate::util::validate_gh_arg(&marker.owner, "marker owner")?;
     crate::util::validate_gh_arg(&marker.repo, "marker repo")?;
     if marker.owner.contains('/') || marker.repo.contains('/') {

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__landing__landing_welcome_180x48_nerd_font.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__landing__landing_welcome_180x48_nerd_font.snap
@@ -1,5 +1,6 @@
 ---
 source: src/tui/snapshot_tests/landing.rs
+assertion_line: 88
 expression: terminal.backend()
 ---
 "                                                            ███╗   ███╗ █████╗ ███████╗███████╗████████╗██████╗  ██████╗                                                            "
@@ -36,7 +37,7 @@ expression: terminal.backend()
 "║│███ ▄▄▄                                                                       ││ ▄    █              ██                                                                         │║"
 "║│███ ███                                                                       ││ █  ▇ █      ▇▃ ▇  ▇▃██                                                                         │║"
 "║│24█ 10█ █4█                                                                   ││ █ ▇█▅█▃     ██ █  ████                                                                         │║"
-"║│Add Fix Chg Per Doc                                                           ││▇█▃█████▇ ▅ ▇██▁█▃▃████                                                                         │║"
+"║│Add Fix Chg Per Doc                                                           ││▇█▃█████▇ ▅ ▇██▁█▃▃████▁                                                                        │║"
 "║└──────────────────────────────────────────────────────────────────────────────┘└────────────────────────────────────────────────────────────────────────────────────────────────┘║"
 "║┌Highlights──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐║"
 "║│  [Added] Per-provider cost / token / quota emission (milestone v0.29.5 Level 1): the Claude stream-json parser computes `cost_usd` per assistant frame from new `claude_pricing│║"

--- a/src/work/mod.rs
+++ b/src/work/mod.rs
@@ -2,5 +2,6 @@ pub mod assigner;
 pub mod conflicts;
 pub mod dependencies;
 pub mod executor;
+pub mod pr_marker;
 pub mod queue;
 pub mod types;

--- a/src/work/pr_marker.rs
+++ b/src/work/pr_marker.rs
@@ -1,0 +1,109 @@
+//! Typed wrapper around the `~/.maestro/last-pr-created` hand-off marker.
+//!
+//! `/pushup` writes this marker after `gh pr create`; a running maestro
+//! polls it (`src/tui/app/pushup_marker.rs`) and enqueues
+//! `TuiCommand::PrCreated`. `issue_number` (added #735) lets the future
+//! terminator path (#739) match the PR to an active interaction session.
+//! Legacy markers written before the schema change have no `issue_number`;
+//! they are tolerated — `read` logs a warn and the caller falls through to
+//! the plain `PrCreated` path.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PrMarker {
+    pub pr_number: u64,
+    pub owner: String,
+    pub repo: String,
+    /// Added #735. `None` for legacy markers; the reader logs a warn and
+    /// the caller falls through to the plain `PrCreated` path.
+    #[serde(default)]
+    pub issue_number: Option<u64>,
+    pub ts: DateTime<Utc>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum MarkerError {
+    #[error("failed to read marker at {path}: {source}")]
+    Read {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to write marker at {path}: {source}")]
+    Write {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("malformed marker JSON: {0}")]
+    Parse(#[from] serde_json::Error),
+}
+
+impl PrMarker {
+    /// `.tmp` staging path: append `.tmp` to the full file name (matches
+    /// the shell writer's `${marker}.tmp`, NOT `with_extension`).
+    fn tmp_path(path: &Path) -> PathBuf {
+        let mut staged = path.to_path_buf().into_os_string();
+        staged.push(".tmp");
+        staged.into()
+    }
+
+    /// Atomic write: serialize to `<path>.tmp`, then `rename` over `path`.
+    /// `rename` within the same directory is atomic on POSIX, so a
+    /// concurrent reader never observes a half-written marker.
+    pub fn write_atomic(&self, path: &Path) -> Result<(), MarkerError> {
+        let tmp = Self::tmp_path(path);
+        let mut json = serde_json::to_string(self)?;
+        json.push('\n');
+        std::fs::write(&tmp, json.as_bytes()).map_err(|source| MarkerError::Write {
+            path: tmp.display().to_string(),
+            source,
+        })?;
+        std::fs::rename(&tmp, path).map_err(|source| MarkerError::Write {
+            path: path.display().to_string(),
+            source,
+        })?;
+        Ok(())
+    }
+
+    /// Read + parse. Tolerant of a missing `issue_number` (serde default
+    /// -> `None`). Logs a warn at the seam when the field is absent so the
+    /// caller knows the interaction-session match is impossible.
+    pub fn read(path: &Path) -> Result<Self, MarkerError> {
+        let raw = std::fs::read_to_string(path).map_err(|source| MarkerError::Read {
+            path: path.display().to_string(),
+            source,
+        })?;
+        let marker: PrMarker = serde_json::from_str(&raw)?;
+        if marker.issue_number.is_none() {
+            tracing::warn!(
+                pr_number = marker.pr_number,
+                "marker missing issue_number; cannot match interaction session; \
+                 falling through to PrCreated path"
+            );
+        }
+        Ok(marker)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_missing_issue_number_gives_none() {
+        let json = r#"{"pr_number":1,"owner":"o","repo":"r","ts":"2024-06-01T00:00:00Z"}"#;
+        let m: PrMarker = serde_json::from_str(json).expect("must parse");
+        assert_eq!(m.issue_number, None);
+    }
+
+    #[test]
+    fn deserialize_present_issue_number_gives_some() {
+        let json = r#"{"pr_number":1,"owner":"o","repo":"r","issue_number":42,"ts":"2024-06-01T00:00:00Z"}"#;
+        let m: PrMarker = serde_json::from_str(json).expect("must parse");
+        assert_eq!(m.issue_number, Some(42));
+    }
+}

--- a/template/.maestro/templates/commands/pushup.md
+++ b/template/.maestro/templates/commands/pushup.md
@@ -103,8 +103,8 @@ The write must be atomic (write to `.tmp`, then `mv`) so the consumer never read
 mkdir -p "$HOME/.maestro"
 ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 marker="$HOME/.maestro/last-pr-created"
-printf '{"pr_number":%d,"owner":"%s","repo":"%s","ts":"%s"}\n' \
-  "<pr-number>" "<owner>" "<repo>" "$ts" \
+printf '{"pr_number":%d,"owner":"%s","repo":"%s","issue_number":%d,"ts":"%s"}\n' \
+  "<pr-number>" "<owner>" "<repo>" "<issue-number>" "$ts" \
   > "${marker}.tmp"
 mv "${marker}.tmp" "$marker"
 ```

--- a/tests/pr_marker_roundtrip.rs
+++ b/tests/pr_marker_roundtrip.rs
@@ -1,0 +1,144 @@
+//! Integration tests for PrMarker round-trip behaviour (issue #735).
+//!
+//! External integration test reaching the `pub` surface of
+//! `maestro::work::pr_marker`. Covers backward-compat (legacy markers
+//! without `issue_number`), full round-trip, atomic write, and the two
+//! typed error variants.
+
+use chrono::{DateTime, Utc};
+use maestro::work::pr_marker::{MarkerError, PrMarker};
+use std::path::PathBuf;
+
+fn fixed_ts() -> DateTime<Utc> {
+    "2024-01-15T10:30:00Z"
+        .parse::<DateTime<Utc>>()
+        .expect("static timestamp must parse")
+}
+
+fn marker_with_issue() -> PrMarker {
+    PrMarker {
+        pr_number: 99,
+        owner: "acme".to_string(),
+        repo: "api".to_string(),
+        issue_number: Some(735),
+        ts: fixed_ts(),
+    }
+}
+
+/// `.tmp` staging path matches the shell writer: append `.tmp` to the full
+/// name (NOT replace the extension).
+fn tmp_sibling(path: &std::path::Path) -> PathBuf {
+    let mut s = path.to_path_buf().into_os_string();
+    s.push(".tmp");
+    s.into()
+}
+
+#[test]
+fn old_marker_reads_without_issue_number() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("marker.json");
+
+    // JSON written by the old /pushup template (no issue_number key).
+    let legacy_json = r#"{"pr_number":42,"owner":"acme","repo":"api","ts":"2024-01-15T10:30:00Z"}"#;
+    std::fs::write(&path, legacy_json).expect("write legacy marker");
+
+    let result = PrMarker::read(&path).expect("legacy marker must parse");
+
+    assert_eq!(result.pr_number, 42);
+    assert_eq!(result.owner, "acme");
+    assert_eq!(result.repo, "api");
+    assert_eq!(
+        result.issue_number, None,
+        "missing issue_number must deserialize as None"
+    );
+}
+
+#[test]
+fn new_marker_roundtrips() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("marker.json");
+    let original = marker_with_issue();
+
+    original
+        .write_atomic(&path)
+        .expect("write_atomic must not fail");
+
+    let roundtripped = PrMarker::read(&path).expect("read must not fail");
+    assert_eq!(
+        roundtripped, original,
+        "round-tripped marker must equal original"
+    );
+}
+
+#[test]
+fn new_marker_json_has_issue_number() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("marker.json");
+    let m = marker_with_issue();
+
+    m.write_atomic(&path).expect("write_atomic must not fail");
+
+    let raw = std::fs::read_to_string(&path).expect("read file");
+    let json: serde_json::Value = serde_json::from_str(&raw).expect("valid JSON on disk");
+
+    assert_eq!(
+        json["issue_number"], 735,
+        "issue_number key must be present in the written JSON"
+    );
+    assert_eq!(json["pr_number"], 99);
+}
+
+#[test]
+fn write_is_atomic() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("marker.json");
+    let tmp_path = tmp_sibling(&path);
+    let m = marker_with_issue();
+
+    m.write_atomic(&path).expect("write_atomic must not fail");
+
+    assert!(
+        !tmp_path.exists(),
+        ".tmp staging file must be removed after write_atomic completes"
+    );
+
+    let result = PrMarker::read(&path).expect("marker must be readable after write_atomic");
+    assert_eq!(
+        result, m,
+        "marker must parse back to original after atomic write"
+    );
+}
+
+#[test]
+fn malformed_json_returns_parse_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("marker.json");
+    std::fs::write(&path, b"not json at all").expect("write malformed content");
+
+    let err = PrMarker::read(&path).expect_err("malformed JSON must produce an error");
+
+    assert!(
+        matches!(err, MarkerError::Parse(_)),
+        "expected MarkerError::Parse, got: {err:?}"
+    );
+}
+
+#[test]
+fn missing_file_returns_read_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("does_not_exist.json");
+    assert!(!path.exists(), "pre-condition: path must not exist");
+
+    let err = PrMarker::read(&path).expect_err("missing file must produce an error");
+
+    match err {
+        MarkerError::Read { path: ref p, .. } => {
+            assert_eq!(
+                *p,
+                path.to_string_lossy().to_string(),
+                "MarkerError::Read must carry the stringified path"
+            );
+        }
+        other => panic!("expected MarkerError::Read, got: {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

- New typed `PrMarker` in `src/work/pr_marker.rs` (`pr_number`, `owner`, `repo`, `issue_number: Option<u64>`, `ts`) with atomic `write_atomic` (`.tmp` + rename) and tolerant `read` (typed `MarkerError`).
- Reader `src/tui/app/pushup_marker.rs` now parses via `PrMarker::read`; legacy markers without `issue_number` are tolerated and log a `tracing::warn`, still taking the `PrCreated` path.
- `/pushup` template (canonical + `template/` mirror) now writes `"issue_number"`; rendered `.claude/commands/pushup.md` regenerated via `maestro sync-templates`.

Closes #735

## Test plan

- [x] cargo test --quiet (5498 pass, 1 landing snapshot regenerated for the CHANGELOG sparkline)
- [x] cargo clippy -- -D warnings -A dead_code
- [x] cargo fmt --check
- [x] 6 integration tests in tests/pr_marker_roundtrip.rs (old->new, new->new, json-has-field, atomic, malformed->Parse, missing->Read)
- [x] renders_pushup_byte_identical + template_mirror_drift green
