### PR TITLE
fix(tui/interaction): confirm before quitting discards unsaved work (RC4)

### DIFF
--- a/src/tui/screens/interaction/input.rs
+++ b/src/tui/screens/interaction/input.rs
@@ -166,11 +166,25 @@ pub(super) fn draw_keybar(f: &mut Frame, area: Rect, theme: &Theme, pushup_enabl
 }
 
 /// Render the `Ctrl+W` quit-confirm modal centered over `area`.
-pub(super) fn draw_quit_modal(f: &mut Frame, area: Rect, theme: &Theme, worktree: &Path) {
-    let text = format!(
-        "Quit interaction? Worktree at {} kept for manual inspection. [y/N]",
-        worktree.display()
-    );
+pub(super) fn draw_quit_modal(
+    f: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    worktree: &Path,
+    warn_unsaved: bool,
+) {
+    let text = if warn_unsaved {
+        // RC4: this session has unpushed work and no linked PR. Quitting
+        // deletes the worktree branch — say so plainly and require a
+        // deliberate second confirm.
+        "Unpushed work will be LOST — no PR was created. Press y again to discard, N to keep working."
+            .to_string()
+    } else {
+        format!(
+            "Quit interaction? Worktree at {} kept for manual inspection. [y/N]",
+            worktree.display()
+        )
+    };
     let modal = centered_rect(area, (text.len() as u16 + 6).min(area.width), 3);
     f.render_widget(Clear, modal);
     let block = theme.styled_block("Confirm", true);

--- a/src/tui/screens/interaction/keymap_tests.rs
+++ b/src/tui/screens/interaction/keymap_tests.rs
@@ -234,6 +234,10 @@ fn quit_modal_y_returns_quit_action_without_terminating() {
     // #949: the app terminates the session + starts the wipe; the screen
     // terminates only when the teardown result lands.
     let mut s = screen_for(9, true, TurnState::Idle);
+    // Work captured in a linked PR → no unsaved work, so `[y]` quits on the
+    // first press (the double-confirm guard only fires when no PR was linked;
+    // see terminator_tests::quit_with_unsaved_pr_work_requires_double_confirm).
+    s.view.pr_linked = Some(1);
     s.handle_input(&ctrl('w'), InputMode::Insert);
     let action = s.handle_input(&key_event(KeyCode::Char('y')), InputMode::Insert);
     assert_eq!(action, ScreenAction::QuitInteraction { issue_number: 9 });
@@ -245,6 +249,8 @@ fn quit_modal_y_returns_quit_action_without_terminating() {
 #[test]
 fn quit_modal_uppercase_y_returns_quit_action() {
     let mut s = screen_for(9, true, TurnState::Idle);
+    // Linked PR → no unsaved work → uppercase `Y` quits on the first press.
+    s.view.pr_linked = Some(1);
     s.handle_input(&ctrl('w'), InputMode::Insert);
     let action = s.handle_input(&key_event(KeyCode::Char('Y')), InputMode::Insert);
     assert_eq!(action, ScreenAction::QuitInteraction { issue_number: 9 });

--- a/src/tui/screens/interaction/mod.rs
+++ b/src/tui/screens/interaction/mod.rs
@@ -73,6 +73,11 @@ pub struct InteractionScreen {
     close_reason: Option<CloseReason>,
     /// True while the `Ctrl+W` confirm modal is visible.
     quit_modal_open: bool,
+    /// Set once the user has seen the "unpushed work will be lost" warning
+    /// on the quit modal (RC4). The first `[y]` on a `produce_pr` session
+    /// with no linked PR flips this and re-shows the modal; the second `[y]`
+    /// confirms the discard. Reset whenever the modal closes.
+    quit_loss_acknowledged: bool,
     /// Wall-clock start of the in-flight turn (from `TurnStarted`). Used to
     /// compute the elapsed-ms figure in the per-turn activity-log line.
     stream_started_at: Option<chrono::DateTime<Utc>>,
@@ -148,6 +153,7 @@ impl InteractionScreen {
             terminated: false,
             close_reason: None,
             quit_modal_open: false,
+            quit_loss_acknowledged: false,
             stream_started_at: None,
             stream_chunks: 0,
             turn_count: 0,

--- a/src/tui/screens/interaction/render.rs
+++ b/src/tui/screens/interaction/render.rs
@@ -98,7 +98,13 @@ impl InteractionScreen {
         }
 
         if self.quit_modal_open {
-            input::draw_quit_modal(f, area, theme, &self.worktree_path);
+            input::draw_quit_modal(
+                f,
+                area,
+                theme,
+                &self.worktree_path,
+                self.quit_loss_acknowledged,
+            );
         }
 
         if let Some(review) = self.diff_review.as_mut() {

--- a/src/tui/screens/interaction/terminator_tests.rs
+++ b/src/tui/screens/interaction/terminator_tests.rs
@@ -17,6 +17,7 @@ use crate::session::interaction::{TurnRecord, TurnRole};
 use crate::tui::activity_log::LogLevel;
 use crate::tui::screens::ScreenAction;
 use crate::work::worktree_teardown::TeardownError;
+use crossterm::event::KeyCode;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::time::Duration;
@@ -140,6 +141,51 @@ fn quit_teardown_wipes_once_and_terminates_userquit() {
             .contains("worktree removed at /tmp/maestro/issue-42")
     );
     assert!(sys[1].content.contains("branch feat/issue-42 deleted"));
+}
+
+// ── RC4 (2026-06-14): quit must not silently discard unpushed work ────────────
+// When a PR was intended (`produce_pr`) but none was ever linked, the work
+// lives only on the local worktree branch (gates failed → no PR → never
+// pushed). The first [y] must WARN and keep the modal open; only a second
+// [y] confirms the discard. A session whose work is already captured in a
+// linked PR quits on the first [y] as before.
+
+#[test]
+fn quit_with_unsaved_pr_work_requires_double_confirm() {
+    let mut screen = wired_screen(Rc::new(MockTeardown::ok()), FakeClock::new());
+    screen.produce_pr = true; // a PR was intended …
+    screen.view.pr_linked = None; // … but none was ever created → uncaptured work
+    screen.quit_modal_open = true;
+
+    let first = screen.handle_quit_modal(KeyCode::Char('y'));
+    assert!(
+        matches!(first, ScreenAction::None),
+        "first [y] with unsaved PR work must warn, not quit"
+    );
+    assert!(
+        screen.quit_modal_open,
+        "modal stays open to surface the data-loss warning"
+    );
+
+    let second = screen.handle_quit_modal(KeyCode::Char('y'));
+    assert!(
+        matches!(second, ScreenAction::QuitInteraction { .. }),
+        "second [y] confirms the discard"
+    );
+}
+
+#[test]
+fn quit_with_linked_pr_confirms_immediately() {
+    let mut screen = wired_screen(Rc::new(MockTeardown::ok()), FakeClock::new());
+    screen.produce_pr = true;
+    screen.view.pr_linked = Some(7); // work captured in a PR → safe to wipe
+    screen.quit_modal_open = true;
+
+    let action = screen.handle_quit_modal(KeyCode::Char('y'));
+    assert!(
+        matches!(action, ScreenAction::QuitInteraction { .. }),
+        "a linked PR means no unsaved work; quit needs no second confirm"
+    );
 }
 
 #[test]

--- a/src/tui/screens/interaction/turn.rs
+++ b/src/tui/screens/interaction/turn.rs
@@ -73,12 +73,32 @@ impl InteractionScreen {
     /// the screen terminates when the teardown result lands. Anything else
     /// cancels the modal.
     pub(super) fn handle_quit_modal(&mut self, code: KeyCode) -> ScreenAction {
-        self.quit_modal_open = false;
         match code {
-            KeyCode::Char('y') | KeyCode::Char('Y') => ScreenAction::QuitInteraction {
-                issue_number: self.issue_number,
-            },
-            _ => ScreenAction::None,
+            KeyCode::Char('y') | KeyCode::Char('Y') => {
+                // RC4 guard: quitting wipes the worktree AND deletes the
+                // branch. When a PR was intended (`produce_pr`) but none was
+                // ever linked, the work lives only on this local branch
+                // (gates failed → no PR → never pushed). Require a second
+                // `[y]` so that work is never discarded silently. Work
+                // already captured in a linked PR quits on the first `[y]`.
+                if self.produce_pr && self.view.pr_linked.is_none() && !self.quit_loss_acknowledged
+                {
+                    self.quit_loss_acknowledged = true;
+                    // Keep the modal open so the render layer can surface the
+                    // stronger "unpushed work will be lost" warning.
+                    return ScreenAction::None;
+                }
+                self.quit_modal_open = false;
+                self.quit_loss_acknowledged = false;
+                ScreenAction::QuitInteraction {
+                    issue_number: self.issue_number,
+                }
+            }
+            _ => {
+                self.quit_modal_open = false;
+                self.quit_loss_acknowledged = false;
+                ScreenAction::None
+            }
         }
     }
 


### PR DESCRIPTION
## Overview
Quitting an interaction session wipes the worktree **and deletes its branch** (`begin_quit_teardown`). When a PR was intended (`produce_pr`) but none was ever linked, the work lives only on that local branch — a failed gate means no PR, so it was never pushed. The old quit modal discarded it on a single `[y]`, with copy that wrongly claimed the worktree was 'kept for manual inspection'.

## Root cause
Found debugging a lucidmate run: a unified #179+#180 session hit a failing `xcodebuild` gate → no PR → the WIP backup commit lived only on `maestro/unified-179-180` → quit wiped worktree + branch → work lost.

## Change
- First `[y]` on a `produce_pr` session with **no linked PR** → sets `quit_loss_acknowledged`, keeps the modal open, renders an explicit **'Unpushed work will be LOST'** warning.
- Second `[y]` → confirms the discard.
- Linked PR (work captured) or non-`produce_pr` (no PR intended) → quits on the first `[y]`, unchanged.

## Tests
- `quit_with_unsaved_pr_work_requires_double_confirm` (new, RED→GREEN)
- `quit_with_linked_pr_confirms_immediately` (new, regression guard)
- Updated two keymap tests to exercise the no-unsaved-work path.
- All 204 interaction lib tests + interaction snapshots green; clippy/fmt clean.

## Scope / follow-ups (not in this PR)
Guard uses `produce_pr && pr_linked.is_none()` as the unsaved-work signal (git-free). A precise `commits-not-on-origin` count is a possible refinement. Sibling root causes from the same run still open: RC2 (interactive launch uses unattended prompt), RC3 (auto_review ignores `[review].enabled` + scrapes unvalidated PR URLs).

## Blocked By
- None