### PR TITLE
feat(session): interactive launch builds real issue prompt + appendix

### DIFF
--- a/docs/superpowers/specs/2026-06-04-unified-interactive-sessions-design.md
+++ b/docs/superpowers/specs/2026-06-04-unified-interactive-sessions-design.md
@@ -78,7 +78,7 @@ An `Interactive`-mode `Session` reuses the entire one-shot pipeline (prompt, app
 
 Each phase is its own issue, its own TDD cycle, its own PR. Phases are sequential.
 
-1. **Context.** Interactive launch builds the real issue prompt + `system_prompt_appendix`; the first turn is the issue work. Issue body fetched/looked up at launch. *(Subsumes #934.)*
+1. **Context.** ✅ **Implemented — #946 (PR pending).** Interactive launch builds the real issue prompt + `system_prompt_appendix`; the first turn carries issue title + body + acceptance criteria + appendix (mode + guardrails + knowledge), identical to a one-shot. Falls back to dialog text on cache miss (fetch-on-miss deferred to a follow-up issue). Resumed sessions inject nothing. New surface: `SessionPool::interaction_appendix()` in `pool.rs`; `App::lookup_issue()` + `App::build_interaction_launch_prompt()` in `data_handler.rs`; `open_interaction_session` in `screen_dispatch.rs` rewired to seed the first turn with the built prompt. *(Subsumes #934.)*
 2. **Pipeline reuse.** Follow-up turns go through the normal resumed-turn path (shared prompt builder + provider routing + telemetry); retire the `interaction_turn.rs` bare-spawn loop.
 3. **State unify.** Add `SessionStatus::Interactive` + `Session.settled_from` + `Session.turn_state`; transition one-shot → Interactive on settle; retire `InteractionState` and `InteractionSession`.
 4. **Teardown rework.** Move `wipe_worktree` to the quit path; strip auto-wipe + auto-nav from #741; repoint #739 to a notifier.
@@ -86,8 +86,9 @@ Each phase is its own issue, its own TDD cycle, its own PR. Phases are sequentia
 
 ## 7. Backlog impact
 
-- **#934** → close, folded into Phase 1.
-- **#935** → this spec (the umbrella). Re-scoped to the phase sequence above.
+- **#934** → closed, folded into Phase 1 (implemented in #946).
+- **#946** → Phase 1 implementation issue. Implemented; PR pending. Branch: `feat/issue-946-feat-session-phase-1-interactive-launch-`.
+- **#935** → this spec (the umbrella). Re-scoped to the phase sequence above. Phase 1 complete; Phase 2 is next.
 - **#739 / #740 / #741** → reworked in Phase 4. PR #940 still ships its chat-shell render + the #943 wrap fix; Phase 4 repurposes the terminator (PR-keeps-alive, teardown-on-quit). #740's `wipe_worktree` primitive is reused unchanged, just re-pointed.
 - **#929 / #930** → gated behind Phase 2 / Phase 5.
 - **#936** (deferred terminator firing) and **#938** (route removals through the wipe guard) → revisit under Phase 4; #936 may be obviated by the kept-alive model.

--- a/src/session/pool.rs
+++ b/src/session/pool.rs
@@ -110,6 +110,35 @@ impl SessionPool {
         self.guardrail_prompt = Some(prompt);
     }
 
+    /// Assemble the system-prompt appendix for an interaction launch (#946):
+    /// mode prompt + guardrail + knowledge, joined with "\n\n". This is the
+    /// subset of `try_promote`'s appendix reachable before a live `Session`
+    /// exists — file-claims and rendered HTTP templates are keyed on a
+    /// promoted session and are intentionally excluded here. Returns `None`
+    /// when every component is empty.
+    pub(crate) fn interaction_appendix(
+        &self,
+        mode_config: Option<&crate::session::types::SessionModeConfig>,
+    ) -> Option<String> {
+        let mut components: Vec<String> = Vec::new();
+        if let Some(mode) = mode_config
+            && !mode.system_prompt.trim().is_empty()
+        {
+            components.push(mode.system_prompt.clone());
+        }
+        if let Some(ref guardrail) = self.guardrail_prompt {
+            components.push(guardrail.clone());
+        }
+        if let Some(ref knowledge) = self.knowledge_appendix {
+            components.push(knowledge.clone());
+        }
+        if components.is_empty() {
+            None
+        } else {
+            Some(components.join("\n\n"))
+        }
+    }
+
     /// Set the allowed tools whitelist for new sessions.
     pub fn set_allowed_tools(&mut self, tools: Vec<String>) {
         self.allowed_tools = tools;
@@ -1608,5 +1637,75 @@ mod tests {
             pool.find_active_interaction_by_issue_mut(42).is_none(),
             "terminated session must not be returned by _mut lookup"
         );
+    }
+
+    // --- interaction_appendix (#946) ---
+    // Subset of try_promote's appendix: mode.system_prompt + guardrail +
+    // knowledge, joined with "\n\n". No file-claims (no live session at
+    // interaction launch). None when every part is empty.
+
+    fn mode_with_prompt(prompt: &str) -> crate::session::types::SessionModeConfig {
+        crate::session::types::SessionModeConfig {
+            system_prompt: prompt.to_string(),
+            allowed_tools: Vec::new(),
+            permission_mode: None,
+        }
+    }
+
+    #[test]
+    fn interaction_appendix_none_when_all_empty() {
+        let pool = make_pool(1);
+        assert!(pool.interaction_appendix(None).is_none());
+    }
+
+    #[test]
+    fn interaction_appendix_includes_mode_system_prompt() {
+        let pool = make_pool(1);
+        let mode = mode_with_prompt("Custom mode prompt");
+        let r = pool
+            .interaction_appendix(Some(&mode))
+            .expect("mode prompt yields Some");
+        assert!(r.contains("Custom mode prompt"));
+    }
+
+    #[test]
+    fn interaction_appendix_includes_guardrail_prompt() {
+        let mut pool = make_pool(1);
+        pool.set_guardrail_prompt("GUARDRAIL: no unsafe".into());
+        let r = pool
+            .interaction_appendix(None)
+            .expect("guardrail yields Some");
+        assert!(r.contains("GUARDRAIL: no unsafe"));
+    }
+
+    #[test]
+    fn interaction_appendix_includes_knowledge_appendix() {
+        let mut pool = make_pool(1);
+        pool.set_knowledge_appendix(Some("KNOWLEDGE: extra".into()));
+        let r = pool
+            .interaction_appendix(None)
+            .expect("knowledge yields Some");
+        assert!(r.contains("KNOWLEDGE: extra"));
+    }
+
+    #[test]
+    fn interaction_appendix_joins_parts_with_double_newline() {
+        let mut pool = make_pool(1);
+        pool.set_guardrail_prompt("PART_B".into());
+        pool.set_knowledge_appendix(Some("PART_C".into()));
+        let mode = mode_with_prompt("PART_A");
+        let r = pool.interaction_appendix(Some(&mode)).unwrap();
+        assert!(r.contains("PART_A\n\nPART_B"));
+        assert!(r.contains("PART_B\n\nPART_C"));
+    }
+
+    #[test]
+    fn interaction_appendix_skips_blank_mode_prompt() {
+        let mut pool = make_pool(1);
+        pool.set_guardrail_prompt("GUARDRAIL_ONLY".into());
+        let mode = mode_with_prompt("   ");
+        let r = pool.interaction_appendix(Some(&mode)).unwrap();
+        assert!(r.contains("GUARDRAIL_ONLY"));
+        assert!(!r.starts_with("   "), "blank mode prompt not injected");
     }
 }

--- a/src/tui/app/data_handler.rs
+++ b/src/tui/app/data_handler.rs
@@ -87,6 +87,37 @@ impl App {
         }
     }
 
