### PR TITLE
feat(work): worktree_teardown wipe_worktree + sanity-check + idempotency

### DIFF
--- a/directory-tree.md
+++ b/directory-tree.md
@@ -1,6 +1,6 @@
 # Project Directory Tree
 
-> Last updated: 2026-06-01 00:00 (UTC)
+> Last updated: 2026-06-01 12:00 (UTC)
 >
 > This is the SINGLE SOURCE OF TRUTH for project structure.
 > All documentation files should reference this file instead of duplicating the tree.
@@ -734,14 +734,15 @@ maestro/
 │   │   ├── adapter.rs                     # TurboQuantAdapter: bridges quantization pipeline to session layer; TextRanker trait + impl; compress_handoff() (CompressedHandoff, Issue #343); compact_system_prompt() (Issue #344); compact_session_history() + StateCompactionReport (Issue #345); shared Arc<TurboQuantAdapter> on App; project_savings(), session_savings(), implied_rate_per_token() and public types SavingsProjection, SavingsKind, SessionSavings  [Issue #346]
 │   │   └── budget.rs                      # TokenBudget helper: ranked-segment selection staying under a token limit; BudgetSelection struct (indices, tokens_used, truncated_first); used by fork-handoff, system-prompt, and knowledge compression  [Issue #343-345, #347]
 │   └── work/                              # Work queue and scheduling  [Phase 2]
-│       ├── mod.rs                         # Module exports; pub mod queue; pub mod pr_marker  [Issue #735]
+│       ├── mod.rs                         # Module exports; pub mod queue; pub mod pr_marker; pub mod worktree_teardown  [Issue #735, #740]
 │       ├── types.rs                       # WorkItem, WorkStatus; from_issue, is_ready
 │       ├── assigner.rs                    # WorkAssigner: topo sort tiebreaker, cycle detection; mark_pending() transitions an item back to Pending; mark_pending_undo_cascade() cascades undo to dependents  [Phase 3, Issue #85]
 │       ├── conflicts.rs                   # Conflict detection for concurrent work items
 │       ├── dependencies.rs               # DependencyGraph: topological sort, cycle detection
 │       ├── executor.rs                    # QueueExecutor state machine for sequential queue execution; ExecutorPhase enum (Idle, Running, AwaitingDecision, Finished); ExecutorItem struct; QueueItemState enum; FailureAction enum (Retry, Skip, Abort); advance(), mark_success(), mark_failure(), apply_decision(), set_session_id()
 │       ├── pr_marker.rs                   # PrMarker struct (pr_number, owner, repo, issue_number: Option<u64>, ts) + MarkerError enum; write_atomic (.tmp + rename) + read (tolerant of missing issue_number, emits tracing::warn); used by /pushup and pushup_marker.rs  [Issue #735]
-│       └── queue.rs                       # WorkQueue, QueuedItem, QueueValidationError; validate_selection()  [Issue #65]
+│       ├── queue.rs                       # WorkQueue, QueuedItem, QueueValidationError; validate_selection()  [Issue #65]
+│       └── worktree_teardown.rs           # Destructive git-worktree teardown primitive; pub fn wipe_worktree(issue_number, path, branch, worktree_root) -> Result<(), TeardownError>; TeardownError enum (OutOfRoot, Io, GitCommandFailed, PathStillExists, UnsafeRoot); sanity-gated (refuses / and $HOME; canonicalized containment check blocks symlink escape); idempotent (missing path/branch → Ok); uses -- end-of-options terminator on all git invocations; not auto-invoked — #741 wires it into the UI lifecycle  [Issue #740]
 ├── docs/
 │   ├── adr/                               # Architecture Decision Records; one file per decision; ADRs that survive a spike are the only artifact merged to main from that spike
 │   │   ├── 001-agent-graph-viz.md         # ADR 001: agent graph visualization — Go/No-Go verdict (concentric/radial bipartite layout, Braille canvas); tracking issue #513
@@ -1273,6 +1274,8 @@ maestro/
 | `src/work/conflicts.rs` | Conflict detection for concurrent work items |
 | `src/work/dependencies.rs` | Dependency graph, topological sort |
 | `src/work/executor.rs` | `QueueExecutor` state machine: `ExecutorPhase` (Idle, Running, AwaitingDecision, Finished); `ExecutorItem`; `QueueItemState`; `FailureAction` (Retry, Skip, Abort); `advance()`, `mark_success()`, `mark_failure()`, `apply_decision()`, `set_session_id()` |
