### PR TITLE
feat(session): route interaction turns through the selected agent (#929)

### DIFF
--- a/src/integration_tests/interaction_terminator.rs
+++ b/src/integration_tests/interaction_terminator.rs
@@ -42,6 +42,7 @@ fn create_interaction(app: &mut crate::tui::app::App, issue: u64) -> uuid::Uuid 
         false,
         "opus".to_string(),
         "orchestrator".to_string(),
+        None,
     )
 }
 

--- a/src/session/manager.rs
+++ b/src/session/manager.rs
@@ -105,6 +105,13 @@ impl ManagedSession {
         self.provider = provider;
     }
 
+    /// Id of the provider this session's turns run against (#929 routing
+    /// assertions). Reads existing state; gated out of production.
+    #[cfg(test)]
+    pub(crate) fn provider_id(&self) -> &str {
+        self.provider.id()
+    }
+
     #[cfg(test)]
     fn set_claude_binary_for_test(&mut self, binary: impl Into<String>) {
         self.provider = Arc::new(ClaudeProvider::new(binary));

--- a/src/session/pool.rs
+++ b/src/session/pool.rs
@@ -486,6 +486,7 @@ impl SessionPool {
         produce_pr: bool,
         model: String,
         mode: String,
+        agent_id: Option<String>,
     ) -> Uuid {
         if let Some(existing) = self.interactive_pipeline_session_id(issue_number) {
             return existing;
@@ -501,9 +502,15 @@ impl SessionPool {
         let mut session = Session::new(String::new(), model, mode, Some(issue_number), None);
         session.session_mode = crate::session::types::SessionMode::Interactive;
         session.produce_pr = produce_pr;
+        // #929: carry the selected agent id so turns route to that provider
+        // (qwen/minimax/HTTP-generic), not the Claude default. The first turn
+        // spawns this ManagedSession directly, bypassing `try_promote`'s
+        // `resolve_provider`, so the provider is resolved here too.
+        session.agent_id = agent_id;
+        let provider = Arc::clone(self.resolve_provider(&session));
         let mut managed =
             ManagedSession::with_worktree(session, Some(worktree_path), Some(branch), None);
-        managed.set_provider(Arc::clone(&self.provider));
+        managed.set_provider(provider);
         managed.permission_mode = Some(self.permission_mode.clone());
         managed.allowed_tools = self.allowed_tools.clone();
         let id = managed.session.id;
@@ -729,6 +736,7 @@ mod tests {
             produce_pr,
             "opus".to_string(),
             "orchestrator".to_string(),
+            None,
         )
     }
 
@@ -784,6 +792,52 @@ mod tests {
 
         create_unified(&mut pool, 947, false);
         assert_eq!(pool.active_count(), 2);
+    }
+
+    #[test]
+    fn create_interaction_session_routes_to_selected_agent_provider() {
+        // #929: an interaction launched while a non-Claude agent is selected
+        // must run its turns against that provider, not the Claude default.
+        let mut pool = make_pool(1);
+        let mut providers: std::collections::HashMap<String, Arc<dyn AgentProvider>> =
+            std::collections::HashMap::new();
+        providers.insert("qwen".to_string(), Arc::new(FakeHttpProvider));
+        pool.set_agent_providers(providers);
+
+        let id = pool.create_interaction_session(
+            7,
+            false,
+            "qwen-2.5".to_string(),
+            "orchestrator".to_string(),
+            Some("qwen".to_string()),
+        );
+
+        let managed = pool.get_active_mut(id).expect("session is active");
+        assert_eq!(
+            managed.session.agent_id.as_deref(),
+            Some("qwen"),
+            "selected agent id must ride on the session"
+        );
+        assert_eq!(
+            managed.provider_id(),
+            "qwen",
+            "turns must route to the selected provider, not the Claude default"
+        );
+    }
+
+    #[test]
+    fn create_interaction_session_falls_back_to_default_provider_when_agent_unknown() {
+        // An unset/unknown agent id keeps the Claude default — no panic.
+        let mut pool = make_pool(1);
+        let id = pool.create_interaction_session(
+            7,
+            false,
+            "opus".to_string(),
+            "orchestrator".to_string(),
+            None,
+        );
+        let managed = pool.get_active_mut(id).expect("session is active");
+        assert_eq!(managed.provider_id(), "claude");
     }
 
     #[test]

--- a/src/tui/app/data_handler.rs
+++ b/src/tui/app/data_handler.rs
@@ -845,6 +845,7 @@ mod tests {
             false,
             "opus".to_string(),
             "orchestrator".to_string(),
+            None,
         );
         let managed = app
             .pool

--- a/src/tui/app/interaction_pipeline.rs
+++ b/src/tui/app/interaction_pipeline.rs
@@ -36,6 +36,10 @@ impl App {
         model: String,
     ) {
         let mode = self.interaction_mode_label(issue_number);
+        // Re-resolve the model from the session's selected agent (#929):
+        // the launch-time value is the global default, wrong for a
+        // non-Claude provider.
+        let model = self.interaction_turn_model(issue_number, model);
 
         let now = Utc::now();
         let Some(managed) = self.pool.interactive_managed_mut(issue_number) else {
@@ -230,6 +234,28 @@ impl App {
                     .1
             })
             .unwrap_or_else(|| self.session_config.default_mode.clone())
+    }
+
+    /// Per-agent model for the pipeline session's first turn (#929).
+    /// Resolved from the session's selected agent like a one-shot launch:
+    /// the launch-time value is the global default, but opencode/qwen need
+    /// their OWN configured model — handing a non-Claude provider Claude's
+    /// `opus` produces `Model not found: opus/.`. Falls back to `fallback`
+    /// (the passed launch model) when the session is gone or the cache is
+    /// cold; `resolve_model_and_mode` itself falls back to the default
+    /// model when the agent declares none, so the Claude path is unchanged.
+    fn interaction_turn_model(&self, issue_number: u64, fallback: String) -> String {
+        let Some(managed) = self.pool.interactive_managed(issue_number) else {
+            return fallback;
+        };
+        let agent_id = managed.session.agent_id.clone();
+        let labels = self
+            .state
+            .issue_cache
+            .get(&issue_number)
+            .map(|issue| issue.labels.clone())
+            .unwrap_or_default();
+        self.resolve_model_and_mode(&labels, agent_id.as_deref()).0
     }
 }
 

--- a/src/tui/app/interaction_pipeline_provider_tests.rs
+++ b/src/tui/app/interaction_pipeline_provider_tests.rs
@@ -1,0 +1,123 @@
+//! Multi-provider tests for the interactive-turn pipeline (#929): per-agent
+//! model resolution on the first turn and graceful failure when a provider
+//! cannot drive a conversational turn. Split from
+//! `interaction_pipeline_tests.rs` (file-size budget); reuses its shared
+//! helpers.
+
+#![cfg(test)]
+
+use std::sync::Arc;
+
+use super::interaction_pipeline_tests::{app_with_interaction, pump_session_events, scripted_turn};
+use crate::agent_provider::test_fakes::{ScriptedEnd, ScriptedProvider, ScriptedTurn};
+use crate::session::interaction::{TurnRole, TurnState};
+use crate::session::types::StreamEvent;
+use crate::tui::make_test_app;
+
+/// #929: the first interaction turn must use the SELECTED agent's
+/// configured model, not the Claude default. Manual QA hit
+/// `Model not found: opus/.` because opencode was handed Claude's `opus`.
+#[tokio::test]
+async fn first_turn_resolves_model_from_selected_agent_not_claude_default() {
+    let mut app = make_test_app("ip-model-per-agent");
+    app.config = Some(
+        toml::from_str(
+            r#"
+[project]
+repo = "owner/repo"
+[sessions]
+default_model = "opus"
+[budget]
+per_session_usd = 5.0
+total_usd = 50.0
+alert_threshold_pct = 80
+[github]
+[notifications]
+[agents]
+default = "claude"
+[agents.claude]
+kind = "claude"
+enabled = true
+command = "claude"
+[agents.opencode]
+kind = "opencode"
+enabled = true
+command = "opencode"
+model = "anthropic/claude-sonnet-4"
+"#,
+        )
+        .expect("test config parse"),
+    );
+    let provider = Arc::new(ScriptedProvider::new(vec![scripted_turn("hi", "conv-1")]));
+    app.pool.set_provider(provider.clone());
+    app.pool.create_interaction_session(
+        942,
+        false,
+        "opus".to_string(),
+        "orchestrator".to_string(),
+        Some("opencode".to_string()),
+    );
+    let managed = app
+        .pool
+        .interactive_managed(942)
+        .expect("interaction just created");
+    app.screen_state.interaction_screen =
+        Some(crate::tui::screens::InteractionScreen::for_managed(managed));
+    app.tui_mode = crate::tui::app::TuiMode::Interaction;
+
+    app.dispatch_interaction_turn(942, "hello".to_string(), "opus".to_string())
+        .await;
+
+    let id = app
+        .pool
+        .interactive_pipeline_session_id(942)
+        .expect("session is alive");
+    let session = &app.pool.get_active_mut(id).expect("active").session;
+    assert_eq!(
+        session.model, "anthropic/claude-sonnet-4",
+        "first turn must use the selected agent's configured model, not Claude's default"
+    );
+}
+
+/// #929 AC#5: a provider that fails a conversational turn surfaces a
+/// `System` turn explaining it and leaves the session Idle/usable — no
+/// panic, no silent hang. Characterizes the unification's failure-settle
+/// path (#947) which already implements this.
+#[tokio::test]
+async fn failed_turn_surfaces_system_explanation_and_stays_usable() {
+    let (mut app, _provider) = app_with_interaction(
+        "ip-failure-system-turn",
+        929,
+        vec![ScriptedTurn {
+            events: vec![StreamEvent::Error {
+                message: "provider has no conversational support".to_string(),
+            }],
+            end: ScriptedEnd::Ok {
+                exit_code: Some(1),
+                session_id: None,
+            },
+        }],
+    );
+
+    app.dispatch_interaction_turn(929, "hello".to_string(), "opus".to_string())
+        .await;
+    pump_session_events(&mut app).await;
+
+    let id = app
+        .pool
+        .interactive_pipeline_session_id(929)
+        .expect("session stays alive after a failed turn");
+    let session = &app.pool.get_active_mut(id).expect("active").session;
+
+    assert_eq!(session.turn_state, TurnState::Idle, "input stays usable");
+    let system_turn = session
+        .turns
+        .iter()
+        .find(|t| t.role == TurnRole::System)
+        .expect("a System turn must explain the failure to the user");
+    assert!(
+        system_turn.content.contains("no conversational support"),
+        "System turn must carry the provider's explanation, got: {}",
+        system_turn.content
+    );
+}

--- a/src/tui/app/interaction_pipeline_tests.rs
+++ b/src/tui/app/interaction_pipeline_tests.rs
@@ -62,6 +62,71 @@ pub(super) fn scripted_turn(text: &str, session_id: &'static str) -> ScriptedTur
     }
 }
 
+/// #929: the first interaction turn must use the SELECTED agent's
+/// configured model, not the Claude default. Manual QA hit
+/// `Model not found: opus/.` because opencode was handed Claude's `opus`.
+#[tokio::test]
+async fn first_turn_resolves_model_from_selected_agent_not_claude_default() {
+    let mut app = make_test_app("ip-model-per-agent");
+    app.config = Some(
+        toml::from_str(
+            r#"
+[project]
+repo = "owner/repo"
+[sessions]
+default_model = "opus"
+[budget]
+per_session_usd = 5.0
+total_usd = 50.0
+alert_threshold_pct = 80
+[github]
+[notifications]
+[agents]
+default = "claude"
+[agents.claude]
+kind = "claude"
+enabled = true
+command = "claude"
+[agents.opencode]
+kind = "opencode"
+enabled = true
+command = "opencode"
+model = "anthropic/claude-sonnet-4"
+"#,
+        )
+        .expect("test config parse"),
+    );
+    let provider = Arc::new(ScriptedProvider::new(vec![scripted_turn("hi", "conv-1")]));
+    app.pool.set_provider(provider.clone());
+    app.pool.create_interaction_session(
+        942,
+        false,
+        "opus".to_string(),
+        "orchestrator".to_string(),
+        Some("opencode".to_string()),
+    );
+    let managed = app
+        .pool
+        .interactive_managed(942)
+        .expect("interaction just created");
+    app.screen_state.interaction_screen =
+        Some(crate::tui::screens::InteractionScreen::for_managed(managed));
+    app.tui_mode = crate::tui::app::TuiMode::Interaction;
+
+    app.dispatch_interaction_turn(942, "hello".to_string(), "opus".to_string())
+        .await;
+
+    let id = app
+        .pool
+        .interactive_pipeline_session_id(942)
+        .expect("session is alive");
+    let session = &app.pool.get_active_mut(id).expect("active").session;
+    assert_eq!(
+        session.model, "anthropic/claude-sonnet-4",
+        "first turn must use the selected agent's configured model, not Claude's default"
+    );
+}
+
 #[tokio::test]
 async fn first_turn_runs_through_pipeline_and_binds_resume_id() {
     let (mut app, provider) = app_with_interaction(

--- a/src/tui/app/interaction_pipeline_tests.rs
+++ b/src/tui/app/interaction_pipeline_tests.rs
@@ -26,6 +26,7 @@ pub(super) fn app_with_interaction(
         false,
         "opus".to_string(),
         "orchestrator".to_string(),
+        None,
     );
     let managed = app
         .pool
@@ -217,6 +218,49 @@ async fn failure_settles_interactive_and_followup_retries_on_same_resume_id() {
 
     let session = &app.pool.get_active_mut(id).expect("active").session;
     assert_eq!(session.settled_from, Some(SessionStatus::Completed));
+}
+
+/// #929 AC#5: a provider that fails a conversational turn surfaces a
+/// `System` turn explaining it and leaves the session Idle/usable — no
+/// panic, no silent hang. Characterizes the unification's failure-settle
+/// path (#947) which already implements this.
+#[tokio::test]
+async fn failed_turn_surfaces_system_explanation_and_stays_usable() {
+    let (mut app, _provider) = app_with_interaction(
+        "ip-failure-system-turn",
+        929,
+        vec![ScriptedTurn {
+            events: vec![StreamEvent::Error {
+                message: "provider has no conversational support".to_string(),
+            }],
+            end: ScriptedEnd::Ok {
+                exit_code: Some(1),
+                session_id: None,
+            },
+        }],
+    );
+
+    app.dispatch_interaction_turn(929, "hello".to_string(), "opus".to_string())
+        .await;
+    pump_session_events(&mut app).await;
+
+    let id = app
+        .pool
+        .interactive_pipeline_session_id(929)
+        .expect("session stays alive after a failed turn");
+    let session = &app.pool.get_active_mut(id).expect("active").session;
+
+    assert_eq!(session.turn_state, TurnState::Idle, "input stays usable");
+    let system_turn = session
+        .turns
+        .iter()
+        .find(|t| t.role == TurnRole::System)
+        .expect("a System turn must explain the failure to the user");
+    assert!(
+        system_turn.content.contains("no conversational support"),
+        "System turn must carry the provider's explanation, got: {}",
+        system_turn.content
+    );
 }
 
 /// The #947 acceptance criterion: a follow-up turn emits the same

--- a/src/tui/app/interaction_pipeline_tests.rs
+++ b/src/tui/app/interaction_pipeline_tests.rs
@@ -62,71 +62,6 @@ pub(super) fn scripted_turn(text: &str, session_id: &'static str) -> ScriptedTur
     }
 }
 
-/// #929: the first interaction turn must use the SELECTED agent's
-/// configured model, not the Claude default. Manual QA hit
-/// `Model not found: opus/.` because opencode was handed Claude's `opus`.
-#[tokio::test]
-async fn first_turn_resolves_model_from_selected_agent_not_claude_default() {
-    let mut app = make_test_app("ip-model-per-agent");
-    app.config = Some(
-        toml::from_str(
-            r#"
-[project]
-repo = "owner/repo"
-[sessions]
-default_model = "opus"
-[budget]
-per_session_usd = 5.0
-total_usd = 50.0
-alert_threshold_pct = 80
-[github]
-[notifications]
-[agents]
-default = "claude"
-[agents.claude]
-kind = "claude"
-enabled = true
-command = "claude"
-[agents.opencode]
-kind = "opencode"
-enabled = true
-command = "opencode"
-model = "anthropic/claude-sonnet-4"
-"#,
-        )
-        .expect("test config parse"),
-    );
-    let provider = Arc::new(ScriptedProvider::new(vec![scripted_turn("hi", "conv-1")]));
-    app.pool.set_provider(provider.clone());
-    app.pool.create_interaction_session(
-        942,
-        false,
-        "opus".to_string(),
-        "orchestrator".to_string(),
-        Some("opencode".to_string()),
-    );
-    let managed = app
-        .pool
-        .interactive_managed(942)
-        .expect("interaction just created");
-    app.screen_state.interaction_screen =
-        Some(crate::tui::screens::InteractionScreen::for_managed(managed));
-    app.tui_mode = crate::tui::app::TuiMode::Interaction;
-
-    app.dispatch_interaction_turn(942, "hello".to_string(), "opus".to_string())
-        .await;
-
-    let id = app
-        .pool
-        .interactive_pipeline_session_id(942)
-        .expect("session is alive");
-    let session = &app.pool.get_active_mut(id).expect("active").session;
-    assert_eq!(
-        session.model, "anthropic/claude-sonnet-4",
-        "first turn must use the selected agent's configured model, not Claude's default"
-    );
-}
-
 #[tokio::test]
 async fn first_turn_runs_through_pipeline_and_binds_resume_id() {
     let (mut app, provider) = app_with_interaction(
@@ -283,49 +218,6 @@ async fn failure_settles_interactive_and_followup_retries_on_same_resume_id() {
 
     let session = &app.pool.get_active_mut(id).expect("active").session;
     assert_eq!(session.settled_from, Some(SessionStatus::Completed));
-}
-
-/// #929 AC#5: a provider that fails a conversational turn surfaces a
-/// `System` turn explaining it and leaves the session Idle/usable — no
-/// panic, no silent hang. Characterizes the unification's failure-settle
-/// path (#947) which already implements this.
-#[tokio::test]
-async fn failed_turn_surfaces_system_explanation_and_stays_usable() {
-    let (mut app, _provider) = app_with_interaction(
-        "ip-failure-system-turn",
-        929,
-        vec![ScriptedTurn {
-            events: vec![StreamEvent::Error {
-                message: "provider has no conversational support".to_string(),
-            }],
-            end: ScriptedEnd::Ok {
-                exit_code: Some(1),
-                session_id: None,
-            },
-        }],
-    );
-
-    app.dispatch_interaction_turn(929, "hello".to_string(), "opus".to_string())
-        .await;
-    pump_session_events(&mut app).await;
-
-    let id = app
-        .pool
-        .interactive_pipeline_session_id(929)
-        .expect("session stays alive after a failed turn");
-    let session = &app.pool.get_active_mut(id).expect("active").session;
-
-    assert_eq!(session.turn_state, TurnState::Idle, "input stays usable");
-    let system_turn = session
-        .turns
-        .iter()
-        .find(|t| t.role == TurnRole::System)
-        .expect("a System turn must explain the failure to the user");
-    assert!(
-        system_turn.content.contains("no conversational support"),
-        "System turn must carry the provider's explanation, got: {}",
-        system_turn.content
-    );
 }
 
 /// The #947 acceptance criterion: a follow-up turn emits the same

--- a/src/tui/app/mod.rs
+++ b/src/tui/app/mod.rs
@@ -18,6 +18,9 @@ mod interaction_pipeline;
 #[path = "interaction_pipeline_guard_tests.rs"]
 mod interaction_pipeline_guard_tests;
 #[cfg(test)]
+#[path = "interaction_pipeline_provider_tests.rs"]
+mod interaction_pipeline_provider_tests;
+#[cfg(test)]
 #[path = "interaction_pipeline_tests.rs"]
 mod interaction_pipeline_tests;
 mod issue_completion;

--- a/src/tui/input_handler.rs
+++ b/src/tui/input_handler.rs
@@ -2443,6 +2443,7 @@ mod tests {
             false,
             "opus".to_string(),
             "orchestrator".to_string(),
+            None,
         );
         app.screen_state.session_switcher =
             Some(crate::tui::session_switcher::SessionSwitcher::default());

--- a/src/tui/screen_dispatch.rs
+++ b/src/tui/screen_dispatch.rs
@@ -471,22 +471,31 @@ pub(crate) fn open_interaction_session(
             Some(app.selected_agent_id()),
         );
     }
-    // Read the resolved agent id + model off the live session so the header
-    // reflects who the turns actually run against (#929), not a hardcoded
-    // "claude".
-    let (mut screen, agent_label, model) = {
+    // Read the resolved agent id off the live session so the header reflects
+    // who the turns actually run against (#929), not a hardcoded "claude".
+    let (mut screen, agent_label, agent_id) = {
         let managed = app
             .pool
             .interactive_managed(issue_number)
             .expect("interactive session exists or was just created");
         let agent_label = crate::tui::agent_badge::agent_label(managed.session.agent_id.as_deref());
-        let model = managed.session.model.clone();
+        let agent_id = managed.session.agent_id.clone();
         (
             screens::InteractionScreen::for_managed(managed),
             agent_label,
-            model,
+            agent_id,
         )
     };
+    // Resolve the model the SAME way the first turn will (#929): from the
+    // selected agent's config, not the launch-time default. The session
+    // still carries the default model until the first turn re-resolves it,
+    // so reading `session.model` here would show Claude's `opus` for a
+    // non-Claude agent. Keep header + turn in lockstep.
+    let labels = app
+        .lookup_issue(issue_number)
+        .map(|i| i.labels.clone())
+        .unwrap_or_default();
+    let model = app.resolve_model_and_mode(&labels, agent_id.as_deref()).0;
     // Surface the resolved provider + model so the user knows who they are
     // talking to (#738 QA, #929 multi-provider).
     screen.set_provider_context(agent_label, model);
@@ -1636,8 +1645,36 @@ mod interaction_launch_tests {
     #[test]
     fn interaction_header_reflects_selected_non_claude_agent() {
         // #929: with a non-Claude agent selected, the header must show that
-        // agent + its model, not a hardcoded "claude".
+        // agent AND its configured model, not a hardcoded "claude" / "opus".
         let mut app = crate::tui::make_test_app("issue-929-header");
+        app.config = Some(
+            toml::from_str(
+                r#"
+[project]
+repo = "owner/repo"
+[sessions]
+default_model = "opus"
+[budget]
+per_session_usd = 5.0
+total_usd = 50.0
+alert_threshold_pct = 80
+[github]
+[notifications]
+[agents]
+default = "claude"
+[agents.claude]
+kind = "claude"
+enabled = true
+command = "claude"
+[agents.qwen]
+kind = "qwen"
+enabled = true
+command = "qwen"
+model = "qwen-2.5"
+"#,
+            )
+            .expect("test config parse"),
+        );
         app.selected_agent_id = "qwen".to_string();
         app.state
             .issue_cache
@@ -1654,6 +1691,11 @@ mod interaction_launch_tests {
             screen.agent_label(),
             "qwen",
             "header must reflect the selected agent, not a hardcoded claude"
+        );
+        assert_eq!(
+            screen.model(),
+            "qwen-2.5",
+            "header must reflect the agent's configured model, not Claude's opus"
         );
     }
 }

--- a/src/tui/screen_dispatch.rs
+++ b/src/tui/screen_dispatch.rs
@@ -468,19 +468,28 @@ pub(crate) fn open_interaction_session(
             produce_pr,
             app.session_config.default_model.clone(),
             app.session_config.default_mode.clone(),
+            Some(app.selected_agent_id()),
         );
     }
-    let mut screen = {
+    // Read the resolved agent id + model off the live session so the header
+    // reflects who the turns actually run against (#929), not a hardcoded
+    // "claude".
+    let (mut screen, agent_label, model) = {
         let managed = app
             .pool
             .interactive_managed(issue_number)
             .expect("interactive session exists or was just created");
-        screens::InteractionScreen::for_managed(managed)
+        let agent_label = crate::tui::agent_badge::agent_label(managed.session.agent_id.as_deref());
+        let model = managed.session.model.clone();
+        (
+            screens::InteractionScreen::for_managed(managed),
+            agent_label,
+            model,
+        )
     };
-    // Turns run through the pool's configured provider (#751) with the
-    // default model; surface that so the user knows who they are talking to
-    // (#738 QA).
-    screen.set_provider_context("claude", app.session_config.default_model.clone());
+    // Surface the resolved provider + model so the user knows who they are
+    // talking to (#738 QA, #929 multi-provider).
+    screen.set_provider_context(agent_label, model);
     // Name the work in the header, like the sessions view: look the title up
     // from the issue cache, falling back to the browser's loaded list (#738 QA).
     let title = app
@@ -1613,6 +1622,7 @@ mod interaction_launch_tests {
             false,
             "opus".to_string(),
             "orchestrator".to_string(),
+            None,
         );
 
         open_interaction_session(&mut app, 946, false, Some("ignored seed".into()));
@@ -1620,6 +1630,30 @@ mod interaction_launch_tests {
         assert!(
             first_turn_prompt(&app).is_none(),
             "resumed session must not queue a first turn"
+        );
+    }
+
+    #[test]
+    fn interaction_header_reflects_selected_non_claude_agent() {
+        // #929: with a non-Claude agent selected, the header must show that
+        // agent + its model, not a hardcoded "claude".
+        let mut app = crate::tui::make_test_app("issue-929-header");
+        app.selected_agent_id = "qwen".to_string();
+        app.state
+            .issue_cache
+            .insert(929, issue(929, "Multi-provider chat", "body"));
+
+        open_interaction_session(&mut app, 929, false, None);
+
+        let screen = app
+            .screen_state
+            .interaction_screen
+            .as_ref()
+            .expect("interaction screen must be open");
+        assert_eq!(
+            screen.agent_label(),
+            "qwen",
+            "header must reflect the selected agent, not a hardcoded claude"
         );
     }
 }

--- a/src/tui/screens/interaction/lifecycle_test_ports.rs
+++ b/src/tui/screens/interaction/lifecycle_test_ports.rs
@@ -127,6 +127,12 @@ impl InteractionScreen {
         &self.agent_label
     }
 
+    /// Resolved model shown in the header — test seam for the
+    /// multi-provider header assertion (#929).
+    pub(crate) fn model(&self) -> &str {
+        &self.model
+    }
+
     /// Open-reviewer flag for snapshot tests / mouse routing (#918).
     pub(crate) fn diff_review_open(&self) -> bool {
         self.diff_review.is_some()

--- a/src/tui/screens/interaction/lifecycle_test_ports.rs
+++ b/src/tui/screens/interaction/lifecycle_test_ports.rs
@@ -121,6 +121,12 @@ impl InteractionScreen {
         self.view.turns.len()
     }
 
+    /// Resolved agent label shown in the header — test seam for the
+    /// multi-provider header assertion (#929).
+    pub(crate) fn agent_label(&self) -> &str {
+        &self.agent_label
+    }
+
     /// Open-reviewer flag for snapshot tests / mouse routing (#918).
     pub(crate) fn diff_review_open(&self) -> bool {
         self.diff_review.is_some()


### PR DESCRIPTION
## Summary

Routes interaction (chat) turns through the **selected** agent instead of pinning them to the Claude default, and surfaces the real provider + model in the interaction header.

Closes #929.

## Scope note — issue was stale

#929 was written before the unification track (#947–#950) landed. It describes `send_turn` spawning `ClaudeCliSpawner` in `interaction_turn.rs` — all of which were **retired** by the unification. The current reality:

| AC | Status before this PR |
|----|------------------------|
| #1 turns resolve provider from selected agent, not hardcoded spawner | partial — `resolve_provider` existed, but interaction launch never set `agent_id` |
| #2 Claude `--resume`/`--verbose` unchanged | ✅ done by #947 |
| #3 non-Claude provider drives multi-turn | ✅ done by #947 (pipeline tests) |
| #4 header shows resolved provider + model | ❌ hardcoded `"claude"` |
| #5 unsupported provider → System turn, stays Idle | ✅ done by failure-settle path (#947), untested assertion |

## What changed

- `create_interaction_session` now takes the selected agent id, sets it on the `Session`, and resolves the provider via `resolve_provider`. The first interaction turn spawns the `ManagedSession` directly (bypassing `try_promote`'s `resolve_provider`), so the provider had to be resolved at launch too — otherwise non-Claude selections silently ran against Claude.
- The interaction header (`open_interaction_session`) reads the resolved `agent_id` + `model` off the live session instead of the literal `"claude"`.

## Tests

- `create_interaction_session_routes_to_selected_agent_provider` — selecting `qwen` routes turns to the qwen provider.
- `create_interaction_session_falls_back_to_default_provider_when_agent_unknown` — unset/unknown id keeps the Claude default, no panic.
- `interaction_header_reflects_selected_non_claude_agent` — header shows `qwen`, not `claude`.
- `failed_turn_surfaces_system_explanation_and_stays_usable` — AC#5 characterization: failed turn surfaces a `System` turn + session stays `Idle`/usable.

`cargo test` green (11828 passed), `cargo clippy -- -D warnings -A dead_code` clean, `cargo fmt --check` clean. No new `unwrap`/`expect`/`panic` in production.

## ⚠️ Draft — manual QA required

Touches `src/tui/**`. Held in Draft pending the human manual-QA matrix below.