+    /// Look up an issue by number: the fetch cache first, then the loaded
+    /// issue-browser list. Returns `None` when neither holds it.
+    pub(crate) fn lookup_issue(&self, issue_number: u64) -> Option<&crate::provider::types::Issue> {
+        self.state.issue_cache.get(&issue_number).or_else(|| {
+            self.screen_state
+                .issue_browser_screen
+                .as_ref()
+                .and_then(|b| b.issues.iter().find(|i| i.number == issue_number))
+        })
+    }
+
+    /// Build the first-turn prompt for an interactive launch (#946) using the
+    /// same assembly as a one-shot: `build_issue_prompt_with_custom` (issue
+    /// title + body + acceptance criteria) followed by the system-prompt
+    /// appendix (mode + guardrails + knowledge). Returns `None` when the issue
+    /// is not yet cached/loaded — the caller decides how to fall back.
+    pub(crate) fn build_interaction_launch_prompt(
+        &self,
+        issue_number: u64,
+        custom_prompt: &Option<String>,
+    ) -> Option<String> {
+        let issue = self.lookup_issue(issue_number)?;
+        let (_model, _mode, mode_config) =
+            self.resolve_model_and_mode(&issue.labels, Some(&self.selected_agent_id()));
+        let body = self.build_issue_prompt_with_custom(issue, custom_prompt);
+        Some(match self.pool.interaction_appendix(mode_config.as_ref()) {
+            Some(appendix) => format!("{body}\n\n{appendix}"),
+            None => body,
+        })
+    }
+
     /// Process a data event from a background fetch task.
     pub fn handle_data_event(&mut self, evt: TuiDataEvent) {
         match evt {
@@ -743,6 +774,130 @@ mod tests {
             app.pending_session_launches[0].agent_id.as_deref(),
             Some("codex")
         );
+    }
+
+    // --- lookup_issue + build_interaction_launch_prompt (#946) ---
+
+    fn issue_numbered(number: u64, title: &str, body: &str) -> Issue {
+        Issue {
+            number,
+            title: title.to_string(),
+            body: body.to_string(),
+            labels: Vec::new(),
+            state: "open".to_string(),
+            html_url: format!("https://github.com/owner/repo/issues/{number}"),
+            milestone: None,
+            assignees: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn lookup_issue_returns_issue_from_cache() {
+        let mut app = crate::tui::make_test_app("lookup-issue-cache");
+        app.state
+            .issue_cache
+            .insert(42, issue_numbered(42, "Cached", "body"));
+        let found = app.lookup_issue(42).expect("cache hit");
+        assert_eq!(found.number, 42);
+        assert_eq!(found.title, "Cached");
+    }
+
+    #[test]
+    fn lookup_issue_returns_issue_from_browser_list() {
+        let mut app = crate::tui::make_test_app("lookup-issue-browser");
+        app.screen_state.issue_browser_screen =
+            Some(crate::tui::screens::IssueBrowserScreen::new(vec![
+                issue_numbered(55, "Browsed", "b"),
+            ]));
+        let found = app.lookup_issue(55).expect("browser hit");
+        assert_eq!(found.number, 55);
+    }
+
+    #[test]
+    fn lookup_issue_cache_takes_priority_over_browser() {
+        let mut app = crate::tui::make_test_app("lookup-issue-priority");
+        app.state
+            .issue_cache
+            .insert(10, issue_numbered(10, "Cache version", "b"));
+        app.screen_state.issue_browser_screen =
+            Some(crate::tui::screens::IssueBrowserScreen::new(vec![
+                issue_numbered(10, "Browser version", "b"),
+            ]));
+        assert_eq!(app.lookup_issue(10).unwrap().title, "Cache version");
+    }
+
+    #[test]
+    fn lookup_issue_returns_none_on_miss() {
+        let app = crate::tui::make_test_app("lookup-issue-miss");
+        assert!(app.lookup_issue(99).is_none());
+    }
+
+    #[test]
+    fn build_interaction_launch_prompt_includes_issue_title_and_number() {
+        let mut app = crate::tui::make_test_app("launch-prompt-basic");
+        app.state.issue_cache.insert(
+            946,
+            issue_numbered(
+                946,
+                "Build interaction launch",
+                "Acceptance Criteria: carries prompt",
+            ),
+        );
+        let p = app
+            .build_interaction_launch_prompt(946, &None)
+            .expect("Some when issue found");
+        assert!(p.contains("946"), "must contain issue number");
+        assert!(p.contains("Build interaction launch"), "must contain title");
+        assert!(
+            p.contains("Acceptance Criteria"),
+            "must carry issue body (AC) into the prompt"
+        );
+    }
+
+    #[test]
+    fn build_interaction_launch_prompt_appends_custom_prompt() {
+        let mut app = crate::tui::make_test_app("launch-prompt-custom");
+        app.state
+            .issue_cache
+            .insert(946, issue_numbered(946, "Title", "body"));
+        let p = app
+            .build_interaction_launch_prompt(946, &Some("My extra instruction".into()))
+            .unwrap();
+        assert!(p.contains("My extra instruction"));
+        assert!(p.contains("946"));
+    }
+
+    #[test]
+    fn build_interaction_launch_prompt_appends_interaction_appendix() {
+        let mut app = crate::tui::make_test_app("launch-prompt-appendix");
+        app.state
+            .issue_cache
+            .insert(10, issue_numbered(10, "Title", "body"));
+        app.pool.set_guardrail_prompt("GUARDRAIL: sentinel".into());
+        let p = app.build_interaction_launch_prompt(10, &None).unwrap();
+        assert!(p.contains("GUARDRAIL: sentinel"), "appendix injected");
+        let idx_body = p.find("Title").unwrap();
+        let idx_guardrail = p.find("GUARDRAIL: sentinel").unwrap();
+        assert!(
+            idx_guardrail > idx_body,
+            "appendix must come after the issue prompt body"
+        );
+    }
+
+    #[test]
+    fn build_interaction_launch_prompt_returns_none_when_issue_not_found() {
+        let app = crate::tui::make_test_app("launch-prompt-miss");
+        assert!(app.build_interaction_launch_prompt(999, &None).is_none());
+    }
+
+    #[test]
+    fn build_interaction_launch_prompt_no_appendix_when_pool_empty() {
+        let mut app = crate::tui::make_test_app("launch-prompt-no-appendix");
+        app.state
+            .issue_cache
+            .insert(7, issue_numbered(7, "Title", "body"));
+        let p = app.build_interaction_launch_prompt(7, &None).unwrap();
+        assert!(!p.ends_with("\n\n"), "no trailing blank appendix section");
     }
 
     #[test]

--- a/src/tui/screen_dispatch.rs
+++ b/src/tui/screen_dispatch.rs
@@ -480,27 +480,22 @@ fn open_interaction_session(
     // Name the work in the header, like the sessions view: look the title up
     // from the issue cache, falling back to the browser's loaded list (#738 QA).
     let title = app
-        .state
-        .issue_cache
-        .get(&issue_number)
+        .lookup_issue(issue_number)
         .map(|i| i.title.clone())
-        .or_else(|| {
-            app.screen_state
-                .issue_browser_screen
-                .as_ref()
-                .and_then(|b| b.issues.iter().find(|i| i.number == issue_number))
-                .map(|i| i.title.clone())
-        })
         .unwrap_or_default();
     screen.set_issue_title(title);
 
-    // A NEW session launched with a dialog prompt sends it as the first turn
-    // so the agent starts on the user's instruction (#738). Re-entry ignores
-    // it (the dialog is skipped, and we don't inject into an ongoing chat).
+    // A NEW session's first turn IS the issue work: build the real issue
+    // prompt + system-prompt appendix, identical to a one-shot (#946). The
+    // dialog text rides along as a custom instruction. On a cache/browser
+    // miss we fall back to the bare dialog text (pre-#946 behavior) so the
+    // launch still proceeds; fetch-on-miss is tracked as a follow-up.
+    // Re-entry injects nothing — we don't seed an ongoing chat.
     let first_turn = if resumed {
         None
     } else {
-        seed_prompt.filter(|p| !p.trim().is_empty())
+        app.build_interaction_launch_prompt(issue_number, &seed_prompt)
+            .or_else(|| seed_prompt.filter(|p| !p.trim().is_empty()))
     };
     if let Some(prompt) = first_turn.clone() {
         screen.seed_turn(prompt);
@@ -1428,5 +1423,74 @@ mod build_known_agents_tests {
         let team_agents = BTreeSet::from(["claude".to_string()]);
         let result = build_known_agents_from_config(team_agents, None);
         assert_eq!(result, vec!["claude".to_string()]);
+    }
+}
+
+#[cfg(test)]
+mod interaction_launch_tests {
+    use super::open_interaction_session;
+    use crate::provider::types::Issue;
+    use crate::tui::app::{self, TuiCommand};
+
+    fn issue(number: u64, title: &str, body: &str) -> Issue {
+        Issue {
+            number,
+            title: title.to_string(),
+            body: body.to_string(),
+            labels: Vec::new(),
+            state: "open".to_string(),
+            html_url: format!("https://github.com/owner/repo/issues/{number}"),
+            milestone: None,
+            assignees: Vec::new(),
+        }
+    }
+
+    fn first_turn_prompt(app: &app::App) -> Option<&str> {
+        app.pending_commands.iter().find_map(|c| match c {
+            TuiCommand::SendInteractionTurn { prompt, .. } => Some(prompt.as_str()),
+            _ => None,
+        })
+    }
+
+    #[test]
+    fn first_turn_argv_carries_built_issue_prompt_and_appendix() {
+        let mut app = crate::tui::make_test_app("issue-946-first-turn");
+        app.state.issue_cache.insert(
+            946,
+            issue(946, "Build interaction launch", "Acceptance Criteria here"),
+        );
+        app.pool
+            .set_guardrail_prompt("GUARDRAIL: test sentinel".into());
+
+        open_interaction_session(&mut app, 946, false, None);
+
+        let prompt = first_turn_prompt(&app).expect("first turn must be queued for a new session");
+        assert!(prompt.contains("946"), "carries issue number");
+        assert!(prompt.contains("Build interaction launch"), "carries title");
+        assert!(
+            prompt.contains("Acceptance Criteria"),
+            "carries issue body / AC"
+        );
+        assert!(
+            prompt.contains("GUARDRAIL: test sentinel"),
+            "carries the system-prompt appendix"
+        );
+    }
+
+    #[test]
+    fn resumed_session_does_not_inject_first_turn_prompt() {
+        let mut app = crate::tui::make_test_app("issue-946-resumed");
+        app.state
+            .issue_cache
+            .insert(946, issue(946, "Title", "body"));
+        // Create an active session first so re-entry is detected as resumed.
+        app.pool.create_interaction_session(946, false);
+
+        open_interaction_session(&mut app, 946, false, Some("ignored seed".into()));
+
+        assert!(
+            first_turn_prompt(&app).is_none(),
+            "resumed session must not queue a first turn"
+        );
     }
 }

--- a/src/tui/screens/interaction/input.rs
+++ b/src/tui/screens/interaction/input.rs
@@ -130,7 +130,7 @@ pub(super) fn draw_keybar(f: &mut Frame, area: Rect, theme: &Theme, pushup_enabl
     }
     spans.extend([
         Span::styled("[Ctrl+L]", active),
-        Span::raw(" Clear  "),
+        Span::raw(" Clear input  "),
         Span::styled("[Ctrl+Q]", active),
         Span::raw(" Quit  "),
         Span::styled("[Esc]", active),

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_ctrl_p_greyed_without_produce_pr.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_ctrl_p_greyed_without_produce_pr.snap
@@ -36,7 +36,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "                                                                                                                        "
 "                                                                                                                        "
-"[Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear  [Ctrl+Q] Quit  [Esc] Back                  "
+"[Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear input  [Ctrl+Q] Quit  [Esc] Back            "
 "╔═════════════════════════════════════════════════════[ Message ]══════════════════════════════════════════════════════╗"
 "║Type a prompt to begin…                                                                                               ║"
 "║                                                                                                                      ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_empty_state.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_empty_state.snap
@@ -36,7 +36,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "                                                                                                                        "
 "                                                                                                                        "
-"[Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup  [Ctrl+L] Clear  [Ctrl+Q] Quit  [Esc] Back                        "
+"[Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup  [Ctrl+L] Clear input  [Ctrl+Q] Quit  [Esc] Back                  "
 "╔═════════════════════════════════════════════════════[ Message ]══════════════════════════════════════════════════════╗"
 "║Type a prompt to begin…                                                                                               ║"
 "║                                                                                                                      ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_header_shows_agent_and_model.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_header_shows_agent_and_model.snap
@@ -36,7 +36,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "                                                                                                                        "
 "                                                                                                                        "
-"[Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup  [Ctrl+L] Clear  [Ctrl+Q] Quit  [Esc] Back                        "
+"[Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup  [Ctrl+L] Clear input  [Ctrl+Q] Quit  [Esc] Back                  "
 "╔═════════════════════════════════════════════════════[ Message ]══════════════════════════════════════════════════════╗"
 "║Type a prompt to begin…                                                                                               ║"
 "║                                                                                                                      ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_one_turn_user.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_one_turn_user.snap
@@ -36,7 +36,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "                                                                                                                        "
 "                                                                                                                        "
-"[Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup  [Ctrl+L] Clear  [Ctrl+Q] Quit  [Esc] Back                        "
+"[Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup  [Ctrl+L] Clear input  [Ctrl+Q] Quit  [Esc] Back                  "
 "╔═════════════════════════════════════════════════════[ Message ]══════════════════════════════════════════════════════╗"
 "║Type a prompt to begin…                                                                                               ║"
 "║                                                                                                                      ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_quit_modal_open.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_quit_modal_open.snap
@@ -36,7 +36,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "                                                                                                                        "
 "                                                                                                                        "
-"[Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup  [Ctrl+L] Clear  [Ctrl+Q] Quit  [Esc] Back                        "
+"[Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup  [Ctrl+L] Clear input  [Ctrl+Q] Quit  [Esc] Back                  "
 "╔═════════════════════════════════════════════════════[ Message ]══════════════════════════════════════════════════════╗"
 "║Type a prompt to begin…                                                                                               ║"
 "║                                                                                                                      ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_scrolled_up.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_scrolled_up.snap
@@ -36,7 +36,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "                                                                                                                        "
 "                                                                                                                        "
-"[Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup  [Ctrl+L] Clear  [Ctrl+Q] Quit  [Esc] Back                        "
+"[Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup  [Ctrl+L] Clear input  [Ctrl+Q] Quit  [Esc] Back                  "
 "╔═════════════════════════════════════════════════════[ Message ]══════════════════════════════════════════════════════╗"
 "║Type a prompt to begin…                                                                                               ║"
 "║                                                                                                                      ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_streaming_locks_input.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_streaming_locks_input.snap
@@ -36,7 +36,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "                                                                                                                        "
 "                                                                                                                        "
-"[Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear  [Ctrl+Q] Quit  [Esc] Back                  "
+"[Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear input  [Ctrl+Q] Quit  [Esc] Back            "
 "╔══════════════════════════════════════════[ Message (⠋ agent responding…) ]═══════════════════════════════════════════╗"
 "║⠋ Agent is responding — input locked…                                                                                 ║"
 "║                                                                                                                      ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_terminated_banner.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_terminated_banner.snap
@@ -36,7 +36,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "                                                                                                                        "
 "                                                                                                                        "
-"[Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear  [Ctrl+Q] Quit  [Esc] Back                  "
+"[Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear input  [Ctrl+Q] Quit  [Esc] Back            "
 "╔════════════════════════════════════════════════════[ Terminated ]════════════════════════════════════════════════════╗"
 "║                          Session terminated (user quit). Press any key to return to Issues.                          ║"
 "║                                                                                                                      ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_three_turns_mixed_with_streaming.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_three_turns_mixed_with_streaming.snap
@@ -36,7 +36,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "                                                                                                                        "
 "                                                                                                                        "
-"[Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup  [Ctrl+L] Clear  [Ctrl+Q] Quit  [Esc] Back                        "
+"[Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup  [Ctrl+L] Clear input  [Ctrl+Q] Quit  [Esc] Back                  "
 "╔═════════════════════════════════════════════════════[ Message ]══════════════════════════════════════════════════════╗"
 "║Type a prompt to begin…                                                                                               ║"
 "║                                                                                                                      ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction_terminator__terminator_idle_success.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction_terminator__terminator_idle_success.snap
@@ -36,7 +36,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "                                                                                                                        "
 "                                                                                                                        "
-"[Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear  [Ctrl+Q] Quit  [Esc] Back                  "
+"[Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear input  [Ctrl+Q] Quit  [Esc] Back            "
 "╔════════════════════════════════════════════════════[ Terminated ]════════════════════════════════════════════════════╗"
 "║                          Session terminated (PR created). Press any key to return to Issues.                         ║"
 "║                                                                                                                      ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction_terminator__terminator_streaming_deferred.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction_terminator__terminator_streaming_deferred.snap
@@ -36,7 +36,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "                                                                                                                        "
 "                                                                                                                        "
-"[Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear  [Ctrl+Q] Quit  [Esc] Back                  "
+"[Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear input  [Ctrl+Q] Quit  [Esc] Back            "
 "╔══════════════════════════════════════════[ Message (⠋ agent responding…) ]═══════════════════════════════════════════╗"
 "║⠋ Agent is responding — input locked…                                                                                 ║"
 "║                                                                                                                      ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction_terminator__terminator_teardown_failure.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction_terminator__terminator_teardown_failure.snap
@@ -36,7 +36,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "                                                                                                                        "
 "                                                                                                                        "
-"[Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear  [Ctrl+Q] Quit  [Esc] Back                  "
+"[Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear input  [Ctrl+Q] Quit  [Esc] Back            "
 "╔════════════════════════════════════════════════════[ Terminated ]════════════════════════════════════════════════════╗"
 "║                        Session terminated (agent failure). Press any key to return to Issues.                        ║"
 "║                                                                                                                      ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction_terminator__terminator_userquit_before_terminator.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction_terminator__terminator_userquit_before_terminator.snap
@@ -36,7 +36,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "                                                                                                                        "
 "                                                                                                                        "
-"[Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear  [Ctrl+Q] Quit  [Esc] Back                  "
+"[Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear input  [Ctrl+Q] Quit  [Esc] Back            "
 "╔════════════════════════════════════════════════════[ Terminated ]════════════════════════════════════════════════════╗"
 "║                          Session terminated (user quit). Press any key to return to Issues.                          ║"
 "║                                                                                                                      ║"


### PR DESCRIPTION
## Summary

Phase 1 of the unified interactive-sessions track (spec §6). An Interactive-mode session launch now builds the **real** issue prompt + system-prompt appendix, killing the bare-chat behavior where the agent had no idea which issue it was on.

- The first interaction turn carries issue title + body + acceptance criteria + appendix (mode + guardrails + knowledge), assembled exactly like a one-shot — `build_issue_prompt_with_custom` is reused, no parallel prompt path.
- `SessionPool::interaction_appendix()` assembles the launch appendix (subset of `try_promote`: mode + guardrail + knowledge; no file-claims, since there is no live session at launch).
- `App::lookup_issue()` (cache → browser fallback) + `App::build_interaction_launch_prompt()` build the prompt; `open_interaction_session` seeds the first turn with it.
- Cache/browser miss → falls back to bare dialog text (fetch-on-miss carved out to #953). Resumed sessions inject nothing.
- No changes to `interaction.rs` / `interaction_turn.rs` — the prompt rides the existing `-p <prompt>` first-turn argv channel.

## Tests

16 new tests (all green): `interaction_appendix` (6), `lookup_issue` (4), `build_interaction_launch_prompt` (5 incl. cache-miss/appendix-order), first-turn argv + resumed-no-inject (2). `cargo test` green, clippy clean, fmt clean. Security review: clean (issue body reaches the CLI as a single `-p` argv element — no shell/argv injection; surface not widened vs. one-shot).

## Draft — manual QA required before merge

This touches `src/tui/**`; holding Draft pending a human-run manual-QA pass (checklist posted below).

## Follow-up

- #953 — fetch issue on cache/browser miss at interaction launch (architect R2 split).

Closes #946
