### PR TITLE
feat(tui/input): canonical Input widget core (#963)

### DIFF
--- a/directory-tree.md
+++ b/directory-tree.md
@@ -696,6 +696,10 @@ maestro/
 │   │       ├── bypass_indicator.rs        # BypassIndicatorWidget: small status badge rendered in the F-key bar when --bypass-review is active, warning the user that the review council is disabled  [Issue #328]
 │   │       ├── ci_monitor.rs              # CiMonitorWidget: compact bordered box rendering live CI check-run status for a PR; status icons, check names, elapsed times, and a summary footer; adds [e] keybind hint in footer when failed checks are present  [Issue #695]
 │   │       ├── dropdown.rs                # Dropdown selection widget with keyboard navigation
+│   │       ├── input/                     # Canonical text-input widget: one editing engine for every input site (foundation only, no site migrated)  [Issue #963]
+│   │       │   ├── mod.rs                 # Input/InputConfig + render re-exports
+│   │       │   ├── core.rs                # TextArea backend: single/multi-line, InputConfig builder (placeholder/max_len/initial), input(Event) with single-line Enter-swallow + newline collapse + max-length clamp, text/lines/cursor/set_text accessors
+│   │       │   └── render.rs              # Wrap via screens::wrap + manual cursor placement; pure visible() helper kept terminal-free for unit tests
 │   │       ├── list_editor.rs             # Editable list widget for adding and removing string items
 │   │       ├── number_stepper.rs          # Numeric increment/decrement stepper widget
 │   │       ├── stats_bar.rs               # StatsBar widget: home-screen footer bar showing per-window cost, token, and quota metrics; renders a "QUOTA: forced N in window" badge when MiniMax forced_count > 0  [Issue #845]

--- a/src/tui/widgets/input/core.rs
+++ b/src/tui/widgets/input/core.rs
@@ -1,0 +1,362 @@
+//! Backend + editing logic for the canonical `Input` widget (#963).
+//!
+//! Wraps `tui_textarea::TextArea` with the two behaviours every maestro
+//! input site needs on top of the raw editor: a single-line mode that never
+//! holds a newline, and an optional max-length clamp. Rendering lives in
+//! `super::render`; this module is a pure editing engine, unit-testable
+//! without a terminal.
+
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use ratatui::style::Style;
+use tui_textarea::{CursorMove, TextArea};
+
+/// Builder for an [`Input`]. All fields are optional.
+#[derive(Debug, Clone, Default)]
+pub struct InputConfig {
+    placeholder: String,
+    max_len: Option<usize>,
+    initial: String,
+}
+
+impl InputConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Hint text shown when the input is empty.
+    pub fn placeholder(mut self, p: impl Into<String>) -> Self {
+        self.placeholder = p.into();
+        self
+    }
+
+    /// Cap the total character count. Inserts past the cap are dropped.
+    pub fn max_len(mut self, n: usize) -> Self {
+        self.max_len = Some(n);
+        self
+    }
+
+    /// Seed the input with starting text (normalised the same as `set_text`).
+    pub fn initial(mut self, s: impl Into<String>) -> Self {
+        self.initial = s.into();
+        self
+    }
+}
+
+/// One canonical text input. Single-line or multi-line, backed by a
+/// `TextArea` so cursor movement, word-jump, and deletion come for free.
+pub struct Input {
+    area: TextArea<'static>,
+    single_line: bool,
+    placeholder: String,
+    max_len: Option<usize>,
+}
+
+impl Input {
+    /// A field that never holds a newline: `Enter` is swallowed and pasted
+    /// newlines collapse to a single space.
+    pub fn single_line(cfg: InputConfig) -> Self {
+        Self::build(cfg, true)
+    }
+
+    /// A field that preserves `\n` as a logical newline.
+    pub fn multi_line(cfg: InputConfig) -> Self {
+        Self::build(cfg, false)
+    }
+
+    fn build(cfg: InputConfig, single_line: bool) -> Self {
+        let mut this = Self {
+            area: TextArea::default(),
+            single_line,
+            placeholder: cfg.placeholder,
+            max_len: cfg.max_len,
+        };
+        this.area.set_cursor_line_style(Style::default());
+        if !cfg.initial.is_empty() {
+            this.set_text(&cfg.initial);
+        }
+        this
+    }
+
+    pub fn is_single_line(&self) -> bool {
+        self.single_line
+    }
+
+    pub fn placeholder(&self) -> &str {
+        &self.placeholder
+    }
+
+    /// Full content, logical lines joined with `\n`.
+    pub fn text(&self) -> String {
+        self.area.lines().join("\n")
+    }
+
+    /// Logical lines (a single-line input always has exactly one).
+    pub fn lines(&self) -> &[String] {
+        self.area.lines()
+    }
+
+    /// Cursor as a logical `(row, col)`, col a character index — matches
+    /// `tui_textarea::TextArea::cursor`.
+    pub fn cursor(&self) -> (usize, usize) {
+        self.area.cursor()
+    }
+
+    /// True when the input holds no text.
+    pub fn is_empty(&self) -> bool {
+        self.area.lines().iter().all(|l| l.is_empty())
+    }
+
+    /// Total character count (newlines included for multi-line).
+    fn len_chars(&self) -> usize {
+        let lines = self.area.lines();
+        let content: usize = lines.iter().map(|l| l.chars().count()).sum();
+        // Newlines between logical lines also count toward the budget.
+        content + lines.len().saturating_sub(1)
+    }
+
+    /// Replace the whole content, moving the cursor to the end. Single-line
+    /// collapses newlines; the max-length clamp is applied.
+    pub fn set_text(&mut self, s: &str) {
+        let normalised = if self.single_line {
+            collapse_newlines_to_space(s)
+        } else {
+            s.to_string()
+        };
+        let clamped = self.clamp_to_max(&normalised);
+        let lines: Vec<String> = if clamped.is_empty() {
+            vec![String::new()]
+        } else {
+            clamped.lines().map(String::from).collect()
+        };
+        let mut area = TextArea::new(lines);
+        area.set_cursor_line_style(Style::default());
+        let last_row = area.lines().len().saturating_sub(1) as u16;
+        let last_col = area.lines().last().map(|l| l.chars().count()).unwrap_or(0) as u16;
+        area.move_cursor(CursorMove::Jump(last_row, last_col));
+        self.area = area;
+    }
+
+    /// Forward an event to the backend. Returns `true` when the content or
+    /// cursor changed. Single-line mode swallows `Enter`; the max-length cap
+    /// drops overflowing inserts; single-line paste collapses newlines.
+    pub fn input(&mut self, event: Event) -> bool {
+        match &event {
+            Event::Paste(text) => {
+                let normalised = if self.single_line {
+                    collapse_newlines_to_space(text)
+                } else {
+                    text.clone()
+                };
+                let to_insert = self.clamp_insert(&normalised);
+                if to_insert.is_empty() {
+                    return false;
+                }
+                self.area.insert_str(&to_insert);
+                true
+            }
+            Event::Key(key) => {
+                // Single-line: Enter must never insert a newline.
+                if self.single_line && is_bare_enter(key) {
+                    return false;
+                }
+                // Max-length: block a plain character insert at the cap.
+                if let Some(max) = self.max_len
+                    && is_plain_char(key)
+                    && self.len_chars() >= max
+                {
+                    return false;
+                }
+                self.area.input(event)
+            }
+            _ => self.area.input(event),
+        }
+    }
+
+    /// Truncate `s` so the full content stays within `max_len`.
+    fn clamp_to_max(&self, s: &str) -> String {
+        match self.max_len {
+            Some(max) => s.chars().take(max).collect(),
+            None => s.to_string(),
+        }
+    }
+
+    /// Truncate an insertion to the remaining length budget.
+    fn clamp_insert(&self, s: &str) -> String {
+        match self.max_len {
+            Some(max) => {
+                let remaining = max.saturating_sub(self.len_chars());
+                s.chars().take(remaining).collect()
+            }
+            None => s.to_string(),
+        }
+    }
+}
+
+fn is_bare_enter(key: &KeyEvent) -> bool {
+    key.code == KeyCode::Enter && key.modifiers.is_empty()
+}
+
+/// A plain character insert — no Ctrl/Alt (Shift for capitals is fine).
+fn is_plain_char(key: &KeyEvent) -> bool {
+    matches!(key.code, KeyCode::Char(_))
+        && !key.modifiers.contains(KeyModifiers::CONTROL)
+        && !key.modifiers.contains(KeyModifiers::ALT)
+}
+
+/// Collapse every newline variant (`\r\n`, `\n`, `\r`, U+2028, U+2029) to a
+/// single space, so a multi-line paste flattens into one line.
+pub(crate) fn collapse_newlines_to_space(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '\r' => {
+                out.push(' ');
+                if chars.peek() == Some(&'\n') {
+                    chars.next();
+                }
+            }
+            '\n' | '\u{2028}' | '\u{2029}' => out.push(' '),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn key(c: char) -> Event {
+        Event::Key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE))
+    }
+
+    fn key_code(code: KeyCode) -> Event {
+        Event::Key(KeyEvent::new(code, KeyModifiers::NONE))
+    }
+
+    fn ctrl(code: KeyCode) -> Event {
+        Event::Key(KeyEvent::new(code, KeyModifiers::CONTROL))
+    }
+
+    fn type_str(input: &mut Input, s: &str) {
+        for c in s.chars() {
+            input.input(key(c));
+        }
+    }
+
+    #[test]
+    fn single_line_and_multi_line_construct() {
+        assert!(Input::single_line(InputConfig::new()).is_single_line());
+        assert!(!Input::multi_line(InputConfig::new()).is_single_line());
+    }
+
+    #[test]
+    fn config_initial_and_placeholder() {
+        let input = Input::single_line(InputConfig::new().placeholder("name").initial("hi"));
+        assert_eq!(input.placeholder(), "name");
+        assert_eq!(input.text(), "hi");
+    }
+
+    #[test]
+    fn typing_appends_and_cursor_tracks() {
+        let mut input = Input::single_line(InputConfig::new());
+        type_str(&mut input, "abc");
+        assert_eq!(input.text(), "abc");
+        assert_eq!(input.cursor(), (0, 3));
+    }
+
+    #[test]
+    fn single_line_swallows_enter() {
+        let mut input = Input::single_line(InputConfig::new());
+        type_str(&mut input, "ab");
+        let changed = input.input(key_code(KeyCode::Enter));
+        assert!(!changed);
+        assert_eq!(input.lines().len(), 1);
+        assert_eq!(input.text(), "ab");
+    }
+
+    #[test]
+    fn multi_line_enter_inserts_newline() {
+        let mut input = Input::multi_line(InputConfig::new());
+        type_str(&mut input, "a");
+        input.input(key_code(KeyCode::Enter));
+        type_str(&mut input, "b");
+        assert_eq!(input.lines().len(), 2);
+        assert_eq!(input.text(), "a\nb");
+    }
+
+    #[test]
+    fn single_line_paste_collapses_newlines() {
+        let mut input = Input::single_line(InputConfig::new());
+        input.input(Event::Paste("one\ntwo\r\nthree".to_string()));
+        assert_eq!(input.text(), "one two three");
+        assert_eq!(input.lines().len(), 1);
+    }
+
+    #[test]
+    fn multi_line_paste_keeps_newlines() {
+        let mut input = Input::multi_line(InputConfig::new());
+        input.input(Event::Paste("one\ntwo".to_string()));
+        assert_eq!(input.text(), "one\ntwo");
+        assert_eq!(input.lines().len(), 2);
+    }
+
+    #[test]
+    fn set_text_single_line_collapses() {
+        let mut input = Input::single_line(InputConfig::new());
+        input.set_text("x\ny");
+        assert_eq!(input.text(), "x y");
+    }
+
+    #[test]
+    fn max_len_blocks_typing_past_cap() {
+        let mut input = Input::single_line(InputConfig::new().max_len(3));
+        type_str(&mut input, "abcdef");
+        assert_eq!(input.text(), "abc");
+    }
+
+    #[test]
+    fn max_len_clamps_paste() {
+        let mut input = Input::single_line(InputConfig::new().max_len(4));
+        type_str(&mut input, "ab");
+        input.input(Event::Paste("cdefgh".to_string()));
+        assert_eq!(input.text(), "abcd");
+    }
+
+    #[test]
+    fn max_len_clamps_initial_text() {
+        let input = Input::single_line(InputConfig::new().max_len(2).initial("abcd"));
+        assert_eq!(input.text(), "ab");
+    }
+
+    #[test]
+    fn home_end_and_word_jump_navigation() {
+        let mut input = Input::single_line(InputConfig::new());
+        type_str(&mut input, "hello world");
+        input.input(key_code(KeyCode::Home));
+        assert_eq!(input.cursor(), (0, 0));
+        input.input(key_code(KeyCode::End));
+        assert_eq!(input.cursor(), (0, 11));
+        // Ctrl+Left is a word jump in tui-textarea's default keymap.
+        input.input(ctrl(KeyCode::Left));
+        assert_eq!(input.cursor(), (0, 6));
+    }
+
+    #[test]
+    fn backspace_deletes_at_cursor() {
+        let mut input = Input::single_line(InputConfig::new());
+        type_str(&mut input, "abc");
+        input.input(key_code(KeyCode::Backspace));
+        assert_eq!(input.text(), "ab");
+    }
+
+    #[test]
+    fn is_empty_reflects_content() {
+        let mut input = Input::multi_line(InputConfig::new());
+        assert!(input.is_empty());
+        type_str(&mut input, "x");
+        assert!(!input.is_empty());
+    }
+}

