### PR TITLE
feat(session): terminate interaction session when its linked PR is detected

### DIFF
--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-05-30 21:00 (UTC)
+> Last updated: 2026-06-01 00:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -412,7 +412,9 @@ maestro/
 │   │   ├── role.rs                        # Role enum (5 variants: Orchestrator, Implementer, Reviewer, QA, Unknown) + derive_role() keyword classifier; Session::role field (O(1) lookup at render time)  [Issue #538]
 │   │   ├── team_runner.rs                 # `TeamLauncher` trait + `run_team()` fn; walks `Scheduler` levels with a `tokio::sync::Semaphore` capped at `max_parallel`; `TeamOutcome`, `IssueFailure` result types  [Issue #881]
 │   │   ├── team_runner_tests.rs           # 5 inline unit tests for `run_team`: happy path, partial failure, semaphore cap, empty levels, single-issue level  [Issue #881]
-│   │   ├── interaction.rs                 # `InteractionSession`, `InteractionState`, `TurnRole`, `CloseReason`, `TurnRecord` types; `new()` / `is_active()` constructors; scaffold for interactive iteration sessions  [Issue #734]
+│   │   ├── interaction.rs                 # `InteractionSession`, `InteractionState`, `TurnRole`, `CloseReason`, `TurnRecord` types; `new()` / `is_active()` constructors; `queued_terminator` field; `signal_terminator()` / `fire_terminator()` state-machine methods; scaffold for interactive iteration sessions  [Issue #734, #739]
+│   │   ├── interaction_lifecycle.rs       # `InteractionLifecycleEvent` enum: `PrLinkedToIssue` (emitted when a PR marker terminates an active interaction), `WorktreeWiped` (scaffold for #740), `SessionClosed` (scaffold for #741)  [Issue #739]
+│   │   ├── interaction_tests.rs           # Unit tests for `interaction.rs` extracted to sibling file via `#[path]` to stay under the 400-LOC cap; covers terminator state machine and Idle-path wiring  [Issue #739]
 │   │   └── interaction_turn.rs            # Per-turn `claude --resume` spawn loop: `SpawnAgent` trait + `ClaudeCliSpawner` (production), `InteractionSession::send_turn`, `TurnEvent` / `TurnError` / `TurnArgv` / `TurnOutcome` / `TurnHandle`, `build_turn_argv`; session_id capture from first result line, streaming chunks, cancellation via `TurnHandle::cancel()`, degraded mode  [Issue #737]
 │   ├── state/
 │   │   ├── mod.rs                         # Module exports (includes file_claims, progress)
@@ -455,7 +457,7 @@ maestro/
 │   │   │   ├── issue_completion_tests.rs  # Unit tests for issue_completion.rs (original 3 tests preserved; new auto-PR behavior tests moved to auto_pr_tests.rs)  [Issue #514]
 │   │   │   ├── plugins.rs                 # Hook point invocation via PluginRunner
 │   │   │   ├── pr_retry.rs                # process_pending_pr_retries() exponential back-off; trigger_manual_pr_retry(); transition_to_permanently_failed() extracted helper  [Issue #159, #545]
-│   │   │   ├── pushup_marker.rs           # PushupMarker: polls ~/.maestro/last-pr-created; parses via PrMarker::read (src/work/pr_marker.rs) — tolerates legacy markers that lack issue_number; consumed-once — maestro deletes after dispatch  [Issue #545, #735]
+│   │   │   ├── pushup_marker.rs           # PushupMarker: polls ~/.maestro/last-pr-created; parses via PrMarker::read (src/work/pr_marker.rs) — tolerates legacy markers that lack issue_number; consumed-once — maestro deletes after dispatch; `poll_last_pr_created_marker` now terminates a matching active interaction session (emits `PrLinkedToIssue`) before enqueuing the existing `PrCreated` event  [Issue #545, #735, #739]
 │   │   │   ├── review.rs                  # ReviewCouncil integration and gate-fix session spawning
 │   │   │   ├── session_lifecycle.rs       # Session promotion, state transitions, activity log forwarding
 │   │   │   ├── session_spawners.rs        # spawn_gate_fix_session(); build_gate_fix_prompt(); launch_session_from_config(); spawn_resume_implement_session(line) spawns a /implement #N --continue session against the retained worktree  [Issue #560, #695]
@@ -687,7 +689,7 @@ maestro/
 │   │       ├── text_input.rs              # Single-line text input widget with cursor support
 │   │       └── toggle.rs                 # Boolean toggle widget for settings and forms; draw() routes through icons::get(IconId::CheckboxOn/Off) instead of hardcoded literals, eliminating the DRY drift that caused blank indicators on iTerm2 + some Nerd Font installs  [Issue #433]
 │   ├── integration_tests/                 # End-to-end integration test suite (no external deps, all mocked)  [Issue #15]
-│   │   ├── mod.rs                         # Module declarations; shared helpers: make_pool(), make_pool_with_worktree(), make_session(), make_session_with_issue(), make_gh_issue(); mod milestone_health_wizard, wip_backup, orchestration_*, adapt_pipeline, doctor_run_health_check, orchestration_smoke, templates_render, templates_runtime, canonical_command_specs, docs_gen, interaction_send_turn, and interaction_turn_live registered  [Issue #500, #562, #663, #665, #701, #702, #707, #717, #737, #738]
+│   │   ├── mod.rs                         # Module declarations; shared helpers: make_pool(), make_pool_with_worktree(), make_session(), make_session_with_issue(), make_gh_issue(); mod milestone_health_wizard, wip_backup, orchestration_*, adapt_pipeline, doctor_run_health_check, orchestration_smoke, templates_render, templates_runtime, canonical_command_specs, docs_gen, interaction_send_turn, interaction_turn_live, and interaction_terminator registered  [Issue #500, #562, #663, #665, #701, #702, #707, #717, #737, #738, #739]
 │   │   ├── adapt_pipeline.rs              # Integration tests for the adapt pipeline
 │   │   ├── completion_pipeline.rs         # 9 tests: label transitions and PR creation
 │   │   ├── concurrent_sessions.rs         # 6 tests: max_concurrent enforcement
