### PR TITLE
feat(v0.30.0): interactive sessions batch — #938 #936 #988 #953 (draft, manual QA pending)

### DIFF
--- a/src/integration_tests/interaction_terminator.rs
+++ b/src/integration_tests/interaction_terminator.rs
@@ -8,8 +8,9 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::session::interaction::{CloseReason, InteractionState};
-use crate::tui::app::types::TuiCommand;
+use crate::session::interaction::{CloseReason, InteractionState, TurnRecord, TurnRole};
+use crate::session::interaction_lifecycle::InteractionLifecycleEvent;
+use crate::tui::app::types::{TuiCommand, TuiDataEvent};
 use crate::work::pr_marker::PrMarker;
 
 fn make_marker_dir(home: &Path) -> PathBuf {
@@ -70,6 +71,129 @@ async fn marker_with_matching_issue_terminates_interaction_and_enqueues_pr_creat
     assert!(
         pr_created_queued(&app, 7),
         "TuiCommand::PrCreated must still be enqueued"
+    );
+}
+
+/// #936: a terminator queued while a turn was streaming must fire once that
+/// turn settles back to `Idle` and its output is merged. This is the deferred
+/// (mid-stream) firing path #739 explicitly did not cover.
+#[tokio::test]
+async fn queued_terminator_fires_after_streaming_turn_settles() {
+    let home = tempfile::tempdir().unwrap();
+    let mut app = make_app_with_home(home.path().to_path_buf());
+    app.pool.create_interaction_session(42, false);
+
+    // The turn's clone is taken BEFORE the marker arrives (mirrors `send_turn`):
+    // Idle, no queued terminator.
+    let mut completing = app
+        .pool
+        .clone_active_interaction(42)
+        .expect("active session to clone");
+
+    // Marker arrives mid-stream: the live slot is `Streaming`, so
+    // `signal_terminator` queues the event instead of firing it.
+    {
+        let live = app
+            .pool
+            .find_active_interaction_by_issue_mut(42)
+            .expect("active");
+        live.state = InteractionState::Streaming;
+        live.signal_terminator(InteractionLifecycleEvent::PrLinkedToIssue {
+            pr_number: 7,
+            issue_number: 42,
+            owner: "owner".into(),
+            repo: "repo".into(),
+        });
+        assert!(
+            live.queued_terminator.is_some(),
+            "precondition: terminator queued while streaming"
+        );
+    }
+
+    // The turn finishes: the clone settles to `Idle` and carries its reply.
+    let at = chrono::Utc::now();
+    completing.state = InteractionState::Idle;
+    completing.history.push(TurnRecord {
+        role: TurnRole::Agent,
+        content: "streamed reply".to_string(),
+        started_at: at,
+        finished_at: Some(at),
+    });
+
+    // Merge through the real turn-complete path.
+    app.handle_data_event(TuiDataEvent::InteractionTurnComplete {
+        session: Box::new(completing),
+    });
+
+    // Terminator fired after the merge → no active session remains.
+    assert!(
+        app.pool.find_active_interaction_by_issue(42).is_none(),
+        "queued terminator must fire once the streaming turn settles"
+    );
+
+    let closed = app
+        .pool
+        .interaction_by_issue(42)
+        .expect("session still registered (terminated)");
+    assert_eq!(closed.state, InteractionState::Terminated);
+    assert_eq!(
+        closed.close_reason,
+        Some(CloseReason::PrCreated { pr_number: 7 })
+    );
+    assert!(
+        closed.closed_at.is_some(),
+        "closed_at must be stamped on the deferred fire"
+    );
+    assert!(
+        closed.queued_terminator.is_none(),
+        "queued_terminator must be cleared after firing"
+    );
+    assert!(
+        closed.history.iter().any(|t| t.content == "streamed reply"),
+        "the completed turn's output must be preserved (fire after merge)"
+    );
+}
+
+/// #936 idempotency: if the user terminated the session by other means while a
+/// turn was in flight, the completing clone must NOT resurrect it, and the
+/// queued terminator is a no-op.
+#[tokio::test]
+async fn completing_turn_does_not_resurrect_user_quit_session() {
+    let home = tempfile::tempdir().unwrap();
+    let mut app = make_app_with_home(home.path().to_path_buf());
+    app.pool.create_interaction_session(42, false);
+
+    let mut completing = app
+        .pool
+        .clone_active_interaction(42)
+        .expect("active session to clone");
+
+    // User quit mid-turn: the live slot is already Terminated.
+    {
+        let live = app
+            .pool
+            .find_active_interaction_by_issue_mut(42)
+            .expect("active");
+        live.state = InteractionState::Terminated;
+        live.close_reason = Some(CloseReason::UserQuit);
+    }
+
+    // The turn completes and tries to merge back as Idle.
+    completing.state = InteractionState::Idle;
+    app.handle_data_event(TuiDataEvent::InteractionTurnComplete {
+        session: Box::new(completing),
+    });
+
+    let closed = app.pool.interaction_by_issue(42).expect("registered");
+    assert_eq!(
+        closed.state,
+        InteractionState::Terminated,
+        "a user-quit session must stay terminated"
+    );
+    assert_eq!(
+        closed.close_reason,
+        Some(CloseReason::UserQuit),
+        "the original close reason must survive the completing merge"
     );
 }
 