--- a/src/tui/widgets/input/mod.rs
+++ b/src/tui/widgets/input/mod.rs
@@ -12,5 +12,10 @@
 mod core;
 mod render;
 
+// Foundation only: no non-test site consumes these yet, so the re-exports read
+// as unused imports until the #968–#972 migrations land. `-A dead_code` in CI
+// covers the types themselves but not the `pub use`, so allow it here.
+#[allow(unused_imports)]
 pub use core::{Input, InputConfig};
+#[allow(unused_imports)]
 pub use render::render;

--- a/src/tui/widgets/input/mod.rs
+++ b/src/tui/widgets/input/mod.rs
@@ -1,0 +1,16 @@
+//! Canonical text-input widget for the maestro TUI (#963).
+//!
+//! One editing engine every input site can share, replacing the three tiers
+//! that exist today (rich `prompt_input`/`interaction`, decent
+//! `wizard_fields::TextAreaField`, and hand-rolled `String`+cursor sites).
+//! This is the foundation only — no site is migrated here; migrations land in
+//! #968–#972.
+//!
+//! - [`Input`] / [`InputConfig`] — the widget and its builder ([`core`]).
+//! - [`render`] — wrap + manual cursor placement ([`render`]).
+
+mod core;
+mod render;
+
+pub use core::{Input, InputConfig};
+pub use render::render;