@@ -711,6 +713,7 @@ maestro/
 │   │   ├── budget_prespawn_gate.rs        # Integration tests for the pre-spawn budget gate: exercises `try_enter_prespawn_gate` and `resolve_budget_prespawn` helpers; covers allow/deny/skip decision paths  [Issue #850]
 │   │   ├── interaction_send_turn.rs       # 9 integration tests for `InteractionSession::send_turn`; `FakeSpawner` test double; covers happy-path streaming, session_id capture, cancellation, empty-chunk skip, degraded-mode fallback, and error propagation  [Issue #737]
 │   │   ├── interaction_turn_live.rs       # End-to-end integration tests for the live turn execution path: screen dispatch → command pump → `send_turn` → `TurnEvent` stream → `data_handler` screen update  [Issue #738]
+│   │   ├── interaction_terminator.rs      # Integration tests for the `signal_terminator` / `fire_terminator` state machine and the `PrLinkedToIssue` emit path wired through `poll_last_pr_created_marker`  [Issue #739]
 │   │   └── snapshots/                     # Insta snapshot files for canonical_command_specs tests  [Issue #702]
 │   │       ├── maestro__integration_tests__canonical_command_specs__snapshot_tokenize_implement.snap
 │   │       ├── maestro__integration_tests__canonical_command_specs__snapshot_tokenize_plan_feature.snap
