### PR TITLE
feat(session): per-turn claude --resume spawn loop + session_id persistence (#737)

### DIFF
--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-05-30 19:00 (UTC)
+> Last updated: 2026-05-30 20:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -397,7 +397,7 @@ maestro/
 │   ├── session/
 │   │   ├── mod.rs                         # Module exports (includes pool, worktree, health, retry, context_monitor, fork)
 │   │   ├── manager.rs                     # Claude CLI process management; handles ContextUpdate events; thinking_start field tracks Thinking block duration; handle_event() emits rich activity messages with file paths, elapsed times for tool calls, and thinking duration on block end; current_activity reflects "Thinking..." while a thinking block is active; emits "STATUS: OLD → NEW" activity log entries when session state changes; 1-line wire in ManagedSession::handle_event() appends CallLogEntry via Session::append_call_log  [Phase 3, Issue #102, #202, #868]
-│   │   ├── parser.rs                      # stream-json output parser; parses system events for context usage; parses "thinking" message type into StreamEvent::Thinking; extracts command field from Bash tool input as command_preview (truncated to 60 chars)  [Phase 3, Issue #102]
+│   │   ├── parser.rs                      # stream-json output parser; parses system events for context usage; parses "thinking" message type into StreamEvent::Thinking; extracts command field from Bash tool input as command_preview (truncated to 60 chars); `pub fn extract_session_id(line) -> Option<String>` added (#737)  [Phase 3, Issue #102, #737]
 │   │   ├── pool.rs                        # Session pool: max_concurrent, queue, auto-promote; branch tracking; guardrail_prompt field; set_guardrail_prompt(); merged into system prompt in try_promote(); find_by_issue_mut(); decrements flash_counter on each session per render tick and emits STATUS activity log entries on state transitions; `interactions: Vec<InteractionSession>` field; `find_active_interaction_by_issue()`  [Phase 3, Issue #40, #43, #202, #734]
 │   │   ├── pr_capture.rs                  # PrCapture: intercepts stream-json output to detect when a session posts a /review PR comment and stores the raw comment body for the review pipeline  [Issue #327]
 │   │   ├── types.rs                       # Session state machine; fork fields (parent_session_id, child_session_ids, fork_depth); ContextUpdate StreamEvent; GatesRunning and NeedsReview status variants; CiFix variant; CiFixContext struct (pr_number, issue_number, branch, attempt); ci_fix_context field on Session; StreamEvent::Thinking { text } variant; command_preview: Option<String> field on StreamEvent::ToolUse; GateResultEntry struct (gate, passed, message); gate_results: Vec<GateResultEntry> field on Session; NeedsPr variant — non-terminal status indicating PR creation failed and is queued for retry; flash_counter: u8 field on Session — decremented each render tick to drive border-flash effect on state transition; worktree_path: Option<PathBuf> field on Session with #[serde(default)] — set at FailedGates transition so the recovery modal can surface the path; CallLogEntry struct (timestamp, kind, payload); CallLogKind enum; Session.call_log: Vec<CallLogEntry> (capped at 500 via append_call_log); render_event_payload() with 10 KB per-text-field cap; `SessionMode` enum (OneShot | Interactive) + `From<bool>`  [Phase 3, Issue #40, #41, #102, #104, #159, #202, #560, #868, #734]
@@ -412,7 +412,8 @@ maestro/
 │   │   ├── role.rs                        # Role enum (5 variants: Orchestrator, Implementer, Reviewer, QA, Unknown) + derive_role() keyword classifier; Session::role field (O(1) lookup at render time)  [Issue #538]
 │   │   ├── team_runner.rs                 # `TeamLauncher` trait + `run_team()` fn; walks `Scheduler` levels with a `tokio::sync::Semaphore` capped at `max_parallel`; `TeamOutcome`, `IssueFailure` result types  [Issue #881]
 │   │   ├── team_runner_tests.rs           # 5 inline unit tests for `run_team`: happy path, partial failure, semaphore cap, empty levels, single-issue level  [Issue #881]
-│   │   └── interaction.rs                 # `InteractionSession`, `InteractionState`, `TurnRole`, `CloseReason`, `TurnRecord` types; `new()` / `is_active()` constructors; scaffold for interactive iteration sessions  [Issue #734]
+│   │   ├── interaction.rs                 # `InteractionSession`, `InteractionState`, `TurnRole`, `CloseReason`, `TurnRecord` types; `new()` / `is_active()` constructors; scaffold for interactive iteration sessions  [Issue #734]
+│   │   └── interaction_turn.rs            # Per-turn `claude --resume` spawn loop: `SpawnAgent` trait + `ClaudeCliSpawner` (production), `InteractionSession::send_turn`, `TurnEvent` / `TurnError` / `TurnArgv` / `TurnOutcome` / `TurnHandle`, `build_turn_argv`; session_id capture from first result line, streaming chunks, cancellation via `TurnHandle::cancel()`, degraded mode  [Issue #737]
 │   ├── state/
 │   │   ├── mod.rs                         # Module exports (includes file_claims, progress)
 │   │   ├── file_claims.rs                 # File claim system: FileClaimManager, conflict prevention  [Phase 1]
@@ -678,7 +679,7 @@ maestro/
 │   │       ├── text_input.rs              # Single-line text input widget with cursor support
 │   │       └── toggle.rs                 # Boolean toggle widget for settings and forms; draw() routes through icons::get(IconId::CheckboxOn/Off) instead of hardcoded literals, eliminating the DRY drift that caused blank indicators on iTerm2 + some Nerd Font installs  [Issue #433]
 │   ├── integration_tests/                 # End-to-end integration test suite (no external deps, all mocked)  [Issue #15]
-│   │   ├── mod.rs                         # Module declarations; shared helpers: make_pool(), make_pool_with_worktree(), make_session(), make_session_with_issue(), make_gh_issue(); mod milestone_health_wizard, wip_backup, orchestration_*, adapt_pipeline, doctor_run_health_check, orchestration_smoke, templates_render, templates_runtime, canonical_command_specs, and docs_gen registered  [Issue #500, #562, #663, #665, #701, #702, #707, #717]
+│   │   ├── mod.rs                         # Module declarations; shared helpers: make_pool(), make_pool_with_worktree(), make_session(), make_session_with_issue(), make_gh_issue(); mod milestone_health_wizard, wip_backup, orchestration_*, adapt_pipeline, doctor_run_health_check, orchestration_smoke, templates_render, templates_runtime, canonical_command_specs, docs_gen, and interaction_send_turn registered  [Issue #500, #562, #663, #665, #701, #702, #707, #717, #737]
 │   │   ├── adapt_pipeline.rs              # Integration tests for the adapt pipeline
 │   │   ├── completion_pipeline.rs         # 9 tests: label transitions and PR creation
 │   │   ├── concurrent_sessions.rs         # 6 tests: max_concurrent enforcement
@@ -700,6 +701,7 @@ maestro/
 │   │   ├── templates_runtime.rs           # Integration tests for HTTP-provider runtime template injection; exercises `SessionPool::try_promote` with `RenderedTemplateStore` installed; covers `DirectUser`+`active_command` injection path and no-op paths (origin mismatch, missing store, target_dir set)  [Issue #707]
 │   │   ├── canonical_command_specs.rs     # 15-invariant test suite for canonical command specs; verifies structural integrity of all four commands/ files (front-matter, placeholder coverage, include directives, section headings); 4 insta snapshots via tokenize()  [Issue #702]
 │   │   ├── budget_prespawn_gate.rs        # Integration tests for the pre-spawn budget gate: exercises `try_enter_prespawn_gate` and `resolve_budget_prespawn` helpers; covers allow/deny/skip decision paths  [Issue #850]
+│   │   ├── interaction_send_turn.rs       # 9 integration tests for `InteractionSession::send_turn`; `FakeSpawner` test double; covers happy-path streaming, session_id capture, cancellation, empty-chunk skip, degraded-mode fallback, and error propagation  [Issue #737]
 │   │   └── snapshots/                     # Insta snapshot files for canonical_command_specs tests  [Issue #702]
 │   │       ├── maestro__integration_tests__canonical_command_specs__snapshot_tokenize_implement.snap
 │   │       ├── maestro__integration_tests__canonical_command_specs__snapshot_tokenize_plan_feature.snap
@@ -1088,6 +1090,7 @@ maestro/
 | `src/session/team_runner.rs` | `TeamLauncher` trait + `run_team()` fn; walks `Scheduler::levels()` with a `tokio::sync::Semaphore` capped at `max_parallel`; `TeamOutcome`, `IssueFailure` result types (Issue #881) |
 | `src/session/team_runner_tests.rs` | 5 inline unit tests for `run_team`: happy path, partial failure, semaphore cap, empty levels, single-issue level (Issue #881) |
 | `src/session/interaction.rs` | `InteractionSession`, `InteractionState`, `TurnRole`, `CloseReason`, `TurnRecord` types; scaffold for interactive iteration sessions (Issue #734) |
+| `src/session/interaction_turn.rs` | Per-turn `claude --resume` spawn loop; `SpawnAgent` trait + `ClaudeCliSpawner`, `InteractionSession::send_turn`, `TurnEvent`/`TurnError`/`TurnArgv`/`TurnOutcome`/`TurnHandle`, `build_turn_argv`; session_id capture, streaming, cancellation, degraded mode (Issue #737) |
 | `src/state/` | State persistence and file conflict management |
 | `src/state/file_claims.rs` | Per-session file claim registry |
 | `src/state/progress.rs` | Session phase tracking (Phase 3) |
@@ -1222,7 +1225,8 @@ maestro/
 | `src/tui/snapshot_tests/turboquant_dashboard.rs` | 3 snapshot tests for `TurboQuantDashboard`: projections-only, mixed actual+projections, empty sessions (Issue #346) |
 | `src/tui/snapshot_tests/snapshots/` | Committed `.snap` files — insta ground-truth for TUI rendering regressions; includes 4 agent_graph baselines (`80x24`, `100x30`, `120x40`, original `single_agent_card`) added in Issue #526; the `single_agent_card` snap was retired in Issue #543 in favor of `single_agent_with_files_as_graph` + `falls_back_when_single_agent_has_no_files` (the fallback was narrowed to no-edges only); 2 agent_graph_dispatcher baselines (`toggle_on_renders_graph`, `toggle_off_renders_panels`) added in Issue #527; 11 agent_personalities snapshots added in Issue #539; several existing agent_graph snaps re-baselined in #539 (nodes now render as sprites/abbrevs); 12 activity_log_dispatch snapshots added in Issue #543 (chip renders per role × mode, guard cases, multi-dispatch composition); 2 completion_overlay snapshots added in Issue #560 (`completion_overlay_success_modal_80x24` and `completion_overlay_failed_gates_modal_80x24`); 2 Budget tab parity baselines added in Issue #785 (`budget_tab_renders_80x24`, `budget_tab_renders_120x40`) |
 | `src/integration_tests/` | End-to-end integration test suite; MockGitHubClient and MockWorktreeManager; no external process dependencies (Issue #15) |
-| `src/integration_tests/mod.rs` | Module declarations and shared helpers: `make_pool()`, `make_pool_with_worktree()`, `make_session()`, `make_session_with_issue()`, `make_gh_issue()`; `mod canonical_command_specs` registered in Issue #702; `mod templates_runtime` registered in Issue #707 |
+| `src/integration_tests/mod.rs` | Module declarations and shared helpers: `make_pool()`, `make_pool_with_worktree()`, `make_session()`, `make_session_with_issue()`, `make_gh_issue()`; `mod canonical_command_specs` registered in Issue #702; `mod templates_runtime` registered in Issue #707; `mod interaction_send_turn` registered in Issue #737 |
+| `src/integration_tests/interaction_send_turn.rs` | 9 integration tests for `InteractionSession::send_turn`; `FakeSpawner` test double; covers happy-path streaming, session_id capture, cancellation, empty-chunk skip, degraded-mode fallback, and error propagation (Issue #737) |
 | `src/integration_tests/doctor_run_health_check.rs` | Smoke tests for `run_health_check` library function (Issue #663) |
 | `src/integration_tests/orchestration_dispatch.rs` | End-to-end L1 dispatch tests with `FakeProvider`; exercises `dispatch_subagent()` path (Issue #663) |
 | `src/integration_tests/session_lifecycle.rs` | 11 tests covering enqueue, promote, and complete session lifecycle via `handle_event()` |

--- a/docs/superpowers/spikes/2026-05-29-nvim-diff-viewer.md
+++ b/docs/superpowers/spikes/2026-05-29-nvim-diff-viewer.md
@@ -143,7 +143,7 @@ diff is the default and, for v1, the only base. Keep it simple (CLAUDE.md: simpl
 
 **Last-turn diff** ("what changed since my last message") is genuinely useful in an iteration
 loop but needs per-turn HEAD snapshots wired into #737's turn loop (capture `git rev-parse
-HEAD` on each `Idle` settle). Defer to a fast-follow toggle; do not block v1 on it.
+HEAD` on each `Idle` settle; #737 implemented in `src/session/interaction_turn.rs`). Defer to a fast-follow toggle; do not block v1 on it.
 
 ---
 

--- a/src/integration_tests/interaction_send_turn.rs
+++ b/src/integration_tests/interaction_send_turn.rs
@@ -1,0 +1,398 @@
+//! Integration tests for `InteractionSession::send_turn` (#737). No real
+//! process is spawned — a `FakeSpawner` feeds canned stream-json + exit outcome.
+
+use std::collections::VecDeque;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::sync::CancellationToken;
+
+use crate::session::interaction::{InteractionSession, TurnRole};
+use crate::session::interaction_turn::{
+    SpawnAgent, SpawnError, TurnArgv, TurnEvent, TurnHandle, TurnOutcome,
+};
+
+const SYS_WITH_SESSION_ID: &str =
+    r#"{"type":"system","subtype":"init","session_id":"abc123","tools":[]}"#;
+const SYS_NO_SESSION_ID: &str = r#"{"type":"system","subtype":"init","tools":[]}"#;
+const ASSISTANT_CHUNK_1: &str =
+    r#"{"type":"assistant","message":{"type":"text","text":"Hello, "}}"#;
+const ASSISTANT_CHUNK_2: &str = r#"{"type":"assistant","message":{"type":"text","text":"world."}}"#;
+const RESULT_EVENT: &str =
+    r#"{"type":"result","subtype":"success","cost_usd":0.01,"session_id":"abc123"}"#;
+/// Degraded fixture: neither the system nor the result line carries a
+/// `session_id`, so the turn must fall into degraded re-init mode.
+const RESULT_NO_SESSION_ID: &str = r#"{"type":"result","subtype":"success","cost_usd":0.01}"#;
+
+/// One canned turn: the stdout lines, plus the process exit outcome.
+struct Batch {
+    lines: Vec<&'static str>,
+    outcome: TurnOutcome,
+}
+
+impl Batch {
+    fn ok(lines: Vec<&'static str>) -> Self {
+        Self {
+            lines,
+            outcome: TurnOutcome {
+                exit_code: Some(0),
+                stderr_tail: String::new(),
+            },
+        }
+    }
+
+    fn exit(lines: Vec<&'static str>, code: i32, stderr: &str) -> Self {
+        Self {
+            lines,
+            outcome: TurnOutcome {
+                exit_code: Some(code),
+                stderr_tail: stderr.to_string(),
+            },
+        }
+    }
+}
+
+/// Real fake `SpawnAgent`: pops a `Batch` per spawn, streams its lines into the
+/// channel, then resolves the outcome. Records every argv it was called with.
+struct FakeSpawner {
+    batches: Mutex<VecDeque<Batch>>,
+    calls: Arc<Mutex<Vec<TurnArgv>>>,
+    fail_next: bool,
+}
+
+impl FakeSpawner {
+    fn new(batches: Vec<Batch>) -> Self {
+        Self {
+            batches: Mutex::new(batches.into()),
+            calls: Arc::new(Mutex::new(Vec::new())),
+            fail_next: false,
+        }
+    }
+
+    fn failing() -> Self {
+        let mut s = Self::new(vec![]);
+        s.fail_next = true;
+        s
+    }
+}
+
+#[async_trait::async_trait]
+impl SpawnAgent for FakeSpawner {
+    async fn spawn(
+        &self,
+        argv: TurnArgv,
+        _cancel: CancellationToken,
+    ) -> Result<TurnHandle, SpawnError> {
+        self.calls.lock().unwrap().push(argv);
+        if self.fail_next {
+            return Err(SpawnError::Other("injected failure".into()));
+        }
+        let batch = self
+            .batches
+            .lock()
+            .unwrap()
+            .pop_front()
+            .unwrap_or_else(|| Batch::ok(vec![]));
+
+        let (lines_tx, lines_rx) = mpsc::channel::<String>(64);
+        let (outcome_tx, outcome_rx) = oneshot::channel::<TurnOutcome>();
+
+        tokio::spawn(async move {
+            for line in batch.lines {
+                if lines_tx.send(line.to_string()).await.is_err() {
+                    break;
+                }
+            }
+            drop(lines_tx);
+            let _ = outcome_tx.send(batch.outcome);
+        });
+
+        Ok(TurnHandle {
+            lines: lines_rx,
+            outcome: outcome_rx,
+        })
+    }
+}
+
+fn make_session() -> InteractionSession {
+    InteractionSession::new(1, PathBuf::from("/tmp/wt"), "feat/issue-1".into(), false)
+}
+
+fn drain(rx: &mut mpsc::Receiver<TurnEvent>) -> Vec<TurnEvent> {
+    let mut events = Vec::new();
+    while let Ok(ev) = rx.try_recv() {
+        events.push(ev);
+    }
+    events
+}
+
+#[tokio::test]
+async fn first_turn_argv_has_expected_flags() {
+    let mut session = make_session();
+    let (tx, _rx) = mpsc::channel(32);
+    let spawner = FakeSpawner::new(vec![Batch::ok(vec![SYS_WITH_SESSION_ID, RESULT_EVENT])]);
+
+    session
+        .send_turn(
+            "fix the bug".into(),
+            "claude-opus-4-8",
+            &spawner,
+            tx,
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+    let calls = spawner.calls.lock().unwrap();
+    assert_eq!(calls.len(), 1);
+    let argv = &calls[0].args;
+    assert!(argv.contains(&"--print".to_string()));
+    assert!(argv.contains(&"--verbose".to_string()));
+    assert!(
+        argv.windows(2)
+            .any(|w| w == ["--output-format", "stream-json"])
+    );
+    assert!(argv.windows(2).any(|w| w == ["--model", "claude-opus-4-8"]));
+    assert!(argv.windows(2).any(|w| w == ["-p", "fix the bug"]));
+    assert!(
+        !argv.contains(&"--resume".to_string()),
+        "first turn must not resume"
+    );
+    assert_eq!(calls[0].cwd, PathBuf::from("/tmp/wt"));
+}
+
+#[tokio::test]
+async fn subsequent_turn_argv_includes_resume_with_session_id() {
+    let mut session = make_session();
+    let spawner = FakeSpawner::new(vec![
+        Batch::ok(vec![SYS_WITH_SESSION_ID, RESULT_EVENT]),
+        Batch::ok(vec![SYS_WITH_SESSION_ID, RESULT_EVENT]),
+    ]);
+
+    let (tx1, _r1) = mpsc::channel(32);
+    session
+        .send_turn("p1".into(), "m", &spawner, tx1, CancellationToken::new())
+        .await
+        .unwrap();
+    let (tx2, _r2) = mpsc::channel(32);
+    session
+        .send_turn("p2".into(), "m", &spawner, tx2, CancellationToken::new())
+        .await
+        .unwrap();
+
+    let calls = spawner.calls.lock().unwrap();
+    assert_eq!(calls.len(), 2);
+    let argv2 = &calls[1].args;
+    let pos = argv2
+        .iter()
+        .position(|a| a == "--resume")
+        .expect("second turn must include --resume");
+    assert_eq!(argv2[pos + 1], "abc123");
+    assert!(
+        !argv2.contains(&"--verbose".to_string()),
+        "resume turn drops --verbose"
+    );
+}
+
+#[tokio::test]
+async fn first_system_event_session_id_persisted_in_memory() {
+    let mut session = make_session();
+    assert!(session.session_id.is_none());
+    let (tx, _rx) = mpsc::channel(32);
+    let spawner = FakeSpawner::new(vec![Batch::ok(vec![SYS_WITH_SESSION_ID, RESULT_EVENT])]);
+
+    session
+        .send_turn("p".into(), "m", &spawner, tx, CancellationToken::new())
+        .await
+        .unwrap();
+
+    assert_eq!(session.session_id, Some("abc123".to_string()));
+}
+
+#[tokio::test]
+async fn stream_chunks_flow_through_events_tx_in_order() {
+    let mut session = make_session();
+    let (tx, mut rx) = mpsc::channel(32);
+    let spawner = FakeSpawner::new(vec![Batch::ok(vec![
+        SYS_WITH_SESSION_ID,
+        ASSISTANT_CHUNK_1,
+        ASSISTANT_CHUNK_2,
+        RESULT_EVENT,
+    ])]);
+
+    session
+        .send_turn("p".into(), "m", &spawner, tx, CancellationToken::new())
+        .await
+        .unwrap();
+
+    let events = drain(&mut rx);
+    assert!(matches!(
+        &events[0],
+        TurnEvent::TurnStarted {
+            role: TurnRole::Agent,
+            ..
+        }
+    ));
+    assert!(matches!(&events[1], TurnEvent::Chunk(s) if s == "Hello, "));
+    assert!(matches!(&events[2], TurnEvent::Chunk(s) if s == "world."));
+    assert!(matches!(
+        events.last(),
+        Some(TurnEvent::TurnFinished { .. })
+    ));
+}
+
+#[tokio::test]
+async fn turn_record_finished_at_set_on_result_event() {
+    let mut session = make_session();
+    let (tx, _rx) = mpsc::channel(32);
+    let spawner = FakeSpawner::new(vec![Batch::ok(vec![
+        SYS_WITH_SESSION_ID,
+        ASSISTANT_CHUNK_1,
+        RESULT_EVENT,
+    ])]);
+
+    session
+        .send_turn(
+            "my prompt".into(),
+            "m",
+            &spawner,
+            tx,
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(session.history.len(), 2, "user + agent turns");
+    assert_eq!(session.history[0].role, TurnRole::User);
+    assert_eq!(session.history[0].content, "my prompt");
+    let agent = &session.history[1];
+    assert_eq!(agent.role, TurnRole::Agent);
+    assert!(agent.finished_at.is_some());
+    assert!(agent.content.contains("Hello, "));
+    assert_eq!(
+        session.state,
+        crate::session::interaction::InteractionState::Idle
+    );
+}
+
+#[tokio::test]
+async fn spawn_failure_sends_error_event_no_panic() {
+    let mut session = make_session();
+    let (tx, mut rx) = mpsc::channel(32);
+    let spawner = FakeSpawner::failing();
+
+    let result = session
+        .send_turn("p".into(), "m", &spawner, tx, CancellationToken::new())
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(crate::session::interaction_turn::TurnError::Spawn(_))
+    ));
+    let events = drain(&mut rx);
+    assert!(matches!(events.last(), Some(TurnEvent::Error(_))));
+    assert_eq!(
+        session.state,
+        crate::session::interaction::InteractionState::Idle
+    );
+}
+
+#[tokio::test]
+async fn nonzero_exit_emits_error_event() {
+    let mut session = make_session();
+    let (tx, mut rx) = mpsc::channel(32);
+    let spawner = FakeSpawner::new(vec![Batch::exit(vec![SYS_WITH_SESSION_ID], 2, "boom")]);
+
+    let result = session
+        .send_turn("p".into(), "m", &spawner, tx, CancellationToken::new())
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(crate::session::interaction_turn::TurnError::NonZeroExit { code: Some(2), .. })
+    ));
+    let events = drain(&mut rx);
+    assert!(events.iter().any(
+        |e| matches!(e, TurnEvent::Error(m) if m.contains("agent exit 2") && m.contains("boom"))
+    ));
+    assert_eq!(
+        session.state,
+        crate::session::interaction::InteractionState::Idle
+    );
+}
+
+#[tokio::test]
+async fn cancellation_appends_system_cancel_turn() {
+    let mut session = make_session();
+    let (tx, _rx) = mpsc::channel(32);
+    let cancel = CancellationToken::new();
+    cancel.cancel(); // pre-cancelled
+    let spawner = FakeSpawner::new(vec![Batch::ok(vec![
+        SYS_WITH_SESSION_ID,
+        ASSISTANT_CHUNK_1,
+    ])]);
+
+    let result = session
+        .send_turn("p".into(), "m", &spawner, tx, cancel)
+        .await;
+
+    assert!(result.is_ok(), "cancellation is a clean exit");
+    let sys: Vec<_> = session
+        .history
+        .iter()
+        .filter(|t| t.role == TurnRole::System)
+        .collect();
+    assert!(!sys.is_empty(), "a System cancel turn must be appended");
+    assert!(
+        sys.iter()
+            .any(|t| t.content.to_lowercase().contains("cancel"))
+    );
+    assert_eq!(
+        session.state,
+        crate::session::interaction::InteractionState::Idle
+    );
+}
+
+#[tokio::test]
+async fn degraded_no_session_id_warns_and_next_turn_is_first_turn() {
+    let mut session = make_session();
+    let spawner = FakeSpawner::new(vec![
+        Batch::ok(vec![
+            SYS_NO_SESSION_ID,
+            ASSISTANT_CHUNK_1,
+            RESULT_NO_SESSION_ID,
+        ]),
+        Batch::ok(vec![SYS_NO_SESSION_ID, RESULT_NO_SESSION_ID]),
+    ]);
+
+    let (tx1, _r1) = mpsc::channel(32);
+    session
+        .send_turn("p1".into(), "m", &spawner, tx1, CancellationToken::new())
+        .await
+        .unwrap();
+
+    assert!(session.session_id.is_none(), "degraded: no session_id");
+    let sys: Vec<_> = session
+        .history
+        .iter()
+        .filter(|t| t.role == TurnRole::System)
+        .collect();
+    assert!(
+        sys.iter().any(|t| t.content.contains("session_id")),
+        "degraded warning System turn must mention session_id"
+    );
+
+    let (tx2, _r2) = mpsc::channel(32);
+    session
+        .send_turn("p2".into(), "m", &spawner, tx2, CancellationToken::new())
+        .await
+        .unwrap();
+
+    let calls = spawner.calls.lock().unwrap();
+    assert_eq!(calls.len(), 2);
+    assert!(
+        !calls[1].args.contains(&"--resume".to_string()),
+        "degraded: turn 2 is a fresh first turn"
+    );
+}

--- a/src/integration_tests/mod.rs
+++ b/src/integration_tests/mod.rs
@@ -22,6 +22,8 @@ mod gate_failure_retention;
 #[cfg(test)]
 mod init;
 #[cfg(test)]
+mod interaction_send_turn;
+#[cfg(test)]
 mod milestone_health_wizard;
 #[cfg(test)]
 mod orchestration_dispatch;

--- a/src/session/interaction_turn.rs
+++ b/src/session/interaction_turn.rs
@@ -1,0 +1,382 @@
+//! Per-turn `claude --resume` spawn loop for interactive sessions (#737).
+//!
+//! Each call to [`InteractionSession::send_turn`] spawns a fresh `claude`
+//! process that resumes Claude CLI's persisted transcript. The spawn is hidden
+//! behind the [`SpawnAgent`] trait so tests feed canned stream-json without a
+//! real process; #751 will reimplement `SpawnAgent` on the `ClaudeTransport`
+//! seam (from #748) without touching `send_turn`.
+//!
+//! Persistence is the caller's job: `send_turn` mutates `self` (history,
+//! `session_id`, `state`) and returns; the owner of `MaestroState` persists via
+//! `StateStore`. This keeps `send_turn` pure/unit-testable (RUST-GUARDRAILS §7)
+//! and respects that the session does not own the state file.
+
+use std::path::PathBuf;
+use std::process::Stdio;
+
+use chrono::Utc;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::sync::CancellationToken;
+
+use super::interaction::{InteractionSession, InteractionState, TurnRecord, TurnRole};
+use super::parser::{extract_session_id, parse_stream_line};
+use super::types::StreamEvent;
+
+/// How many bytes of child stderr to retain for error reporting.
+const STDERR_TAIL_CAP: usize = 2_000;
+/// Bounded capacity for the per-turn stdout line channel.
+const LINE_CHANNEL_CAP: usize = 64;
+
+/// Args + working directory for one spawned turn. Built by
+/// [`InteractionSession::build_turn_argv`]; consumed by [`SpawnAgent::spawn`].
+/// The program name is owned by the spawner (e.g. [`ClaudeCliSpawner::binary`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnArgv {
+    pub args: Vec<String>,
+    pub cwd: PathBuf,
+}
+
+/// Terminal summary of a spawned turn: process exit code + a capped stderr tail.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TurnOutcome {
+    pub exit_code: Option<i32>,
+    pub stderr_tail: String,
+}
+
+/// Live handle to a spawned turn: a bounded stream of stdout lines and a
+/// one-shot that resolves once the process exits.
+pub struct TurnHandle {
+    pub lines: mpsc::Receiver<String>,
+    pub outcome: oneshot::Receiver<TurnOutcome>,
+}
+
+/// Failure to launch the agent process.
+#[derive(Debug, thiserror::Error)]
+pub enum SpawnError {
+    #[error("spawn failed: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("spawn failed: {0}")]
+    Other(String),
+}
+
+/// Error returned by [`InteractionSession::send_turn`]. Cancellation is NOT an
+/// error — it returns `Ok(())` after appending a `System` marker turn.
+#[derive(Debug, thiserror::Error)]
+pub enum TurnError {
+    /// The agent process failed to launch.
+    #[error("failed to spawn claude: {0}")]
+    Spawn(#[from] SpawnError),
+    /// The agent process exited non-zero.
+    #[error("agent exit {code:?}: {stderr_tail}")]
+    NonZeroExit {
+        code: Option<i32>,
+        stderr_tail: String,
+    },
+}
+
+/// Streaming events emitted to the caller (TUI screen, #738) as a turn runs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TurnEvent {
+    TurnStarted {
+        role: TurnRole,
+        at: chrono::DateTime<Utc>,
+    },
+    Chunk(String),
+    TurnFinished {
+        at: chrono::DateTime<Utc>,
+    },
+    Error(String),
+}
+
+/// Spawns one agent turn. Mockable so tests inject canned stream-json. The
+/// production impl is [`ClaudeCliSpawner`]; #751 implements this on the
+/// `ClaudeTransport` seam instead.
+#[async_trait::async_trait]
+pub trait SpawnAgent: Send + Sync {
+    async fn spawn(
+        &self,
+        argv: TurnArgv,
+        cancel: CancellationToken,
+    ) -> Result<TurnHandle, SpawnError>;
+}
+
+/// Production [`SpawnAgent`]: launches the real `claude` CLI via
+/// `tokio::process`. Mirrors the headless subprocess lifecycle
+/// (RUST-GUARDRAILS §5): explicit pipes, background line readers,
+/// `tokio::select!` cancel arm with `child.kill().await`.
+pub struct ClaudeCliSpawner {
+    binary: String,
+}
+
+impl ClaudeCliSpawner {
+    pub fn new(binary: impl Into<String>) -> Self {
+        Self {
+            binary: binary.into(),
+        }
+    }
+}
+
+impl Default for ClaudeCliSpawner {
+    fn default() -> Self {
+        Self::new("claude")
+    }
+}
+
+#[async_trait::async_trait]
+impl SpawnAgent for ClaudeCliSpawner {
+    async fn spawn(
+        &self,
+        argv: TurnArgv,
+        cancel: CancellationToken,
+    ) -> Result<TurnHandle, SpawnError> {
+        let mut cmd = Command::new(&self.binary);
+        cmd.args(&argv.args)
+            .current_dir(&argv.cwd)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let mut child = cmd.spawn().map_err(SpawnError::Io)?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| SpawnError::Other("no stdout from claude CLI".to_string()))?;
+        let stderr = child.stderr.take();
+
+        let (lines_tx, lines_rx) = mpsc::channel::<String>(LINE_CHANNEL_CAP);
+        let (outcome_tx, outcome_rx) = oneshot::channel::<TurnOutcome>();
+
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(stdout).lines();
+            let stderr_handle = stderr.map(|s| {
+                tokio::spawn(async move {
+                    let mut buf = String::new();
+                    let mut lines = BufReader::new(s).lines();
+                    while let Ok(Some(line)) = lines.next_line().await {
+                        if !buf.is_empty() {
+                            buf.push('\n');
+                        }
+                        buf.push_str(&line);
+                        if buf.len() > STDERR_TAIL_CAP {
+                            let start = buf.len() - STDERR_TAIL_CAP;
+                            buf = buf.split_off(start);
+                        }
+                    }
+                    buf
+                })
+            });
+
+            loop {
+                tokio::select! {
+                    _ = cancel.cancelled() => {
+                        let _ = child.kill().await;
+                        break;
+                    }
+                    next = reader.next_line() => match next {
+                        Ok(Some(line)) => {
+                            if lines_tx.send(line).await.is_err() {
+                                // Receiver dropped — stop reading, kill child.
+                                let _ = child.kill().await;
+                                break;
+                            }
+                        }
+                        _ => break,
+                    },
+                }
+            }
+
+            let status = child.wait().await.ok();
+            let stderr_tail = match stderr_handle {
+                Some(h) => h.await.unwrap_or_default(),
+                None => String::new(),
+            };
+            let _ = outcome_tx.send(TurnOutcome {
+                exit_code: status.and_then(|s| s.code()),
+                stderr_tail,
+            });
+        });
+
+        Ok(TurnHandle {
+            lines: lines_rx,
+            outcome: outcome_rx,
+        })
+    }
+}
+
+impl InteractionSession {
+    /// Build the argv for one turn. First turn (no `session_id`) starts a fresh
+    /// transcript; subsequent turns resume via `--resume <id>`.
+    pub fn build_turn_argv(&self, prompt: &str, model: &str) -> TurnArgv {
+        let args = match self.session_id.as_deref() {
+            None => vec![
+                "--print".to_string(),
+                "--verbose".to_string(),
+                "--output-format".to_string(),
+                "stream-json".to_string(),
+                "--model".to_string(),
+                model.to_string(),
+                "-p".to_string(),
+                prompt.to_string(),
+            ],
+            Some(id) => vec![
+                "--resume".to_string(),
+                id.to_string(),
+                "--print".to_string(),
+                "--output-format".to_string(),
+                "stream-json".to_string(),
+                "-p".to_string(),
+                prompt.to_string(),
+            ],
+        };
+        TurnArgv {
+            args,
+            cwd: self.worktree_path.clone(),
+        }
+    }
+
+    /// Run one conversational turn: spawn `claude`, stream chunks through
+    /// `events_tx`, capture `session_id`, and append the turn to `history`.
+    ///
+    /// Mutates `self` (history, `session_id`, `state`) in place; the caller
+    /// persists via `StateStore`. Cancellation is a clean `Ok(())` after a
+    /// `System` marker turn. Stream parse errors are logged and skipped, never
+    /// fatal.
+    pub async fn send_turn(
+        &mut self,
+        prompt: String,
+        model: &str,
+        spawner: &dyn SpawnAgent,
+        events_tx: mpsc::Sender<TurnEvent>,
+        cancel: CancellationToken,
+    ) -> Result<(), TurnError> {
+        // argv is keyed on the *current* session_id, before this turn captures
+        // a new one — build it first.
+        let argv = self.build_turn_argv(&prompt, model);
+
+        let user_at = Utc::now();
+        self.history.push(TurnRecord {
+            role: TurnRole::User,
+            content: prompt,
+            started_at: user_at,
+            finished_at: Some(user_at),
+        });
+        self.state = InteractionState::Streaming;
+
+        let mut handle = match spawner.spawn(argv, cancel.clone()).await {
+            Ok(handle) => handle,
+            Err(err) => {
+                let _ = events_tx
+                    .send(TurnEvent::Error(format!("failed to spawn claude: {err}")))
+                    .await;
+                self.state = InteractionState::Idle;
+                return Err(TurnError::Spawn(err));
+            }
+        };
+
+        let started_at = Utc::now();
+        let _ = events_tx
+            .send(TurnEvent::TurnStarted {
+                role: TurnRole::Agent,
+                at: started_at,
+            })
+            .await;
+        let agent_idx = self.history.len();
+        self.history.push(TurnRecord {
+            role: TurnRole::Agent,
+            content: String::new(),
+            started_at,
+            finished_at: None,
+        });
+
+        let mut cancelled = false;
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => {
+                    cancelled = true;
+                    break;
+                }
+                line = handle.lines.recv() => match line {
+                    Some(line) => self.apply_line(&line, agent_idx, &events_tx).await,
+                    None => break,
+                },
+            }
+        }
+
+        let finished_at = Utc::now();
+        self.history[agent_idx].finished_at = Some(finished_at);
+        self.state = InteractionState::Idle;
+
+        if cancelled {
+            self.push_system("turn cancelled by user", finished_at);
+            let _ = events_tx
+                .send(TurnEvent::Error("turn cancelled by user".to_string()))
+                .await;
+            return Ok(());
+        }
+
+        if let Ok(outcome) = handle.outcome.await
+            && let Some(code) = outcome.exit_code
+            && code != 0
+        {
+            let msg = format!("agent exit {code}: {}", outcome.stderr_tail);
+            let _ = events_tx.send(TurnEvent::Error(msg)).await;
+            self.push_system(&format!("agent exit {code}"), finished_at);
+            return Err(TurnError::NonZeroExit {
+                code: Some(code),
+                stderr_tail: outcome.stderr_tail,
+            });
+        }
+
+        // Degraded mode: a successful turn that never yielded a session_id.
+        // The next turn re-inits (build_turn_argv stays on the first-turn arm).
+        if self.session_id.is_none() {
+            self.push_system(
+                "could not bind session_id; subsequent turns will re-init context",
+                finished_at,
+            );
+        }
+
+        let _ = events_tx
+            .send(TurnEvent::TurnFinished { at: finished_at })
+            .await;
+        Ok(())
+    }
+
+    /// Apply one stdout line: capture `session_id` (first one wins), forward
+    /// assistant text as a `Chunk`, log-and-skip unparseable lines.
+    async fn apply_line(
+        &mut self,
+        line: &str,
+        agent_idx: usize,
+        events_tx: &mpsc::Sender<TurnEvent>,
+    ) {
+        if self.session_id.is_none()
+            && let Some(id) = extract_session_id(line)
+        {
+            self.session_id = Some(id);
+        }
+        for event in parse_stream_line(line) {
+            match event {
+                StreamEvent::AssistantMessage { text } => {
+                    self.history[agent_idx].content.push_str(&text);
+                    let _ = events_tx.send(TurnEvent::Chunk(text)).await;
+                }
+                StreamEvent::Unknown { raw } => {
+                    tracing::warn!(line = %raw, "interaction: unparsed stream-json line; skipping");
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn push_system(&mut self, content: &str, at: chrono::DateTime<Utc>) {
+        self.history.push(TurnRecord {
+            role: TurnRole::System,
+            content: content.to_string(),
+            started_at: at,
+            finished_at: Some(at),
+        });
+    }
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -5,6 +5,7 @@ pub mod health;
 pub mod image;
 pub mod intent;
 pub mod interaction;
+pub mod interaction_turn;
 pub mod logger;
 pub mod manager;
 pub mod parser;

--- a/src/session/parser.rs
+++ b/src/session/parser.rs
@@ -140,6 +140,30 @@ pub fn parse_stream_line(line: &str) -> Vec<StreamEvent> {
     events
 }
 
+/// Extract the Claude session id from a stream-json line, if present.
+///
+/// Claude CLI emits the id on the `system`/init line
+/// (`{"type":"system","subtype":"init","session_id":"…"}`) and repeats it on
+/// the terminal `result` line. Both carry `session_id` as a top-level field, so
+/// this reads that key regardless of event type. Returns `None` for non-JSON
+/// lines or lines without the field. Used by the interaction spawn loop (#737)
+/// to bind `--resume <id>` on subsequent turns.
+pub fn extract_session_id(line: &str) -> Option<String> {
+    let v = serde_json::from_str::<Value>(line.trim()).ok()?;
+    let id = v.get("session_id")?.as_str()?;
+    // Defense-in-depth: the id is reused verbatim as a `--resume <id>` argv
+    // operand, so reject anything outside the UUID charset. A rejected id just
+    // falls through to degraded re-init mode rather than into an argv.
+    if id.is_empty()
+        || !id
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+    {
+        return None;
+    }
+    Some(id.to_string())
+}
+
 fn parse_assistant_event(v: &Value) -> StreamEvent {
     let msg = v.get("message").or_else(|| v.get("content_block"));
 
@@ -684,6 +708,49 @@ mod tests {
     fn parse_garbage() {
         let events = parse_stream_line("not json at all");
         assert!(matches!(events[0], StreamEvent::Unknown { .. }));
+    }
+
+    // --- Issue #737: session_id extraction for the resume spawn loop ---
+
+    #[test]
+    fn extract_session_id_from_system_init_line() {
+        let line = r#"{"type":"system","subtype":"init","session_id":"abc123","tools":[]}"#;
+        assert_eq!(extract_session_id(line), Some("abc123".to_string()));
+    }
+
+    #[test]
+    fn extract_session_id_from_result_line() {
+        let line = r#"{"type":"result","subtype":"success","session_id":"xyz789","cost_usd":0.01}"#;
+        assert_eq!(extract_session_id(line), Some("xyz789".to_string()));
+    }
+
+    #[test]
+    fn extract_session_id_absent_returns_none() {
+        let line = r#"{"type":"system","tools":[]}"#;
+        assert_eq!(extract_session_id(line), None);
+    }
+
+    #[test]
+    fn extract_session_id_empty_string_returns_none() {
+        let line = r#"{"type":"system","session_id":""}"#;
+        assert_eq!(extract_session_id(line), None);
+    }
+
+    #[test]
+    fn extract_session_id_non_json_returns_none() {
+        assert_eq!(extract_session_id("not json"), None);
+    }
+
+    #[test]
+    fn extract_session_id_rejects_non_uuid_charset() {
+        // A flag-like or path-like value must not survive into the argv.
+        let line = r#"{"type":"system","session_id":"--foo /etc/passwd"}"#;
+        assert_eq!(extract_session_id(line), None);
+        let uuid = r#"{"type":"system","session_id":"a1b2c3d4-5678-90ab-cdef-1234567890ab"}"#;
+        assert_eq!(
+            extract_session_id(uuid),
+            Some("a1b2c3d4-5678-90ab-cdef-1234567890ab".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #737.

## What

`InteractionSession::send_turn` — a per-turn spawn of the `claude` CLI that resumes Claude's persisted transcript.

- **First turn:** `claude --print --verbose --output-format stream-json --model <m> -p <prompt>`
- **Subsequent turns:** `claude --resume <session_id> --print --output-format stream-json -p <prompt>`
- cwd = `worktree_path`.

## New: `src/session/interaction_turn.rs`

- `SpawnAgent` trait (mockable seam) + `ClaudeCliSpawner` production impl over `tokio::process` — bounded line channel (cap 64), stderr-tail cap (2000 B), child kill on cancel and on receiver-drop (RUST-GUARDRAILS §5).
- `send_turn`: appends User + Agent turns, streams assistant text as `TurnEvent::Chunk` through a bounded `mpsc`, captures `session_id`, sets `finished_at` + `Idle` on `result`/exit. Cancellation = clean `Ok` with a `System` marker turn. Degraded mode (no `session_id`) appends a warning turn; the next turn re-inits.
- `TurnEvent` / `TurnError` (thiserror), `TurnArgv` / `TurnOutcome` / `TurnHandle`.

## `parser.rs`: `extract_session_id`

Reads the top-level `session_id` from the `system`/init and `result` lines (both carry it per the existing stream-json contract). A UUID-charset guard (`[A-Za-z0-9_-]`) ensures an untrusted value can never become a `--resume` flag — defense-in-depth on the untrusted-stdout → argv path. A rejected value falls to safe degraded mode.

## Design decisions (flagged for veto)

- **Persistence is caller-owned.** `send_turn` mutates `self` (history, `session_id`, `state`); the `MaestroState` owner persists via `StateStore`. Keeps `send_turn` pure/unit-testable and leaves the #751 `ClaudeTransport` retrofit clean. AC#3 ("persist into session_store.json") is therefore satisfied **in-memory** here; the disk write is the caller layer.
- **`TurnRole`, not `Role`.** The issue's `TurnEvent` used `Role`; the real scaffold type (#734) is `TurnRole` — mapped accordingly.
- **`model` is a `send_turn` param,** not a new persisted field on `InteractionSession` (keeps the serde surface minimal).
- **Engine-only scope.** The Interaction-screen wiring is **#738** (depends on #736 + #737), so this PR ships the spawn engine + a `FakeSpawner`-backed integration suite — **no `src/tui/**` changes**. The architect's "split TUI wiring" recommendation is already represented by #738; no new follow-up filed.
- **No `docs/api-contracts/` schema added** for the stream-json `session_id` — the shape is already documented in `parse_stream_line`'s doc and exercised by the parser tests; a separate contract file would be scope creep.

## Tests

9 integration tests (`src/integration_tests/interaction_send_turn.rs`): per-turn argv shape, `--resume` on turn 2, `session_id` capture, chunk ordering, `finished_at`, spawn failure, non-zero exit, cancellation, degraded mode. 6 parser unit tests for `extract_session_id` (incl. charset rejection). Full suite green, `clippy -D warnings` clean, both new files ≤ 400 LOC.

## Security

Reviewed: no shell / no interpolation (args are a `Vec`), `session_id` charset-guarded before argv reuse, no new production `unwrap`/`expect`/`panic`, bounded channel + child-kill + capped stderr, env inheritance unchanged (does not pre-empt the #749 `ANTHROPIC_API_KEY` scrub).
