### PR TITLE
test(tui/markdown): fix flaky perf assertion under coverage (closes #1017)

### DIFF
--- a/src/tui/markdown.rs
+++ b/src/tui/markdown.rs
@@ -1171,7 +1171,7 @@ mod tests {
     }
 
     #[test]
-    fn performance_10kb_under_5ms() {
+    fn performance_10kb_render_stays_fast() {
         let mut doc = String::with_capacity(10_240);
         for i in 0..50 {
             doc.push_str(&format!("# Heading {}\n\n", i));
@@ -1185,9 +1185,14 @@ mod tests {
             let _ = render_markdown(&doc, &t, 80);
         }
         let elapsed = start.elapsed() / 10;
+        // Gross-regression smoke test, not a microbenchmark. It also runs under
+        // llvm-cov (Coverage Tiers), whose instrumentation multiplies wall-clock
+        // time — a tight 5ms bound flaked at the boundary (#1017). A 50ms ceiling
+        // still catches an O(n²) blowup on a 10KB doc while surviving instrumented
+        // builds. If you need a precise number, use a criterion bench, not this.
         assert!(
-            elapsed.as_millis() < 5,
-            "render_markdown should complete in <5ms, took {}ms",
+            elapsed.as_millis() < 50,
+            "render_markdown regressed badly: {}ms for 10KB (expected < 50ms)",
             elapsed.as_millis()
         );
     }


### PR DESCRIPTION
## Summary

`performance_10kb_render_stays_fast` (was `performance_10kb_under_5ms`) asserted a <5ms average render on a 10KB doc. A truncated integer-millis bound at the 5ms boundary is fragile, and under **llvm-cov** (the Coverage Tiers gate) instrumentation multiplies wall-clock time — so the required gate flaked at random. It **blocked the v0.31.1 release CI** and needed a manual job re-run.

## Fix

Raise the ceiling to **50ms** with a comment explaining why. This is a gross-regression smoke test, not a microbenchmark: 50ms still catches an O(n²) blowup on a 10KB doc while surviving instrumented builds. Renamed the test so the name no longer claims a specific 5ms number.

## Validation

`cargo test --lib performance_10kb_render_stays_fast` passes; `cargo fmt --check` clean.

Closes #1017.