+| `src/work/worktree_teardown.rs` | `wipe_worktree(issue_number, path, branch, worktree_root)` — sanity-gated destructive teardown; `TeardownError` enum (`OutOfRoot`, `Io`, `GitCommandFailed`, `PathStillExists`, `UnsafeRoot`); idempotent; `--` argument terminator on all git calls (Issue #740) |
+| `tests/worktree_teardown.rs` | 9 real-git + tempdir integration tests for `wipe_worktree`: happy path, idempotency (already removed), `UnsafeRoot` for `/` and `$HOME`, `OutOfRoot` for path outside root, symlink-escape rejection, leading-dash argument injection block (Issue #740) |
 | `tests/legacy_skills_removed.rs` | 4 regression-guard tests asserting `.claude/skills/simplify/` is absent; prevents re-introduction of the deprecated simplify skill (Issue #760) |
 | `tests/settings_caveman.rs` | Integration tests for `FsSettingsStore`: real-tempfile read/write/toggle round-trips, missing-key defaults, malformed JSON handling (Issue #490) |
 | `template/` | Reproducible project template |

--- a/src/work/mod.rs
+++ b/src/work/mod.rs
@@ -5,3 +5,4 @@ pub mod executor;
 pub mod pr_marker;
 pub mod queue;
 pub mod types;
+pub mod worktree_teardown;

--- a/src/work/worktree_teardown.rs
+++ b/src/work/worktree_teardown.rs
@@ -1,0 +1,323 @@
+//! Destructive worktree teardown primitive (issue #740).
+//!
+//! `wipe_worktree` removes a git worktree and its branch when a PR-terminator
+//! fires for an interaction session. It is the destructive primitive that #741
+//! wires into the UI lifecycle; this module exposes it and tests it in
+//! isolation — there is **no** automatic invocation here.
+//!
+//! Two non-negotiable safety properties:
+//!
+//! 1. **Sanity-gated.** The worktree path must canonicalize to a location under
+//!    the configured `worktree_root`. A root of `/` or `$HOME` is refused
+//!    outright (`UnsafeRoot`). Symlinks that escape the root resolve to their
+//!    real location and fail the containment check (`OutOfRoot`).
+//! 2. **Idempotent.** The terminator may fire twice across crashes, so a
+//!    missing path, an already-removed worktree, or a missing branch are all
+//!    treated as success, not error.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Typed failure modes for [`wipe_worktree`]. No path here ever panics; every
+/// fallible step maps to one of these variants.
+#[derive(Debug, thiserror::Error)]
+pub enum TeardownError {
+    /// The worktree path canonicalizes outside `worktree_root`.
+    #[error("worktree path {} is outside the worktree root {}", path.display(), root.display())]
+    OutOfRoot { path: PathBuf, root: PathBuf },
+
+    /// A filesystem operation (canonicalize, existence check) failed.
+    #[error("io error on {}: {source}", path.display())]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// A `git` invocation exited non-zero with an stderr we do not treat as a
+    /// benign "already clean" signal.
+    #[error("git command failed ({cmd}) status={status}: {stderr}")]
+    GitCommandFailed {
+        cmd: String,
+        stderr: String,
+        status: i32,
+    },
+
+    /// `git worktree remove` reported success but the directory is still on disk.
+    #[error("worktree path still exists after teardown: {}", _0.display())]
+    PathStillExists(PathBuf),
+
+    /// `worktree_root` resolved to `/` or `$HOME` — refused as a misconfiguration.
+    #[error("refusing to operate on unsafe worktree root: {}", _0.display())]
+    UnsafeRoot(PathBuf),
+}
+
+/// Remove the worktree at `path` and delete `branch`, refusing to act unless
+/// `path` canonicalizes safely under `worktree_root`. Idempotent: a second call
+/// after the worktree is gone returns `Ok(())`.
+pub fn wipe_worktree(
+    issue_number: u64,
+    path: &Path,
+    branch: &str,
+    worktree_root: &Path,
+) -> Result<(), TeardownError> {
+    tracing::info!(
+        issue_number,
+        branch,
+        path = %path.display(),
+        "worktree teardown requested"
+    );
+
+    // `sanity_check_under_root` canonicalizes and gates the worktree root; the
+    // git commands only need a cwd inside the owning repo, so the raw
+    // `worktree_root` (always under the repo) serves as that cwd directly.
+    match sanity_check_under_root(path, worktree_root)? {
+        None => {
+            // Path already gone (idempotent re-entry). Still attempt the branch
+            // delete — it may have survived a partial earlier teardown.
+            tracing::warn!(issue_number, path = %path.display(), "worktree path already absent; skipping remove");
+            run_git_branch_delete(worktree_root, branch, true)?;
+            Ok(())
+        }
+        Some(canon_path) => {
+            run_git_worktree_remove(worktree_root, &canon_path)?;
+            run_git_branch_delete(worktree_root, branch, true)?;
+            if canon_path.exists() {
+                return Err(TeardownError::PathStillExists(canon_path));
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Canonicalize `p`, mapping any io error into [`TeardownError::Io`].
+fn canonicalize(p: &Path) -> Result<PathBuf, TeardownError> {
+    p.canonicalize().map_err(|source| TeardownError::Io {
+        path: p.into(),
+        source,
+    })
+}
+
+/// The user's `$HOME`, canonicalized. `None` when unset or unresolvable — a
+/// missing HOME is not itself unsafe, so we simply skip that guard.
+fn canonical_home() -> Option<PathBuf> {
+    std::env::var_os("HOME").and_then(|h| PathBuf::from(h).canonicalize().ok())
+}
+
+/// Canonicalize `path` and `worktree_root`, refuse unsafe roots, and enforce
+/// containment. Returns `Ok(None)` when `path` does not exist (idempotent skip),
+/// `Ok(Some(canonical_path))` when it exists safely under the root.
+fn sanity_check_under_root(
+    path: &Path,
+    worktree_root: &Path,
+) -> Result<Option<PathBuf>, TeardownError> {
+    // Validate the root first: an unsafe root (`/` or `$HOME`) is refused even
+    // when the worktree path is already gone, so this must precede the
+    // missing-path idempotency skip below.
+    let canon_root = canonicalize(worktree_root)?;
+    if is_unsafe_root(&canon_root, canonical_home().as_deref()) {
+        return Err(TeardownError::UnsafeRoot(canon_root));
+    }
+
+    // Missing path → idempotent no-op. Checked before `canonicalize(path)`,
+    // which would otherwise fail with NotFound on an absent path.
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let canon_path = canonicalize(path)?;
+    if !canon_path.starts_with(&canon_root) {
+        return Err(TeardownError::OutOfRoot {
+            path: canon_path,
+            root: canon_root,
+        });
+    }
+    Ok(Some(canon_path))
+}
+
+/// `git worktree remove --force <path>`, run from `repo_dir`. Idempotent: an
+/// "is not a working tree" stderr (already removed) maps to `Ok(())`.
+fn run_git_worktree_remove(repo_dir: &Path, path: &Path) -> Result<(), TeardownError> {
+    let output = Command::new("git")
+        .arg("worktree")
+        .arg("remove")
+        .arg("--force")
+        .arg("--")
+        .arg(path)
+        .current_dir(repo_dir)
+        .output()
+        .map_err(|source| TeardownError::Io {
+            path: path.into(),
+            source,
+        })?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if is_worktree_absent(&stderr) {
+        tracing::warn!(path = %path.display(), "worktree already absent from git; treating remove as success");
+        return Ok(());
+    }
+    Err(TeardownError::GitCommandFailed {
+        cmd: format!("git worktree remove --force -- {}", path.display()),
+        stderr: stderr.into_owned(),
+        status: output.status.code().unwrap_or(-1),
+    })
+}
+
+/// `git branch -D|-d <branch>`, run from `repo_dir`. Idempotent: a
+/// "branch ... not found" stderr maps to `Ok(())`.
+fn run_git_branch_delete(repo_dir: &Path, branch: &str, force: bool) -> Result<(), TeardownError> {
+    let flag = if force { "-D" } else { "-d" };
+    let output = Command::new("git")
+        .arg("branch")
+        .arg(flag)
+        // `--` terminates option parsing so a branch name beginning with `-`
+        // (e.g. `-r`) is treated as a literal name, not a git flag (#740 sec).
+        .arg("--")
+        .arg(branch)
+        .current_dir(repo_dir)
+        .output()
+        .map_err(|source| TeardownError::Io {
+            path: repo_dir.into(),
+            source,
+        })?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if is_branch_absent(&stderr) {
+        tracing::warn!(branch, "branch already absent; treating delete as success");
+        return Ok(());
+    }
+    Err(TeardownError::GitCommandFailed {
+        cmd: format!("git branch {flag} -- {branch}"),
+        stderr: stderr.into_owned(),
+        status: output.status.code().unwrap_or(-1),
+    })
+}
+
+/// True when `canon_root` is a root we must never tear a worktree out of.
+/// `canon_home` is injected (already canonicalized) so this stays a pure,
+/// env-free predicate — see risk R2/R3 in the architect blueprint.
+fn is_unsafe_root(canon_root: &Path, canon_home: Option<&Path>) -> bool {
+    canon_root == Path::new("/") || canon_home == Some(canon_root)
+}
+
+/// True when git stderr indicates the worktree is not registered (already gone).
+/// Verified against git's `fatal: '<path>' is not a working tree`.
+fn is_worktree_absent(stderr: &str) -> bool {
+    stderr.contains("is not a working tree")
+}
+
+/// True when git stderr indicates the branch does not exist (already deleted).
+/// Anchored on git's actual phrasing `error: branch '<name>' not found` rather
+/// than two free-floating substrings, so an unrelated failure that happens to
+/// mention both words cannot mask a real error (#740 sec — false-absent guard).
+fn is_branch_absent(stderr: &str) -> bool {
+    stderr
+        .lines()
+        .any(|line| line.trim_start().starts_with("error: branch ") && line.contains("not found"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_unsafe_root_slash_is_unsafe() {
+        assert!(is_unsafe_root(Path::new("/"), None));
+    }
+
+    #[test]
+    fn is_unsafe_root_home_is_unsafe() {
+        let home = Path::new("/home/user");
+        assert!(is_unsafe_root(home, Some(home)));
+    }
+
+    #[test]
+    fn is_unsafe_root_normal_root_is_safe() {
+        assert!(!is_unsafe_root(
+            Path::new("/tmp/maestro/worktrees"),
+            Some(Path::new("/home/user"))
+        ));
+    }
+
+    #[test]
+    fn is_unsafe_root_home_subdir_is_safe() {
+        // A subdir of HOME is fine — only HOME *exactly* is unsafe.
+        assert!(!is_unsafe_root(
+            Path::new("/home/user/projects/foo"),
+            Some(Path::new("/home/user"))
+        ));
+    }
+
+    #[test]
+    fn is_worktree_absent_matches_known_phrase() {
+        assert!(is_worktree_absent("fatal: '/tmp/wt' is not a working tree"));
+    }
+
+    #[test]
+    fn is_worktree_absent_false_for_other_errors() {
+        assert!(!is_worktree_absent("fatal: not a git repository"));
+    }
+
+    #[test]
+    fn is_branch_absent_matches_known_phrase() {
+        assert!(is_branch_absent("error: branch 'feat/issue-740' not found"));
+    }
+
+    #[test]
+    fn is_branch_absent_false_for_other_errors() {
+        assert!(!is_branch_absent(
+            "error: Cannot delete branch 'main' checked out at '/repo'"
+        ));
+    }
+
+    #[test]
+    fn sanity_check_out_of_root_when_path_escapes() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().join("root");
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir_all(&root).expect("mkdir root");
+        std::fs::create_dir_all(&outside).expect("mkdir outside");
+
+        let result = sanity_check_under_root(&outside, &root);
+        assert!(
+            matches!(result, Err(TeardownError::OutOfRoot { .. })),
+            "expected OutOfRoot, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn sanity_check_none_when_path_missing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("does_not_exist");
+        let result = sanity_check_under_root(&path, tmp.path());
+        assert!(
+            matches!(result, Ok(None)),
+            "expected Ok(None), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn sanity_check_some_when_path_inside_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("wt-1");
+        std::fs::create_dir_all(&path).expect("mkdir wt");
+
+        let result = sanity_check_under_root(&path, tmp.path());
+        match result {
+            Ok(Some(canon)) => {
+                let canon_root = tmp.path().canonicalize().expect("canon root");
+                assert!(
+                    canon.starts_with(&canon_root),
+                    "returned path {canon:?} must be under root {canon_root:?}"
+                );
+            }
+            other => panic!("expected Ok(Some(_)), got {other:?}"),
+        }
+    }
+}

--- a/tests/worktree_teardown.rs
+++ b/tests/worktree_teardown.rs
@@ -1,0 +1,219 @@
+//! Integration tests for `wipe_worktree` (issue #740).
+//!
+//! External integration tests reaching the `pub` surface of
+//! `maestro::work::{wipe_worktree, TeardownError}`. These spawn a real `git`
+//! and build real worktrees under a `tempfile::tempdir`, so they exercise the
+//! destructive path end-to-end (not mocked).
+//!
+//! `git` must be on `PATH`; CI provides it.
+
+use maestro::work::worktree_teardown::{TeardownError, wipe_worktree};
+use std::path::Path;
+use std::process::Command;
+
+/// Run a git command in `dir`, asserting it succeeds. Used only for fixture
+/// setup — the code under test does its own error handling.
+fn git_ok(dir: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("git must be spawnable");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// `git init` a repo with one commit on `main` so `git worktree add` works.
+fn init_repo(dir: &Path) {
+    git_ok(dir, &["init", "-q", "-b", "main"]);
+    git_ok(dir, &["config", "user.email", "test@example.com"]);
+    git_ok(dir, &["config", "user.name", "Test"]);
+    git_ok(dir, &["commit", "-q", "--allow-empty", "-m", "init"]);
+}
+
+/// True when `git branch --list <branch>` in `dir` is empty (branch gone).
+fn branch_absent(dir: &Path, branch: &str) -> bool {
+    let output = Command::new("git")
+        .args(["branch", "--list", branch])
+        .current_dir(dir)
+        .output()
+        .expect("git branch --list must spawn");
+    String::from_utf8_lossy(&output.stdout).trim().is_empty()
+}
+
+const BRANCH: &str = "feat/issue-740";
+
+#[test]
+fn happy_path_removes_worktree_and_branch() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    init_repo(tmp.path());
+    let wt = tmp.path().join("wt");
+    git_ok(
+        tmp.path(),
+        &["worktree", "add", wt.to_str().unwrap(), "-b", BRANCH],
+    );
+    assert!(wt.exists(), "pre-condition: worktree dir exists");
+
+    let result = wipe_worktree(740, &wt, BRANCH, tmp.path());
+
+    assert!(result.is_ok(), "expected Ok, got {result:?}");
+    assert!(!wt.exists(), "worktree dir must be gone");
+    assert!(branch_absent(tmp.path(), BRANCH), "branch must be deleted");
+}
+
+#[test]
+fn idempotent_second_call_returns_ok() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    init_repo(tmp.path());
+    let wt = tmp.path().join("wt");
+    git_ok(
+        tmp.path(),
+        &["worktree", "add", wt.to_str().unwrap(), "-b", BRANCH],
+    );
+
+    wipe_worktree(740, &wt, BRANCH, tmp.path()).expect("first call succeeds");
+    let second = wipe_worktree(740, &wt, BRANCH, tmp.path());
+
+    assert!(
+        second.is_ok(),
+        "second call must be idempotent, got {second:?}"
+    );
+}
+
+#[test]
+fn uncommitted_file_is_force_removed() {
+    // A destructive primitive must force-remove even a dirty worktree.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    init_repo(tmp.path());
+    let wt = tmp.path().join("wt");
+    git_ok(
+        tmp.path(),
+        &["worktree", "add", wt.to_str().unwrap(), "-b", BRANCH],
+    );
+    std::fs::write(wt.join("dirty.txt"), b"uncommitted").expect("write dirty file");
+
+    let result = wipe_worktree(740, &wt, BRANCH, tmp.path());
+
+    assert!(
+        result.is_ok(),
+        "force removal of dirty worktree must succeed, got {result:?}"
+    );
+    assert!(!wt.exists(), "dirty worktree dir must be gone");
+}
+
+#[test]
+fn out_of_root_path_is_rejected() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().join("root");
+    let outside = tmp.path().join("outside");
+    std::fs::create_dir_all(&root).expect("mkdir root");
+    std::fs::create_dir_all(&outside).expect("mkdir outside");
+
+    let result = wipe_worktree(740, &outside, BRANCH, &root);
+
+    assert!(
+        matches!(result, Err(TeardownError::OutOfRoot { .. })),
+        "expected OutOfRoot, got {result:?}"
+    );
+    assert!(outside.exists(), "rejected path must be left untouched");
+}
+
+#[test]
+fn unsafe_root_slash_is_rejected() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let wt = tmp.path().join("wt");
+
+    // root = "/" must be refused even though the path under it is missing —
+    // the unsafe-root guard runs before the missing-path idempotency skip.
+    let result = wipe_worktree(740, &wt, BRANCH, Path::new("/"));
+
+    assert!(
+        matches!(result, Err(TeardownError::UnsafeRoot(_))),
+        "expected UnsafeRoot, got {result:?}"
+    );
+}
+
+#[test]
+fn symlink_escape_is_rejected() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().join("root");
+    let outside = tmp.path().join("outside");
+    std::fs::create_dir_all(&root).expect("mkdir root");
+    std::fs::create_dir_all(&outside).expect("mkdir outside");
+
+    // A symlink *inside* the root that points outside it. Canonicalize resolves
+    // it to `outside`, so the containment check must reject it.
+    let link = root.join("escape");
+    std::os::unix::fs::symlink(&outside, &link).expect("create symlink");
+
+    let result = wipe_worktree(740, &link, BRANCH, &root);
+
+    assert!(
+        matches!(result, Err(TeardownError::OutOfRoot { .. })),
+        "expected OutOfRoot for symlink escape, got {result:?}"
+    );
+}
+
+#[test]
+fn missing_branch_is_ok() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    init_repo(tmp.path());
+    let wt = tmp.path().join("wt");
+    git_ok(
+        tmp.path(),
+        &["worktree", "add", wt.to_str().unwrap(), "-b", BRANCH],
+    );
+    // Remove worktree + branch out-of-band; wipe_worktree must still return Ok.
+    git_ok(
+        tmp.path(),
+        &["worktree", "remove", "--force", wt.to_str().unwrap()],
+    );
+    git_ok(tmp.path(), &["branch", "-D", BRANCH]);
+
+    let result = wipe_worktree(740, &wt, BRANCH, tmp.path());
+
+    assert!(result.is_ok(), "missing branch must be Ok, got {result:?}");
+}
+
+#[test]
+fn leading_dash_branch_is_treated_as_literal() {
+    // Security regression (#740): a branch value beginning with `-` must be
+    // passed as a literal name, never re-parsed by git as a flag. Without the
+    // `--` end-of-options terminator, `git branch -D -r` means "delete
+    // remote-tracking branches", not "delete the branch named -r".
+    let tmp = tempfile::tempdir().expect("tempdir");
+    init_repo(tmp.path());
+    let wt = tmp.path().join("wt");
+    git_ok(
+        tmp.path(),
+        &["worktree", "add", wt.to_str().unwrap(), "-b", BRANCH],
+    );
+    // An unrelated branch that must survive the teardown.
+    git_ok(tmp.path(), &["branch", "keep-me"]);
+
+    let result = wipe_worktree(740, &wt, "-r", tmp.path());
+
+    assert!(
+        result.is_ok(),
+        "leading-dash branch must be treated as a literal (absent) name, got {result:?}"
+    );
+    assert!(
+        !branch_absent(tmp.path(), "keep-me"),
+        "unrelated branch must survive a leading-dash branch teardown"
+    );
+}
+
+#[test]
+fn missing_path_is_ok() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    init_repo(tmp.path());
+    let wt = tmp.path().join("never-existed");
+    assert!(!wt.exists(), "pre-condition: path is absent");
+
+    let result = wipe_worktree(740, &wt, BRANCH, tmp.path());
+
+    assert!(result.is_ok(), "missing path must be Ok, got {result:?}");
+}


### PR DESCRIPTION
## Summary

- New `src/work/worktree_teardown.rs`: `wipe_worktree(issue_number, path, branch, worktree_root)` — destructive git-worktree + branch teardown, consumed as `maestro::work::worktree_teardown::{wipe_worktree, TeardownError}` (no re-export, matching `pr_marker`).
- Sanity-gated: canonicalizes path + root, refuses root `/` or `$HOME` (`UnsafeRoot`), enforces containment so symlink escapes resolve out and fail (`OutOfRoot`). Idempotent: missing path/branch/already-removed worktree all return `Ok`. `--` end-of-options terminator on git calls blocks leading-dash argument injection (security label).
- No automatic invocation yet — #741 wires this into the interaction lifecycle. Follow-up #938 (blocked by #741) converges the existing `session/worktree.rs` + `session/cleanup.rs` removals onto this guard.

Closes #740

## Test plan

- [x] cargo test --quiet (11 inline unit + 9 real-git tempdir integration tests)
- [x] cargo clippy -- -D warnings -A dead_code
- [x] cargo fmt --check
- [x] manual verification: not required — backend primitive, no `src/tui/**` touched