@@ -1089,7 +1092,7 @@ maestro/
 | `src/session/` | Claude CLI process and session lifecycle management |
 | `src/session/health.rs` | Stall detection and HealthCheck trait (Phase 3) |
 | `src/session/retry.rs` | Configurable retry policy; `hollow: HollowRetryConfig` field; `effective_max()` dispatches by policy + session intent (Phase 3, Issue #275) |
-| `src/session/pool.rs` | Concurrent session pool with queue and auto-promote; guardrail_prompt merged into system prompt; `find_by_issue_mut()`; `create_interaction_session`, `clone_active_interaction`, `upsert_interaction` (with terminated-resurrection guard) (Issue #40, #43, #738) |
+| `src/session/pool.rs` | Concurrent session pool with queue and auto-promote; guardrail_prompt merged into system prompt; `find_by_issue_mut()`; `create_interaction_session`, `clone_active_interaction`, `upsert_interaction` (with terminated-resurrection guard); `find_active_interaction_by_issue_mut()`; `#[cfg(test)] interaction_close_reason` accessor (Issue #40, #43, #738, #739) |
 | `src/session/worktree.rs` | Git worktree isolation per session |
 | `src/session/cleanup.rs` | Orphaned worktree detection and removal (Phase 3) |
 | `src/session/logger.rs` | Per-session file logging to .maestro/logs/ (Phase 3) |
@@ -1098,7 +1101,9 @@ maestro/
 | `src/session/role.rs` | Role enum (5 variants) + derive_role() keyword classifier; Session::role field for O(1) render-time lookup (Issue #538); `role_for_subagent_name()` lookup mapping the 7-entry maestro subagent registry to Roles; `#[allow(dead_code)]` on `ToolMeta::subagent_name` and `role_for_subagent_name` removed now that both are consumed by the activity-log chip renderer (Issues #542, #543) |
 | `src/session/team_runner.rs` | `TeamLauncher` trait + `run_team()` fn; walks `Scheduler::levels()` with a `tokio::sync::Semaphore` capped at `max_parallel`; `TeamOutcome`, `IssueFailure` result types (Issue #881) |
 | `src/session/team_runner_tests.rs` | 5 inline unit tests for `run_team`: happy path, partial failure, semaphore cap, empty levels, single-issue level (Issue #881) |
-| `src/session/interaction.rs` | `InteractionSession`, `InteractionState`, `TurnRole`, `CloseReason`, `TurnRecord` types; scaffold for interactive iteration sessions (Issue #734) |
+| `src/session/interaction.rs` | `InteractionSession`, `InteractionState`, `TurnRole`, `CloseReason`, `TurnRecord` types; `queued_terminator` field; `signal_terminator()` / `fire_terminator()` state-machine methods; scaffold for interactive iteration sessions (Issue #734, #739) |
+| `src/session/interaction_lifecycle.rs` | `InteractionLifecycleEvent` enum: `PrLinkedToIssue` (emitted when a PR marker terminates an active interaction), `WorktreeWiped` (scaffold for #740), `SessionClosed` (scaffold for #741) (Issue #739) |
+| `src/session/interaction_tests.rs` | Unit tests for `interaction.rs` extracted via `#[path]` to stay under the 400-LOC cap; covers terminator state machine and Idle-path wiring (Issue #739) |
 | `src/session/interaction_turn.rs` | Per-turn `claude --resume` spawn loop; `SpawnAgent` trait + `ClaudeCliSpawner`, `InteractionSession::send_turn`, `TurnEvent`/`TurnError`/`TurnArgv`/`TurnOutcome`/`TurnHandle`, `build_turn_argv`; session_id capture, streaming, cancellation, degraded mode (Issue #737) |
 | `src/state/` | State persistence and file conflict management |
 | `src/state/file_claims.rs` | Per-session file claim registry |
@@ -1241,9 +1246,10 @@ maestro/
 | `src/tui/snapshot_tests/turboquant_dashboard.rs` | 3 snapshot tests for `TurboQuantDashboard`: projections-only, mixed actual+projections, empty sessions (Issue #346) |
 | `src/tui/snapshot_tests/snapshots/` | Committed `.snap` files — insta ground-truth for TUI rendering regressions; includes 4 agent_graph baselines (`80x24`, `100x30`, `120x40`, original `single_agent_card`) added in Issue #526; the `single_agent_card` snap was retired in Issue #543 in favor of `single_agent_with_files_as_graph` + `falls_back_when_single_agent_has_no_files` (the fallback was narrowed to no-edges only); 2 agent_graph_dispatcher baselines (`toggle_on_renders_graph`, `toggle_off_renders_panels`) added in Issue #527; 11 agent_personalities snapshots added in Issue #539; several existing agent_graph snaps re-baselined in #539 (nodes now render as sprites/abbrevs); 12 activity_log_dispatch snapshots added in Issue #543 (chip renders per role × mode, guard cases, multi-dispatch composition); 2 completion_overlay snapshots added in Issue #560 (`completion_overlay_success_modal_80x24` and `completion_overlay_failed_gates_modal_80x24`); 2 Budget tab parity baselines added in Issue #785 (`budget_tab_renders_80x24`, `budget_tab_renders_120x40`) |
 | `src/integration_tests/` | End-to-end integration test suite; MockGitHubClient and MockWorktreeManager; no external process dependencies (Issue #15) |
-| `src/integration_tests/mod.rs` | Module declarations and shared helpers: `make_pool()`, `make_pool_with_worktree()`, `make_session()`, `make_session_with_issue()`, `make_gh_issue()`; `mod canonical_command_specs` registered in Issue #702; `mod templates_runtime` registered in Issue #707; `mod interaction_send_turn` registered in Issue #737; `mod interaction_turn_live` registered in Issue #738 |
+| `src/integration_tests/mod.rs` | Module declarations and shared helpers: `make_pool()`, `make_pool_with_worktree()`, `make_session()`, `make_session_with_issue()`, `make_gh_issue()`; `mod canonical_command_specs` registered in Issue #702; `mod templates_runtime` registered in Issue #707; `mod interaction_send_turn` registered in Issue #737; `mod interaction_turn_live` registered in Issue #738; `mod interaction_terminator` registered in Issue #739 |
 | `src/integration_tests/interaction_send_turn.rs` | 9 integration tests for `InteractionSession::send_turn`; `FakeSpawner` test double; covers happy-path streaming, session_id capture, cancellation, empty-chunk skip, degraded-mode fallback, and error propagation (Issue #737) |
 | `src/integration_tests/interaction_turn_live.rs` | End-to-end integration tests for the live turn execution path: screen dispatch → command pump → `send_turn` → `TurnEvent` stream → `data_handler` screen update (Issue #738) |
+| `src/integration_tests/interaction_terminator.rs` | Integration tests for the `signal_terminator` / `fire_terminator` state machine and the `PrLinkedToIssue` emit path wired through `poll_last_pr_created_marker` (Issue #739) |
 | `src/integration_tests/doctor_run_health_check.rs` | Smoke tests for `run_health_check` library function (Issue #663) |
 | `src/integration_tests/orchestration_dispatch.rs` | End-to-end L1 dispatch tests with `FakeProvider`; exercises `dispatch_subagent()` path (Issue #663) |
 | `src/integration_tests/session_lifecycle.rs` | 11 tests covering enqueue, promote, and complete session lifecycle via `handle_event()` |

--- a/src/integration_tests/interaction_terminator.rs
+++ b/src/integration_tests/interaction_terminator.rs
@@ -1,0 +1,123 @@
+//! Integration tests for #739 — InteractionLifecycleEvent + signal_terminator
+//! wired into `poll_last_pr_created_marker`.
+//!
+//! A `/pushup` marker carrying `issue_number` that matches an active
+//! interaction session must terminate that session AND still enqueue the
+//! existing `PrCreated` command (single read → both events). Legacy markers
+//! (no `issue_number`) take only the `PrCreated` path.
+
+use std::path::{Path, PathBuf};
+
+use crate::session::interaction::{CloseReason, InteractionState};
+use crate::tui::app::types::TuiCommand;
+use crate::work::pr_marker::PrMarker;
+
+fn make_marker_dir(home: &Path) -> PathBuf {
+    let dir = home.join(".maestro");
+    std::fs::create_dir_all(&dir).expect("create .maestro dir");
+    dir.join("last-pr-created")
+}
+
+fn write_marker(path: &Path, pr_number: u64, issue_number: Option<u64>) {
+    let marker = PrMarker {
+        pr_number,
+        owner: "owner".into(),
+        repo: "repo".into(),
+        issue_number,
+        ts: chrono::Utc::now(),
+    };
+    marker.write_atomic(path).expect("write marker");
+}
+
+fn make_app_with_home(home: PathBuf) -> crate::tui::app::App {
+    crate::tui::make_test_app("interaction-terminator").with_home_dir(home)
+}
+
+fn pr_created_queued(app: &crate::tui::app::App, pr_number: u64) -> bool {
+    app.pending_commands
+        .iter()
+        .any(|c| matches!(c, TuiCommand::PrCreated { pr_number: n, .. } if *n == pr_number))
+}
+
+#[tokio::test]
+async fn marker_with_matching_issue_terminates_interaction_and_enqueues_pr_created() {
+    let home = tempfile::tempdir().unwrap();
+    let marker_path = make_marker_dir(home.path());
+    write_marker(&marker_path, 7, Some(42));
+
+    let mut app = make_app_with_home(home.path().to_path_buf());
+    app.pool.create_interaction_session(42, false);
+
+    app.poll_last_pr_created_marker().await;
+
+    // Marker consumed.
+    assert!(!marker_path.exists(), "marker must be deleted");
+
+    // Interaction terminated — no active session remains for issue 42.
+    assert!(
+        app.pool.find_active_interaction_by_issue(42).is_none(),
+        "interaction for issue 42 must be terminated"
+    );
+
+    // close_reason is PrCreated { pr_number: 7 }.
+    let reason = app
+        .pool
+        .interaction_close_reason(42)
+        .expect("close_reason must be set");
+    assert_eq!(*reason, CloseReason::PrCreated { pr_number: 7 });
+
+    // The existing PrCreated path still fires (single read → both events).
+    assert!(
+        pr_created_queued(&app, 7),
+        "TuiCommand::PrCreated must still be enqueued"
+    );
+}
+
+#[tokio::test]
+async fn marker_with_no_matching_active_interaction_still_enqueues_pr_created() {
+    let home = tempfile::tempdir().unwrap();
+    let marker_path = make_marker_dir(home.path());
+    write_marker(&marker_path, 7, Some(42));
+
+    let mut app = make_app_with_home(home.path().to_path_buf());
+    // No interaction seeded for issue 42.
+
+    app.poll_last_pr_created_marker().await;
+
+    assert!(!marker_path.exists(), "marker must be deleted");
+    assert!(
+        pr_created_queued(&app, 7),
+        "PrCreated must still be enqueued when no session matches"
+    );
+}
+
+#[tokio::test]
+async fn legacy_marker_without_issue_number_enqueues_pr_created_only() {
+    let home = tempfile::tempdir().unwrap();
+    let marker_path = make_marker_dir(home.path());
+    // Legacy marker JSON with no issue_number field.
+    std::fs::write(
+        &marker_path,
+        r#"{"pr_number":3,"owner":"owner","repo":"repo","ts":"2026-01-01T00:00:00Z"}"#,
+    )
+    .unwrap();
+
+    let mut app = make_app_with_home(home.path().to_path_buf());
+    // Seed an unrelated interaction — must not be touched.
+    app.pool.create_interaction_session(99, false);
+
+    app.poll_last_pr_created_marker().await;
+
+    assert!(!marker_path.exists(), "marker must be deleted");
+    assert!(
+        pr_created_queued(&app, 3),
+        "PrCreated must be enqueued for legacy marker"
+    );
+
+    // The seeded interaction for issue 99 must remain active and Idle.
+    let still_active = app
+        .pool
+        .find_active_interaction_by_issue(99)
+        .expect("interaction 99 must remain active");
+    assert_eq!(still_active.state, InteractionState::Idle);
+}

--- a/src/integration_tests/mod.rs
+++ b/src/integration_tests/mod.rs
@@ -24,6 +24,8 @@ mod init;
 #[cfg(test)]
 mod interaction_send_turn;
 #[cfg(test)]
+mod interaction_terminator;
+#[cfg(test)]
 mod interaction_turn_live;
 #[cfg(test)]
 mod milestone_health_wizard;

--- a/src/session/interaction.rs
+++ b/src/session/interaction.rs
@@ -6,6 +6,7 @@
 //! deliberately separate from `super::types::SessionStatus`, which models
 //! one-shot work.
 
+use super::interaction_lifecycle::InteractionLifecycleEvent;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -70,6 +71,11 @@ pub struct InteractionSession {
     pub closed_at: Option<DateTime<Utc>>,
     #[serde(default)]
     pub close_reason: Option<CloseReason>,
+    /// A terminator queued while a turn was streaming; fired once the turn
+    /// returns to `Idle` (#739). `None` in the common Idle path (fired
+    /// immediately). Purely in-memory turn-boundary state — never persisted.
+    #[serde(skip)]
+    pub queued_terminator: Option<InteractionLifecycleEvent>,
 }
 
 impl InteractionSession {
@@ -93,6 +99,7 @@ impl InteractionSession {
             created_at: Utc::now(),
             closed_at: None,
             close_reason: None,
+            queued_terminator: None,
         }
     }
 
@@ -101,239 +108,42 @@ impl InteractionSession {
     pub fn is_active(&self) -> bool {
         self.state != InteractionState::Terminated
     }
+
+    /// Signal that this session should terminate because a PR was linked
+    /// (#739).
+    ///
+    /// - `Idle`: fire now — state → `Terminated`, stamp `close_reason`/
+    ///   `closed_at`.
+    /// - `Streaming`: queue it; the in-flight turn finishes untouched and the
+    ///   turn-completion path fires it later (mid-turn deferral).
+    /// - `Terminated`: idempotent no-op (debug-logged).
+    pub fn signal_terminator(&mut self, event: InteractionLifecycleEvent) {
+        match self.state {
+            InteractionState::Terminated => {
+                tracing::debug!(
+                    issue_number = self.issue_number,
+                    "terminator already fired; ignoring"
+                );
+            }
+            InteractionState::Streaming => {
+                self.queued_terminator = Some(event);
+            }
+            InteractionState::Idle => self.fire_terminator(event),
+        }
+    }
+
+    /// Apply a terminator immediately: `Terminated` + `close_reason` +
+    /// `closed_at`. Only `PrLinkedToIssue` maps to a `CloseReason` today;
+    /// other variants set the terminal state without a reason.
+    fn fire_terminator(&mut self, event: InteractionLifecycleEvent) {
+        if let InteractionLifecycleEvent::PrLinkedToIssue { pr_number, .. } = event {
+            self.close_reason = Some(CloseReason::PrCreated { pr_number });
+        }
+        self.state = InteractionState::Terminated;
+        self.closed_at = Some(Utc::now());
+    }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use chrono::Utc;
-    use std::path::PathBuf;
-
-    fn make_interaction(issue: u64) -> InteractionSession {
-        InteractionSession::new(
-            issue,
-            PathBuf::from("/tmp/test-wt"),
-            format!("feat/issue-{issue}"),
-            false,
-        )
-    }
-
-    // --- InteractionState ---
-
-    #[test]
-    fn interaction_state_default_is_idle() {
-        assert_eq!(InteractionState::default(), InteractionState::Idle);
-    }
-
-    #[test]
-    fn interaction_state_idle_serializes_as_snake_case() {
-        let json = serde_json::to_string(&InteractionState::Idle).unwrap();
-        assert_eq!(json, r#""idle""#);
-    }
-
-    #[test]
-    fn interaction_state_streaming_serializes_as_snake_case() {
-        let json = serde_json::to_string(&InteractionState::Streaming).unwrap();
-        assert_eq!(json, r#""streaming""#);
-    }
-
-    #[test]
-    fn interaction_state_terminated_serializes_as_snake_case() {
-        let json = serde_json::to_string(&InteractionState::Terminated).unwrap();
-        assert_eq!(json, r#""terminated""#);
-    }
-
-    #[test]
-    fn interaction_state_round_trips_via_serde() {
-        for state in [
-            InteractionState::Idle,
-            InteractionState::Streaming,
-            InteractionState::Terminated,
-        ] {
-            let json = serde_json::to_string(&state).unwrap();
-            let rt: InteractionState = serde_json::from_str(&json).unwrap();
-            assert_eq!(rt, state);
-        }
-    }
-
-    // --- TurnRole ---
-
-    #[test]
-    fn turn_role_user_serializes_as_snake_case() {
-        let json = serde_json::to_string(&TurnRole::User).unwrap();
-        assert_eq!(json, r#""user""#);
-    }
-
-    #[test]
-    fn turn_role_agent_serializes_as_snake_case() {
-        let json = serde_json::to_string(&TurnRole::Agent).unwrap();
-        assert_eq!(json, r#""agent""#);
-    }
-
-    #[test]
-    fn turn_role_system_serializes_as_snake_case() {
-        let json = serde_json::to_string(&TurnRole::System).unwrap();
-        assert_eq!(json, r#""system""#);
-    }
-
-    #[test]
-    fn turn_role_round_trips_via_serde() {
-        for role in [TurnRole::User, TurnRole::Agent, TurnRole::System] {
-            let json = serde_json::to_string(&role).unwrap();
-            let rt: TurnRole = serde_json::from_str(&json).unwrap();
-            assert_eq!(rt, role);
-        }
-    }
-
-    // --- CloseReason ---
-
-    #[test]
-    fn close_reason_pr_created_serializes_pr_number() {
-        let json = serde_json::to_string(&CloseReason::PrCreated { pr_number: 42 }).unwrap();
-        assert!(json.contains(r#""pr_number":42"#), "got: {json}");
-    }
-
-    #[test]
-    fn close_reason_user_quit_serializes_as_snake_case() {
-        let json = serde_json::to_string(&CloseReason::UserQuit).unwrap();
-        assert!(json.contains("user_quit"), "got: {json}");
-    }
-
-    #[test]
-    fn close_reason_agent_failure_serializes_tail() {
-        let json = serde_json::to_string(&CloseReason::AgentFailure {
-            tail: "oom".to_string(),
-        })
-        .unwrap();
-        assert!(json.contains(r#""tail":"oom""#), "got: {json}");
-    }
-
-    #[test]
-    fn close_reason_round_trips_via_serde() {
-        let reasons = [
-            CloseReason::PrCreated { pr_number: 7 },
-            CloseReason::UserQuit,
-            CloseReason::AgentFailure { tail: "err".into() },
-        ];
-        for reason in reasons {
-            let json = serde_json::to_string(&reason).unwrap();
-            let rt: CloseReason = serde_json::from_str(&json).unwrap();
-            assert_eq!(rt, reason);
-        }
-    }
-
-    // --- TurnRecord ---
-
-    #[test]
-    fn turn_record_finished_at_defaults_to_none_via_serde() {
-        let json = r#"{"role":"user","content":"hi","started_at":"2026-05-30T00:00:00Z"}"#;
-        let rt: TurnRecord = serde_json::from_str(json).unwrap();
-        assert!(rt.finished_at.is_none());
-    }
-
-    #[test]
-    fn turn_record_round_trips_via_serde() {
-        let record = TurnRecord {
-            role: TurnRole::User,
-            content: "hello".into(),
-            started_at: Utc::now(),
-            finished_at: Some(Utc::now()),
-        };
-        let json = serde_json::to_string(&record).unwrap();
-        let rt: TurnRecord = serde_json::from_str(&json).unwrap();
-        assert_eq!(rt.role, TurnRole::User);
-        assert_eq!(rt.content, "hello");
-        assert!(rt.finished_at.is_some());
-    }
-
-    // --- InteractionSession ---
-
-    #[test]
-    fn interaction_session_new_stamps_created_at_and_state_is_idle() {
-        let before = Utc::now();
-        let s = InteractionSession::new(42, PathBuf::from("/tmp/wt"), "feat/x".into(), true);
-        let after = Utc::now();
-        assert_eq!(s.issue_number, 42);
-        assert_eq!(s.worktree_path, PathBuf::from("/tmp/wt"));
-        assert_eq!(s.branch, "feat/x");
-        assert!(s.produce_pr);
-        assert_eq!(s.state, InteractionState::Idle);
-        assert!(s.history.is_empty());
-        assert!(s.session_id.is_none());
-        assert!(s.closed_at.is_none());
-        assert!(s.close_reason.is_none());
-        assert!(s.created_at >= before && s.created_at <= after);
-    }
-
-    #[test]
-    fn interaction_session_is_active_when_idle() {
-        let s = make_interaction(1);
-        assert!(s.is_active());
-    }
-
-    #[test]
-    fn interaction_session_is_active_when_streaming() {
-        let mut s = make_interaction(1);
-        s.state = InteractionState::Streaming;
-        assert!(s.is_active());
-    }
-
-    #[test]
-    fn interaction_session_is_not_active_when_terminated() {
-        let mut s = make_interaction(1);
-        s.state = InteractionState::Terminated;
-        assert!(!s.is_active());
-    }
-
-    #[test]
-    fn interaction_session_round_trips_via_serde() {
-        let mut s = InteractionSession::new(7, PathBuf::from("/tmp/w"), "main".into(), false);
-        s.history.push(TurnRecord {
-            role: TurnRole::Agent,
-            content: "done".into(),
-            started_at: Utc::now(),
-            finished_at: None,
-        });
-        let json = serde_json::to_string(&s).unwrap();
-        let rt: InteractionSession = serde_json::from_str(&json).unwrap();
-        assert_eq!(rt.issue_number, 7);
-        assert!(!rt.produce_pr);
-        assert_eq!(rt.history.len(), 1);
-    }
-
-    #[test]
-    fn interaction_session_closed_at_deserializes_with_default_when_absent() {
-        let s = make_interaction(3);
-        let json = serde_json::to_string(&s).unwrap();
-        let stripped = json.replace(r#","closed_at":null"#, "");
-        let rt: InteractionSession = serde_json::from_str(&stripped).unwrap();
-        assert!(rt.closed_at.is_none());
-    }
-
-    #[test]
-    fn interaction_session_close_reason_deserializes_with_default_when_absent() {
-        let s = make_interaction(3);
-        let json = serde_json::to_string(&s).unwrap();
-        let stripped = json.replace(r#","close_reason":null"#, "");
-        let rt: InteractionSession = serde_json::from_str(&stripped).unwrap();
-        assert!(rt.close_reason.is_none());
-    }
-
-    #[test]
-    fn interaction_session_session_id_deserializes_with_default_when_absent() {
-        let s = make_interaction(3);
-        let json = serde_json::to_string(&s).unwrap();
-        let stripped = json.replace(r#","session_id":null"#, "");
-        let rt: InteractionSession = serde_json::from_str(&stripped).unwrap();
-        assert!(rt.session_id.is_none());
-    }
-
-    #[test]
-    fn interaction_session_history_deserializes_with_default_when_absent() {
-        let s = make_interaction(3);
-        let json = serde_json::to_string(&s).unwrap();
-        let stripped = json.replace(r#","history":[]"#, "");
-        let rt: InteractionSession = serde_json::from_str(&stripped).unwrap();
-        assert!(rt.history.is_empty());
-    }
-}
+#[path = "interaction_tests.rs"]
+mod tests;

--- a/src/session/interaction_lifecycle.rs
+++ b/src/session/interaction_lifecycle.rs
@@ -1,0 +1,34 @@
+//! Lifecycle events emitted as an interactive session winds down (#739).
+//!
+//! `PrLinkedToIssue` is raised by the `/pushup` marker consumer
+//! (`src/tui/app/pushup_marker.rs`) when a PR marker carries an
+//! `issue_number` that matches an active interaction session. It drives
+//! [`super::interaction::InteractionSession::signal_terminator`].
+//!
+//! `WorktreeWiped` and `SessionClosed` are scaffold for #740 (worktree
+//! teardown) and #741 (terminator UI flow); they have no consumer yet, hence
+//! the module-level `dead_code` allow.
+#![allow(dead_code)] // Reason: WorktreeWiped/SessionClosed are scaffold for #740/#741
+
+use super::interaction::CloseReason;
+use std::path::PathBuf;
+
+/// An event in the shutdown lifecycle of an interactive session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InteractionLifecycleEvent {
+    /// A `/pushup` PR was linked to this session's issue. Terminates the
+    /// session with `CloseReason::PrCreated`.
+    PrLinkedToIssue {
+        pr_number: u64,
+        issue_number: u64,
+        owner: String,
+        repo: String,
+    },
+    /// The session's worktree was removed (#740).
+    WorktreeWiped { issue_number: u64, path: PathBuf },
+    /// The session was closed for `reason` (#741).
+    SessionClosed {
+        issue_number: u64,
+        reason: CloseReason,
+    },
+}

--- a/src/session/interaction_tests.rs
+++ b/src/session/interaction_tests.rs
@@ -1,0 +1,318 @@
+use super::*;
+use chrono::Utc;
+use std::path::PathBuf;
+
+fn make_interaction(issue: u64) -> InteractionSession {
+    InteractionSession::new(
+        issue,
+        PathBuf::from("/tmp/test-wt"),
+        format!("feat/issue-{issue}"),
+        false,
+    )
+}
+
+// --- InteractionState ---
+
+#[test]
+fn interaction_state_default_is_idle() {
+    assert_eq!(InteractionState::default(), InteractionState::Idle);
+}
+
+#[test]
+fn interaction_state_idle_serializes_as_snake_case() {
+    let json = serde_json::to_string(&InteractionState::Idle).unwrap();
+    assert_eq!(json, r#""idle""#);
+}
+
+#[test]
+fn interaction_state_streaming_serializes_as_snake_case() {
+    let json = serde_json::to_string(&InteractionState::Streaming).unwrap();
+    assert_eq!(json, r#""streaming""#);
+}
+
+#[test]
+fn interaction_state_terminated_serializes_as_snake_case() {
+    let json = serde_json::to_string(&InteractionState::Terminated).unwrap();
+    assert_eq!(json, r#""terminated""#);
+}
+
+#[test]
+fn interaction_state_round_trips_via_serde() {
+    for state in [
+        InteractionState::Idle,
+        InteractionState::Streaming,
+        InteractionState::Terminated,
+    ] {
+        let json = serde_json::to_string(&state).unwrap();
+        let rt: InteractionState = serde_json::from_str(&json).unwrap();
+        assert_eq!(rt, state);
+    }
+}
+
+// --- TurnRole ---
+
+#[test]
+fn turn_role_user_serializes_as_snake_case() {
+    let json = serde_json::to_string(&TurnRole::User).unwrap();
+    assert_eq!(json, r#""user""#);
+}
+
+#[test]
+fn turn_role_agent_serializes_as_snake_case() {
+    let json = serde_json::to_string(&TurnRole::Agent).unwrap();
+    assert_eq!(json, r#""agent""#);
+}
+
+#[test]
+fn turn_role_system_serializes_as_snake_case() {
+    let json = serde_json::to_string(&TurnRole::System).unwrap();
+    assert_eq!(json, r#""system""#);
+}
+
+#[test]
+fn turn_role_round_trips_via_serde() {
+    for role in [TurnRole::User, TurnRole::Agent, TurnRole::System] {
+        let json = serde_json::to_string(&role).unwrap();
+        let rt: TurnRole = serde_json::from_str(&json).unwrap();
+        assert_eq!(rt, role);
+    }
+}
+
+// --- CloseReason ---
+
+#[test]
+fn close_reason_pr_created_serializes_pr_number() {
+    let json = serde_json::to_string(&CloseReason::PrCreated { pr_number: 42 }).unwrap();
+    assert!(json.contains(r#""pr_number":42"#), "got: {json}");
+}
+
+#[test]
+fn close_reason_user_quit_serializes_as_snake_case() {
+    let json = serde_json::to_string(&CloseReason::UserQuit).unwrap();
+    assert!(json.contains("user_quit"), "got: {json}");
+}
+
+#[test]
+fn close_reason_agent_failure_serializes_tail() {
+    let json = serde_json::to_string(&CloseReason::AgentFailure {
+        tail: "oom".to_string(),
+    })
+    .unwrap();
+    assert!(json.contains(r#""tail":"oom""#), "got: {json}");
+}
+
+#[test]
+fn close_reason_round_trips_via_serde() {
+    let reasons = [
+        CloseReason::PrCreated { pr_number: 7 },
+        CloseReason::UserQuit,
+        CloseReason::AgentFailure { tail: "err".into() },
+    ];
+    for reason in reasons {
+        let json = serde_json::to_string(&reason).unwrap();
+        let rt: CloseReason = serde_json::from_str(&json).unwrap();
+        assert_eq!(rt, reason);
+    }
+}
+
+// --- TurnRecord ---
+
+#[test]
+fn turn_record_finished_at_defaults_to_none_via_serde() {
+    let json = r#"{"role":"user","content":"hi","started_at":"2026-05-30T00:00:00Z"}"#;
+    let rt: TurnRecord = serde_json::from_str(json).unwrap();
+    assert!(rt.finished_at.is_none());
+}
+
+#[test]
+fn turn_record_round_trips_via_serde() {
+    let record = TurnRecord {
+        role: TurnRole::User,
+        content: "hello".into(),
+        started_at: Utc::now(),
+        finished_at: Some(Utc::now()),
+    };
+    let json = serde_json::to_string(&record).unwrap();
+    let rt: TurnRecord = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.role, TurnRole::User);
+    assert_eq!(rt.content, "hello");
+    assert!(rt.finished_at.is_some());
+}
+
+// --- InteractionSession ---
+
+#[test]
+fn interaction_session_new_stamps_created_at_and_state_is_idle() {
+    let before = Utc::now();
+    let s = InteractionSession::new(42, PathBuf::from("/tmp/wt"), "feat/x".into(), true);
+    let after = Utc::now();
+    assert_eq!(s.issue_number, 42);
+    assert_eq!(s.worktree_path, PathBuf::from("/tmp/wt"));
+    assert_eq!(s.branch, "feat/x");
+    assert!(s.produce_pr);
+    assert_eq!(s.state, InteractionState::Idle);
+    assert!(s.history.is_empty());
+    assert!(s.session_id.is_none());
+    assert!(s.closed_at.is_none());
+    assert!(s.close_reason.is_none());
+    assert!(s.created_at >= before && s.created_at <= after);
+}
+
+#[test]
+fn interaction_session_is_active_when_idle() {
+    let s = make_interaction(1);
+    assert!(s.is_active());
+}
+
+#[test]
+fn interaction_session_is_active_when_streaming() {
+    let mut s = make_interaction(1);
+    s.state = InteractionState::Streaming;
+    assert!(s.is_active());
+}
+
+#[test]
+fn interaction_session_is_not_active_when_terminated() {
+    let mut s = make_interaction(1);
+    s.state = InteractionState::Terminated;
+    assert!(!s.is_active());
+}
+
+#[test]
+fn interaction_session_round_trips_via_serde() {
+    let mut s = InteractionSession::new(7, PathBuf::from("/tmp/w"), "main".into(), false);
+    s.history.push(TurnRecord {
+        role: TurnRole::Agent,
+        content: "done".into(),
+        started_at: Utc::now(),
+        finished_at: None,
+    });
+    let json = serde_json::to_string(&s).unwrap();
+    let rt: InteractionSession = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.issue_number, 7);
+    assert!(!rt.produce_pr);
+    assert_eq!(rt.history.len(), 1);
+}
+
+#[test]
+fn interaction_session_closed_at_deserializes_with_default_when_absent() {
+    let s = make_interaction(3);
+    let json = serde_json::to_string(&s).unwrap();
+    let stripped = json.replace(r#","closed_at":null"#, "");
+    let rt: InteractionSession = serde_json::from_str(&stripped).unwrap();
+    assert!(rt.closed_at.is_none());
+}
+
+#[test]
+fn interaction_session_close_reason_deserializes_with_default_when_absent() {
+    let s = make_interaction(3);
+    let json = serde_json::to_string(&s).unwrap();
+    let stripped = json.replace(r#","close_reason":null"#, "");
+    let rt: InteractionSession = serde_json::from_str(&stripped).unwrap();
+    assert!(rt.close_reason.is_none());
+}
+
+#[test]
+fn interaction_session_session_id_deserializes_with_default_when_absent() {
+    let s = make_interaction(3);
+    let json = serde_json::to_string(&s).unwrap();
+    let stripped = json.replace(r#","session_id":null"#, "");
+    let rt: InteractionSession = serde_json::from_str(&stripped).unwrap();
+    assert!(rt.session_id.is_none());
+}
+
+#[test]
+fn interaction_session_history_deserializes_with_default_when_absent() {
+    let s = make_interaction(3);
+    let json = serde_json::to_string(&s).unwrap();
+    let stripped = json.replace(r#","history":[]"#, "");
+    let rt: InteractionSession = serde_json::from_str(&stripped).unwrap();
+    assert!(rt.history.is_empty());
+}
+
+// --- Issue #739: signal_terminator ---
+
+use super::super::interaction_lifecycle::InteractionLifecycleEvent;
+
+fn pr_linked(pr_number: u64, issue_number: u64) -> InteractionLifecycleEvent {
+    InteractionLifecycleEvent::PrLinkedToIssue {
+        pr_number,
+        issue_number,
+        owner: "owner".into(),
+        repo: "repo".into(),
+    }
+}
+
+#[test]
+fn signal_terminator_idle_fires_immediately() {
+    let before = Utc::now();
+    let mut s = make_interaction(42);
+    s.signal_terminator(pr_linked(7, 42));
+    let after = Utc::now();
+
+    assert_eq!(s.state, InteractionState::Terminated);
+    assert_eq!(
+        s.close_reason,
+        Some(CloseReason::PrCreated { pr_number: 7 })
+    );
+    let closed = s.closed_at.expect("closed_at must be set");
+    assert!(closed >= before && closed <= after);
+    assert!(s.queued_terminator.is_none());
+}
+
+#[test]
+fn signal_terminator_streaming_queues_and_stays_streaming() {
+    let mut s = make_interaction(42);
+    s.state = InteractionState::Streaming;
+
+    s.signal_terminator(pr_linked(99, 42));
+
+    assert_eq!(s.state, InteractionState::Streaming);
+    assert!(s.close_reason.is_none());
+    assert!(s.closed_at.is_none());
+    assert!(matches!(
+        s.queued_terminator.as_ref().unwrap(),
+        InteractionLifecycleEvent::PrLinkedToIssue { pr_number: 99, .. }
+    ));
+}
+
+#[test]
+fn signal_terminator_terminated_is_noop() {
+    let mut s = make_interaction(1);
+    s.state = InteractionState::Terminated;
+    s.close_reason = Some(CloseReason::UserQuit);
+    s.closed_at = Some(Utc::now());
+
+    s.signal_terminator(pr_linked(5, 1));
+
+    assert_eq!(s.state, InteractionState::Terminated);
+    assert_eq!(s.close_reason, Some(CloseReason::UserQuit));
+    assert!(s.queued_terminator.is_none());
+}
+
+#[test]
+fn signal_terminator_double_call_second_call_is_noop() {
+    let mut s = make_interaction(1);
+    s.signal_terminator(pr_linked(10, 1));
+    s.signal_terminator(pr_linked(20, 1));
+
+    assert_eq!(s.state, InteractionState::Terminated);
+    assert_eq!(
+        s.close_reason,
+        Some(CloseReason::PrCreated { pr_number: 10 })
+    );
+}
+
+#[test]
+fn interaction_session_serde_roundtrip_queued_terminator_is_skipped() {
+    let mut s = make_interaction(3);
+    s.state = InteractionState::Streaming;
+    s.signal_terminator(pr_linked(55, 3));
+    assert!(s.queued_terminator.is_some(), "precondition: event queued");
+
+    let json = serde_json::to_string(&s).unwrap();
+    let rt: InteractionSession = serde_json::from_str(&json).unwrap();
+
+    assert!(rt.queued_terminator.is_none());
+    assert_eq!(rt.state, InteractionState::Streaming);
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -5,6 +5,7 @@ pub mod health;
 pub mod image;
 pub mod intent;
 pub mod interaction;
+pub mod interaction_lifecycle;
 pub mod interaction_turn;
 pub mod logger;
 pub mod manager;

--- a/src/session/pool.rs
+++ b/src/session/pool.rs
@@ -431,6 +431,31 @@ impl SessionPool {
             .find(|i| i.issue_number == issue_number && i.is_active())
     }
 
+    /// Mutable twin of [`Self::find_active_interaction_by_issue`] (#739).
+    /// Used by the `/pushup` marker consumer to call `signal_terminator` on
+    /// the live session.
+    pub fn find_active_interaction_by_issue_mut(
+        &mut self,
+        issue_number: u64,
+    ) -> Option<&mut InteractionSession> {
+        self.interactions
+            .iter_mut()
+            .find(|i| i.issue_number == issue_number && i.is_active())
+    }
+
+    /// Return the `close_reason` of the first interaction registered for
+    /// `issue_number` (active or terminated). Test-only introspection.
+    #[cfg(test)]
+    pub fn interaction_close_reason(
+        &self,
+        issue_number: u64,
+    ) -> Option<&super::interaction::CloseReason> {
+        self.interactions
+            .iter()
+            .find(|i| i.issue_number == issue_number)
+            .and_then(|i| i.close_reason.as_ref())
+    }
+
     /// Create a fresh interaction session for `issue_number`, building a
     /// worktree (non-fatal — falls back to cwd) and registering it. Returns a
     /// reference to the newly created session. Mirrors the worktree handling
@@ -1541,6 +1566,47 @@ mod tests {
         assert!(
             appendix.contains("Implement Command"),
             "template body must survive TurboQuant compaction: {appendix}"
+        );
+    }
+
+    // --- Issue #739: find_active_interaction_by_issue_mut ---
+
+    #[test]
+    fn find_active_interaction_by_issue_mut_returns_mutable_ref_for_active() {
+        let mut pool = make_pool(2);
+        pool.interactions.push(make_interaction(42));
+
+        let found = pool.find_active_interaction_by_issue_mut(42);
+        assert!(found.is_some());
+        found.unwrap().session_id = Some("mutated".into());
+
+        assert_eq!(
+            pool.find_active_interaction_by_issue(42)
+                .unwrap()
+                .session_id
+                .as_deref(),
+            Some("mutated"),
+            "mutation through the mutable ref must persist"
+        );
+    }
+
+    #[test]
+    fn find_active_interaction_by_issue_mut_returns_none_when_absent() {
+        let mut pool = make_pool(2);
+        assert!(pool.find_active_interaction_by_issue_mut(99).is_none());
+    }
+
+    #[test]
+    fn find_active_interaction_by_issue_mut_skips_terminated() {
+        use crate::session::interaction::InteractionState;
+        let mut pool = make_pool(2);
+        let mut s = make_interaction(42);
+        s.state = InteractionState::Terminated;
+        pool.interactions.push(s);
+
+        assert!(
+            pool.find_active_interaction_by_issue_mut(42).is_none(),
+            "terminated session must not be returned by _mut lookup"
         );
     }
 }

--- a/src/tui/app/pushup_marker.rs
+++ b/src/tui/app/pushup_marker.rs
@@ -112,6 +112,23 @@ impl App {
             self.consume_marker(&path);
             return;
         }
+        // #739: a marker carrying issue_number that matches an active
+        // interaction session terminates that session. Runs BEFORE the
+        // PrCreated enqueue so the single marker read drives both events.
+        // owner/repo are cloned here because they are moved into PrCreated
+        // below.
+        if let Some(issue_number) = marker.issue_number
+            && let Some(session) = self.pool.find_active_interaction_by_issue_mut(issue_number)
+        {
+            session.signal_terminator(
+                crate::session::interaction_lifecycle::InteractionLifecycleEvent::PrLinkedToIssue {
+                    pr_number: marker.pr_number,
+                    issue_number,
+                    owner: marker.owner.clone(),
+                    repo: marker.repo.clone(),
+                },
+            );
+        }
         self.activity_log.push_simple(
             "PUSHUP".into(),
             format!(


### PR DESCRIPTION
## Summary

- A `/pushup` PR marker carrying `issue_number` that matches an active interaction session now terminates that session (emits `InteractionLifecycleEvent::PrLinkedToIssue`) **and** still fires the existing `PrCreated` auto-review path — a single marker read drives both events.
- Adds `InteractionSession::signal_terminator` (Idle fires immediately → `Terminated` + `CloseReason::PrCreated`; Streaming queues into `queued_terminator`; Terminated is an idempotent no-op) and a mutable `SessionPool::find_active_interaction_by_issue_mut` lookup.
- Mid-turn deferred firing (draining `queued_terminator` after a Streaming turn settles, across the background-turn merge) is **split to follow-up #936** per the architect's scope correction — this PR only emits the event + wires the Idle path.

Closes #739

## Manual QA gate

This diff touches `src/tui/app/pushup_marker.rs`, which trips `/auto`'s path-based UI gate (`^src/tui/`). That file is **non-visual marker-polling glue** — no rendered surface, keybind, widget, or theme changed in #739 (the visible terminator UI is #741). Gate overridden by maintainer decision: shipped Ready, not Draft.

## Test plan

- [x] cargo test --quiet (5806 lib tests pass; +4 unit, +3 pool, +3 integration for #739)
- [x] cargo clippy -- -D warnings -A dead_code (clean — matches CI)
- [x] cargo fmt --check
- [x] file-size cap (interaction.rs test module relocated to interaction_tests.rs via `#[path]`, mirroring git.rs/git_tests.rs; all files < 400 LOC)
- [x] security review (OWASP pass — marker owner/repo guard runs before the new branch; no new unwrap/expect/panic; serde(skip) field sound)