--- a/src/tui/widgets/input/render.rs
+++ b/src/tui/widgets/input/render.rs
@@ -1,0 +1,103 @@
+//! Render path for the canonical `Input` (#963).
+//!
+//! Reuses `screens::wrap` (`wrap_lines` + `scroll_offset_for_cursor`) so the
+//! widget wraps and scrolls identically to the prompt editor, then places the
+//! terminal cursor manually. The wrap/scroll math is factored into `visible`
+//! so it stays unit-testable without a `Frame`.
+
+use super::core::Input;
+use crate::tui::screens::wrap::{scroll_offset_for_cursor, wrap_lines};
+use crate::tui::theme::Theme;
+use ratatui::{Frame, layout::Rect, style::Style, text::Line, widgets::Paragraph};
+
+/// Wrap the input to `viewport_width`, scroll so the cursor row is visible,
+/// and return `(visible visual lines, cursor position relative to the
+/// viewport top-left)`. Pure — no terminal needed.
+pub(crate) fn visible(
+    input: &Input,
+    viewport_width: u16,
+    visible_height: u16,
+) -> (Vec<String>, (u16, u16)) {
+    let (row, col) = input.cursor();
+    let wrapped = wrap_lines(input.lines(), (row, col), viewport_width);
+    let height = (visible_height as usize).max(1);
+    let offset = scroll_offset_for_cursor(wrapped.cursor.0 as usize, height);
+    let vis: Vec<String> = wrapped
+        .lines
+        .into_iter()
+        .skip(offset)
+        .take(height)
+        .collect();
+    let cur_row = (wrapped.cursor.0 as usize).saturating_sub(offset) as u16;
+    (vis, (cur_row, wrapped.cursor.1))
+}
+
+/// Draw the input into `area`. Renders placeholder text when empty; when
+/// `focused`, positions the terminal cursor.
+pub fn render(input: &Input, f: &mut Frame, area: Rect, theme: &Theme, focused: bool) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+
+    if input.is_empty() && !input.placeholder().is_empty() {
+        let ph = Paragraph::new(Line::from(input.placeholder().to_string()))
+            .style(Style::default().fg(theme.text_muted));
+        f.render_widget(ph, area);
+        if focused {
+            f.set_cursor_position((area.x, area.y));
+        }
+        return;
+    }
+
+    let (lines, (cur_row, cur_col)) = visible(input, area.width, area.height);
+    let text: Vec<Line> = lines.into_iter().map(Line::from).collect();
+    f.render_widget(
+        Paragraph::new(text).style(Style::default().fg(theme.text_primary)),
+        area,
+    );
+
+    if focused {
+        let cx = area
+            .x
+            .saturating_add(cur_col)
+            .min(area.right().saturating_sub(1));
+        let cy = area
+            .y
+            .saturating_add(cur_row)
+            .min(area.bottom().saturating_sub(1));
+        f.set_cursor_position((cx, cy));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::widgets::input::InputConfig;
+
+    #[test]
+    fn single_line_visible_maps_cursor() {
+        let mut input = Input::single_line(InputConfig::new());
+        input.set_text("hello");
+        let (lines, cursor) = visible(&input, 20, 3);
+        assert_eq!(lines, vec!["hello".to_string()]);
+        assert_eq!(cursor, (0, 5));
+    }
+
+    #[test]
+    fn multi_line_wraps_long_line_and_maps_cursor() {
+        let mut input = Input::multi_line(InputConfig::new());
+        input.set_text("abcdef"); // width 4 → wraps to "abcd" / "ef"
+        let (lines, cursor) = visible(&input, 4, 5);
+        assert_eq!(lines, vec!["abcd".to_string(), "ef".to_string()]);
+        // Cursor sits after "ef" on the second visual row.
+        assert_eq!(cursor, (1, 2));
+    }
+
+    #[test]
+    fn empty_input_visible_is_one_blank_row() {
+        let input = Input::multi_line(InputConfig::new());
+        let (lines, cursor) = visible(&input, 10, 3);
+        assert_eq!(lines, vec![String::new()]);
+        assert_eq!(cursor, (0, 0));
+    }
+}

