### PR TITLE
docs(readme): update Discord invite to permalink

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Release](https://img.shields.io/github/v/release/CarlosDanielDev/maestro)](https://github.com/CarlosDanielDev/maestro/releases/latest)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![MSRV](https://img.shields.io/badge/rustc-1.89%2B-orange.svg)](Cargo.toml)
-[![Discord](https://img.shields.io/discord/1498709440465998038?logo=discord&logoColor=white&label=Discord&color=5865F2)](https://discord.gg/vUTuhRmq)
+[![Discord](https://img.shields.io/discord/1498709440465998038?logo=discord&logoColor=white&label=Discord&color=5865F2)](https://discord.gg/WHsk2FuQEH)
 
 > Multi-session [Claude Code](https://claude.ai/claude-code) orchestrator with a Matrix-style terminal control center.
 


### PR DESCRIPTION
Update the README Discord badge link to the permanent invite: https://discord.gg/WHsk2FuQEH (was a temporary invite that expires).

## Test plan
- [x] Link updated in README.md badge
- [ ] Visual: badge resolves to the permalink