### PR TITLE
fix(test): azure DevOps iteration tests time-bomb on fixed fixture dates

### DIFF
--- a/src/provider/azure_devops/tests/iteration_creation.rs
+++ b/src/provider/azure_devops/tests/iteration_creation.rs
@@ -9,7 +9,7 @@ async fn create_milestone_duplicate_title_returns_existed_without_create() {
         r#"[{
             "name": "Sprint 2",
             "path": "Project\\Sprint 2",
-            "attributes": { "finishDate": "2026-06-04T00:00:00Z" }
+            "attributes": { "finishDate": "2999-12-31T00:00:00Z" }
         }]"#,
     )]));
     let client = test_client(runner.clone());
@@ -38,14 +38,14 @@ async fn create_milestone_creates_iteration_updates_description_and_returns_stab
             r#"{
                 "name": "Sprint 2",
                 "path": "Project\\Sprint 2",
-                "attributes": { "finishDate": "2026-06-04T00:00:00Z" }
+                "attributes": { "finishDate": "2999-12-31T00:00:00Z" }
             }"#,
         ),
         MockAzRunner::success(
             r#"{
                 "name": "Sprint 2",
                 "path": "Project\\Sprint 2",
-                "attributes": { "finishDate": "2026-06-04T00:00:00Z" }
+                "attributes": { "finishDate": "2999-12-31T00:00:00Z" }
             }"#,
         ),
     ]));
@@ -83,7 +83,7 @@ async fn create_milestone_duplicate_create_error_recovers_existing_iteration() {
             r#"[{
                 "name": "Sprint 2",
                 "path": "Project\\Sprint 2",
-                "attributes": { "finishDate": "2026-06-04T00:00:00Z" }
+                "attributes": { "finishDate": "2999-12-31T00:00:00Z" }
             }]"#,
         ),
     ]));

--- a/src/provider/azure_devops/tests/iterations.rs
+++ b/src/provider/azure_devops/tests/iterations.rs
@@ -22,7 +22,7 @@ pub(super) fn iterations_fixture() -> &'static str {
             "name": "Sprint Past",
             "path": "Project\\Sprint Past",
             "structureType": "iteration",
-            "attributes": { "finishDate": "2026-05-03T00:00:00Z" },
+            "attributes": { "finishDate": "2000-01-01T00:00:00Z" },
             "url": "https://dev.azure.com/example/Project/_apis/wit/classificationNodes/Iterations/Sprint%20Past"
         },
         {
@@ -30,7 +30,7 @@ pub(super) fn iterations_fixture() -> &'static str {
             "name": "Sprint Future",
             "path": "Project\\Sprint Future",
             "structureType": "iteration",
-            "attributes": { "finishDate": "2026-06-04T00:00:00Z" },
+            "attributes": { "finishDate": "2999-12-31T00:00:00Z" },
             "url": "https://dev.azure.com/example/Project/_apis/wit/classificationNodes/Iterations/Sprint%20Future"
         }
     ]"#
@@ -56,7 +56,7 @@ fn parse_iterations_json_maps_nodes_to_milestones() {
     assert_eq!(iterations[2].path, "Project\\Sprint Future");
     assert_eq!(
         iterations[2].finish_date,
-        Some(NaiveDate::from_ymd_opt(2026, 6, 4).unwrap())
+        Some(NaiveDate::from_ymd_opt(2999, 12, 31).unwrap())
     );
 
     let milestones =


### PR DESCRIPTION
Sentinel-date fix for the time-bomb azure iteration tests failing on main (and blocking all PRs incl. #945). Far-past/far-future fixture `finishDate`s so past/future classification is date-independent.

Closes #951