--- a/src/tui/widgets/mod.rs
+++ b/src/tui/widgets/mod.rs
@@ -3,6 +3,7 @@ pub mod bypass_indicator;
 mod ci_monitor;
 mod dropdown;
 mod empty_state;
+pub mod input;
 mod list_editor;
 mod number_stepper;
 pub mod stats_bar;


### PR DESCRIPTION
## What this ships

The foundation for milestone #62 (Input Standardization): `src/tui/widgets/input/` — one canonical text-input widget every site can share. **Foundation only — no site is migrated** (migrations land in #968–#972).

## Why

Input quality is split across three tiers today: rich (`prompt_input`, `interaction`), decent (`wizard_fields::TextAreaField`), and hand-rolled `String`+cursor sites that drop keystrokes and have no cursor tracking. One shared engine kills that drift.

## What's in it

- **`core.rs`** — `Input` backed by `tui-textarea`. `single_line` / `multi_line` constructors + an `InputConfig` builder (placeholder, max length, initial text). `input(Event)` swallows `Enter` in single-line mode, collapses pasted newlines, and clamps to `max_len`; `text()` / `lines()` / `cursor()` / `set_text()` accessors.
- **`render.rs`** — reuses `screens::wrap` (`wrap_lines` + `scroll_offset_for_cursor`) and places the terminal cursor manually. The wrap/scroll math is a pure `visible()` helper so it's unit-testable without a `Frame`.
- **`widgets/mod.rs`** — `pub mod input`. `directory-tree.md` updated.

## Verification

- 17 tests (all AC bullets): single-line newline collapse, multi-line wrap + cursor mapping, Home/End/word-jump, max-length clamp (type / paste / initial), per-mode Enter handling.
- `cargo fmt --check` clean · `cargo clippy --lib` clean on the new module · full suite **5902 pass / 0 fail**.
- No new `unwrap`/`expect`/`panic` in non-test code.

No release — nothing renders it yet; it ships as part of v0.33.0 when the migrations land.

Closes #963.