--- a/src/session/cleanup.rs
+++ b/src/session/cleanup.rs
@@ -3,6 +3,8 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use crate::work::worktree_teardown::wipe_worktree;
+
 /// Manages cleanup of orphaned worktrees left by crashed processes.
 pub struct CleanupManager {
     worktree_dir: PathBuf,
@@ -61,25 +63,29 @@ impl CleanupManager {
     }
 
     /// Remove orphaned worktrees. Returns the count removed.
+    ///
+    /// #938: each removal routes through the hardened [`wipe_worktree`]
+    /// primitive (rooted at `self.worktree_dir`), so it inherits the root
+    /// sanity-check (refuses `/` / `$HOME`, canonicalized containment) and the
+    /// leading-dash injection guard. The previous raw `git worktree remove`
+    /// call and the `std::fs::remove_dir_all` fallback — neither root-gated —
+    /// are gone. A refused or failed orphan is logged and skipped (best-effort,
+    /// no longer aborts the whole batch on the first failure).
     pub fn remove_orphans(&self, orphans: &[OrphanWorktree]) -> Result<usize> {
         let mut removed = 0;
         for orphan in orphans {
-            // Try git worktree remove first
-            let result = Command::new("git")
-                .args(["worktree", "remove", "--force"])
-                .arg(&orphan.path)
-                .output();
-
-            match result {
-                Ok(output) if output.status.success() => {
-                    removed += 1;
-                }
-                _ => {
-                    // Fallback: just remove the directory
-                    if orphan.path.exists() {
-                        std::fs::remove_dir_all(&orphan.path)?;
-                        removed += 1;
-                    }
+            // The orphan dir name is the worktree slug; its branch (if any) is
+            // `maestro/<name>`. `wipe_worktree` is idempotent, so a missing
+            // branch is treated as success.
+            let branch = format!("maestro/{}", orphan.name);
+            match wipe_worktree(0, &orphan.path, &branch, &self.worktree_dir) {
+                Ok(()) => removed += 1,
+                Err(e) => {
+                    tracing::warn!(
+                        "orphan worktree teardown refused/failed for {}: {}",
+                        orphan.name,
+                        e
+                    );
                 }
             }
         }
@@ -105,5 +111,30 @@ mod tests {
         let mgr = CleanupManager::new(Path::new("/tmp/nonexistent-repo-12345"));
         let orphans = mgr.scan_orphans().unwrap();
         assert!(orphans.is_empty());
+    }
+
+    // #938: a misconfigured worktree root of `/` must be refused before any
+    // destructive call. We construct the manager with `worktree_dir = "/"`
+    // directly (same module → private field is reachable) and assert the orphan
+    // is NOT counted as removed — `wipe_worktree`'s `UnsafeRoot` guard fires
+    // before it ever shells out to git or touches the filesystem.
+    #[test]
+    fn remove_orphans_refuses_unsafe_root() {
+        let mgr = CleanupManager {
+            worktree_dir: PathBuf::from("/"),
+        };
+        let orphan = OrphanWorktree {
+            path: PathBuf::from("/etc"),
+            name: "etc".to_string(),
+        };
+        let removed = mgr.remove_orphans(&[orphan]).expect("must not error");
+        assert_eq!(
+            removed, 0,
+            "an unsafe `/` root must refuse, removing nothing"
+        );
+        assert!(
+            Path::new("/etc").exists(),
+            "the guard must run before any destructive call — /etc stays put"
+        );
     }
 }

--- a/src/session/interaction.rs
+++ b/src/session/interaction.rs
@@ -132,6 +132,30 @@ impl InteractionSession {
         }
     }
 
+    /// Fire a terminator that was deferred while the session was `Streaming`
+    /// (#936), now that the in-flight turn has settled back to `Idle` and its
+    /// output has been merged. Called after the completing turn is written
+    /// back into the pool.
+    ///
+    /// - `Idle` with a queued terminator → fire it (state → `Terminated`,
+    ///   `close_reason` stamped, `closed_at` set, queue cleared).
+    /// - `Terminated` → drop the queue. The session was already closed by other
+    ///   means (e.g. the user quit mid-turn); never resurrect it (idempotent).
+    /// - `Streaming`, or no queued terminator → no-op.
+    pub fn settle_queued_terminator(&mut self) {
+        match self.state {
+            InteractionState::Idle => {
+                if let Some(event) = self.queued_terminator.take() {
+                    self.fire_terminator(event);
+                }
+            }
+            InteractionState::Terminated => {
+                self.queued_terminator = None;
+            }
+            InteractionState::Streaming => {}
+        }
+    }
+
     /// Apply a terminator immediately: `Terminated` + `close_reason` +
     /// `closed_at`. Only `PrLinkedToIssue` maps to a `CloseReason` today;
     /// other variants set the terminal state without a reason.

--- a/src/session/pool.rs
+++ b/src/session/pool.rs
@@ -485,6 +485,17 @@ impl SessionPool {
             .and_then(|i| i.close_reason.as_ref())
     }
 
+    /// First interaction registered for `issue_number`, in any state. Test-only
+    /// introspection — `find_active_interaction_by_issue` returns `None` once a
+    /// session is `Terminated`, so this lets tests inspect a closed session's
+    /// preserved history / cleared queue (#936).
+    #[cfg(test)]
+    pub fn interaction_by_issue(&self, issue_number: u64) -> Option<&InteractionSession> {
+        self.interactions
+            .iter()
+            .find(|i| i.issue_number == issue_number)
+    }
+
     /// Create a fresh interaction session for `issue_number`, building a
     /// worktree (non-fatal — falls back to cwd) and registering it. Returns a
     /// reference to the newly created session. Mirrors the worktree handling
@@ -548,14 +559,25 @@ impl SessionPool {
     /// in-flight when the user quit (`Ctrl+Q`), its completing clone arrives
     /// here `Idle` and must not overwrite the `Terminated` record — otherwise
     /// re-entry would reopen a quit session.
-    pub fn upsert_interaction(&mut self, session: InteractionSession) {
+    pub fn upsert_interaction(&mut self, mut session: InteractionSession) {
         if let Some(slot) = self
             .interactions
             .iter_mut()
             .find(|i| i.issue_number == session.issue_number)
         {
             if slot.is_active() {
+                // #936: a PR terminator may have been queued on the live slot
+                // while this turn was streaming. The completing clone was taken
+                // before the marker arrived, so it does not carry the queue —
+                // carry it forward, then fire it now that the turn has settled
+                // (the streamed output is preserved because we fire *after* the
+                // overwrite, not before). A slot the user already quit is
+                // `!is_active()` and is left untouched above (never resurrected).
+                if session.queued_terminator.is_none() {
+                    session.queued_terminator = slot.queued_terminator.take();
+                }
                 *slot = session;
+                slot.settle_queued_terminator();
             }
         } else {
             self.interactions.push(session);

--- a/src/session/worktree.rs
+++ b/src/session/worktree.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::util::validate_slug;
+use crate::work::worktree_teardown::{TeardownError, wipe_worktree};
 
 /// Trait for managing git worktrees. Mockable in tests.
 pub trait WorktreeManager: Send {
@@ -37,6 +38,20 @@ impl GitWorktreeManager {
 
     fn branch_name(&self, slug: &str) -> String {
         format!("maestro/{}", slug)
+    }
+
+    /// Guarded teardown step used by [`WorktreeManager::remove`] (#938). Routes
+    /// the worktree + branch removal through the sanity-checked
+    /// [`wipe_worktree`] primitive. `issue_number` is unattributed here (the
+    /// slug, not an issue id, owns these worktrees), so `0` is passed for the
+    /// tracing field only. Returns the typed error so the caller can choose to
+    /// warn-and-continue (best-effort cleanup).
+    fn guarded_remove(
+        path: &Path,
+        branch: &str,
+        worktree_root: &Path,
+    ) -> Result<(), TeardownError> {
+        wipe_worktree(0, path, branch, worktree_root)
     }
 }
 
@@ -86,17 +101,14 @@ impl WorktreeManager for GitWorktreeManager {
     fn remove(&self, slug: &str) -> Result<()> {
         validate_slug(slug)?;
         let path = self.worktree_path(slug);
-        let output = std::process::Command::new("git")
-            .arg("worktree")
-            .arg("remove")
-            .arg(&path)
-            .arg("--force")
-            .current_dir(&self.repo_root)
-            .output()?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            tracing::warn!("git worktree remove failed for {}: {}", slug, stderr);
+        let branch = self.branch_name(slug);
+        // #938: route the destructive step through the hardened `wipe_worktree`
+        // primitive so it inherits the root sanity-check (refuses `/` / `$HOME`,
+        // canonicalized containment) and the leading-dash injection guard. Keep
+        // the existing best-effort contract: a refusal or git failure is logged,
+        // never propagated — `remove` has always returned `Ok` on failure.
+        if let Err(e) = Self::guarded_remove(&path, &branch, &self.worktree_dir()) {
+            tracing::warn!("worktree teardown refused/failed for {}: {}", slug, e);
         }
         Ok(())
     }
@@ -255,5 +267,29 @@ mod tests {
     fn exists_returns_false_for_invalid_slug() {
         let mock = MockWorktreeManager::new();
         assert!(!mock.exists("../escape"));
+    }
+
+    // #938: the destructive step of `GitWorktreeManager::remove` now routes
+    // through the guarded `wipe_worktree` primitive. `guarded_remove` is that
+    // exact teardown function, so exercising it with an unsafe root proves the
+    // site refuses `/` (and, by the primitive, `$HOME`).
+    #[test]
+    fn guarded_remove_refuses_root_slash() {
+        let result =
+            GitWorktreeManager::guarded_remove(Path::new("/etc"), "maestro/x", Path::new("/"));
+        assert!(
+            matches!(result, Err(TeardownError::UnsafeRoot(_))),
+            "expected UnsafeRoot for `/` root, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn guarded_remove_refuses_empty_root() {
+        let result =
+            GitWorktreeManager::guarded_remove(Path::new("wt"), "maestro/x", Path::new(""));
+        assert!(
+            matches!(result, Err(TeardownError::UnsafeRoot(_))),
+            "expected UnsafeRoot for empty root, got {result:?}"
+        );
     }
 }

--- a/src/tui/app/data_handler.rs
+++ b/src/tui/app/data_handler.rs
@@ -707,7 +707,65 @@ impl App {
             TuiDataEvent::InteractionTurnComplete { session } => {
                 self.pool.upsert_interaction(*session);
             }
+            TuiDataEvent::InteractionIssueFetched {
+                issue_number,
+                seed_prompt,
+                result,
+            } => {
+                self.apply_interaction_issue_fetched(issue_number, seed_prompt, result);
+            }
         }
+    }
+
+    /// Land a deferred interactive launch's issue fetch (#953). On success the
+    /// real issue prompt + appendix is built and sent as the first turn; on
+    /// failure the launch falls back to bare dialog text with a warning, never
+    /// leaving the agent without context silently.
+    fn apply_interaction_issue_fetched(
+        &mut self,
+        issue_number: u64,
+        seed_prompt: Option<String>,
+        result: anyhow::Result<crate::provider::types::Issue>,
+    ) {
+        let prompt = match result {
+            Ok(gh_issue) => {
+                let title = gh_issue.title.clone();
+                self.state.issue_cache.insert(issue_number, gh_issue);
+                if let Some(screen) = self.screen_state.interaction_screen.as_mut()
+                    && screen.is_for_issue(issue_number)
+                {
+                    screen.set_issue_title(title);
+                }
+                // Now that the issue is cached, build the real prompt; fall back
+                // to dialog text only if the build still cannot assemble one.
+                self.build_interaction_launch_prompt(issue_number, &seed_prompt)
+                    .or_else(|| seed_prompt.filter(|p| !p.trim().is_empty()))
+            }
+            Err(e) => {
+                tracing::warn!("interaction issue fetch for #{issue_number} failed: {e}");
+                self.activity_log.push_simple(
+                    "INTERACTION".into(),
+                    format!("#{issue_number} fetch failed; launching with dialog text only"),
+                    LogLevel::Warn,
+                );
+                seed_prompt.filter(|p| !p.trim().is_empty())
+            }
+        };
+
+        let Some(prompt) = prompt else {
+            return;
+        };
+        if let Some(screen) = self.screen_state.interaction_screen.as_mut()
+            && screen.is_for_issue(issue_number)
+        {
+            screen.seed_turn(prompt.clone());
+        }
+        self.pending_commands
+            .push(crate::tui::app::TuiCommand::SendInteractionTurn {
+                issue_number,
+                prompt,
+                model: self.session_config.default_model.clone(),
+            });
     }
 }
 
@@ -727,6 +785,116 @@ mod tests {
             milestone: None,
             assignees: Vec::new(),
         }
+    }
+
+    fn issue_with_body(number: u64, title: &str, body: &str) -> Issue {
+        Issue {
+            number,
+            title: title.to_string(),
+            body: body.to_string(),
+            labels: Vec::new(),
+            state: "open".to_string(),
+            html_url: format!("https://github.com/owner/repo/issues/{number}"),
+            milestone: None,
+            assignees: Vec::new(),
+        }
+    }
+
+    /// Open an interaction screen bound to `issue_number` with a cold cache,
+    /// mirroring `open_interaction_session`'s deferred-launch state (#953).
+    fn app_with_deferred_interaction(name: &str, issue_number: u64) -> App {
+        let mut app = crate::tui::make_test_app(name);
+        app.pool.create_interaction_session(issue_number, false);
+        let session = app
+            .pool
+            .find_active_interaction_by_issue(issue_number)
+            .expect("session just created");
+        app.screen_state.interaction_screen =
+            Some(crate::tui::screens::InteractionScreen::for_session(session));
+        app.tui_mode = crate::tui::app::TuiMode::Interaction;
+        app
+    }
+
+    fn first_interaction_turn(app: &App) -> Option<&str> {
+        app.pending_commands.iter().find_map(|c| match c {
+            crate::tui::app::TuiCommand::SendInteractionTurn { prompt, .. } => {
+                Some(prompt.as_str())
+            }
+            _ => None,
+        })
+    }
+
+    #[test]
+    fn interaction_issue_fetched_ok_builds_real_first_turn() {
+        // #953: once the deferred fetch lands, the first turn carries the real
+        // issue prompt (title + acceptance criteria), not the bare dialog text.
+        let mut app = app_with_deferred_interaction("issue-953-fetch-ok", 953);
+
+        app.handle_data_event(TuiDataEvent::InteractionIssueFetched {
+            issue_number: 953,
+            seed_prompt: Some("focus on the parser".into()),
+            result: Ok(issue_with_body(
+                953,
+                "Fix the scroll bug",
+                "Acceptance Criteria\n- scroll works",
+            )),
+        });
+
+        let prompt = first_interaction_turn(&app).expect("a first interaction turn must be queued");
+        assert!(prompt.contains("Fix the scroll bug"), "carries the title");
+        assert!(
+            prompt.contains("Acceptance Criteria"),
+            "carries the issue body / AC"
+        );
+        assert!(
+            app.state.issue_cache.contains_key(&953),
+            "the fetched issue is cached for later lookups"
+        );
+        let screen = app.screen_state.interaction_screen.as_ref().unwrap();
+        assert_eq!(screen.history_len(), 1, "the real first turn is seeded");
+    }
+
+    #[test]
+    fn interaction_issue_fetched_err_falls_back_to_dialog_text() {
+        // #953: a failed fetch falls back to the bare dialog text and warns,
+        // rather than leaving the agent with no prompt.
+        let mut app = app_with_deferred_interaction("issue-953-fetch-err", 953);
+
+        app.handle_data_event(TuiDataEvent::InteractionIssueFetched {
+            issue_number: 953,
+            seed_prompt: Some("just chat with me".into()),
+            result: Err(anyhow::anyhow!("network down")),
+        });
+
+        assert_eq!(
+            first_interaction_turn(&app),
+            Some("just chat with me"),
+            "fetch failure falls back to the bare dialog text"
+        );
+        assert!(
+            app.activity_log
+                .entries()
+                .iter()
+                .any(|e| e.message.contains("fetch failed")),
+            "a warning must be logged on fetch failure"
+        );
+    }
+
+    #[test]
+    fn interaction_issue_fetched_err_without_seed_sends_nothing() {
+        // No dialog text + failed fetch → nothing to send; must not panic.
+        let mut app = app_with_deferred_interaction("issue-953-fetch-err-empty", 953);
+
+        app.handle_data_event(TuiDataEvent::InteractionIssueFetched {
+            issue_number: 953,
+            seed_prompt: None,
+            result: Err(anyhow::anyhow!("network down")),
+        });
+
+        assert!(
+            first_interaction_turn(&app).is_none(),
+            "no prompt to fall back to → no first turn queued"
+        );
     }
 
     #[test]

--- a/src/tui/app/types.rs
+++ b/src/tui/app/types.rs
@@ -296,6 +296,15 @@ pub struct SuggestionDataPayload {
 /// Commands queued by synchronous screen action handlers for async processing.
 pub enum TuiCommand {
     FetchIssues,
+    /// Fetch a single issue to build the first turn of an interactive launch
+    /// that hit a cache/browser miss (#953). The result lands as
+    /// [`TuiDataEvent::InteractionIssueFetched`], NOT the one-shot
+    /// `TuiDataEvent::Issue` path, so the deferred first turn is built rather
+    /// than a new one-shot session.
+    FetchInteractionIssue {
+        issue_number: u64,
+        seed_prompt: Option<String>,
+    },
     FetchMilestones,
     FetchSuggestionData,
     /// Create a new GitHub issue from a wizard payload (#291+#298).
@@ -466,6 +475,14 @@ pub enum TuiDataEvent {
     /// pool can persist its `session_id`/history (#738).
     InteractionTurnComplete {
         session: Box<crate::session::interaction::InteractionSession>,
+    },
+    /// Result of [`TuiCommand::FetchInteractionIssue`] (#953). On `Ok` the
+    /// deferred first turn is built from the real issue prompt + appendix; on
+    /// `Err` the launch falls back to bare dialog text plus a warning.
+    InteractionIssueFetched {
+        issue_number: u64,
+        seed_prompt: Option<String>,
+        result: anyhow::Result<Issue>,
     },
 }
 

--- a/src/tui/background_tasks.rs
+++ b/src/tui/background_tasks.rs
@@ -32,6 +32,29 @@ pub(super) fn spawn_issue_fetch(
     }
 }
 
+/// Fetch a single issue for a deferred interactive launch (#953) and deliver it
+/// as [`app::TuiDataEvent::InteractionIssueFetched`]. Distinct from
+/// [`spawn_issue_fetch`] so the result builds the interaction's first turn
+/// instead of a one-shot session.
+pub(super) fn spawn_interaction_issue_fetch(
+    tx: tokio::sync::mpsc::UnboundedSender<app::TuiDataEvent>,
+    issue_number: u64,
+    seed_prompt: Option<String>,
+    provider_config: ProviderConfig,
+) {
+    tokio::spawn(async move {
+        let result = match create_provider(&provider_config) {
+            Ok(client) => client.get_issue(issue_number).await,
+            Err(e) => Err(e),
+        };
+        let _ = tx.send(app::TuiDataEvent::InteractionIssueFetched {
+            issue_number,
+            seed_prompt,
+            result,
+        });
+    });
+}
+
 /// Spawn a non-blocking version check that sends the result via the data channel.
 pub(crate) fn spawn_version_check(tx: tokio::sync::mpsc::UnboundedSender<app::TuiDataEvent>) {
     tokio::spawn(async move {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -103,6 +103,32 @@ pub(crate) fn leave_tui_mode<W: io::Write>(out: &mut W) -> io::Result<()> {
     )
 }
 
+/// Route a mouse wheel-up to the right scroll target (#988). On the
+/// Interaction screen the wheel scrolls the chat transcript; everywhere else it
+/// keeps the legacy `panel_view` behavior so no other screen regresses.
+fn route_mouse_scroll_up(app: &mut App) {
+    const WHEEL_LINES: usize = 3;
+    if app.tui_mode == app::TuiMode::Interaction
+        && let Some(screen) = app.screen_state.interaction_screen.as_mut()
+    {
+        screen.scroll_up(WHEEL_LINES);
+    } else {
+        app.panel_view.scroll_up();
+    }
+}
+
+/// Wheel-down counterpart of [`route_mouse_scroll_up`] (#988).
+fn route_mouse_scroll_down(app: &mut App) {
+    const WHEEL_LINES: usize = 3;
+    if app.tui_mode == app::TuiMode::Interaction
+        && let Some(screen) = app.screen_state.interaction_screen.as_mut()
+    {
+        screen.scroll_down(WHEEL_LINES);
+    } else {
+        app.panel_view.scroll_down();
+    }
+}
+
 /// Run the TUI event loop.
 pub async fn run(mut app: App) -> anyhow::Result<()> {
     let no_splash = app.no_splash;
@@ -207,12 +233,8 @@ async fn event_loop(
                     }
                 }
                 Event::Mouse(mouse) => match mouse.kind {
-                    MouseEventKind::ScrollUp => {
-                        app.panel_view.scroll_up();
-                    }
-                    MouseEventKind::ScrollDown => {
-                        app.panel_view.scroll_down();
-                    }
+                    MouseEventKind::ScrollUp => route_mouse_scroll_up(app),
+                    MouseEventKind::ScrollDown => route_mouse_scroll_down(app),
                     _ => {}
                 },
                 Event::Paste(data) => {
@@ -1103,6 +1125,56 @@ mod handle_screen_action_tests {
             produce_pr,
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn mouse_scroll_in_interaction_mode_moves_the_interaction_screen() {
+        // #988: a wheel event in Interaction mode must scroll the chat
+        // transcript (scroll_up takes manual control → auto_scroll off), not
+        // the legacy panel_view.
+        let mut app = make_app();
+        app.tui_mode = app::TuiMode::Interaction;
+        app.screen_state.interaction_screen = Some(screens::InteractionScreen::new());
+        assert!(
+            app.screen_state
+                .interaction_screen
+                .as_ref()
+                .unwrap()
+                .auto_scroll_for_test(),
+            "precondition: a fresh screen tail-follows"
+        );
+
+        route_mouse_scroll_up(&mut app);
+
+        assert!(
+            !app.screen_state
+                .interaction_screen
+                .as_ref()
+                .unwrap()
+                .auto_scroll_for_test(),
+            "wheel-up in Interaction mode must drive the interaction scroll"
+        );
+    }
+
+    #[test]
+    fn mouse_scroll_outside_interaction_mode_leaves_interaction_untouched() {
+        // A wheel event in any other mode keeps the legacy panel_view routing,
+        // so a present-but-inactive interaction screen must not move (no
+        // regression for other screens).
+        let mut app = make_app();
+        app.tui_mode = app::TuiMode::Dashboard;
+        app.screen_state.interaction_screen = Some(screens::InteractionScreen::new());
+
+        route_mouse_scroll_up(&mut app);
+
+        assert!(
+            app.screen_state
+                .interaction_screen
+                .as_ref()
+                .unwrap()
+                .auto_scroll_for_test(),
+            "wheel events outside Interaction mode must not touch the chat scroll"
+        );
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -262,6 +262,17 @@ async fn event_loop(
                         let _ = tx.send(app::TuiDataEvent::Issues(result));
                     });
                 }
+                app::TuiCommand::FetchInteractionIssue {
+                    issue_number,
+                    seed_prompt,
+                } => {
+                    background_tasks::spawn_interaction_issue_fetch(
+                        app.data_tx.clone(),
+                        issue_number,
+                        seed_prompt,
+                        provider_config_from_app(app),
+                    );
+                }
                 app::TuiCommand::FetchSuggestionData => {
                     let tx = app.data_tx.clone();
                     let provider_config = provider_config_from_app(app);
@@ -1267,6 +1278,23 @@ mod handle_screen_action_tests {
     #[test]
     fn launch_interaction_with_dialog_prompt_sends_it_as_first_turn() {
         let mut app = make_app();
+        // With the issue cached, the first turn is built immediately and the
+        // dialog prompt rides along as a custom instruction (#946). The cache
+        // *miss* path now defers + fetches (#953) — covered by
+        // `screen_dispatch::interaction_launch_tests::cache_miss_defers_*`.
+        app.state.issue_cache.insert(
+            10,
+            crate::provider::types::Issue {
+                number: 10,
+                title: "Cached issue".into(),
+                body: "Acceptance Criteria\n- done".into(),
+                labels: Vec::new(),
+                state: "open".into(),
+                html_url: "https://github.com/owner/repo/issues/10".into(),
+                milestone: None,
+                assignees: Vec::new(),
+            },
+        );
         let mut cfg = interaction_config(10, false);
         cfg.custom_prompt = Some("plan the work".into());
         handle_screen_action(&mut app, ScreenAction::LaunchSession(cfg));
@@ -1278,9 +1306,9 @@ mod handle_screen_action_tests {
             app.pending_commands.iter().any(|c| matches!(
                 c,
                 app::TuiCommand::SendInteractionTurn { issue_number, prompt, .. }
-                    if *issue_number == 10 && prompt == "plan the work"
+                    if *issue_number == 10 && prompt.contains("plan the work")
             )),
-            "the first turn command must be queued"
+            "the first turn command must carry the dialog prompt"
         );
     }
 

--- a/src/tui/screen_dispatch.rs
+++ b/src/tui/screen_dispatch.rs
@@ -487,16 +487,19 @@ fn open_interaction_session(
 
     // A NEW session's first turn IS the issue work: build the real issue
     // prompt + system-prompt appendix, identical to a one-shot (#946). The
-    // dialog text rides along as a custom instruction. On a cache/browser
-    // miss we fall back to the bare dialog text (pre-#946 behavior) so the
-    // launch still proceeds; fetch-on-miss is tracked as a follow-up.
-    // Re-entry injects nothing — we don't seed an ongoing chat.
+    // dialog text rides along as a custom instruction. Re-entry injects
+    // nothing — we don't seed an ongoing chat.
     let first_turn = if resumed {
         None
     } else {
         app.build_interaction_launch_prompt(issue_number, &seed_prompt)
-            .or_else(|| seed_prompt.filter(|p| !p.trim().is_empty()))
     };
+    // A non-resumed launch with no built prompt means the issue is not yet in
+    // the cache/browser. Instead of seeding bare dialog text (pre-#953), defer
+    // the first turn and fetch the issue so the agent always gets the real
+    // issue context. The fetch result lands on `InteractionIssueFetched`.
+    let needs_fetch = !resumed && first_turn.is_none();
+
     if let Some(prompt) = first_turn.clone() {
         screen.seed_turn(prompt);
     }
@@ -515,6 +518,17 @@ fn open_interaction_session(
                 issue_number,
                 prompt,
                 model: app.session_config.default_model.clone(),
+            });
+    } else if needs_fetch {
+        app.activity_log.push_simple(
+            "INTERACTION".into(),
+            format!("fetching #{issue_number} to build the first turn…"),
+            crate::tui::activity_log::LogLevel::Info,
+        );
+        app.pending_commands
+            .push(app::TuiCommand::FetchInteractionIssue {
+                issue_number,
+                seed_prompt,
             });
     }
 
@@ -1474,6 +1488,41 @@ mod interaction_launch_tests {
         assert!(
             prompt.contains("GUARDRAIL: test sentinel"),
             "carries the system-prompt appendix"
+        );
+    }
+
+    #[test]
+    fn cache_miss_defers_first_turn_and_enqueues_fetch() {
+        // #953: the issue is not in the cache or browser list, so the first
+        // turn is deferred and an issue fetch is queued instead of seeding bare
+        // dialog text.
+        let mut app = crate::tui::make_test_app("issue-953-miss");
+
+        open_interaction_session(&mut app, 953, false, Some("please help".into()));
+
+        assert!(
+            first_turn_prompt(&app).is_none(),
+            "first turn must be deferred on a cache/browser miss"
+        );
+        assert!(
+            app.pending_commands.iter().any(|c| matches!(
+                c,
+                TuiCommand::FetchInteractionIssue {
+                    issue_number: 953,
+                    seed_prompt: Some(p),
+                } if p == "please help"
+            )),
+            "expected a FetchInteractionIssue for #953 carrying the seed prompt"
+        );
+        let screen = app
+            .screen_state
+            .interaction_screen
+            .as_ref()
+            .expect("interaction screen must be open");
+        assert_eq!(
+            screen.history_len(),
+            0,
+            "no bare first turn may be seeded on a miss"
         );
     }
 

--- a/src/tui/screens/interaction/input.rs
+++ b/src/tui/screens/interaction/input.rs
@@ -71,6 +71,7 @@ pub(super) fn draw_input(
     editor: &TextArea<'static>,
     locked: bool,
     spinner: char,
+    wave: &str,
 ) {
     let title = if locked {
         format!("Message ({spinner} agent responding…)")
@@ -85,7 +86,7 @@ pub(super) fn draw_input(
     let is_empty = lines.len() == 1 && lines[0].is_empty();
     let paragraph = if locked {
         Paragraph::new(Line::from(Span::styled(
-            format!("{spinner} Agent is responding — input locked…"),
+            format!("{wave}  Agent is responding — input locked…"),
             Style::default().fg(theme.accent_warning),
         )))
     } else if is_empty {

--- a/src/tui/screens/interaction/input.rs
+++ b/src/tui/screens/interaction/input.rs
@@ -149,8 +149,10 @@ pub(super) fn draw_keybar(f: &mut Frame, area: Rect, theme: &Theme, pushup_enabl
         Span::raw(" Quit  "),
         Span::styled("[Esc]", active),
         Span::raw(" Back  "),
-        Span::styled("[Up/Down]", active),
-        Span::raw(" Scroll "),
+        Span::styled("[Up/Dn/PgUp/PgDn]", active),
+        Span::raw(" Scroll  "),
+        Span::styled("[End]", active),
+        Span::raw(" Latest "),
     ]);
 
     // Fill the rest of the row with the rule so the chords read as a border.

--- a/src/tui/screens/interaction/keymap.rs
+++ b/src/tui/screens/interaction/keymap.rs
@@ -32,6 +32,12 @@ pub(crate) enum InteractionIntent {
     ScrollUp,
     /// `Down` — scroll history down (any state).
     ScrollDown,
+    /// `PageUp` — scroll history up by one viewport (any state).
+    PageUp,
+    /// `PageDown` — scroll history down by one viewport (any state).
+    PageDown,
+    /// `End` — jump to the newest message and re-pin tail-following (any state).
+    JumpToLatest,
     /// Any other key in `Idle` — feed it to the text editor.
     FeedEditor,
     /// A send/edit key while `Streaming` — input locked, ignore.
@@ -59,6 +65,9 @@ pub(crate) fn classify(
         KeyCode::Esc => return Back,
         KeyCode::Up => return ScrollUp,
         KeyCode::Down => return ScrollDown,
+        KeyCode::PageUp => return PageUp,
+        KeyCode::PageDown => return PageDown,
+        KeyCode::End => return JumpToLatest,
         _ => {}
     }
     let ctrl = mods.contains(KeyModifiers::CONTROL);
@@ -138,8 +147,12 @@ impl KeymapProvider for InteractionScreen {
                     description: "Back",
                 },
                 KeyBinding {
-                    key: "Up/Down",
+                    key: "Up/Down/PgUp/PgDn",
                     description: "Scroll history",
+                },
+                KeyBinding {
+                    key: "End",
+                    description: "Jump to latest",
                 },
             ],
         }]
@@ -265,6 +278,26 @@ mod tests {
             assert_eq!(
                 classify(state, true, KeyCode::Down, KeyModifiers::NONE),
                 ScrollDown
+            );
+        }
+    }
+
+    #[test]
+    fn page_and_jump_keys_work_in_every_state() {
+        // #988: PageUp/PageDown/End resolve before the streaming lock, so they
+        // page/jump the transcript in both Idle and Streaming.
+        for state in [Idle, Streaming] {
+            assert_eq!(
+                classify(state, true, KeyCode::PageUp, KeyModifiers::NONE),
+                PageUp
+            );
+            assert_eq!(
+                classify(state, true, KeyCode::PageDown, KeyModifiers::NONE),
+                PageDown
+            );
+            assert_eq!(
+                classify(state, true, KeyCode::End, KeyModifiers::NONE),
+                JumpToLatest
             );
         }
     }

--- a/src/tui/screens/interaction/keymap_tests.rs
+++ b/src/tui/screens/interaction/keymap_tests.rs
@@ -281,7 +281,8 @@ fn keybindings_list_expected_keys() {
         "Ctrl+L",
         "Ctrl+W",
         "Esc",
-        "Up/Down",
+        "Up/Down/PgUp/PgDn",
+        "End",
     ] {
         assert!(keys.contains(&expected), "missing {expected} in {keys:?}");
     }

--- a/src/tui/screens/interaction/mod.rs
+++ b/src/tui/screens/interaction/mod.rs
@@ -82,6 +82,9 @@ pub struct InteractionScreen {
     /// Max scroll offset (`total - viewport`) at the last draw. Lets
     /// `scroll_down` clamp/re-pin without recomputing the viewport math.
     last_max_offset: usize,
+    /// History viewport height (rows) at the last draw. Drives PageUp/PageDown
+    /// paging math (#988).
+    last_viewport: usize,
     /// Branch backing this session's worktree. Passed to teardown (#741).
     branch: String,
     /// Root the worktree lives under (`worktree_path`'s parent). Gates the
@@ -131,6 +134,7 @@ impl InteractionScreen {
             scroll_offset: 0,
             auto_scroll: true,
             last_max_offset: 0,
+            last_viewport: 0,
             branch: String::new(),
             worktree_root: PathBuf::new(),
             queued_terminator: None,
@@ -196,20 +200,41 @@ impl InteractionScreen {
     }
 
     /// Scroll the history up by `n` lines. Takes manual control of the
-    /// viewport (disables tail-following).
-    fn scroll_up(&mut self, n: usize) {
+    /// viewport (disables tail-following). `pub(crate)` so the mouse-wheel
+    /// routing in `tui::mod` can drive it (#988).
+    pub(crate) fn scroll_up(&mut self, n: usize) {
         self.auto_scroll = false;
         self.scroll_offset = self.scroll_offset.saturating_sub(n);
     }
 
     /// Scroll the history down by `n` lines, clamped to the last-known
-    /// bottom. Re-pins tail-following once the bottom is reached.
-    fn scroll_down(&mut self, n: usize) {
+    /// bottom. Re-pins tail-following once the bottom is reached. `pub(crate)`
+    /// for the mouse-wheel routing (#988).
+    pub(crate) fn scroll_down(&mut self, n: usize) {
         let max = self.last_max_offset;
         self.scroll_offset = self.scroll_offset.saturating_add(n).min(max);
         if self.scroll_offset >= max {
             self.auto_scroll = true;
         }
+    }
+
+    /// Page the transcript up by one viewport height (#988). Clamps at the top
+    /// via `scroll_up`'s `saturating_sub`.
+    fn page_up(&mut self) {
+        self.scroll_up(self.last_viewport.max(1));
+    }
+
+    /// Page the transcript down by one viewport height (#988). Clamps at
+    /// `last_max_offset` and re-pins tail-following via `scroll_down`.
+    fn page_down(&mut self) {
+        self.scroll_down(self.last_viewport.max(1));
+    }
+
+    /// Jump to the newest message and resume tail-following (#988). The draw
+    /// path recomputes the concrete offset from `auto_scroll`.
+    fn jump_to_latest(&mut self) {
+        self.auto_scroll = true;
+        self.scroll_offset = self.last_max_offset;
     }
 
     fn draw_impl(&mut self, f: &mut Frame, area: Rect, theme: &Theme) {
@@ -241,6 +266,7 @@ impl InteractionScreen {
         let total = history::visual_total(&self.history, theme, history_area.width);
         let viewport = history_area.height as usize;
         self.last_max_offset = total.saturating_sub(viewport);
+        self.last_viewport = viewport;
         let offset = effective_offset(self.auto_scroll, self.scroll_offset, total, viewport);
         if self.auto_scroll {
             self.scroll_offset = offset;
@@ -300,6 +326,13 @@ impl InteractionScreen {
     fn scroll_down_for_test(&mut self, n: usize) {
         self.scroll_down(n);
     }
+
+    /// Tail-follow flag — cross-module test seam for the mouse-routing
+    /// assertion in `tui::mod` (#988).
+    #[cfg(test)]
+    pub(crate) fn auto_scroll_for_test(&self) -> bool {
+        self.auto_scroll
+    }
 }
 
 impl Default for InteractionScreen {
@@ -332,6 +365,18 @@ impl Screen for InteractionScreen {
             }
             InteractionIntent::ScrollDown => {
                 self.scroll_down(1);
+                ScreenAction::None
+            }
+            InteractionIntent::PageUp => {
+                self.page_up();
+                ScreenAction::None
+            }
+            InteractionIntent::PageDown => {
+                self.page_down();
+                ScreenAction::None
+            }
+            InteractionIntent::JumpToLatest => {
+                self.jump_to_latest();
                 ScreenAction::None
             }
             InteractionIntent::InsertNewline => {

--- a/src/tui/screens/interaction/mod.rs
+++ b/src/tui/screens/interaction/mod.rs
@@ -248,10 +248,12 @@ impl InteractionScreen {
         if self.state == InteractionState::Terminated {
             input::draw_terminated_banner(f, input_area, theme, self.close_reason.as_ref());
         } else {
-            let spinner = crate::tui::spinner::graph_node_frame(
-                self.spinner_tick,
-                crate::icon_mode::use_nerd_font(),
-            );
+            let nerd = crate::icon_mode::use_nerd_font();
+            // Slow the throbber to ~7fps (the loop redraws at ~20fps): a calmer
+            // rotation reads as a clear spinner instead of a vibrating blob.
+            let calm = self.spinner_tick / 3;
+            let spinner = crate::tui::spinner::graph_node_frame(calm, nerd);
+            let wave = crate::tui::spinner::responding_wave(calm, nerd);
             input::draw_input(
                 f,
                 input_area,
@@ -259,6 +261,7 @@ impl InteractionScreen {
                 &self.editor,
                 self.is_streaming(),
                 spinner,
+                &wave,
             );
         }
 

--- a/src/tui/screens/interaction/mod.rs
+++ b/src/tui/screens/interaction/mod.rs
@@ -11,6 +11,7 @@ mod keymap;
 mod keymap_tests;
 mod layout;
 pub(crate) mod lifecycle;
+mod scroll;
 #[cfg(test)]
 mod terminator_tests;
 #[cfg(test)]
@@ -197,44 +198,6 @@ impl InteractionScreen {
     /// Current editor contents joined into one string. Seam for #738's submit.
     pub fn editor_text(&self) -> String {
         self.editor.lines().join("\n")
-    }
-
-    /// Scroll the history up by `n` lines. Takes manual control of the
-    /// viewport (disables tail-following). `pub(crate)` so the mouse-wheel
-    /// routing in `tui::mod` can drive it (#988).
-    pub(crate) fn scroll_up(&mut self, n: usize) {
-        self.auto_scroll = false;
-        self.scroll_offset = self.scroll_offset.saturating_sub(n);
-    }
-
-    /// Scroll the history down by `n` lines, clamped to the last-known
-    /// bottom. Re-pins tail-following once the bottom is reached. `pub(crate)`
-    /// for the mouse-wheel routing (#988).
-    pub(crate) fn scroll_down(&mut self, n: usize) {
-        let max = self.last_max_offset;
-        self.scroll_offset = self.scroll_offset.saturating_add(n).min(max);
-        if self.scroll_offset >= max {
-            self.auto_scroll = true;
-        }
-    }
-
-    /// Page the transcript up by one viewport height (#988). Clamps at the top
-    /// via `scroll_up`'s `saturating_sub`.
-    fn page_up(&mut self) {
-        self.scroll_up(self.last_viewport.max(1));
-    }
-
-    /// Page the transcript down by one viewport height (#988). Clamps at
-    /// `last_max_offset` and re-pins tail-following via `scroll_down`.
-    fn page_down(&mut self) {
-        self.scroll_down(self.last_viewport.max(1));
-    }
-
-    /// Jump to the newest message and resume tail-following (#988). The draw
-    /// path recomputes the concrete offset from `auto_scroll`.
-    fn jump_to_latest(&mut self) {
-        self.auto_scroll = true;
-        self.scroll_offset = self.last_max_offset;
     }
 
     fn draw_impl(&mut self, f: &mut Frame, area: Rect, theme: &Theme) {

--- a/src/tui/screens/interaction/scroll.rs
+++ b/src/tui/screens/interaction/scroll.rs
@@ -1,0 +1,46 @@
+//! Scroll / paging state transitions for the Interaction transcript (#988).
+//! Split out of `mod.rs` to keep that file under the 400-line cap. Pure state
+//! mutation over `auto_scroll` / `scroll_offset`; the concrete offset is
+//! recomputed at draw time by `layout::effective_offset`.
+
+use super::InteractionScreen;
+
+impl InteractionScreen {
+    /// Scroll the history up by `n` lines. Takes manual control of the
+    /// viewport (disables tail-following). `pub(crate)` so the mouse-wheel
+    /// routing in `tui::mod` can drive it (#988).
+    pub(crate) fn scroll_up(&mut self, n: usize) {
+        self.auto_scroll = false;
+        self.scroll_offset = self.scroll_offset.saturating_sub(n);
+    }
+
+    /// Scroll the history down by `n` lines, clamped to the last-known
+    /// bottom. Re-pins tail-following once the bottom is reached. `pub(crate)`
+    /// for the mouse-wheel routing (#988).
+    pub(crate) fn scroll_down(&mut self, n: usize) {
+        let max = self.last_max_offset;
+        self.scroll_offset = self.scroll_offset.saturating_add(n).min(max);
+        if self.scroll_offset >= max {
+            self.auto_scroll = true;
+        }
+    }
+
+    /// Page the transcript up by one viewport height (#988). Clamps at the top
+    /// via `scroll_up`'s `saturating_sub`.
+    pub(super) fn page_up(&mut self) {
+        self.scroll_up(self.last_viewport.max(1));
+    }
+
+    /// Page the transcript down by one viewport height (#988). Clamps at
+    /// `last_max_offset` and re-pins tail-following via `scroll_down`.
+    pub(super) fn page_down(&mut self) {
+        self.scroll_down(self.last_viewport.max(1));
+    }
+
+    /// Jump to the newest message and resume tail-following (#988). The draw
+    /// path recomputes the concrete offset from `auto_scroll`.
+    pub(super) fn jump_to_latest(&mut self) {
+        self.auto_scroll = true;
+        self.scroll_offset = self.last_max_offset;
+    }
+}

--- a/src/tui/screens/interaction/tests.rs
+++ b/src/tui/screens/interaction/tests.rs
@@ -168,6 +168,89 @@ fn scroll_down_already_at_bottom_re_pins_auto_scroll() {
     assert!(s.auto_scroll);
 }
 
+// --- #988: page / jump-to-latest math ---
+
+#[test]
+fn page_up_pages_by_one_viewport_and_disables_auto_scroll() {
+    let mut s = InteractionScreen::new();
+    s.last_viewport = 10;
+    s.last_max_offset = 50;
+    s.scroll_offset = 30;
+    s.page_up();
+    assert_eq!(s.scroll_offset, 20, "paged up by one viewport height");
+    assert!(!s.auto_scroll, "paging up takes manual control");
+}
+
+#[test]
+fn page_up_clamps_at_top() {
+    let mut s = InteractionScreen::new();
+    s.last_viewport = 10;
+    s.last_max_offset = 50;
+    s.scroll_offset = 5;
+    s.page_up();
+    assert_eq!(s.scroll_offset, 0, "must not underflow past the top");
+}
+
+#[test]
+fn page_down_clamps_at_bottom_and_re_pins() {
+    let mut s = InteractionScreen::new();
+    s.last_viewport = 10;
+    s.last_max_offset = 50;
+    s.auto_scroll = false;
+    s.scroll_offset = 45;
+    s.page_down();
+    assert_eq!(s.scroll_offset, 50, "clamped at last_max_offset");
+    assert!(s.auto_scroll, "reaching the bottom re-pins tail-following");
+}
+
+#[test]
+fn page_with_zero_viewport_still_moves_one_line() {
+    // Before the first draw `last_viewport` is 0; `.max(1)` keeps paging alive.
+    let mut s = InteractionScreen::new();
+    s.last_max_offset = 50;
+    s.scroll_offset = 5;
+    s.page_up();
+    assert_eq!(s.scroll_offset, 4);
+}
+
+#[test]
+fn jump_to_latest_pins_to_bottom() {
+    let mut s = InteractionScreen::new();
+    s.last_max_offset = 42;
+    s.auto_scroll = false;
+    s.scroll_offset = 3;
+    s.jump_to_latest();
+    assert!(s.auto_scroll, "End resumes tail-following");
+    assert_eq!(s.scroll_offset, 42, "End jumps to the newest line");
+}
+
+#[test]
+fn streaming_chunk_while_scrolled_up_does_not_yank_the_view() {
+    // #988: the user scrolled up to read history; a streaming chunk arriving
+    // must not reset auto_scroll or move scroll_offset (no yank to the tail).
+    use crate::session::interaction_turn::TurnEvent;
+    let mut s = InteractionScreen::with_history(three_turn_fixture());
+    // Begin an agent turn, then scroll up away from the tail.
+    let at = fixed_t0();
+    let _ = s.apply_turn_event(&TurnEvent::TurnStarted {
+        role: TurnRole::Agent,
+        at,
+    });
+    s.auto_scroll = false;
+    s.scroll_offset = 2;
+
+    let _ = s.apply_turn_event(&TurnEvent::Chunk("streamed text".to_string()));
+
+    assert!(
+        !s.auto_scroll,
+        "a streaming chunk must not re-enable tail-following"
+    );
+    assert_eq!(
+        s.scroll_offset, 2,
+        "a streaming chunk must not move the user's scroll position"
+    );
+}
+
 #[test]
 fn push_turn_appends_to_history() {
     let mut s = InteractionScreen::new();

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_ctrl_p_greyed_without_produce_pr.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_ctrl_p_greyed_without_produce_pr.snap
@@ -36,7 +36,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "                                                                                                                        "
 "                                                                                                                        "
-"─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Down"
+"─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Dn/P"
 "╔═════════════════════════════════════════════════════[ Message ]══════════════════════════════════════════════════════╗"
 "║Type a prompt to begin…                                                                                               ║"
 "║                                                                                                                      ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_empty_state.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_empty_state.snap
@@ -36,7 +36,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "                                                                                                                        "
 "                                                                                                                        "
-"─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Down] Scro"
+"─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Dn/PgUp/Pg"
 "╔═════════════════════════════════════════════════════[ Message ]══════════════════════════════════════════════════════╗"
 "║Type a prompt to begin…                                                                                               ║"
 "║                                                                                                                      ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_header_shows_agent_and_model.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_header_shows_agent_and_model.snap
@@ -36,7 +36,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "                                                                                                                        "
 "                                                                                                                        "
-"─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Down] Scro"
+"─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Dn/PgUp/Pg"
 "╔═════════════════════════════════════════════════════[ Message ]══════════════════════════════════════════════════════╗"
 "║Type a prompt to begin…                                                                                               ║"
 "║                                                                                                                      ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_one_turn_user.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_one_turn_user.snap
@@ -36,7 +36,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "                                                                                                                        "
 "                                                                                                                        "
-"─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Down] Scro"
+"─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Dn/PgUp/Pg"
 "╔═════════════════════════════════════════════════════[ Message ]══════════════════════════════════════════════════════╗"
 "║Type a prompt to begin…                                                                                               ║"
 "║                                                                                                                      ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_quit_modal_open.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_quit_modal_open.snap
@@ -36,7 +36,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "                                                                                                                        "
 "                                                                                                                        "
-"─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Down] Scro"
+"─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Dn/PgUp/Pg"
 "╔═════════════════════════════════════════════════════[ Message ]══════════════════════════════════════════════════════╗"
 "║Type a prompt to begin…                                                                                               ║"
 "║                                                                                                                      ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_scrolled_up.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_scrolled_up.snap
@@ -36,7 +36,7 @@ expression: terminal.backend()
 " │ Message 7                                                                                                          │ "
 " ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ "
 "                                                                                                                        "
-"─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Down] Scro"
+"─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Dn/PgUp/Pg"
 "╔═════════════════════════════════════════════════════[ Message ]══════════════════════════════════════════════════════╗"
 "║Type a prompt to begin…                                                                                               ║"
 "║                                                                                                                      ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_streaming_locks_input.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_streaming_locks_input.snap
@@ -36,7 +36,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "                                                                                                                        "
 "                                                                                                                        "
-"─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Down"
+"─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Dn/P"
 "╔══════════════════════════════════════════[ Message (⠋ agent responding…) ]═══════════════════════════════════════════╗"
 "║⠋ Agent is responding — input locked…                                                                                 ║"
 "║                                                                                                                      ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_streaming_locks_input.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_streaming_locks_input.snap
@@ -38,7 +38,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Dn/P"
 "╔══════════════════════════════════════════[ Message (⠋ agent responding…) ]═══════════════════════════════════════════╗"
-"║⠋ Agent is responding — input locked…                                                                                 ║"
+"║⠿       Agent is responding — input locked…                                                                           ║"
 "║                                                                                                                      ║"
 "║                                                                                                                      ║"
 "╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_terminated_banner.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_terminated_banner.snap
@@ -36,7 +36,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "                                                                                                                        "
 "                                                                                                                        "
-"─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Down"
+"─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Dn/P"
 "╔════════════════════════════════════════════════════[ Terminated ]════════════════════════════════════════════════════╗"
 "║                          Session terminated (user quit). Press any key to return to Issues.                          ║"
 "║                                                                                                                      ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_three_turns_mixed_with_streaming.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction__interaction_screen_three_turns_mixed_with_streaming.snap
@@ -36,7 +36,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "                                                                                                                        "
 "                                                                                                                        "
-"─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Down] Scro"
+"─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Dn/PgUp/Pg"
 "╔═════════════════════════════════════════════════════[ Message ]══════════════════════════════════════════════════════╗"
 "║Type a prompt to begin…                                                                                               ║"
 "║                                                                                                                      ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction_terminator__terminator_idle_success.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction_terminator__terminator_idle_success.snap
@@ -36,7 +36,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "                                                                                                                        "
 "                                                                                                                        "
-"─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Down"
+"─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Dn/P"
 "╔════════════════════════════════════════════════════[ Terminated ]════════════════════════════════════════════════════╗"
 "║                          Session terminated (PR created). Press any key to return to Issues.                         ║"
 "║                                                                                                                      ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction_terminator__terminator_streaming_deferred.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction_terminator__terminator_streaming_deferred.snap
@@ -36,7 +36,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "                                                                                                                        "
 "                                                                                                                        "
-"─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Down"
+"─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Dn/P"
 "╔══════════════════════════════════════════[ Message (⠋ agent responding…) ]═══════════════════════════════════════════╗"
 "║⠋ Agent is responding — input locked…                                                                                 ║"
 "║                                                                                                                      ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction_terminator__terminator_streaming_deferred.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction_terminator__terminator_streaming_deferred.snap
@@ -38,7 +38,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Dn/P"
 "╔══════════════════════════════════════════[ Message (⠋ agent responding…) ]═══════════════════════════════════════════╗"
-"║⠋ Agent is responding — input locked…                                                                                 ║"
+"║⠿       Agent is responding — input locked…                                                                           ║"
 "║                                                                                                                      ║"
 "║                                                                                                                      ║"
 "╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction_terminator__terminator_teardown_failure.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction_terminator__terminator_teardown_failure.snap
@@ -36,7 +36,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "                                                                                                                        "
 "                                                                                                                        "
-"─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Down"
+"─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Dn/P"
 "╔════════════════════════════════════════════════════[ Terminated ]════════════════════════════════════════════════════╗"
 "║                        Session terminated (agent failure). Press any key to return to Issues.                        ║"
 "║                                                                                                                      ║"

--- a/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction_terminator__terminator_userquit_before_terminator.snap
+++ b/src/tui/snapshot_tests/snapshots/maestro__tui__snapshot_tests__interaction_terminator__terminator_userquit_before_terminator.snap
@@ -36,7 +36,7 @@ expression: terminal.backend()
 "                                                                                                                        "
 "                                                                                                                        "
 "                                                                                                                        "
-"─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Down"
+"─ [Enter] Send  [Shift+Enter] Newline  [Ctrl+P] /pushup (off)  [Ctrl+L] Clear input  [Ctrl+W] Quit  [Esc] Back  [Up/Dn/P"
 "╔════════════════════════════════════════════════════[ Terminated ]════════════════════════════════════════════════════╗"
 "║                          Session terminated (user quit). Press any key to return to Issues.                          ║"
 "║                                                                                                                      ║"

--- a/src/tui/spinner.rs
+++ b/src/tui/spinner.rs
@@ -1,5 +1,8 @@
 use crate::session::types::SessionStatus;
 
+mod wave;
+pub use wave::responding_wave;
+
 const ASCII_SPINNER_FRAMES: &[char] = &['|', '/', '-', '\\'];
 
 /// Tool-use animation: progress bar style.

--- a/src/tui/spinner/wave.rs
+++ b/src/tui/spinner/wave.rs
@@ -1,0 +1,93 @@
+//! Braille "agent responding" wave indicator (#990 follow-up). Split out of
+//! `spinner.rs` to keep that file under the 400-line cap. Pure, tick-driven,
+//! fixed-width so the surrounding layout never shifts.
+
+use super::tool_frame;
+
+/// Width (cells) of the wave bar.
+const WAVE_WIDTH: usize = 6;
+
+/// Density ramp, empty → full: ` ⠁⠃⠇⠧⠷⠿`. The head of the comet uses the last
+/// (densest) glyph; the tail fades toward the first.
+const WAVE_LEVELS: &[char] = &[
+    ' ', '\u{2801}', '\u{2803}', '\u{2807}', '\u{2827}', '\u{2837}', '\u{283F}',
+];
+
+/// A braille "comet" that sweeps left→right as `tick` advances — the calm
+/// "agent is responding" indicator. Brightest at the head, fading to a tail
+/// behind it, with a brief clear at the end of each sweep for a gentle pulse.
+pub fn braille_wave(tick: usize) -> String {
+    let tail = WAVE_LEVELS.len() - 1;
+    let span = WAVE_WIDTH + tail; // head travels fully off the right before repeating
+    let head = (tick % span) as isize;
+    (0..WAVE_WIDTH as isize)
+        .map(|i| {
+            let d = head - i; // how far cell `i` sits behind the head
+            if (0..=tail as isize).contains(&d) {
+                WAVE_LEVELS[WAVE_LEVELS.len() - 1 - d as usize]
+            } else {
+                ' '
+            }
+        })
+        .collect()
+}
+
+/// The "agent responding" indicator string: the braille wave on Nerd-Font
+/// terminals, an ASCII progress bar ([`tool_frame`]) otherwise so non-nerd
+/// terminals still get motion. Fixed width in both modes.
+pub fn responding_wave(tick: usize, use_nerd_font: bool) -> String {
+    if use_nerd_font {
+        braille_wave(tick)
+    } else {
+        tool_frame(tick).to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn braille_wave_is_fixed_width() {
+        // Width never changes, so the surrounding layout never shifts.
+        for t in 0..40 {
+            assert_eq!(
+                braille_wave(t).chars().count(),
+                WAVE_WIDTH,
+                "wave width drifted at tick {t}"
+            );
+        }
+    }
+
+    #[test]
+    fn braille_wave_head_sweeps_left_to_right() {
+        // tick 0: brightest head at the left edge.
+        let f0: Vec<char> = braille_wave(0).chars().collect();
+        assert_eq!(f0[0], '\u{283F}', "head starts at cell 0");
+        assert_eq!(f0[1], ' ', "nothing ahead of the head yet");
+        // tick 1: the head moved one cell right; cell 0 now trails (dimmer).
+        let f1: Vec<char> = braille_wave(1).chars().collect();
+        assert_eq!(f1[1], '\u{283F}', "head moved to cell 1");
+        assert!(
+            f1[0] != ' ' && f1[0] != '\u{283F}',
+            "cell 0 fades to a tail"
+        );
+    }
+
+    #[test]
+    fn braille_wave_clears_once_per_cycle() {
+        // The sweep ends with an all-blank frame for a gentle pulse before it
+        // repeats, so there is exactly one empty frame per period.
+        let period = WAVE_WIDTH + WAVE_LEVELS.len() - 1;
+        let blanks = (0..period)
+            .filter(|&t| braille_wave(t).trim().is_empty())
+            .count();
+        assert_eq!(blanks, 1, "expected exactly one clear frame per cycle");
+    }
+
+    #[test]
+    fn responding_wave_falls_back_to_ascii_without_nerd_font() {
+        assert_eq!(responding_wave(0, false), tool_frame(0));
+        assert_eq!(responding_wave(0, true), braille_wave(0));
+    }
+}


### PR DESCRIPTION
# v0.30.0 batch — Interactive Iteration Sessions (4 issues)

**Draft on purpose.** This bundles four independent v0.30.0 issues on one branch (autonomous overnight run). It touches `src/tui/**`, so per the project manual-QA gate it stays Draft until a human runs the UX scenarios below.

Branched fresh from `main`. Each issue is its own commit, in order, each compiling + green before the next — so any commit can be cherry-picked or reverted in isolation.

| Issue | Type | Summary | UI? |
|------|------|---------|-----|
| #938 | refactor(session) | route worktree + orphan removals through the hardened `wipe_worktree` guard | no |
| #936 | feat(session) | fire the queued interaction terminator after a streaming turn settles | no |
| #988 | feat(tui) | interaction transcript scroll rework (wheel + PageUp/Down + End) | **yes** |
| #953 | feat(session) | fetch the issue on a cache/browser miss at interaction launch | partial |

**Verification:** `cargo build`, `cargo fmt --check`, `cargo clippy -- -D warnings -A dead_code`, and the full `cargo test` suite are all green. **11,650 tests pass, 0 fail** (+34 new tests over `main`'s 11,616).

> Note: `cargo clippy --all-targets` surfaces pre-existing lints on `main` in files this PR does not touch (`templates/mod.rs`, `settings/validation.rs`, `tests/subagent_manifest_drift.rs`, `integration_tests/canonical_command_specs.rs`). Not introduced here. The project gate (`cargo clippy -- -D warnings -A dead_code`) is clean.

---

## #938 — route worktree + orphan removals through `wipe_worktree`

Two git-worktree removal sites shelled out `git worktree remove --force` directly with **no** root guard, and `cleanup.rs` fell back to a raw `std::fs::remove_dir_all`. Both now route through the `wipe_worktree` primitive (#740), inheriting its root sanity-check (refuses `/` and `$HOME`, canonicalized containment) and the leading-dash injection guard.

```gherkin
Feature: Hardened worktree removal

  Scenario: GitWorktreeManager refuses an unsafe root
    Given a teardown targeting "/etc" with worktree root "/"
    When GitWorktreeManager::guarded_remove runs
    Then it returns TeardownError::UnsafeRoot
    And no git command or filesystem delete is executed

  Scenario: orphan cleanup refuses an unsafe root
    Given a CleanupManager whose worktree root is "/"
    And an orphan at "/etc"
    When remove_orphans runs
    Then nothing is removed (count = 0)
    And "/etc" still exists

  Scenario: a normal orphan is removed through the guard
    Given an orphan under ".maestro/worktrees"
    When remove_orphans runs
    Then the worktree and its "maestro/<name>" branch are removed (idempotent)
```

Behaviour change worth noting: `GitWorktreeManager::remove` now also deletes the throwaway `maestro/<slug>` branch (idempotent). `remove_orphans` is now best-effort per orphan (logs + skips a failure instead of aborting the whole batch on the first error).

---

## #936 — fire queued terminator after the streaming turn settles

When a `/pushup` PR marker matched an interaction session that was **Streaming**, `signal_terminator` queued the event instead of firing (so the in-flight turn was not interrupted). That queued terminator was then lost: the turn runs on a background clone taken *before* the marker arrived, and `upsert_interaction` overwrote the live slot on completion — wiping the queue. The session stayed open forever.

```gherkin
Feature: Deferred interaction terminator

  Scenario: terminator fires after a mid-stream PR marker
    Given an interactive session that is Streaming a turn
    When a PR marker for its issue arrives mid-stream
    And the streaming turn then completes
    Then the session transitions to Terminated with close_reason PrCreated
    And the streamed reply text is preserved in the history
    And the queued terminator is cleared

  Scenario: a user-quit session is not resurrected
    Given the user quit the session while a turn was in flight
    When the completing turn merges back
    Then the session stays Terminated with close_reason UserQuit
```

### Manual QA (#936)
| # | Steps | Expected |
|---|-------|----------|
| 1 | `cargo run`, open an Interactive session on a test issue; send a prompt | turn streams |
| 2 | While it streams, in another terminal: `echo '{"pr_number":1,"owner":"<you>","repo":"<repo>","issue_number":<n>,"ts":"2026-06-01T00:00:00Z"}' > ~/.maestro/last-pr-created` | session keeps streaming, not interrupted |
| 3 | wait for the streamed reply to finish | session transitions to terminated/closed right after the turn ends (not mid-stream); the streamed reply text is intact |

---

## #988 — interaction transcript scroll rework

The mouse wheel routed to `app.panel_view` (a different panel) so it never scrolled the chat; the keyboard moved one line at a time with no paging or jump-to-latest.

- Mouse wheel over the Interaction screen scrolls the transcript (3 lines/notch); every other mode keeps the legacy `panel_view` routing (no regression).
- PageUp / PageDown page by one viewport height, clamped at top and bottom.
- End jumps to the newest message and resumes tail-following.
- Streaming-yank locked by a regression test: a chunk arriving while you are scrolled up does not move your view.
- New keys resolve before the streaming lock (work in Idle and Streaming) and do not collide with the outer chord set.

```gherkin
Feature: Interaction transcript scrolling

  Scenario: mouse wheel scrolls the chat
    Given the Interaction screen is showing an overflowing transcript
    When the user scrolls the mouse wheel up
    Then the transcript scrolls (auto-follow turns off)
    And in any other screen the wheel still scrolls panel_view

  Scenario: paging
    When the user presses PageUp / PageDown
    Then the transcript pages by one screenful, clamped at top and bottom

  Scenario: jump to latest
    When the user presses End
    Then the view jumps to the newest message and resumes tail-following

  Scenario: streaming does not yank the view
    Given the user has scrolled up to read history
    When a streaming chunk arrives
    Then the scroll position and auto-follow flag are unchanged
```

### Manual QA (#988) — **required before this leaves Draft**
| # | Steps | Expected |
|---|-------|----------|
| 1 | `cargo run`, launch an Interaction, accumulate several long turns so the transcript overflows | content overflows the pane |
| 2 | scroll with the **mouse wheel** | the chat scrolls (not a hidden panel) |
| 3 | press **PageUp/PageDown**; then **End** | pages by a screenful; End jumps to newest |
| 4 | scroll up to an old message, send a prompt, let the reply stream | view **stays put** (no yank to bottom) until you press End |
| 5 | switch to Sessions/Dashboard, use the wheel | its scroll still works (no regression) |
| 6 | check the footer keybar | shows `[Up/Dn/PgUp/PgDn] Scroll` and `[End] Latest` |

---

## #953 — fetch issue on cache/browser miss at interaction launch

Phase 1 (#946) built the real issue prompt + appendix only when the issue was already cached/loaded. On a miss, the launch fell back to bare dialog text — the agent lost issue context. Now a miss defers the first turn and fetches the issue (via a dedicated `FetchInteractionIssue` command + `InteractionIssueFetched` event, kept off the one-shot session path), then builds the real prompt. On fetch failure it falls back to dialog text + a warning.

```gherkin
Feature: Issue fetch on interactive-launch cache miss

  Scenario: cache miss defers and fetches
    Given an interactive launch for an issue absent from cache and browser
    When the session opens
    Then no bare first turn is seeded
    And a FetchInteractionIssue command is queued carrying the dialog text

  Scenario: fetched issue builds the real first turn
    When the issue fetch returns successfully
    Then the first turn carries the issue title + acceptance criteria + appendix
    And the issue is cached for later lookups

  Scenario: fetch failure falls back to dialog text
    When the issue fetch fails
    Then the first turn is the bare dialog text (if any) and a warning is logged
    And no panic occurs
```

### Manual QA (#953)
| # | Steps | Expected |
|---|-------|----------|
| 1 | `cargo run`, launch an Interaction on an issue **without** opening/fetching it first (cold cache) | agent's first turn references the issue (title / AC), not "which issue?" |
| 2 | break `gh` auth / kill network, repeat | launch still proceeds with dialog text + a warning; no hang/panic |

---

## Not in this PR (remaining v0.30.0 work)

Deliberately left out of the autonomous run — each documented so the milestone graph stays honest:

- **#941** move worktree teardown off the UI thread (`spawn_blocking`) — a cross-boundary async refactor: the screen cannot spawn (the app owns the runtime + `data_tx`), so both firing paths plus the terminator test + snapshot suite need rewriting. The issue records it is **LOW** priority (architect + security: "local, self-inflicted only"). Best done with you awake to confirm UI responsiveness. Not started here to avoid destabilizing this clean batch.
- **#918** native in-session diff reviewer (gitui-derived) — large new feature, likely new deps; not an overnight-safe blind build.
- **#919** extend Produce-PR / Interaction checkboxes to multi-issue + free-form dialogs — has an open design question (per-session vs disallow-with-unified-PR) that wants a human decision first.
- **#947 → #948 → #949 → #950** the unification chain (Phase 2–5) — a sequential refactor of the live session pipeline; too risky to run blind end-to-end.
- **#935** unification umbrella (spike); **#929** provider-routed turns (blocked on v0.30.5/#751); **#930** folded into #950; **#743** docs (blocked on #742); **#942** is a manual-QA sandbox fixture, not code.

## Notes
- Issues are **not** closed and the milestone graph is **not** updated — this is Draft pending manual QA. Promote per the normal `/pushup` flow once the matrices above pass.
- No new `unwrap`/`expect`/`panic` in production code across the four changes.

Closes #938, #936, #988, #953 *(on merge, after manual QA)*
